### PR TITLE
New command structuring - issue #182

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -1,25 +1,14 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
-	"strconv"
-	"time"
 
 	"github.com/superfly/flyctl/cmdctx"
 
-	"github.com/AlecAivazis/survey/v2"
-	"github.com/briandowns/spinner"
-	"github.com/logrusorgru/aurora"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/cmd/presenters"
 	"github.com/superfly/flyctl/docstrings"
-	"github.com/superfly/flyctl/flyctl"
-	"github.com/superfly/flyctl/helpers"
 )
-
-//TODO: Move all output to status styled begin/done updates
 
 func newAppListCommand() *Command {
 
@@ -40,7 +29,7 @@ func newAppListCommand() *Command {
 
 	appsCreateStrings := docstrings.Get("apps.create")
 
-	create := BuildCommand(cmd, runAppsCreate, appsCreateStrings.Usage, appsCreateStrings.Short, appsCreateStrings.Long, os.Stdout, requireSession)
+	create := BuildCommand(cmd, runInit, appsCreateStrings.Usage, appsCreateStrings.Short, appsCreateStrings.Long, os.Stdout, requireSession)
 	create.Args = cobra.RangeArgs(0, 1)
 
 	// TODO: Move flag descriptions into the docStrings
@@ -66,13 +55,13 @@ func newAppListCommand() *Command {
 	})
 
 	appsDestroyStrings := docstrings.Get("apps.destroy")
-	destroy := BuildCommand(cmd, runDestroyApp, appsDestroyStrings.Usage, appsDestroyStrings.Short, appsDestroyStrings.Long, os.Stdout, requireSession)
+	destroy := BuildCommand(cmd, runDestroy, appsDestroyStrings.Usage, appsDestroyStrings.Short, appsDestroyStrings.Long, os.Stdout, requireSession)
 	destroy.Args = cobra.ExactArgs(1)
 	// TODO: Move flag descriptions into the docStrings
 	destroy.AddBoolFlag(BoolFlagOpts{Name: "yes", Shorthand: "y", Description: "Accept all confirmations"})
 
 	appsMoveStrings := docstrings.Get("apps.move")
-	move := BuildCommand(cmd, runAppsMove, appsMoveStrings.Usage, appsMoveStrings.Short, appsMoveStrings.Long, os.Stdout, requireSession)
+	move := BuildCommand(cmd, runMove, appsMoveStrings.Usage, appsMoveStrings.Short, appsMoveStrings.Long, os.Stdout, requireSession)
 	move.Args = cobra.ExactArgs(1)
 	// TODO: Move flag descriptions into the docStrings
 	move.AddBoolFlag(BoolFlagOpts{Name: "yes", Shorthand: "y", Description: "Accept all confirmations"})
@@ -82,15 +71,15 @@ func newAppListCommand() *Command {
 	})
 
 	appsSuspendStrings := docstrings.Get("apps.suspend")
-	appsSuspendCmd := BuildCommand(cmd, runAppsSuspend, appsSuspendStrings.Usage, appsSuspendStrings.Short, appsSuspendStrings.Long, os.Stdout, requireSession, requireAppNameAsArg)
+	appsSuspendCmd := BuildCommand(cmd, runSuspend, appsSuspendStrings.Usage, appsSuspendStrings.Short, appsSuspendStrings.Long, os.Stdout, requireSession, requireAppNameAsArg)
 	appsSuspendCmd.Args = cobra.RangeArgs(0, 1)
 
 	appsResumeStrings := docstrings.Get("apps.resume")
-	appsResumeCmd := BuildCommand(cmd, runAppsResume, appsResumeStrings.Usage, appsResumeStrings.Short, appsResumeStrings.Long, os.Stdout, requireSession, requireAppNameAsArg)
+	appsResumeCmd := BuildCommand(cmd, runResume, appsResumeStrings.Usage, appsResumeStrings.Short, appsResumeStrings.Long, os.Stdout, requireSession, requireAppNameAsArg)
 	appsResumeCmd.Args = cobra.RangeArgs(0, 1)
 
 	appsRestartStrings := docstrings.Get("apps.restart")
