### PR TITLE
Adds init --nowrite as option

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -70,10 +70,12 @@ func (c *Command) AddStringFlag(options StringFlagOpts) {
 	fullName := namespace(c.Command) + "." + options.Name
 	c.Flags().StringP(options.Name, options.Shorthand, options.Default, options.Description)
 
-	viper.BindPFlag(fullName, c.Flags().Lookup(options.Name))
+	err := viper.BindPFlag(fullName, c.Flags().Lookup(options.Name))
+	checkErr(err)
 
 	if options.EnvName != "" {
-		viper.BindEnv(fullName, options.EnvName)
+		err := viper.BindEnv(fullName, options.EnvName)
+		checkErr(err)
 	}
 }
 
@@ -84,10 +86,12 @@ func (c *Command) AddBoolFlag(options BoolFlagOpts) {
 
 	flag := c.Flags().Lookup(options.Name)
 	flag.Hidden = options.Hidden
-	viper.BindPFlag(fullName, flag)
+	err := viper.BindPFlag(fullName, flag)
+	checkErr(err)
 
 	if options.EnvName != "" {
-		viper.BindEnv(fullName, options.EnvName)
+		err := viper.BindEnv(fullName, options.EnvName)
+		checkErr(err)
 	}
 }
 
@@ -108,10 +112,12 @@ func (c *Command) AddIntFlag(options IntFlagOpts) {
 
 	flag := c.Flags().Lookup(options.Name)
 	flag.Hidden = options.Hidden
-	viper.BindPFlag(fullName, flag)
+	err := viper.BindPFlag(fullName, flag)
+	checkErr(err)
 
 	if options.EnvName != "" {
-		viper.BindEnv(fullName, options.EnvName)
+		err := viper.BindEnv(fullName, options.EnvName)
+		checkErr(err)
 	}
 }
 
@@ -134,10 +140,12 @@ func (c *Command) AddStringSliceFlag(options StringSliceFlagOpts) {
 		c.Flags().StringSlice(options.Name, options.Default, options.Description)
 	}
 
