### PR TITLE
Fix instructions for installing a specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ curl -L https://fly.io/install.sh | sh
 Installing a specific version:
 
 ```bash
-curl -L https://fly.io/install.sh | sh -s v0.0.1
+curl -L https://fly.io/install.sh | sh -s 0.0.200
 ```
 
 ## Downloading from GitHub

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -35,7 +35,7 @@ else
 		fi
 		flyctl_uri="https://github.com${flyctl_asset_path}"
 	else
-		flyctl_uri="https://github.com/superfly/flyctl/releases/download/${1}/flyctl-${target}.tar.gz"
+		flyctl_uri="https://github.com/superfly/flyctl/releases/download/v${1}/flyctl_${1}_${target}.tar.gz"
 	fi
 fi
 


### PR DESCRIPTION
The URL was incorrect, and the version tag in the README no longer matches flyctl's version tags.