### PR TITLE
JSON Snagging

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 
@@ -14,9 +15,14 @@ import (
 )
 
 var baseURL string
+var errorLog bool
 
 func SetBaseURL(url string) {
 	baseURL = url
+}
+
+func SetErrorLog(log bool) {
+	errorLog = log
 }
 
 type Client struct {
@@ -58,6 +64,11 @@ func (c *Client) RunWithContext(ctx context.Context, req *graphql.Request) (Quer
 	if err != nil && strings.HasPrefix(err.Error(), "graphql: ") {
 		return resp, errors.New(strings.TrimPrefix(err.Error(), "graphql: "))
 	}
+
+	if resp.Errors != nil && errorLog {
+		fmt.Fprintf(os.Stderr, "Error: %+v\n", resp.Errors)
+	}
+
 	return resp, err
 }
 

--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -97,10 +97,10 @@ func (client *Client) GetApp(appName string) (*App, error) {
 	return &data.App, nil
 }
 
-func (client *Client) GetCompactApp(appName string) (*CompactApp, error) {
+func (client *Client) GetAppCompact(appName string) (*AppCompact, error) {
 	query := `
 		query ($appName: String!) {
-			compactapp:app(name: $appName) {
+			appcompact:app(name: $appName) {
 				id
 				name
 				hostname
@@ -140,7 +140,7 @@ func (client *Client) GetCompactApp(appName string) (*CompactApp, error) {
 		return nil, err
 	}
 
-	return &data.CompactApp, nil
+	return &data.AppCompact, nil
 }
 
 func (client *Client) CreateApp(name string, orgId string) (*App, error) {

--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -97,6 +97,52 @@ func (client *Client) GetApp(appName string) (*App, error) {
 	return &data.App, nil
 }
 
+func (client *Client) GetCompactApp(appName string) (*CompactApp, error) {
+	query := `
+		query ($appName: String!) {
+			compactapp:app(name: $appName) {
+				id
+				name
+				hostname
+				deployed
+				status
+				version
+				appUrl
+				organization {
+					slug
+				}
+				services {
+					description
+					protocol
+					internalPort
+					ports {
+						port
+						handlers
+					}
+				}
+				ipAddresses {
+					nodes {
+						id
+						address
+						type
+						createdAt
+					}
+				}
+			}
+		}
+	`
+
+	req := client.NewRequest(query)
+	req.Var("appName", appName)
+
+	data, err := client.Run(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data.CompactApp, nil
+}
+
 func (client *Client) CreateApp(name string, orgId string) (*App, error) {
 	query := `
 		mutation($input: CreateAppInput!) {

--- a/api/resource_deploy.go
+++ b/api/resource_deploy.go
@@ -80,7 +80,7 @@ func (c *Client) GetDeploymentStatus(appName string, deploymentID string) (*Depl
 						desiredStatus
 						version
 						healthy
-            failed
+            			failed
 						canary
 						restarts
 						checks {

--- a/api/resource_monitoring.go
+++ b/api/resource_monitoring.go
@@ -1,9 +1,9 @@
 package api
 
-func (c *Client) GetAppStatus(appName string, showCompleted bool) (*App, error) {
+func (c *Client) GetAppStatus(appName string, showCompleted bool) (*AppStatus, error) {
 	query := `
 		query($appName: String!, $showCompleted: Boolean!) {
-			app(name: $appName) {
+			appstatus:app(name: $appName) {
 				id
 				name
 				deployed
@@ -57,7 +57,7 @@ func (c *Client) GetAppStatus(appName string, showCompleted bool) (*App, error) 
 		return nil, err
 	}
 
-	return &data.App, nil
+	return &data.AppStatus, nil
 }
 
 func (c *Client) GetAllocationStatus(appName string, allocID string, logLimit int) (*AllocationStatus, error) {

--- a/api/types.go
+++ b/api/types.go
@@ -1,13 +1,19 @@
 package api
 
-import "time"
+import (
+	"time"
+)
 
+// Query - Master query which encapsulates all possible returned structures
 type Query struct {
+	Errors Errors
+
 	Apps struct {
 		Nodes []App
 	}
 	App           App
-	CompactApp    CompactApp
+	AppCompact    AppCompact
+	AppStatus     AppStatus
 	CurrentUser   User
 	Organizations struct {
 		Nodes []Organization
@@ -140,7 +146,7 @@ type App struct {
 	Regions          *[]Region
 }
 
-type CompactApp struct {
+type AppCompact struct {
 	ID           string
 	Name         string
 	Status       string
@@ -154,6 +160,19 @@ type CompactApp struct {
 		Nodes []IPAddress
 	}
 	Services []Service
+}
+
+type AppStatus struct {
+	ID               string
+	Name             string
+	Deployed         bool
+	Status           string
+	Hostname         string
+	Version          int
+	AppURL           string
+	Organization     Organization
+	DeploymentStatus *DeploymentStatus
+	Allocations      []*AllocationStatus
 }
 
 type AppConfig struct {
@@ -480,4 +499,19 @@ type ConfigureRegionsInput struct {
 	AppID        string   `json:"appId"`
 	AllowRegions []string `json:"allowRegions"`
 	DenyRegions  []string `json:"denyRegions"`
+}
+
+type Errors []Error
+
+type Error struct {
+	Message    string
+	Path       []string
+	Extensions Extensions
+}
+
+type Extensions struct {
+	Code        string
+	ServiceName string
+	Query       string
+	Variables   map[string]string
 }

--- a/api/types.go
+++ b/api/types.go
@@ -7,6 +7,7 @@ type Query struct {
 		Nodes []App
 	}
 	App           App
+	CompactApp    CompactApp
 	CurrentUser   User
 	Organizations struct {
 		Nodes []Organization
@@ -137,6 +138,22 @@ type App struct {
 	Autoscaling      *AutoscalingConfig
 	VMSize           VMSize
 	Regions          *[]Region
+}
+
+type CompactApp struct {
+	ID           string
+	Name         string
+	Status       string
+	Deployed     bool
+	Hostname     string
+	AppURL       string
+	Version      int
+	Release      *Release
+	Organization Organization
+	IPAddresses  struct {
+		Nodes []IPAddress
+	}
+	Services []Service
 }
 
 type AppConfig struct {

--- a/cmd/appInfo.go
+++ b/cmd/appInfo.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/superfly/flyctl/cmdctx"
 	"os"
+
+	"github.com/superfly/flyctl/cmdctx"
 
 	"github.com/superfly/flyctl/docstrings"
 
@@ -15,12 +16,12 @@ func newAppInfoCommand() *Command {
 }
 
 func runAppInfo(ctx *cmdctx.CmdContext) error {
-	app, err := ctx.Client.API().GetApp(ctx.AppName)
+	app, err := ctx.Client.API().GetCompactApp(ctx.AppName)
 	if err != nil {
 		return err
 	}
 
-	err = ctx.Frender(cmdctx.PresenterOption{Presentable: &presenters.AppInfo{App: *app}, HideHeader: true, Vertical: true, Title: "App"})
+	err = ctx.Frender(cmdctx.PresenterOption{Presentable: &presenters.CompactAppInfo{CompactApp: *app}, HideHeader: true, Vertical: true, Title: "App"})
 	if err != nil {
 		return err
 	}

--- a/cmd/appInfo.go
+++ b/cmd/appInfo.go
@@ -16,12 +16,12 @@ func newAppInfoCommand() *Command {
 }
 
 func runAppInfo(ctx *cmdctx.CmdContext) error {
-	app, err := ctx.Client.API().GetCompactApp(ctx.AppName)
+	app, err := ctx.Client.API().GetAppCompact(ctx.AppName)
 	if err != nil {
 		return err
 	}
 
-	err = ctx.Frender(cmdctx.PresenterOption{Presentable: &presenters.CompactAppInfo{CompactApp: *app}, HideHeader: true, Vertical: true, Title: "App"})
+	err = ctx.Frender(cmdctx.PresenterOption{Presentable: &presenters.AppCompact{AppCompact: *app}, HideHeader: true, Vertical: true, Title: "App"})
 	if err != nil {
 		return err
 	}

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superfly/flyctl/cmdctx"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/briandowns/spinner"
 	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -112,14 +113,24 @@ func runAppsPause(ctx *cmdctx.CmdContext) error {
 
 	allocount := len(appstatus.Allocations)
 
+	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
+	s.Writer = os.Stderr
+	s.Prefix = fmt.Sprintf("Pausing %s with %d instances to stop ", appstatus.Name, allocount)
+	s.Start()
+
 	for allocount > 0 {
-		fmt.Printf("Pausing %s with %d instance(s)\n", appstatus.Name, allocount)
-		time.Sleep(5 * time.Second)
+		plural := ""
+		if allocount > 1 {
+			plural = "s"
+		}
+		s.Prefix = fmt.Sprintf("Pausing %s with %d instance%s to stop ", appstatus.Name, allocount, plural)
 		appstatus, err = ctx.Client.API().GetAppStatus(ctx.AppName, false)
 		allocount = len(appstatus.Allocations)
 	}
 
-	fmt.Printf("%s is now %s with no instances running\n", appstatus.Name, appstatus.Status)
+	s.FinalMSG = fmt.Sprintf("Pause complete - %s is now paused with no running instances\n", appstatus.Name)
+	s.Stop()
+
 	return nil
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -93,6 +93,16 @@ func runDeploy(commandContext *cmdctx.CmdContext) error {
 		}
 	}
 
+	appcheck, err := commandContext.Client.API().GetApp(commandContext.AppName)
+
+	if err != nil {
+		return err
+	}
+
+	if appcheck.Status == "dead" {
+		return fmt.Errorf("app %s is currently paused - resume it with flyctl apps resume", commandContext.AppName)
+	}
+
 	var strategy = docker.DefaultDeploymentStrategy
 	if val, _ := commandContext.Config.GetString("strategy"); val != "" {
 		strategy, err = docker.ParseDeploymentStrategy(val)
@@ -291,7 +301,6 @@ func watchDeployment(ctx context.Context, commandContext *cmdctx.CmdContext) err
 		commandContext.Statusf("deploy", cmdctx.SDETAIL, "v%d %s - %s\n", d.Version, d.Status, d.Description)
 
 		if len(failedAllocs) > 0 {
-			fmt.Fprintln(commandContext.Out)
 			commandContext.Status("flyctl", cmdctx.STITLE, "Failed Allocations")
 
 			x := make(chan *api.AllocationStatus)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -105,7 +105,7 @@ func runDeploy(commandContext *cmdctx.CmdContext) error {
 
 	if imageRef, _ := commandContext.Config.GetString("image"); imageRef != "" {
 		// image specified, resolve it, tagging and pushing if docker+local
-		// fmt.Printf("Deploying image: %s\n", imageRef)
+
 		commandContext.Statusf("flyctl", cmdctx.SINFO, "Deploying image: %s\n", imageRef)
 
 		img, err := op.ResolveImage(ctx, commandContext, imageRef)
@@ -182,7 +182,6 @@ func runDeploy(commandContext *cmdctx.CmdContext) error {
 			commandContext.Status("flyctl", cmdctx.SDONE, "Done Pushing Image")
 
 			if commandContext.Config.GetBool("build-only") {
-				//fmt.Printf("Image: %s\n", image.Tag)
 				commandContext.Statusf("flyctl", cmdctx.SINFO, "Image: %s\n", image.Tag)
 
 				return nil
@@ -204,7 +203,9 @@ func runDeploy(commandContext *cmdctx.CmdContext) error {
 
 			buildMonitor := builds.NewBuildMonitor(build.ID, commandContext.Client.API())
 			for line := range buildMonitor.Logs(ctx) {
-				fmt.Println(line)
+				s.Stop()
+				commandContext.Status("remotebuild", cmdctx.SINFO, line)
+				s.Start()
 			}
 
 			s.FinalMSG = fmt.Sprintf("Build complete - %s\n", buildMonitor.Status())

--- a/cmd/presenters/appstatus.go
+++ b/cmd/presenters/appstatus.go
@@ -1,0 +1,40 @@
+package presenters
+
+import (
+	"strconv"
+
+	"github.com/superfly/flyctl/api"
+)
+
+type AppStatus struct {
+	AppStatus api.AppStatus
+}
+
+func (p *AppStatus) APIStruct() interface{} {
+	return p.AppStatus
+}
+
+func (p *AppStatus) FieldNames() []string {
+	return []string{"Name", "Owner", "Version", "Status", "Hostname"}
+}
+
+func (p *AppStatus) Records() []map[string]string {
+	out := []map[string]string{}
+
+	info := map[string]string{
+		"Name":    p.AppStatus.Name,
+		"Owner":   p.AppStatus.Organization.Slug,
+		"Version": strconv.Itoa(p.AppStatus.Version),
+		"Status":  p.AppStatus.Status,
+	}
+
+	if len(p.AppStatus.Hostname) > 0 {
+		info["Hostname"] = p.AppStatus.Hostname
+	} else {
+		info["Hostname"] = "<empty>"
+	}
+
+	out = append(out, info)
+
+	return out
+}

--- a/cmd/presenters/compactappInfo.go
+++ b/cmd/presenters/compactappInfo.go
@@ -6,30 +6,30 @@ import (
 	"github.com/superfly/flyctl/api"
 )
 
-type CompactAppInfo struct {
-	CompactApp api.CompactApp
+type AppCompact struct {
+	AppCompact api.AppCompact
 }
 
-func (p *CompactAppInfo) APIStruct() interface{} {
-	return p.CompactApp
+func (p *AppCompact) APIStruct() interface{} {
+	return p.AppCompact
 }
 
-func (p *CompactAppInfo) FieldNames() []string {
+func (p *AppCompact) FieldNames() []string {
 	return []string{"Name", "Owner", "Version", "Status", "Hostname"}
 }
 
-func (p *CompactAppInfo) Records() []map[string]string {
+func (p *AppCompact) Records() []map[string]string {
 	out := []map[string]string{}
 
 	info := map[string]string{
-		"Name":    p.CompactApp.Name,
-		"Owner":   p.CompactApp.Organization.Slug,
-		"Version": strconv.Itoa(p.CompactApp.Version),
-		"Status":  p.CompactApp.Status,
+		"Name":    p.AppCompact.Name,
+		"Owner":   p.AppCompact.Organization.Slug,
+		"Version": strconv.Itoa(p.AppCompact.Version),
+		"Status":  p.AppCompact.Status,
 	}
 
-	if len(p.CompactApp.Hostname) > 0 {
-		info["Hostname"] = p.CompactApp.Hostname
+	if len(p.AppCompact.Hostname) > 0 {
+		info["Hostname"] = p.AppCompact.Hostname
 	} else {
 		info["Hostname"] = "<empty>"
 	}

--- a/cmd/presenters/compactappInfo.go
+++ b/cmd/presenters/compactappInfo.go
@@ -1,0 +1,40 @@
+package presenters
+
+import (
+	"strconv"
+
+	"github.com/superfly/flyctl/api"
+)
+
+type CompactAppInfo struct {
+	CompactApp api.CompactApp
+}
+
+func (p *CompactAppInfo) APIStruct() interface{} {
+	return p.CompactApp
+}
+
+func (p *CompactAppInfo) FieldNames() []string {
+	return []string{"Name", "Owner", "Version", "Status", "Hostname"}
+}
+
+func (p *CompactAppInfo) Records() []map[string]string {
+	out := []map[string]string{}
+
+	info := map[string]string{
+		"Name":    p.CompactApp.Name,
+		"Owner":   p.CompactApp.Organization.Slug,
+		"Version": strconv.Itoa(p.CompactApp.Version),
+		"Status":  p.CompactApp.Status,
+	}
+
+	if len(p.CompactApp.Hostname) > 0 {
+		info["Hostname"] = p.CompactApp.Hostname
+	} else {
+		info["Hostname"] = "<empty>"
+	}
+
+	out = append(out, info)
+
+	return out
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,10 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("json", "j", false, "json output")
 	viper.BindPFlag(flyctl.ConfigJSONOutput, rootCmd.PersistentFlags().Lookup("json"))
 
+	rootCmd.PersistentFlags().Bool("gqlerrorlogging", false, "Log GraphQL errors directly to stdout")
+
+	rootCmd.Flags().MarkHidden("gqlerrorlogging")
+
 	rootCmd.AddCommand(
 		newAuthCommand(),
 		newAppStatusCommand(),

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/superfly/flyctl/cmdctx"
 	"io"
 	"os"
+
+	"github.com/superfly/flyctl/cmdctx"
 
 	"github.com/segmentio/textio"
 	"github.com/spf13/cobra"
@@ -34,7 +35,7 @@ func runAppStatus(ctx *cmdctx.CmdContext) error {
 		return err
 	}
 
-	err = ctx.Frender(cmdctx.PresenterOption{Presentable: &presenters.AppInfo{App: *app}, HideHeader: true, Vertical: true, Title: "App"})
+	err = ctx.Frender(cmdctx.PresenterOption{Presentable: &presenters.AppStatus{AppStatus: *app}, HideHeader: true, Vertical: true, Title: "App"})
 	if err != nil {
 		return err
 	}

--- a/cmdctx/cmdcontext.go
+++ b/cmdctx/cmdcontext.go
@@ -123,7 +123,7 @@ func (commandContext *CmdContext) FrenderPrefix(prefix string, views ...Presente
 	p := textio.NewPrefixWriter(commandContext.Out, "    ")
 
 	if commandContext.OutputJSON() {
-		for i, _ := range views {
+		for i := range views {
 			views[i].AsJSON = true
 		}
 	}

--- a/docker/build.go
+++ b/docker/build.go
@@ -3,12 +3,13 @@ package docker
 import (
 	"errors"
 	"fmt"
-	"github.com/superfly/flyctl/cmdctx"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
 	"time"
+
+	"github.com/superfly/flyctl/cmdctx"
 
 	"github.com/briandowns/spinner"
 	"github.com/buildpacks/pack"
@@ -20,10 +21,16 @@ import (
 	"github.com/superfly/flyctl/terminal"
 )
 
+// ErrNoDockerfile - No dockerfile or builder specified error
 var ErrNoDockerfile = errors.New("Project does not contain a Dockerfile or specify a builder")
+
+// ErrDockerDaemon - Docker daemon needs to be running error
 var ErrDockerDaemon = errors.New("Docker daemon must be running to perform this action")
+
+// ErrNoBuildpackBuilder - Unable to find Buildpack builder
 var ErrNoBuildpackBuilder = errors.New("No buildpack builder")
 
+// ResolveDockerfile - Resolve the location of the dockerfile, allowing for upper and lowercase naming
 func ResolveDockerfile(cwd string) string {
 	dockerfilePath := path.Join(cwd, "Dockerfile")
 	if helpers.FileExists(dockerfilePath) {
@@ -36,13 +43,14 @@ func ResolveDockerfile(cwd string) string {
 	return ""
 }
 
+// Image - A type to hold information about a Docker image, including ID, Tag and Size
 type Image struct {
 	ID   string
 	Tag  string
 	Size int64
 }
 
-//func (op *DeployOperation) BuildWithDocker(appConfig *flyctl.AppConfig, cwd string, dockerfilePath string, buildArgs map[string]string) (*Image, error) {
+// BuildWithDocker - Run a Docker Build operation reporting back via the command context
 func (op *DeployOperation) BuildWithDocker(commandContext *cmdctx.CmdContext, dockerfilePath string, buildArgs map[string]string) (*Image, error) {
 	spinning := commandContext.OutputJSON()
 	cwd := commandContext.WorkingDir
@@ -131,6 +139,7 @@ func initPackClient() pack.Client {
 	return *client
 }
 
+// BuildWithPack - Perform a Docker build using a Buildpack (buildpack.io)
 func (op *DeployOperation) BuildWithPack(commandContext *cmdctx.CmdContext, buildArgs map[string]string) (*Image, error) {
 	cwd := commandContext.WorkingDir
 	appConfig := commandContext.AppConfig
@@ -186,14 +195,17 @@ func (op *DeployOperation) BuildWithPack(commandContext *cmdctx.CmdContext, buil
 	return image, nil
 }
 
+// PushImage - Push the Image (where?)
 func (op *DeployOperation) PushImage(image Image) error {
 	return op.pushImage(image.Tag)
 }
 
+// OptimizeImage - Optimize the Image for deployment
 func (op *DeployOperation) OptimizeImage(image Image) error {
 	return op.optimizeImage(image.Tag)
 }
 
+// StartRemoteBuild - Start a remote build and track its progress
 func (op *DeployOperation) StartRemoteBuild(cwd string, appConfig *flyctl.AppConfig, dockerfilePath string, buildArgs map[string]string) (*api.Build, error) {
 	buildContext, err := newBuildContext()
 	if err != nil {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -119,7 +119,7 @@ func (c *DockerClient) PullImage(ctx context.Context, imageName string, out io.W
 	defer resp.Close()
 
 	termFd, isTerm := term.GetFdInfo(os.Stderr)
-	return jsonmessage.DisplayJSONMessagesStream(resp, os.Stderr, termFd, isTerm, nil)
+	return jsonmessage.DisplayJSONMessagesStream(resp, out, termFd, isTerm, nil)
 }
 
 func (c *DockerClient) TagImage(ctx context.Context, sourceRef, tag string) error {
@@ -183,7 +183,7 @@ func (c *DockerClient) BuildImage(ctx context.Context, tar io.Reader, tag string
 
 	termFd, isTerm := term.GetFdInfo(os.Stderr)
 
-	if err := jsonmessage.DisplayJSONMessagesStream(resp.Body, os.Stderr, termFd, isTerm, nil); err != nil {
+	if err := jsonmessage.DisplayJSONMessagesStream(resp.Body, out, termFd, isTerm, nil); err != nil {
 		return nil, err
 	}
 
@@ -300,7 +300,7 @@ func (c *DockerClient) PushImage(ctx context.Context, imageName string, out io.W
 	defer resp.Close()
 
 	termFd, isTerm := term.GetFdInfo(os.Stderr)
-	return jsonmessage.DisplayJSONMessagesStream(resp, os.Stderr, termFd, isTerm, nil)
+	return jsonmessage.DisplayJSONMessagesStream(resp, out, termFd, isTerm, nil)
 }
 
 func CheckManifest(ctx context.Context, imageRef string, token string) (*dockerparser.Reference, error) {

--- a/flyctl/config.go
+++ b/flyctl/config.go
@@ -5,11 +5,12 @@ import (
 )
 
 const (
-	ConfigAPIToken      = "access_token"
-	ConfigAPIBaseURL    = "api_base_url"
-	ConfigAppName       = "app"
-	ConfigVerboseOutput = "verbose"
-	ConfigJSONOutput    = "json"
+	ConfigAPIToken        = "access_token"
+	ConfigAPIBaseURL      = "api_base_url"
+	ConfigAppName         = "app"
+	ConfigVerboseOutput   = "verbose"
+	ConfigJSONOutput      = "json"
+	ConfigGQLErrorLogging = "gqlerrorlogging"
 
 	ConfigRegistryHost             = "registry_host"
 	ConfigUpdateCheckLatestVersion = "update_check.latest_version"

--- a/flyctl/flyctl.go
+++ b/flyctl/flyctl.go
@@ -65,11 +65,13 @@ func initViper() {
 	viper.BindEnv(ConfigAPIToken, "FLY_ACCESS_TOKEN")
 	viper.BindEnv(ConfigAPIToken, "FLY_API_TOKEN")
 	viper.BindEnv(ConfigVerboseOutput, "VERBOSE")
+	viper.BindEnv(ConfigGQLErrorLogging, "GQLErrorLogging")
 
 	viper.SetEnvPrefix("FLY")
 	viper.AutomaticEnv()
 
 	api.SetBaseURL(viper.GetString(ConfigAPIBaseURL))
+	api.SetErrorLog(viper.GetBool(ConfigGQLErrorLogging))
 }
 
 func loadConfig() error {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"runtime/debug"
 	"time"
 
@@ -34,6 +35,8 @@ func main() {
 				fmt.Println(err)
 				fmt.Println(string(debug.Stack()))
 			}
+
+			os.Exit(1)
 		}
 	}()
 


### PR DESCRIPTION
Review - "This passive aggressive pogrom of capable code is horrifying in detail"

Mostly fixups for the JSON release

Remote build output is now wrapped (local build output goes back to stdout till we can test with stagable remote build config).

CompactApp (aliased smalled structures) in for specfic calls

GQL Error logging installed with hidden flag

apps pause/resume with workaround for incorrect status issue

apps pause now counts down instances

blocker on deploying to dead/paused deployments added.