-	viper.BindPFlag(fullName, c.Flags().Lookup(options.Name))
+	err := viper.BindPFlag(fullName, c.Flags().Lookup(options.Name))
+	checkErr(err)
 
 	if options.EnvName != "" {
-		viper.BindEnv(fullName, options.EnvName)
+		err := viper.BindEnv(fullName, options.EnvName)
+		checkErr(err)
 	}
 }
 

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -289,6 +290,15 @@ func requireAppName(cmd *Command) Initializer {
 			}
 
 			if ctx.AppConfig.AppName != "" && ctx.AppConfig.AppName != ctx.AppName {
+				// Quick check for a fly.alias
+				present, err := checkAliasFile(ctx.AppName)
+				if err != nil {
+					return err
+				}
+				if present {
+					return nil
+				}
+
 				terminal.Warnf("app flag '%s' does not match app name in config file '%s'\n", ctx.AppName, ctx.AppConfig.AppName)
 
 				if !confirm(fmt.Sprintf("Continue using '%s'", ctx.AppName)) {
@@ -373,6 +383,15 @@ func requireAppNameAsArg(cmd *Command) Initializer {
 			}
 
 			if ctx.AppConfig.AppName != "" && ctx.AppConfig.AppName != ctx.AppName {
+				// Quick check for a fly.alias
+				present, err := checkAliasFile(ctx.AppName)
+				if err != nil {
+					return err
+				}
+				if present {
+					return nil
+				}
+
 				terminal.Warnf("app flag '%s' does not match app name in config file '%s'\n", ctx.AppName, ctx.AppConfig.AppName)
 
 				if !confirm(fmt.Sprintf("Continue using '%s'", ctx.AppName)) {
@@ -385,6 +404,27 @@ func requireAppNameAsArg(cmd *Command) Initializer {
 	}
 }
 
+func checkAliasFile(appname string) (present bool, err error) {
+	if helpers.FileExists("fly.alias") {
+		file, err := os.Open("fly.alias")
+		if err != nil {
+			return false, err
+		}
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			if scanner.Text() == appname {
+				return true, nil
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			return false, err
+		}
+	}
+	return false, nil
+}
 func workingDirectoryFromArg(index int) func(*Command) Initializer {
 	return func(cmd *Command) Initializer {
 		return Initializer{

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -73,6 +73,11 @@ func newInitCommand() *Command {
 		Description: "Always overwrite an existing fly.toml file",
 	})
 
+	cmd.AddBoolFlag(BoolFlagOpts{
+		Name:        "nowrite",
+		Description: "Never write a fly.toml file",
+	})
+
 	return cmd
 }
 
@@ -96,34 +101,37 @@ func runInit(commandContext *cmdctx.CmdContext) error {
 		}
 	}
 	overwrite := commandContext.Config.GetBool("overwrite")
+	nowrite := commandContext.Config.GetBool("nowrite")
 
 	configfilename, err := flyctl.ResolveConfigFileFromPath(commandContext.WorkingDir)
-
-	if helpers.FileExists(configfilename) {
-		if !overwrite {
-			commandContext.Status("init", cmdctx.SERROR, "An existing configuration file has been found.")
-			confirmation := confirm(fmt.Sprintf("Overwrite file '%s'", configfilename))
-			if !confirmation {
-				return nil
-			}
-		} else {
-			commandContext.Status("init", cmdctx.SWARN, "Overwriting existing configuration (--overwrite)")
-		}
-	}
-
 	newAppConfig := flyctl.NewAppConfig()
+	name := ""
 
-	name, _ := commandContext.Config.GetString("name")
+	if !nowrite {
+		if helpers.FileExists(configfilename) {
+			if !overwrite {
+				commandContext.Status("init", cmdctx.SERROR, "An existing configuration file has been found.")
+				confirmation := confirm(fmt.Sprintf("Overwrite file '%s'", configfilename))
+				if !confirmation {
+					return nil
+				}
+			} else {
+				commandContext.Status("init", cmdctx.SWARN, "Overwriting existing configuration (--overwrite)")
+			}
+		}
 
-	if name != "" && appName != "" {
-		return fmt.Errorf(`two app names specified %s and %s. Select and specify only one`, appName, name)
+		name, _ := commandContext.Config.GetString("name")
+
+		if name != "" && appName != "" {
+			return fmt.Errorf(`two app names specified %s and %s. Select and specify only one`, appName, name)
+		}
+
+		if name == "" && appName != "" {
+			name = appName
+		}
+
+		fmt.Println()
 	}
-
-	if name == "" && appName != "" {
-		name = appName
-	}
-
-	fmt.Println()
 
 	if name == "" {
 		prompt := &survey.Input{
@@ -172,102 +180,109 @@ func runInit(commandContext *cmdctx.CmdContext) error {
 		return err
 	}
 
-	// If we are importing or using a builtin, assume builders are set in the template
-	if importfile == "" && builtinname == "" && imagename == "" {
-		// Otherwise get a Builder from the user while checking the dockerfile setting
-		dockerfileSet := commandContext.Config.IsSet("dockerfile")
-		dockerfile := commandContext.Config.GetBool("dockerfile")
+	if !nowrite {
+		// If we are importing or using a builtin, assume builders are set in the template
+		if importfile == "" && builtinname == "" && imagename == "" {
+			// Otherwise get a Builder from the user while checking the dockerfile setting
+			dockerfileSet := commandContext.Config.IsSet("dockerfile")
+			dockerfile := commandContext.Config.GetBool("dockerfile")
 
-		if builder == "" && !dockerfileSet {
-			builder, builtin, err := selectBuildtype(commandContext)
+			if builder == "" && !dockerfileSet {
+				builder, builtin, err := selectBuildtype(commandContext)
 
-			switch {
-			case isInterrupt(err):
-				return nil
-			case err != nil || builder == "":
-				return fmt.Errorf("Error setting builder: %s", err)
-			}
-			// If image, prompt for name
-			if builder == "Image" {
-				imagename, err = selectImage(commandContext)
-				if err != nil {
-					return err
+				switch {
+				case isInterrupt(err):
+					return nil
+				case err != nil || builder == "":
+					return fmt.Errorf("Error setting builder: %s", err)
 				}
-			} else if builder != "Dockerfile" && builder != "None" && !builtin {
-				// Not a dockerfile setting and not set to none. This is a classic buildpack
-				newAppConfig.Build = &flyctl.Build{Builder: builder}
-			} else if builder != "None" && builtin {
-				// Builder not none and the user apparently selected a builtin builder
-				builtinname = builder
-			}
-		} else if builder != "" {
-			// If the builder was set and there's not dockerfile setting, write the builder
-			if !dockerfile {
-				newAppConfig.Build = &flyctl.Build{Builder: builder}
+				// If image, prompt for name
+				if builder == "Image" {
+					imagename, err = selectImage(commandContext)
+					if err != nil {
+						return err
+					}
+				} else if builder != "Dockerfile" && builder != "None" && !builtin {
+					// Not a dockerfile setting and not set to none. This is a classic buildpack
+					newAppConfig.Build = &flyctl.Build{Builder: builder}
+				} else if builder != "None" && builtin {
+					// Builder not none and the user apparently selected a builtin builder
+					builtinname = builder
+				}
+			} else if builder != "" {
+				// If the builder was set and there's not dockerfile setting, write the builder
+				if !dockerfile {
+					newAppConfig.Build = &flyctl.Build{Builder: builder}
+				}
 			}
 		}
 	}
-
 	// The creation magic happens here....
 	app, err := commandContext.Client.API().CreateApp(name, org.ID)
 	if err != nil {
 		return err
 	}
 
-	if imagename != "" {
-		newAppConfig.AppName = app.Name
-		newAppConfig.Build = &flyctl.Build{Image: imagename}
-		newAppConfig.Definition = app.Config.Definition
-	} else if importfile != "" {
-		fmt.Printf("Importing configuration from %s\n", importfile)
+	if !nowrite {
+		if imagename != "" {
+			newAppConfig.AppName = app.Name
+			newAppConfig.Build = &flyctl.Build{Image: imagename}
+			newAppConfig.Definition = app.Config.Definition
+		} else if importfile != "" {
+			fmt.Printf("Importing configuration from %s\n", importfile)
 
-		tmpappconfig, err := flyctl.LoadAppConfig(importfile)
+			tmpappconfig, err := flyctl.LoadAppConfig(importfile)
+			if err != nil {
+				return err
+			}
+			newAppConfig = tmpappconfig
+			// And then overwrite the app name
+			newAppConfig.AppName = app.Name
+		} else if builtinname != "" {
+			newAppConfig.AppName = app.Name
+			newAppConfig.Build = &flyctl.Build{Builtin: builtinname}
+			newAppConfig.Definition = app.Config.Definition
+		} else if builder != "None" {
+			newAppConfig.AppName = app.Name
+			newAppConfig.Definition = app.Config.Definition
+		}
+
+		if configPort != "" { // If the config port has been set externally, set that
+			newAppConfig.SetInternalPort(internalPort)
+		} else if importfile == "" { // If we are not importing, get the default, ask for new setting
+			currentport, err := newAppConfig.GetInternalPort()
+			if err != nil {
+				return err
+			}
+			internalPort, err = selectPort(commandContext, currentport)
+			if err != nil {
+				return err
+			}
+			newAppConfig.SetInternalPort(internalPort)
+		}
+
+		fmt.Println()
+
+		err = commandContext.Frender(cmdctx.PresenterOption{Presentable: &presenters.AppInfo{App: *app}, HideHeader: true, Vertical: true, Title: "New app created"})
 		if err != nil {
 			return err
 		}
-		newAppConfig = tmpappconfig
-		// And then overwrite the app name
-		newAppConfig.AppName = app.Name
-	} else if builtinname != "" {
-		newAppConfig.AppName = app.Name
-		newAppConfig.Build = &flyctl.Build{Builtin: builtinname}
-		newAppConfig.Definition = app.Config.Definition
-	} else if builder != "None" {
-		newAppConfig.AppName = app.Name
-		newAppConfig.Definition = app.Config.Definition
-	}
 
-	if configPort != "" { // If the config port has been set externally, set that
-		newAppConfig.SetInternalPort(internalPort)
-	} else if importfile == "" { // If we are not importing, get the default, ask for new setting
-		currentport, err := newAppConfig.GetInternalPort()
-		if err != nil {
-			return err
+		if commandContext.ConfigFile == "" {
+			newCfgFile, err := flyctl.ResolveConfigFileFromPath(commandContext.WorkingDir)
+			if err != nil {
+				return err
+			}
+			commandContext.ConfigFile = newCfgFile
 		}
-		internalPort, err = selectPort(commandContext, currentport)
-		if err != nil {
-			return err
-		}
-		newAppConfig.SetInternalPort(internalPort)
+
+		commandContext.AppName = app.Name
+		commandContext.AppConfig = newAppConfig
+
+		return writeAppConfig(commandContext.ConfigFile, newAppConfig)
 	}
 
-	fmt.Println()
+	fmt.Printf("New app created: %s", app.Name)
 
-	err = commandContext.Frender(cmdctx.PresenterOption{Presentable: &presenters.AppInfo{App: *app}, HideHeader: true, Vertical: true, Title: "New app created"})
-	if err != nil {
-		return err
-	}
-
-	if commandContext.ConfigFile == "" {
-		newCfgFile, err := flyctl.ResolveConfigFileFromPath(commandContext.WorkingDir)
-		if err != nil {
-			return err
-		}
-		commandContext.ConfigFile = newCfgFile
-	}
-
-	commandContext.AppName = app.Name
-	commandContext.AppConfig = newAppConfig
-
-	return writeAppConfig(commandContext.ConfigFile, newAppConfig)
+	return nil
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -104,8 +104,11 @@ func runInit(commandContext *cmdctx.CmdContext) error {
 	nowrite := commandContext.Config.GetBool("nowrite")
 
 	configfilename, err := flyctl.ResolveConfigFileFromPath(commandContext.WorkingDir)
+	if err != nil {
+		return err
+	}
+
 	newAppConfig := flyctl.NewAppConfig()
-	name := ""
 
 	if !nowrite {
 		if helpers.FileExists(configfilename) {
@@ -119,19 +122,19 @@ func runInit(commandContext *cmdctx.CmdContext) error {
 				commandContext.Status("init", cmdctx.SWARN, "Overwriting existing configuration (--overwrite)")
 			}
 		}
-
-		name, _ := commandContext.Config.GetString("name")
-
-		if name != "" && appName != "" {
-			return fmt.Errorf(`two app names specified %s and %s. Select and specify only one`, appName, name)
-		}
-
-		if name == "" && appName != "" {
-			name = appName
-		}
-
-		fmt.Println()
 	}
+
+	name, _ := commandContext.Config.GetString("name")
+
+	if name != "" && appName != "" {
+		return fmt.Errorf(`two app names specified %s and %s. Select and specify only one`, appName, name)
+	}
+
+	if name == "" && appName != "" {
+		name = appName
+	}
+
+	fmt.Println()
 
 	if name == "" {
 		prompt := &survey.Input{

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -284,5 +284,16 @@ func runInit(commandContext *cmdctx.CmdContext) error {
 
 	fmt.Printf("New app created: %s", app.Name)
 
+	f, err := os.OpenFile("fly.alias", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	if _, err = f.WriteString(app.Name + "\n"); err != nil {
+		return err
+	}
+
 	return nil
 }


### PR DESCRIPTION
fly init --nowrite creates an app slot without rewriting fly.toml. The app is an mirror of the app in fly.toml. The new app name is also saved in `fly.alias`, a file which is checked by fly before asking for confirmation that a given app name is the right name.