-	appsRestartCmd := BuildCommand(cmd, runAppsRestart, appsRestartStrings.Usage, appsRestartStrings.Short, appsRestartStrings.Long, os.Stdout, requireSession, requireAppNameAsArg)
+	appsRestartCmd := BuildCommand(cmd, runRestart, appsRestartStrings.Usage, appsRestartStrings.Short, appsRestartStrings.Long, os.Stdout, requireSession, requireAppNameAsArg)
 	appsRestartCmd.Args = cobra.RangeArgs(0, 1)
 
 	return cmd
@@ -103,231 +92,4 @@ func runAppsList(ctx *cmdctx.CmdContext) error {
 	}
 
 	return ctx.Render(&presenters.Apps{Apps: apps})
-}
-
-func runAppsSuspend(ctx *cmdctx.CmdContext) error {
-	// appName := ctx.Args[0]
-	// fmt.Println(appName, len(ctx.Args))
-	// if appName == "" {
-	// 	appName = ctx.AppName
-	// }
-	appName := ctx.AppName
-
-	_, err := ctx.Client.API().SuspendApp(appName)
-	if err != nil {
-		return err
-	}
-
-	appstatus, err := ctx.Client.API().GetAppStatus(appName, false)
-
-	fmt.Printf("%s is now %s\n", appstatus.Name, appstatus.Status)
-
-	allocount := len(appstatus.Allocations)
-
-	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
-	s.Writer = os.Stderr
-	s.Prefix = fmt.Sprintf("Suspending %s with %d instances to stop ", appstatus.Name, allocount)
-	s.Start()
-
-	for allocount > 0 {
-		plural := ""
-		if allocount > 1 {
-			plural = "s"
-		}
-		s.Prefix = fmt.Sprintf("Suspending %s with %d instance%s to stop ", appstatus.Name, allocount, plural)
-		appstatus, err = ctx.Client.API().GetAppStatus(ctx.AppName, false)
-		allocount = len(appstatus.Allocations)
-	}
-
-	s.FinalMSG = fmt.Sprintf("Suspend complete - %s is now suspended with no running instances\n", appstatus.Name)
-	s.Stop()
-
-	return nil
-}
-
-func runAppsResume(ctx *cmdctx.CmdContext) error {
-	app, err := ctx.Client.API().ResumeApp(ctx.AppName)
-	if err != nil {
-		return err
-	}
-
-	app, err = ctx.Client.API().GetApp(ctx.AppName)
-
-	fmt.Printf("%s is now %s\n", app.Name, app.Status)
-
-	return nil
-}
-
-func runAppsRestart(ctx *cmdctx.CmdContext) error {
-	app, err := ctx.Client.API().RestartApp(ctx.AppName)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("%s is being restarted\n", app.Name)
-	return nil
-}
-
-func runDestroyApp(ctx *cmdctx.CmdContext) error {
-	appName := ctx.Args[0]
-
-	if !ctx.Config.GetBool("yes") {
-		fmt.Println(aurora.Red("Destroying an app is not reversible."))
-
-		confirm := false
-		prompt := &survey.Confirm{
-			Message: fmt.Sprintf("Destroy app %s?", appName),
-		}
-		survey.AskOne(prompt, &confirm)
-
-		if !confirm {
-			return nil
-		}
-	}
-
-	if err := ctx.Client.API().DeleteApp(appName); err != nil {
-		return err
-	}
-
-	fmt.Println("Destroyed app", appName)
-
-	return nil
-}
-
-func runAppsCreate(commandContext *cmdctx.CmdContext) error {
-	var appName = ""
-	var internalPort = 0
-
-	if len(commandContext.Args) > 0 {
-		appName = commandContext.Args[0]
-	}
-
-	configPort, _ := commandContext.Config.GetString("port")
-
-	// If ports set, validate
-	if configPort != "" {
-		var err error
-
-		internalPort, err = strconv.Atoi(configPort)
-		if err != nil {
-			return fmt.Errorf(`-p ports must be numeric`)
-		}
-	}
-
-	configfilename, err := flyctl.ResolveConfigFileFromPath(commandContext.WorkingDir)
-
-	if helpers.FileExists(configfilename) {
-		commandContext.Status("create", cmdctx.SERROR, "An existing configuration file has been found.")
-		confirmation := confirm(fmt.Sprintf("Overwrite file '%s'", configfilename))
-		if !confirmation {
-			return nil
-		}
-	}
-
-	newAppConfig := flyctl.NewAppConfig()
-
-	if builder, _ := commandContext.Config.GetString("builder"); builder != "" {
-		newAppConfig.Build = &flyctl.Build{Builder: builder}
-	}
-
-	name, _ := commandContext.Config.GetString("name")
-
-	if name != "" && appName != "" {
-		return fmt.Errorf(`two app names specified %s and %s. Select and specify only one`, appName, name)
-	}
-
-	if name == "" && appName != "" {
-		name = appName
-	}
-
-	if name == "" {
-		prompt := &survey.Input{
-			Message: "App Name (leave blank to use an auto-generated name)",
-		}
-		if err := survey.AskOne(prompt, &name); err != nil {
-			if isInterrupt(err) {
-				return nil
-			}
-		}
-	} else {
-		fmt.Printf("Selected App Name: %s\n", name)
-	}
-
-	targetOrgSlug, _ := commandContext.Config.GetString("org")
-	org, err := selectOrganization(commandContext.Client.API(), targetOrgSlug)
-
-	switch {
-	case isInterrupt(err):
-		return nil
-	case err != nil || org == nil:
-		return fmt.Errorf("Error setting organization: %s", err)
-	}
-
-	app, err := commandContext.Client.API().CreateApp(name, org.ID)
-	if err != nil {
-		return err
-	}
-	newAppConfig.AppName = app.Name
-	newAppConfig.Definition = app.Config.Definition
-
-	if configPort != "" {
-		newAppConfig.SetInternalPort(internalPort)
-	}
-
-	err = commandContext.Frender(cmdctx.PresenterOption{Presentable: &presenters.AppInfo{App: *app}, HideHeader: true, Vertical: true, Title: "New app created"})
-	if err != nil {
-		return err
-	}
-
-	if commandContext.ConfigFile == "" {
-		newCfgFile, err := flyctl.ResolveConfigFileFromPath(commandContext.WorkingDir)
-		if err != nil {
-			return err
-		}
-		commandContext.ConfigFile = newCfgFile
-	}
-
-	return writeAppConfig(commandContext.ConfigFile, newAppConfig)
-}
-
-func runAppsMove(commandContext *cmdctx.CmdContext) error {
-	appName := commandContext.Args[0]
-
-	targetOrgSlug, _ := commandContext.Config.GetString("org")
-	org, err := selectOrganization(commandContext.Client.API(), targetOrgSlug)
-
-	switch {
-	case isInterrupt(err):
-		return nil
-	case err != nil || org == nil:
-		return fmt.Errorf("Error setting organization: %s", err)
-	}
-
-	app, err := commandContext.Client.API().GetApp(appName)
-	if err != nil {
-		return errors.Wrap(err, "Error fetching app")
-	}
-
-	if !commandContext.Config.GetBool("yes") {
-		fmt.Println(aurora.Red("Are you sure you want to move this app?"))
-
-		confirm := false
-		prompt := &survey.Confirm{
-			Message: fmt.Sprintf("Move %s from %s to %s?", appName, app.Organization.Slug, org.Slug),
-		}
-		survey.AskOne(prompt, &confirm)
-
-		if !confirm {
-			return nil
-		}
-	}
-
-	app, err = commandContext.Client.API().MoveApp(appName, org.ID)
-	if err != nil {
-		return errors.WithMessage(err, "Failed to move app")
-	}
-
-	fmt.Printf("Successfully moved %s to %s\n", appName, org.Slug)
-
-	return nil
 }

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -274,7 +274,7 @@ func requireAppName(cmd *Command) Initializer {
 		},
 		PreRun: func(ctx *cmdctx.CmdContext) error {
 			if ctx.AppName == "" {
-				return fmt.Errorf("No app specified. Maybe create one with 'flyctl apps create [APPNAME]'")
+				return fmt.Errorf("No app specified. Specify an app or create an app with 'flyctl init'")
 			}
 
 			if ctx.AppConfig == nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -68,6 +68,11 @@ func newDeployCommand() *Command {
 }
 
 func runDeploy(commandContext *cmdctx.CmdContext) error {
+	if commandContext.AppName == "" {
+		commandContext.Status("flyctl", cmdctx.SERROR, "No initialized application")
+		runInit(commandContext)
+	}
+
 	ctx := createCancellableContext()
 	op, err := docker.NewDeployOperation(ctx, commandContext)
 	if err != nil {

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/superfly/flyctl/cmdctx"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/logrusorgru/aurora"
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/docstrings"
+)
+
+//TODO: Move all output to status styled begin/done updates
+
+func newDestroyCommand() *Command {
+
+	destroyStrings := docstrings.Get("destroy")
+
+	destroy := BuildCommand(nil, runDestroyApp, destroyStrings.Usage, destroyStrings.Short, destroyStrings.Long, os.Stdout, requireSession)
+
+	destroy.Args = cobra.ExactArgs(1)
+
+	destroy.AddBoolFlag(BoolFlagOpts{Name: "yes", Shorthand: "y", Description: "Accept all confirmations"})
+
+	return destroy
+}
+
+func runDestroy(ctx *cmdctx.CmdContext) error {
+	appName := ctx.Args[0]
+
+	if !ctx.Config.GetBool("yes") {
+		fmt.Println(aurora.Red("Destroying an app is not reversible."))
+
+		confirm := false
+		prompt := &survey.Confirm{
+			Message: fmt.Sprintf("Destroy app %s?", appName),
+		}
+		survey.AskOne(prompt, &confirm)
+
+		if !confirm {
+			return nil
+		}
+	}
+
+	if err := ctx.Client.API().DeleteApp(appName); err != nil {
+		return err
+	}
+
+	fmt.Println("Destroyed app", appName)
+
+	return nil
+}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -18,7 +18,7 @@ func newDestroyCommand() *Command {
 
 	destroyStrings := docstrings.Get("destroy")
 
-	destroy := BuildCommand(nil, runDestroyApp, destroyStrings.Usage, destroyStrings.Short, destroyStrings.Long, os.Stdout, requireSession)
+	destroy := BuildCommand(nil, runDestroy, destroyStrings.Usage, destroyStrings.Short, destroyStrings.Long, os.Stdout, requireSession)
 
 	destroy.Args = cobra.ExactArgs(1)
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/superfly/flyctl/cmdctx"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/cmd/presenters"
+	"github.com/superfly/flyctl/docstrings"
+	"github.com/superfly/flyctl/flyctl"
+	"github.com/superfly/flyctl/helpers"
+)
+
+//TODO: Move all output to status styled begin/done updates
+
+func newInitCommand() *Command {
+
+	initStrings := docstrings.Get("init")
+
+	cmd := BuildCommand(nil, runInit, initStrings.Usage, initStrings.Short, initStrings.Long, os.Stdout, requireSession)
+
+	cmd.Args = cobra.RangeArgs(0, 1)
+
+	// TODO: Move flag descriptions into the docStrings
+	cmd.AddStringFlag(StringFlagOpts{
+		Name:        "name",
+		Description: "The app name to use",
+	})
+
+	cmd.AddStringFlag(StringFlagOpts{
+		Name:        "org",
+		Description: `The organization that will own the app`,
+	})
+
+	cmd.AddStringFlag(StringFlagOpts{
+		Name:        "port",
+		Shorthand:   "p",
+		Description: "Internal port on application to connect to external services",
+	})
+
+	cmd.AddStringFlag(StringFlagOpts{
+		Name:        "builder",
+		Description: `The Cloud Native Buildpacks builder to use when deploying the app`,
+	})
+
+	return cmd
+}
+
+func runInit(commandContext *cmdctx.CmdContext) error {
+	var appName = ""
+	var internalPort = 0
+
+	if len(commandContext.Args) > 0 {
+		appName = commandContext.Args[0]
+	}
+
+	configPort, _ := commandContext.Config.GetString("port")
+
+	// If ports set, validate
+	if configPort != "" {
+		var err error
+
+		internalPort, err = strconv.Atoi(configPort)
+		if err != nil {
+			return fmt.Errorf(`-p ports must be numeric`)
+		}
+	}
+
+	configfilename, err := flyctl.ResolveConfigFileFromPath(commandContext.WorkingDir)
+
+	if helpers.FileExists(configfilename) {
+		commandContext.Status("create", cmdctx.SERROR, "An existing configuration file has been found.")
+		confirmation := confirm(fmt.Sprintf("Overwrite file '%s'", configfilename))
+		if !confirmation {
+			return nil
+		}
+	}
+
+	newAppConfig := flyctl.NewAppConfig()
+
+	if builder, _ := commandContext.Config.GetString("builder"); builder != "" {
+		newAppConfig.Build = &flyctl.Build{Builder: builder}
+	}
+
+	name, _ := commandContext.Config.GetString("name")
+
+	if name != "" && appName != "" {
+		return fmt.Errorf(`two app names specified %s and %s. Select and specify only one`, appName, name)
+	}
+
+	if name == "" && appName != "" {
+		name = appName
+	}
+
+	if name == "" {
+		prompt := &survey.Input{
+			Message: "App Name (leave blank to use an auto-generated name)",
+		}
+		if err := survey.AskOne(prompt, &name); err != nil {
+			if isInterrupt(err) {
+				return nil
+			}
+		}
+	} else {
+		fmt.Printf("Selected App Name: %s\n", name)
+	}
+
+	targetOrgSlug, _ := commandContext.Config.GetString("org")
+	org, err := selectOrganization(commandContext.Client.API(), targetOrgSlug)
+
+	switch {
+	case isInterrupt(err):
+		return nil
+	case err != nil || org == nil:
+		return fmt.Errorf("Error setting organization: %s", err)
+	}
+
+	app, err := commandContext.Client.API().CreateApp(name, org.ID)
+	if err != nil {
+		return err
+	}
+	newAppConfig.AppName = app.Name
+	newAppConfig.Definition = app.Config.Definition
+
+	if configPort != "" {
+		newAppConfig.SetInternalPort(internalPort)
+	}
+
+	err = commandContext.Frender(cmdctx.PresenterOption{Presentable: &presenters.AppInfo{App: *app}, HideHeader: true, Vertical: true, Title: "New app created"})
+	if err != nil {
+		return err
+	}
+
+	if commandContext.ConfigFile == "" {
+		newCfgFile, err := flyctl.ResolveConfigFileFromPath(commandContext.WorkingDir)
+		if err != nil {
+			return err
+		}
+		commandContext.ConfigFile = newCfgFile
+	}
+
+	return writeAppConfig(commandContext.ConfigFile, newAppConfig)
+}

--- a/cmd/move.go
+++ b/cmd/move.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/superfly/flyctl/cmdctx"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/logrusorgru/aurora"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/docstrings"
+)
+
+//TODO: Move all output to status styled begin/done updates
+
+func newMoveCommand() *Command {
+
+	moveStrings := docstrings.Get("move")
+	moveCmd := BuildCommand(nil, runMove, moveStrings.Usage, moveStrings.Short, moveStrings.Long, os.Stdout, requireSession)
+	moveCmd.Args = cobra.ExactArgs(1)
+	// TODO: Move flag descriptions into the docStrings
+	moveCmd.AddBoolFlag(BoolFlagOpts{Name: "yes", Shorthand: "y", Description: "Accept all confirmations"})
+	moveCmd.AddStringFlag(StringFlagOpts{
+		Name:        "org",
+		Description: `The organization to move the app to`,
+	})
+
+	return moveCmd
+}
+
+func runMove(commandContext *cmdctx.CmdContext) error {
+	appName := commandContext.Args[0]
+
+	targetOrgSlug, _ := commandContext.Config.GetString("org")
+	org, err := selectOrganization(commandContext.Client.API(), targetOrgSlug)
+
+	switch {
+	case isInterrupt(err):
+		return nil
+	case err != nil || org == nil:
+		return fmt.Errorf("Error setting organization: %s", err)
+	}
+
+	app, err := commandContext.Client.API().GetApp(appName)
+	if err != nil {
+		return errors.Wrap(err, "Error fetching app")
+	}
+
+	if !commandContext.Config.GetBool("yes") {
+		fmt.Println(aurora.Red("Are you sure you want to move this app?"))
+
+		confirm := false
+		prompt := &survey.Confirm{
+			Message: fmt.Sprintf("Move %s from %s to %s?", appName, app.Organization.Slug, org.Slug),
+		}
+		survey.AskOne(prompt, &confirm)
+
+		if !confirm {
+			return nil
+		}
+	}
+
+	app, err = commandContext.Client.API().MoveApp(appName, org.ID)
+	if err != nil {
+		return errors.WithMessage(err, "Failed to move app")
+	}
+
+	fmt.Printf("Successfully moved %s to %s\n", appName, org.Slug)
+
+	return nil
+}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/superfly/flyctl/cmdctx"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/docstrings"
+)
+
+//TODO: Move all output to status styled begin/done updates
+
+func newRestartCommand() *Command {
+	restartStrings := docstrings.Get("restart")
+	restartCmd := BuildCommand(nil, runRestart, restartStrings.Usage, restartStrings.Short, restartStrings.Long, os.Stdout, requireSession, requireAppNameAsArg)
+	restartCmd.Args = cobra.RangeArgs(0, 1)
+
+	return restartCmd
+}
+
+func runRestart(ctx *cmdctx.CmdContext) error {
+	app, err := ctx.Client.API().RestartApp(ctx.AppName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s is being restarted\n", app.Name)
+	return nil
+}

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/superfly/flyctl/cmdctx"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/docstrings"
+)
+
+//TODO: Move all output to status styled begin/done updates
+
+func newResumeCommand() *Command {
+
+	resumeStrings := docstrings.Get("resume")
+	resumeCmd := BuildCommand(nil, runResume, resumeStrings.Usage, resumeStrings.Short, resumeStrings.Long, os.Stdout, requireSession, requireAppNameAsArg)
+	resumeCmd.Args = cobra.RangeArgs(0, 1)
+	return resumeCmd
+}
+
+func runResume(ctx *cmdctx.CmdContext) error {
+	app, err := ctx.Client.API().ResumeApp(ctx.AppName)
+	if err != nil {
+		return err
+	}
+
+	app, err = ctx.Client.API().GetApp(ctx.AppName)
+
+	fmt.Printf("%s is now %s\n", app.Name, app.Status)
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/superfly/flyctl/docstrings"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/client"
 )
