### PR TITLE
Improve CLI Messages

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -71,6 +71,9 @@ func runDeploy(cc *CmdContext) error {
 
 	parsedCfg, err := op.ValidateConfig()
 	if err != nil {
+		for _, error := range parsedCfg.Errors {
+			fmt.Println("   ", aurora.Red("✘").String(), error)
+		}
 		return err
 	}
 

--- a/docker/deploy.go
+++ b/docker/deploy.go
@@ -96,11 +96,11 @@ func (op *DeployOperation) ValidateConfig() (*api.AppConfig, error) {
 
 	parsedConfig, err := op.apiClient.ParseConfig(op.appName, op.appConfig.Definition)
 	if err != nil {
-		return nil, err
+		return parsedConfig, err
 	}
 
 	if !parsedConfig.Valid {
-		return nil, errors.New("App configuration is not valid")
+		return parsedConfig, errors.New("App configuration is not valid")
 	}
 
 	op.appConfig.Definition = parsedConfig.Definition


### PR DESCRIPTION
I tried running my first deploy with a bad `fly.toml`.

The message I got back was:
```
==> Validating app configuration
Error App configuration is not valid
```

This PR changes the `docker` package to return failed configs along with an error so that `cmd` can print the errors.

With these changes, the `flyctl` binary prints:
```
==> Validating app configuration
    ✘ services.0.ports.0.port: must be one of: [80, 443, 5000, 10000..10100]
    ✘ services.0.ports.1.port: must be one of: [80, 443, 5000, 10000..10100]
Error App configuration is not valid```