### PR TITLE
Support for backup regions

### DIFF
--- a/api/resource_regions.go
+++ b/api/resource_regions.go
@@ -1,10 +1,14 @@
 package api
 
-func (c *Client) ConfigureRegions(input ConfigureRegionsInput) ([]Region, error) {
+func (c *Client) ConfigureRegions(input ConfigureRegionsInput) ([]Region, []Region, error) {
 	query := `
 		mutation ($input: ConfigureRegionsInput!) {
 			configureRegions(input: $input) {
 				regions {
+					code
+					name
+				}
+				backupRegions{
 					code
 					name
 				}
@@ -18,17 +22,21 @@ func (c *Client) ConfigureRegions(input ConfigureRegionsInput) ([]Region, error)
 
 	data, err := c.Run(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return data.ConfigureRegions.Regions, nil
+	return data.ConfigureRegions.Regions, data.ConfigureRegions.BackupRegions, nil
 }
 
-func (c *Client) ListAppRegions(appName string) ([]Region, error) {
+func (c *Client) ListAppRegions(appName string) ([]Region, []Region, error) {
 	query := `
 		query ($appName: String!) {
 			app(name: $appName) {
-				regions {
+				regions{
+					code
+					name
+				}
+				backupRegions{
 					code
 					name
 				}
@@ -42,8 +50,8 @@ func (c *Client) ListAppRegions(appName string) ([]Region, error) {
 
 	data, err := c.Run(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return *data.App.Regions, nil
+	return *data.App.Regions, *data.App.BackupRegions, nil
 }

--- a/api/types.go
+++ b/api/types.go
@@ -90,8 +90,9 @@ type Query struct {
 	}
 
 	ConfigureRegions struct {
-		App     App
-		Regions []Region
+		App           App
+		Regions       []Region
+		BackupRegions []Region
 	}
 
 	ResumeApp struct {
@@ -147,6 +148,7 @@ type App struct {
 	Autoscaling      *AutoscalingConfig
 	VMSize           VMSize
 	Regions          *[]Region
+	BackupRegions    *[]Region
 }
 
 type AppCertsCompact struct {
@@ -523,9 +525,10 @@ type BuildArgInput struct {
 }
 
 type ConfigureRegionsInput struct {
-	AppID        string   `json:"appId"`
-	AllowRegions []string `json:"allowRegions"`
-	DenyRegions  []string `json:"denyRegions"`
+	AppID         string   `json:"appId"`
+	AllowRegions  []string `json:"allowRegions"`
+	DenyRegions   []string `json:"denyRegions"`
+	BackupRegions []string `json:"backupRegions"`
 }
 
 type Errors []Error

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -433,6 +433,12 @@ shortHelp="Sets the region pool with provided regions"
 longHelp="""Sets the region pool with provided regions
 """
 
+[regions.backup]
+usage="backup REGION ..."
+shortHelp="Sets the backup region pool with provided regions"
+longHelp="""Sets the backup region pool with provided regions
+"""
+
 [regions.list]
 usage="list"
 shortHelp="Shows the list if regions the app is allowed to run in"


### PR DESCRIPTION
This adds backup regions to `flyctl region list` output, and adds `flyctl regions backup [region]` for setting backup regions.

Related community discussion: https://community.fly.io/t/different-region-on-each-deploy/52/