@@ -18,11 +19,12 @@ import (
 var ErrAbort = errors.New("abort")
 var flyctlClient *client.Client
 
+var rootStrings = docstrings.Get("flyctl")
 var rootCmd = &Command{
 	Command: &cobra.Command{
-		Use:   "flyctl",
-		Short: "The Fly CLI",
-		Long:  `flyctl is a command line interface for the Fly.io platform`,
+		Use:   rootStrings.Usage,
+		Short: rootStrings.Short,
+		Long:  rootStrings.Long,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
@@ -83,6 +85,12 @@ func init() {
 		newMonitorCommand(),
 		newListCommand(),
 		newDashboardCommand(),
+		newInitCommand(),
+		newDestroyCommand(),
+		newSuspendCommand(),
+		newResumeCommand(),
+		newRestartCommand(),
+		newMoveCommand(),
 	)
 
 	initConfig()

--- a/cmd/suspend.go
+++ b/cmd/suspend.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/superfly/flyctl/cmdctx"
+
+	"github.com/briandowns/spinner"
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/docstrings"
+)
+
+//TODO: Move all output to status styled begin/done updates
+
+func newSuspendCommand() *Command {
+
+	suspendStrings := docstrings.Get("suspend")
+
+	suspendCmd := BuildCommand(nil, runSuspend, suspendStrings.Usage, suspendStrings.Short, suspendStrings.Long, os.Stdout, requireSession, requireAppNameAsArg)
+	suspendCmd.Args = cobra.RangeArgs(0, 1)
+
+	return suspendCmd
+}
+
+func runSuspend(ctx *cmdctx.CmdContext) error {
+	// appName := ctx.Args[0]
+	// fmt.Println(appName, len(ctx.Args))
+	// if appName == "" {
+	// 	appName = ctx.AppName
+	// }
+	appName := ctx.AppName
+
+	_, err := ctx.Client.API().SuspendApp(appName)
+	if err != nil {
+		return err
+	}
+
+	appstatus, err := ctx.Client.API().GetAppStatus(appName, false)
+
+	fmt.Printf("%s is now %s\n", appstatus.Name, appstatus.Status)
+
+	allocount := len(appstatus.Allocations)
+
+	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
+	s.Writer = os.Stderr
+	s.Prefix = fmt.Sprintf("Suspending %s with %d instances to stop ", appstatus.Name, allocount)
+	s.Start()
+
+	for allocount > 0 {
+		plural := ""
+		if allocount > 1 {
+			plural = "s"
+		}
+		s.Prefix = fmt.Sprintf("Suspending %s with %d instance%s to stop ", appstatus.Name, allocount, plural)
+		appstatus, err = ctx.Client.API().GetAppStatus(ctx.AppName, false)
+		allocount = len(appstatus.Allocations)
+	}
+
+	s.FinalMSG = fmt.Sprintf("Suspend complete - %s is now suspended with no running instances\n", appstatus.Name)
+	s.Stop()
+
+	return nil
+}

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -3,9 +3,15 @@ usage="flyctl"
 shortHelp="The Fly CLI"
 longHelp="""flyctl is a command line interface to the Fly.io platform.
 
-It allows users to manage authentication, application creation, deployment,
+It allows users to manage authentication, application initialization, deployment,
 network configuration, logging and more with just the one command.
 
+Initialize an App with the init command
+Deploy an App with the deploy command
+View a Deployed web application with the open command
+Check the status of an application with the status command
+
+To read more, use the docs command to view Fly's help on the web.
 """
 
 
@@ -25,6 +31,54 @@ usage="open [PATH]"
 shortHelp="Open browser to current deployed application"
 longHelp="""Open browser to current deployed application. If an optional path is specified, this is appended to the
 URL for deployed application. 
+"""
+
+[init]
+usage="init [APPNAME]"
+shortHelp="Initialise a new application"
+longHelp="""The INIT command will both register a new application 
+with the Fly platform and create the fly.toml file which controls how 
+the application will be deployed. The --builder flag allows a cloud native 
+buildpack to be specified which will be used instead of a Dockerfile to 
+create the application image when it is deployed.
+"""
+
+[destroy]
+usage="destroy [APPNAME]"
+shortHelp="Permanently destroys an App"
+longHelp="""The DESTROY command will remove an application 
+from the Fly platform.
+"""
+
+[suspend]
+usage="suspend [APPNAME]"
+shortHelp="Suspend an application"
+longHelp="""The SUSPEND command will suspend an application. 
+All allocations will be deallocated leaving the application running nowhere.
+It will continue to consume networking resources (IP address). See RESUME
+for details on restarting it.
+"""
+
+[resume]
+usage="resume [APPNAME]"
+shortHelp="Resume an application"
+longHelp="""The RESUME command will restart a previously suspended application. 
+The application will resume with its original region pool and a min count of one
+meaning there will be one running instance once restarted. Use SCALE SET MIN= to raise
+the number of configured instances.
+"""
+
+[restart]
+usage="restart [APPNAME]"
+shortHelp="Restart an application"
+longHelp="""The RESTART command will restart all running vms. 
+"""
+
+[move]
+usage="move [APPNAME]"
+shortHelp="Move an App to another organization"
+longHelp="""The MOVE command will move an application to another 
+organization the current user belongs to.
 """
 
 [apps]


### PR DESCRIPTION
Promote the Apps/App command set to toplevel with some naming changes

apps create -> init
apps move -> move
apps list -> list (already exists)
apps pause/suspend -> suspend
apps restart -> restart
apps resume -> resume
apps destroy -> destroy

Will join the other top level commands

deploy
status
open
dash
logs
