### PR TITLE
Do not use black text for titles

### DIFF
--- a/cmdctx/cmdcontext.go
+++ b/cmdctx/cmdcontext.go
@@ -185,7 +185,7 @@ func statusToEffect(status string, message string) string {
 	case SDETAIL:
 		return aurora.Faint(message).String()
 	case STITLE:
-		return aurora.Bold(message).Black().String()
+		return aurora.Bold(message).String()
 	case SBEGIN:
 		return aurora.Green("==> " + message).String()
 	case SDONE:


### PR DESCRIPTION
Black does not work well for terminals with black backgrounds, and removing black makes the behaviour consistent with how presenter.go renders titles in [renderTable()](https://github.com/superfly/flyctl/blob/master/cmd/presenters/presenter.go#L49) and [renderFieldList()](https://github.com/superfly/flyctl/blob/master/cmd/presenters/presenter.go#L88).

Output from running `flyctl regions list` before change:
<img width="157" alt="before" src="https://user-images.githubusercontent.com/277251/100274823-5cc8e380-2f5f-11eb-96c8-9d843bd51859.png">

Output from running `flyctl regions list` after change:
<img width="159" alt="after" src="https://user-images.githubusercontent.com/277251/100274835-5fc3d400-2f5f-11eb-9470-17d54db2fce6.png">