### PR TITLE
docker: Fix Dropped Errors

### DIFF
--- a/docker/build.go
+++ b/docker/build.go
@@ -147,6 +147,9 @@ func (op *DeployOperation) PackAndDeploy(cwd string, appConfig *flyctl.AppConfig
 	fmt.Println("Image built", imageName)
 
 	img, err := op.dockerClient.findImage(op.ctx, imageName)
+	if err != nil {
+		return nil, err
+	}
 
 	printImageSize(uint64(img.Size))
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -327,6 +327,9 @@ func checkManifest(ctx context.Context, imageRef string, token string) (*dockerp
 	url := fmt.Sprintf("https://%s/v2/%s/manifests/%s", registry, ref.ShortName(), ref.Tag())
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
 	if token != "" {
 		req.Header.Add("Authorization", "Bearer "+token)


### PR DESCRIPTION
This fixes two dropped errors in the `docker` package.