### PR TITLE
show private ips on status output

### DIFF
--- a/api/resource_monitoring.go
+++ b/api/resource_monitoring.go
@@ -41,6 +41,7 @@ func (c *Client) GetAppStatus(appName string, showCompleted bool) (*AppStatus, e
 					canary
 					region
 					restarts
+					privateIP
 					checks {
 						status
 					}
@@ -81,6 +82,7 @@ func (c *Client) GetAllocationStatus(appName string, allocID string, logLimit in
 					canary
 					region
 					restarts
+					privateIP
 					checks {
 						status
 						output

--- a/api/types.go
+++ b/api/types.go
@@ -576,6 +576,7 @@ type AllocationStatus struct {
 	WarningCheckCount  int
 	CriticalCheckCount int
 	Transitioning      bool
+	PrivateIP          string
 	RecentLogs         []LogEntry
 }
 

--- a/cmd/presenters/allocations.go
+++ b/cmd/presenters/allocations.go
@@ -18,7 +18,7 @@ func (p *Allocations) APIStruct() interface{} {
 }
 
 func (p *Allocations) FieldNames() []string {
-	return []string{"ID", "Version", "Region", "Desired", "Status", "Health Checks", "Restarts", "Created"}
+	return []string{"ID", "Version", "Region", "Desired", "Status", "Health Checks", "Restarts", "Private IP", "Created"}
 }
 
 func (p *Allocations) Records() []map[string]string {
@@ -50,6 +50,7 @@ func (p *Allocations) Records() []map[string]string {
 			"Created":       FormatRelativeTime(alloc.CreatedAt),
 			"Health Checks": FormatHealthChecksSummary(alloc),
 			"Restarts":      strconv.Itoa(alloc.Restarts),
+			"Private IP":    alloc.PrivateIP,
 		})
 	}
 


### PR DESCRIPTION
This isn't the best output because ipv6 is ugly. It looks like this:

```
Instances
ID       VERSION REGION DESIRED STATUS  HEALTH CHECKS      RESTARTS PRIVATE IP                CREATED
9f1043b8 28      vin    run     running 1 total, 1 passing 0        fdaa:0:4a:a7b:6d:0:3c5:2  15m12s ago
093c6a41 28      vin    run     running 1 total, 1 passing 0        fdaa:0:4a:a7b:5e:0:3ca:2  15m12s ago
5ebebc9d 28      vin    run     running 1 total, 1 passing 0        fdaa:0:4a:a7b:5b:0:3c3:2  15m33s ago
16fe191f 28      vin    run     running 1 total, 1 passing 0        fdaa:0:4a:a7b:5f:0:3c2:2  15m36s ago
2d8e060e 28      vin    run     running 1 total, 1 passing 0        fdaa:0:4a:a7b:6d:0:3be:2  15m36s ago
ec7efe8f 28      vin    run     running 1 total, 1 passing 0        fdaa:0:4a:a7b:5e:0:3c4:2  15m36s ago
3d9ba387 28      vin    run     running 1 total, 1 passing 0        fdaa:0:4a:a7b:a9e:0:3bf:2 15m58s ago
26f2ddfc 28      vin    run     running 1 total, 1 passing 0        fdaa:0:4a:a7b:a9c:0:3c7:2 15m58s ago
935e2ee9 28      vin    run     running 1 total, 1 passing 0        fdaa:0:4a:a7b:a9c:0:3c0:2 15m58s ago
2a599655 28      vin    run     running 1 total, 1 passing 0        fdaa:0:4a:a7b:5d:0:3c1:2  15m58s ago
```