### PR TITLE
Add Network field to CreateAppInput

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -470,6 +470,7 @@ type CreateAppInput struct {
 	Runtime         string  `json:"runtime"`
 	Name            string  `json:"name"`
 	PreferredRegion *string `json:"preferredRegion,omitempty"`
+	Network         *string `json:"network,omitempty"`
 }
 
 type LogEntry struct {


### PR DESCRIPTION
The `Network` field is an optional field in the GraphQL schema for `CreateAppInput`, but it's not present in the Go struct, so this change adds it.