### PR TITLE
allow extra memory: flyctl scale vm shared-cpu-1x memory=1024

### DIFF
--- a/api/resource_scale.go
+++ b/api/resource_scale.go
@@ -121,7 +121,7 @@ func (c *Client) AppVMSize(appName string) (VMSize, error) {
 	return data.App.VMSize, nil
 }
 
-func (c *Client) SetAppVMSize(appID string, sizeName string) (VMSize, error) {
+func (c *Client) SetAppVMSize(appID string, sizeName string, memoryMb int64) (VMSize, error) {
 	query := `
 		mutation ($input: SetVMSizeInput!) {
 			setVmSize(input: $input) {
@@ -139,7 +139,7 @@ func (c *Client) SetAppVMSize(appID string, sizeName string) (VMSize, error) {
 
 	req := c.NewRequest(query)
 
-	req.Var("input", SetVMSizeInput{AppID: appID, SizeName: sizeName})
+	req.Var("input", SetVMSizeInput{AppID: appID, SizeName: sizeName, MemoryMb: memoryMb})
 
 	data, err := c.Run(req)
 	if err != nil {

--- a/api/types.go
+++ b/api/types.go
@@ -660,6 +660,7 @@ type VMSize struct {
 type SetVMSizeInput struct {
 	AppID    string `json:"appId"`
 	SizeName string `json:"sizeName"`
+	MemoryMb int64  `json:"memoryMb"`
 }
 
 type StartBuildInput struct {


### PR DESCRIPTION
This is in support of our soon-to-be-release new VM sizes.

Don't merge this yet, I want to get new VM size names in here first.