### PR TITLE
Scale command cleanup

### DIFF
--- a/api/resource_scale.go
+++ b/api/resource_scale.go
@@ -93,7 +93,7 @@ func (c *Client) AppAutoscalingConfig(appName string) (*AutoscalingConfig, error
 	return data.App.Autoscaling, nil
 }
 
-func (c *Client) AppVMSize(appName string) (VMSize, error) {
+func (c *Client) AppVMResources(appName string) (VMSize, []TaskGroupCount, error) {
 	query := `
 		query($appName: String!) {
 			app(name: $appName) {
@@ -105,6 +105,10 @@ func (c *Client) AppVMSize(appName string) (VMSize, error) {
 					priceMonth
 					priceSecond
 				}
+				taskGroupCounts {
+					name
+					count
+				}
 			}
 		}
 	`
@@ -115,10 +119,10 @@ func (c *Client) AppVMSize(appName string) (VMSize, error) {
 
 	data, err := c.Run(req)
 	if err != nil {
-		return VMSize{}, err
+		return VMSize{}, []TaskGroupCount{}, err
 	}
 
-	return data.App.VMSize, nil
+	return data.App.VMSize, data.App.TaskGroupCounts, nil
 }
 
 func (c *Client) SetAppVMSize(appID string, sizeName string, memoryMb int64) (VMSize, error) {

--- a/api/resource_scale.go
+++ b/api/resource_scale.go
@@ -148,3 +148,60 @@ func (c *Client) SetAppVMSize(appID string, sizeName string, memoryMb int64) (VM
 
 	return *data.SetVMSize.VMSize, nil
 }
+
+func (c *Client) GetAppVMCount(appID string) ([]TaskGroupCount, error) {
+	query := `
+		query ($appName: String!) {
+			app(name: $appName) {
+				id
+				name
+				taskGroupCounts {
+					name
+					count
+				}
+			}
+		}
+	`
+
+	req := c.NewRequest(query)
+
+	req.Var("appName", appID)
+
+	data, err := c.Run(req)
+	if err != nil {
+		return []TaskGroupCount{}, err
+	}
+
+	return data.App.TaskGroupCounts, nil
+}
+
+func (c *Client) SetAppVMCount(appID string, count int) ([]TaskGroupCount, []string, error) {
+	query := `
+		mutation ($input: SetVMCountInput!) {
+			setVmCount(input: $input) {
+				app {
+					taskGroupCounts {
+						name
+						count
+					}
+				}
+				warnings
+			}
+		}
+	`
+
+	req := c.NewRequest(query)
+
+	req.Var("input", SetVMCountInput{
+		AppID: appID,
+		GroupCounts: []VMCountInput{
+			{Group: "app", Count: count},
+		}})
+
+	data, err := c.Run(req)
+	if err != nil {
+		return []TaskGroupCount{}, []string{}, err
+	}
+
+	return data.SetVMCount.App.TaskGroupCounts, data.SetVMCount.Warnings, nil
+}

--- a/api/types.go
+++ b/api/types.go
@@ -96,6 +96,11 @@ type Query struct {
 		VMSize *VMSize
 	}
 
+	SetVMCount struct {
+		App      App
+		Warnings []string
+	}
+
 	ConfigureRegions struct {
 		App           App
 		Regions       []Region
@@ -195,6 +200,12 @@ type App struct {
 	Volumes          struct {
 		Nodes []Volume
 	}
+	TaskGroupCounts []TaskGroupCount
+}
+
+type TaskGroupCount struct {
+	Name  string
+	Count int
 }
 
 type Volume struct {
@@ -664,6 +675,16 @@ type SetVMSizeInput struct {
 	AppID    string `json:"appId"`
 	SizeName string `json:"sizeName"`
 	MemoryMb int64  `json:"memoryMb"`
+}
+
+type SetVMCountInput struct {
+	AppID       string         `json:"appId"`
+	GroupCounts []VMCountInput `json:"groupCounts"`
+}
+
+type VMCountInput struct {
+	Group string `json:"group"`
+	Count int    `json:"count"`
 }
 
 type StartBuildInput struct {

--- a/cmd/autoscaling.go
+++ b/cmd/autoscaling.go
@@ -1,0 +1,156 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/superfly/flyctl/cmdctx"
+
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/docstrings"
+
+	"github.com/spf13/cobra"
+)
+
+func newAutoscaleCommand() *Command {
+	autoscaleStrings := docstrings.Get("autoscale")
+
+	cmd := BuildCommandKS(nil, nil, autoscaleStrings, os.Stdout, requireSession, requireAppName)
+	cmd.Deprecated = "use `flyctl scale` instead"
+
+	balanceCmdStrings := docstrings.Get("autoscale.balanced")
+	balanceCmd := BuildCommand(cmd, runBalanceScale, balanceCmdStrings.Usage, balanceCmdStrings.Short, balanceCmdStrings.Long, os.Stdout, requireSession, requireAppName)
+	balanceCmd.Args = cobra.RangeArgs(0, 2)
+
+	standardCmdStrings := docstrings.Get("autoscale.standard")
+	standardCmd := BuildCommand(cmd, runStandardScale, standardCmdStrings.Usage, standardCmdStrings.Short, standardCmdStrings.Long, os.Stdout, requireSession, requireAppName)
+	standardCmd.Args = cobra.RangeArgs(0, 2)
+
+	setCmdStrings := docstrings.Get("autoscale.set")
+	setCmd := BuildCommand(cmd, runSetParamsOnly, setCmdStrings.Usage, setCmdStrings.Short, setCmdStrings.Long, os.Stdout, requireSession, requireAppName)
+	setCmd.Args = cobra.RangeArgs(0, 2)
+
+	showCmdStrings := docstrings.Get("autoscale.show")
+	BuildCommand(cmd, runAutoscalingShow, showCmdStrings.Usage, showCmdStrings.Short, showCmdStrings.Long, os.Stdout, requireSession, requireAppName)
+
+	return cmd
+}
+
+func runBalanceScale(commandContext *cmdctx.CmdContext) error {
+	return actualScale(commandContext, true, false)
+}
+
+func runStandardScale(commandContext *cmdctx.CmdContext) error {
+	return actualScale(commandContext, false, false)
+}
+
+func runSetParamsOnly(commandContext *cmdctx.CmdContext) error {
+	return actualScale(commandContext, false, true)
+}
+
+func actualScale(commandContext *cmdctx.CmdContext, balanceRegions bool, setParamsOnly bool) error {
+	currentcfg, err := commandContext.Client.API().AppAutoscalingConfig(commandContext.AppName)
+	if err != nil {
+		return err
+	}
+
+	newcfg := api.UpdateAutoscaleConfigInput{AppID: commandContext.AppName}
+
+	newcfg.BalanceRegions = &balanceRegions
+	newcfg.MinCount = &currentcfg.MinCount
+	newcfg.MaxCount = &currentcfg.MaxCount
+
+	kvargs := make(map[string]string)
+
+	for _, pair := range commandContext.Args {
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("Scale parameters must be provided as NAME=VALUE pairs (%s is invalid)", pair)
+		}
+		key := parts[0]
+		value := parts[1]
+		kvargs[strings.ToLower(key)] = value
+	}
+
+	minval, found := kvargs["min"]
+
+	if found {
+		minint64val, err := strconv.ParseInt(minval, 10, 64)
+
+		if err != nil {
+			return errors.New("could not parse min count value")
+		}
+		minintval := int(minint64val)
+		newcfg.MinCount = &minintval
+		delete(kvargs, "min")
+	}
+
+	maxval, found := kvargs["max"]
+
+	if found {
+		maxint64val, err := strconv.ParseInt(maxval, 10, 64)
+
+		if err != nil {
+			return errors.New("could not parse max count value")
+		}
+		maxintval := int(maxint64val)
+		newcfg.MaxCount = &maxintval
+		delete(kvargs, "max")
+	}
+
+	if len(kvargs) != 0 {
+		unusedkeys := ""
+		for k := range kvargs {
+			if unusedkeys == "" {
+				unusedkeys = k
+			} else {
+				unusedkeys = unusedkeys + ", " + k
+			}
+		}
+		return errors.New("unrecognised parameters in command:" + unusedkeys)
+	}
+
+	cfg, err := commandContext.Client.API().UpdateAutoscaleConfig(newcfg)
+	if err != nil {
+		return err
+	}
+
+	printScaleConfig(commandContext, cfg)
+
+	return nil
+}
+
+func runAutoscalingShow(commandContext *cmdctx.CmdContext) error {
+	cfg, err := commandContext.Client.API().AppAutoscalingConfig(commandContext.AppName)
+	if err != nil {
+		return err
+	}
+
+	printScaleConfig(commandContext, cfg)
+
+	return nil
+}
+
+func printScaleConfig(commandContext *cmdctx.CmdContext, cfg *api.AutoscalingConfig) {
+
+	asJSON := commandContext.OutputJSON()
+
+	if asJSON {
+		commandContext.WriteJSON(cfg)
+	} else {
+		var mode string
+
+		if cfg.BalanceRegions {
+			mode = "Balanced"
+		} else {
+			mode = "Standard"
+		}
+
+		fmt.Fprintf(commandContext.Out, "%15s: %s\n", "Scale Mode", mode)
+		fmt.Fprintf(commandContext.Out, "%15s: %d\n", "Min Count", cfg.MinCount)
+		fmt.Fprintf(commandContext.Out, "%15s: %d\n", "Max Count", cfg.MaxCount)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,6 +93,7 @@ func init() {
 		newRestartCommand(),
 		newResumeCommand(),
 		newScaleCommand(),
+		newAutoscaleCommand(),
 		newSecretsCommand(),
 		newStatusCommand(),
 		newSuspendCommand(),

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -470,6 +470,12 @@ the number of configured instances.`,
 min=int - minimum number of instances to be allocated from region pool. 
 max=int - maximum number of instances to be allocated from region pool.`,
 		}
+	case "scale.count":
+		return KeyStrings{"count <count>", "Change an App's VM count to the given value",
+			`Change an App's VM count to the given value. Shows the application's current VM counts if no arguments are given. 
+
+For pricing, see https://fly.io/docs/about/pricing/`,
+		}
 	case "scale.set":
 		return KeyStrings{"set", "Set current models scaling parameters",
 			`Allows the setting of the current models scaling parameters:

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -102,6 +102,10 @@ authenticated and in use.`,
 min=int - minimum number of instances to be allocated from region pool. 
 max=int - maximum number of instances to be allocated from region pool.`,
 		}
+	case "autoscale.disable":
+		return KeyStrings{"disable", "Disable autoscaling",
+			`Disable autoscaling to manually controlling app resources`,
+		}
 	case "autoscale.set":
 		return KeyStrings{"set", "Set current models autoscaling parameters",
 			`Allows the setting of the current models autoscaling parameters:
@@ -499,8 +503,8 @@ the number of configured instances.`,
 For pricing, see https://fly.io/docs/about/pricing/`,
 		}
 	case "scale.show":
-		return KeyStrings{"show", "Show current scaling configuration",
-			`Show current scaling configuration`,
+		return KeyStrings{"show", "Show current resources",
+			`Show current resources`,
 		}
 	case "scale.vm":
 		return KeyStrings{"vm [SIZENAME] [flags]", "Change an App's VM to a named size (eg. shared-cpu-1x, dedicated-cpu-1x, dedicated-cpu-2x...)",

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -91,6 +91,35 @@ independent of flyctl.`,
 			`Displays the users email address/service identity currently 
 authenticated and in use.`,
 		}
+	case "autoscale":
+		return KeyStrings{"autoscale", "Autoscaling App resources",
+			`Autoscaling application resources`,
+		}
+	case "autoscale.balanced":
+		return KeyStrings{"balanced", "Configure a traffic balanced App with params (min=int max=int)",
+			`Configure the App to balance regions based on traffic with given parameters:
+
+min=int - minimum number of instances to be allocated from region pool. 
+max=int - maximum number of instances to be allocated from region pool.`,
+		}
+	case "autoscale.set":
+		return KeyStrings{"set", "Set current models autoscaling parameters",
+			`Allows the setting of the current models autoscaling parameters:
+
+min=int - minimum number of instances to be allocated from region pool. 
+max=int - maximum number of instances to be allocated from region pool.`,
+		}
+	case "autoscale.show":
+		return KeyStrings{"show", "Show current autoscaling configuration",
+			`Show current autoscaling configuration`,
+		}
+	case "autoscale.standard":
+		return KeyStrings{"standard", "Configure a standard balanced App with params (min=int max=int)",
+			`Configure the App without traffic balancing with the given parameters:
+
+min=int - minimum number of instances to be allocated from region pool. 
+max=int - maximum number of instances to be allocated from region pool.`,
+		}
 	case "builds":
 		return KeyStrings{"builds", "Work with Fly Builds",
 			`Fly Builds are templates to make developing Fly applications easier.`,
@@ -463,36 +492,15 @@ the number of configured instances.`,
 		return KeyStrings{"scale", "Scale App resources",
 			`Scale application resources`,
 		}
-	case "scale.balanced":
-		return KeyStrings{"balanced", "Configure a traffic balanced App with params (min=int max=int)",
-			`Configure the App to balance regions based on traffic with given parameters:
-
-min=int - minimum number of instances to be allocated from region pool. 
-max=int - maximum number of instances to be allocated from region pool.`,
-		}
 	case "scale.count":
 		return KeyStrings{"count <count>", "Change an App's VM count to the given value",
 			`Change an App's VM count to the given value. Shows the application's current VM counts if no arguments are given. 
 
 For pricing, see https://fly.io/docs/about/pricing/`,
 		}
-	case "scale.set":
-		return KeyStrings{"set", "Set current models scaling parameters",
-			`Allows the setting of the current models scaling parameters:
-
-min=int - minimum number of instances to be allocated from region pool. 
-max=int - maximum number of instances to be allocated from region pool.`,
-		}
 	case "scale.show":
 		return KeyStrings{"show", "Show current scaling configuration",
 			`Show current scaling configuration`,
-		}
-	case "scale.standard":
-		return KeyStrings{"standard", "Configure a standard balanced App with params (min=int max=int)",
-			`Configure the App without traffic balancing with the given parameters:
-
-min=int - minimum number of instances to be allocated from region pool. 
-max=int - maximum number of instances to be allocated from region pool.`,
 		}
 	case "scale.vm":
 		return KeyStrings{"vm [SIZENAME] [flags]", "Change an App's VM to a named size (eg. shared-cpu-1x, dedicated-cpu-1x, dedicated-cpu-2x...)",

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -498,17 +498,17 @@ the number of configured instances.`,
 		}
 	case "scale.count":
 		return KeyStrings{"count <count>", "Change an App's VM count to the given value",
-			`Change an App's VM count to the given value. Shows the application's current VM counts if no arguments are given. 
+			`Change an App's VM count to the given value. 
 
 For pricing, see https://fly.io/docs/about/pricing/`,
 		}
 	case "scale.show":
 		return KeyStrings{"show", "Show current resources",
-			`Show current resources`,
+			`Show current VM size and counts`,
 		}
 	case "scale.vm":
 		return KeyStrings{"vm [SIZENAME] [flags]", "Change an App's VM to a named size (eg. shared-cpu-1x, dedicated-cpu-1x, dedicated-cpu-2x...)",
-			`Change an application's VM size to one of the named VM sizes. Shows the application's current VM size if no arguments are given. 
+			`Change an application's VM size to one of the named VM sizes.
 
 Size names include shared-cpu-1x, dedicated-cpu-1x, dedicated-cpu-2x.
 

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -569,6 +569,15 @@ For shared vms, this can be 256MB or a a multiple of 1024MB.
 For pricing, see https://fly.io/docs/about/pricing/
 """
 
+    [scale.count]
+    usage     = "count <count>"
+    shortHelp = "Change an App's VM count to the given value"
+    longHelp  = """Change an App's VM count to the given value. Shows the application's current VM counts if no arguments are given. 
+
+For pricing, see https://fly.io/docs/about/pricing/
+"""
+
+
 [secrets]
 usage     = "secrets"
 shortHelp = "Manage App secrets"

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -564,7 +564,7 @@ longHelp  = """Scale application resources
     [scale.vm]
     usage     = "vm [SIZENAME] [flags]"
     shortHelp = "Change an App's VM to a named size (eg. shared-cpu-1x, dedicated-cpu-1x, dedicated-cpu-2x...)"
-    longHelp  = """Change an application's VM size to one of the named VM sizes. Shows the application's current VM size if no arguments are given. 
+    longHelp  = """Change an application's VM size to one of the named VM sizes.
 
 Size names include shared-cpu-1x, dedicated-cpu-1x, dedicated-cpu-2x.
 
@@ -584,7 +584,7 @@ For pricing, see https://fly.io/docs/about/pricing/
     [scale.count]
     usage     = "count <count>"
     shortHelp = "Change an App's VM count to the given value"
-    longHelp  = """Change an App's VM count to the given value. Shows the application's current VM counts if no arguments are given. 
+    longHelp  = """Change an App's VM count to the given value. 
 
 For pricing, see https://fly.io/docs/about/pricing/
 """
@@ -592,7 +592,7 @@ For pricing, see https://fly.io/docs/about/pricing/
     [scale.show]
     usage     = "show"
     shortHelp = "Show current resources"
-    longHelp  = """Show current resources
+    longHelp  = """Show current VM size and counts
 """
 
 [secrets]

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -516,6 +516,12 @@ shortHelp = "Autoscaling App resources"
 longHelp  = """Autoscaling application resources
 """
 
+    [autoscale.disable]
+    usage     = "disable"
+    shortHelp = "Disable autoscaling"
+    longHelp  = """Disable autoscaling to manually controlling app resources
+"""
+
     [autoscale.balanced]
     usage     = "balanced"
     shortHelp = "Configure a traffic balanced App with params (min=int max=int)"

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -510,13 +510,13 @@ longHelp  = """List all the releases of the application onto the Fly platform,
 including type, when, success/fail and which user triggered the release.
 """
 
-[scale]
-usage     = "scale"
-shortHelp = "Scale App resources"
-longHelp  = """Scale application resources
+[autoscale]
+usage     = "autoscale"
+shortHelp = "Autoscaling App resources"
+longHelp  = """Autoscaling application resources
 """
 
-    [scale.balanced]
+    [autoscale.balanced]
     usage     = "balanced"
     shortHelp = "Configure a traffic balanced App with params (min=int max=int)"
     longHelp  = """Configure the App to balance regions based on traffic with given parameters:
@@ -525,7 +525,7 @@ min=int - minimum number of instances to be allocated from region pool.
 max=int - maximum number of instances to be allocated from region pool.
 """
 
-    [scale.standard]
+    [autoscale.standard]
     usage     = "standard"
     shortHelp = "Configure a standard balanced App with params (min=int max=int)"
     longHelp  = """Configure the App without traffic balancing with the given parameters:
@@ -534,19 +534,25 @@ min=int - minimum number of instances to be allocated from region pool.
 max=int - maximum number of instances to be allocated from region pool.
 """
 
-    [scale.show]
+    [autoscale.show]
     usage     = "show"
-    shortHelp = "Show current scaling configuration"
-    longHelp  = """Show current scaling configuration
+    shortHelp = "Show current autoscaling configuration"
+    longHelp  = """Show current autoscaling configuration
 """
 
-    [scale.set]
+    [autoscale.set]
     usage     = "set"
-    shortHelp = "Set current models scaling parameters"
-    longHelp  = """Allows the setting of the current models scaling parameters:
+    shortHelp = "Set current models autoscaling parameters"
+    longHelp  = """Allows the setting of the current models autoscaling parameters:
 
 min=int - minimum number of instances to be allocated from region pool. 
 max=int - maximum number of instances to be allocated from region pool.
+"""
+
+[scale]
+usage     = "scale"
+shortHelp = "Scale App resources"
+longHelp  = """Scale application resources
 """
 
     [scale.vm]
@@ -577,6 +583,11 @@ For pricing, see https://fly.io/docs/about/pricing/
 For pricing, see https://fly.io/docs/about/pricing/
 """
 
+    [scale.show]
+    usage     = "show"
+    shortHelp = "Show current resources"
+    longHelp  = """Show current resources
+"""
 
 [secrets]
 usage     = "secrets"


### PR DESCRIPTION
- add a new `scale count` command which directly changes the VM count
- updates the output of `scale vm` and `scale show`
- moves old autoscaling commands to a new hidden `autoscale` top level command
- adds an `autoscale disable` command to allow disabling autoscaling entirely

cc @mrkurt @codepope

## examples

#### updated: `flyctl scale`
```bash
$ flyctl scale --help
Scale application resources

Usage:
  flyctl scale [command]

Available Commands:
  count       Change an App's VM count to the given value
  show        Show current resources
  vm          Change an App's VM to a named size (eg. shared-cpu-1x, dedicated-cpu-1x, dedicated-cpu-2x...)

Flags:
  -a, --app string      App name to operate on
  -c, --config string   Path to an app config file or directory containing one (default "./fly.toml")
  -h, --help            help for scale

Global Flags:
  -t, --access-token string   Fly API Access Token
  -j, --json                  json output
  -v, --verbose               verbose output

Use "flyctl scale [command] --help" for more information about a command.

```

#### updated: `flyctl scale show`
```bash
$ flyctl scale show -a md-website
VM Resources for md-website
        VM Size: micro-1x
      VM Memory: 128 MB
          Count: 2
```

#### new: `flyctl scale count`
```bash
$ flyctl scale count 4 -a md-website
Warning: Autoscaling is enabled for md-website, manual count will be reset during an autoscaling event

Count changed to 4
```

#### updated: `flyctl scale vm`
```bash
$ flyctl scale vm shared-cpu-1x -a md-website
Scaled VM size to shared-cpu-1x
      CPU Cores: 1
         Memory: 256 MB
```

#### deprecated: `flyctl autoscale`
```shell
$ flyctl autoscale --help
Command "autoscale" is deprecated, use `flyctl scale` instead
Autoscaling application resources

Usage:
  flyctl autoscale [command]

Available Commands:
  balanced    Configure a traffic balanced App with params (min=int max=int)
  disable     Disable autoscaling
  set         Set current models autoscaling parameters
  show        Show current autoscaling configuration
  standard    Configure a standard balanced App with params (min=int max=int)

Flags:
  -a, --app string      App name to operate on
  -c, --config string   Path to an app config file or directory containing one (default "./fly.toml")
  -h, --help            help for autoscale

Global Flags:
  -t, --access-token string   Fly API Access Token
  -j, --json                  json output
  -v, --verbose               verbose output

Use "flyctl autoscale [command] --help" for more information about a command.
```

#### new: `flyctl autoscale disable`
```bash
flyctl autoscale disable  -a md-website                                                                                                                                 
     Scale Mode: Disabled
```


