### PR TITLE
send [build] section in config with deploy

### DIFF
--- a/docker/deploy.go
+++ b/docker/deploy.go
@@ -75,6 +75,8 @@ func (op *DeployOperation) ValidateConfig() (*api.AppConfig, error) {
 		return parsedConfig, errors.New("App configuration is not valid")
 	}
 
+	def := parsedConfig.Definition
+	def["build"] = o.appConfig.Definition["build"]
 	op.appConfig.Definition = parsedConfig.Definition
 
 	return parsedConfig, nil


### PR DESCRIPTION
This is a tiny change to send the original config contents with a deploy, instead of sending the `validateConfig` response.