### PR TITLE
api: fix dropped error

### DIFF
--- a/api/resource_logs.go
+++ b/api/resource_logs.go
@@ -29,13 +29,15 @@ func (c *Client) GetAppLogs(appName string, nextToken string, region string, ins
 	}
 
 	url := fmt.Sprintf("%s/api/v1/apps/%s/logs?%s", baseURL, appName, data.Encode())
+	entries := []LogEntry{}
 
 	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return entries, "", err
+	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.accessToken))
 
 	var result getLogsResponse
-
-	entries := []LogEntry{}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
This fixes a dropped error in the `api` package.