### PR TITLE
Fix build on systems where sh is not bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ build: generate
 
 cmddocs: generate
 	@echo Running Docs Generation
-	sh scripts/generate_docs.sh
+	bash scripts/generate_docs.sh

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo "Running doc/main.go"
 go run doc/main.go
 


### PR DESCRIPTION
When invoking `make` to build flyctl, I got the following error:

scripts/generate_docs.sh: 6: [[: not found

It looks like `scripts/generate_docs.sh` expects to run with bash, but the
Makefile invokes it using `sh scripts/generate_docs.sh`. Change the
Makefile to use `bash`, and also add a bash shebang to the script.