### PR TITLE
Remote builders over wireguard

### DIFF
--- a/cmd/ssh_terminal.go
+++ b/cmd/ssh_terminal.go
@@ -14,6 +14,7 @@ import (
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/cmdctx"
 	"github.com/superfly/flyctl/helpers"
+	"github.com/superfly/flyctl/internal/wireguard"
 	"github.com/superfly/flyctl/pkg/ssh"
 	"github.com/superfly/flyctl/pkg/wg"
 	"github.com/superfly/flyctl/terminal"
@@ -26,7 +27,7 @@ func runSSHShell(ctx *cmdctx.CmdContext) error {
 		return err
 	}
 
-	state, err := wireGuardForOrg(ctx, org)
+	state, err := wireguard.StateForOrg(ctx.Client.API(), org, ctx.Config.GetString("region"), "")
 	if err != nil {
 		return err
 	}
@@ -74,7 +75,7 @@ func runSSHConsole(ctx *cmdctx.CmdContext) error {
 		return fmt.Errorf("get app: %w", err)
 	}
 
-	state, err := wireGuardForOrg(ctx, &app.Organization)
+	state, err := wireguard.StateForOrg(ctx.Client.API(), &app.Organization, ctx.Config.GetString("region"), "")
 	if err != nil {
 		return fmt.Errorf("create wireguard config: %w", err)
 	}

--- a/cmd/wireguard.go
+++ b/cmd/wireguard.go
@@ -7,25 +7,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	badrand "math/rand"
 	"net"
 	"net/http"
 	"os"
-	"regexp"
 	"strings"
 	"text/template"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/cmdctx"
 	"github.com/superfly/flyctl/docstrings"
-	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/client"
-	"github.com/superfly/flyctl/pkg/wg"
-	"github.com/superfly/flyctl/terminal"
+	"github.com/superfly/flyctl/internal/wireguard"
 	"golang.org/x/crypto/curve25519"
 )
 
@@ -213,127 +208,25 @@ func c25519pair() (string, string) {
 		base64.StdEncoding.EncodeToString(private[:])
 }
 
-type WireGuardState struct {
-	Org          string
-	Name         string
-	Region       string
-	LocalPublic  string
-	LocalPrivate string
-	DNS          string
-	Peer         api.CreatedWireGuardPeer
-}
-
-// BUG(tqbf): Obviously all this needs to go, and I should just
-// make my code conform to the marshal/unmarshal protocol wireguard-go
-// uses, but in the service of landing this feature, I'm just going
-// to apply a layer of spackle for now.
-func (s *WireGuardState) TunnelConfig() *wg.Config {
-	skey := wg.PrivateKey{}
-	if err := skey.UnmarshalText([]byte(s.LocalPrivate)); err != nil {
-		panic(fmt.Sprintf("martian local private key: %s", err))
-	}
-
-	pkey := wg.PublicKey{}
-	if err := pkey.UnmarshalText([]byte(s.Peer.Pubkey)); err != nil {
-		panic(fmt.Sprintf("martian local public key: %s", err))
-	}
-
-	_, lnet, err := net.ParseCIDR(fmt.Sprintf("%s/120", s.Peer.Peerip))
-	if err != nil {
-		panic(fmt.Sprintf("martian local public: %s/120: %s", s.Peer.Peerip, err))
-	}
-
-	raddr := net.ParseIP(s.Peer.Peerip).To16()
-	for i := 6; i < 16; i++ {
-		raddr[i] = 0
-	}
-
-	// BUG(tqbf): for now, we never manage tunnels for different
-	// organizations, and while this comment is eating more space
-	// than the code I'd need to do this right, it's more fun to
-	// type, so we just hardcode.
-	_, rnet, _ := net.ParseCIDR(fmt.Sprintf("%s/48", raddr))
-
-	raddr[15] = 3
-	dns := net.ParseIP(fmt.Sprintf("%s", raddr))
-
-	// BUG(tqbf): I think this dance just because these needed to
-	// parse for Ben's TOML code.
-	wgl := wg.IPNet(*lnet)
-	wgr := wg.IPNet(*rnet)
-
-	return &wg.Config{
-		LocalPrivateKey: skey,
-		LocalNetwork:    &wgl,
-		RemotePublicKey: pkey,
-		RemoteNetwork:   &wgr,
-		Endpoint:        s.Peer.Endpointip + ":51820",
-		DNS:             dns,
-		// LogLevel:        9999999,
-	}
-
-}
-
-func wireGuardCreate(ctx *cmdctx.CmdContext, org *api.Organization, regionp, namep *string) (*WireGuardState, error) {
-	var (
-		region, name string
-		err          error
-		rx           = regexp.MustCompile("^[a-zA-Z0-9\\-]+$")
-		client       = ctx.Client.API()
-	)
-
-	if org == nil {
-		org, err = orgByArg(ctx)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if regionp == nil {
-		region, err = argOrPrompt(ctx, 1, "Region in which to add WireGuard peer: ")
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		region = *regionp
-	}
-
-	if namep == nil {
-		for !rx.MatchString(name) {
-			if name != "" {
-				fmt.Println("Name must consist solely of letters, numbers, and the dash character.")
-			}
-
-			name, err = argOrPromptLoop(ctx, 2, "New DNS name for WireGuard peer: ", name)
-			if err != nil {
-				return nil, err
-			}
-		}
-	} else {
-		name = *namep
-	}
-
-	fmt.Printf("Creating WireGuard peer \"%s\" in region \"%s\" for organization %s\n", name, region, org.Slug)
-
-	pubkey, privatekey := c25519pair()
-
-	data, err := client.CreateWireGuardPeer(org, region, name, pubkey)
-	if err != nil {
-		return nil, err
-	}
-
-	return &WireGuardState{
-		Name:         name,
-		Region:       region,
-		Org:          org.Slug,
-		LocalPublic:  pubkey,
-		LocalPrivate: privatekey,
-		Peer:         *data,
-	}, nil
-}
-
 func runWireGuardCreate(ctx *cmdctx.CmdContext) error {
-	state, err := wireGuardCreate(ctx, nil, nil, nil)
+
+	org, err := orgByArg(ctx)
+	if err != nil {
+		return err
+	}
+
+	var region string
+	var name string
+
+	if len(ctx.Args) > 1 && ctx.Args[1] != "" {
+		region = ctx.Args[1]
+	}
+
+	if len(ctx.Args) > 2 && ctx.Args[2] != "" {
+		name = ctx.Args[2]
+	}
+
+	state, err := wireguard.Create(ctx.Client.API(), org, region, name)
 	if err != nil {
 		return err
 	}
@@ -668,86 +561,4 @@ func runWireGuardTokenUpdatePeer(ctx *cmdctx.CmdContext) error {
 	}
 
 	return nil
-}
-
-func wireGuardForOrg(ctx *cmdctx.CmdContext, org *api.Organization) (*WireGuardState, error) {
-	var (
-		svm map[string]interface{}
-		ok  bool
-	)
-
-	sv := viper.Get(flyctl.ConfigWireGuardState)
-	if sv != nil {
-		terminal.Debugf("Found WireGuard state in local configuration\n")
-
-		svm, ok = sv.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("garbage stored in wireguard_state in config")
-		}
-
-		// no state saved for this org
-		savedStatev, ok := svm[org.Slug]
-		if !ok {
-			goto NEW_CONNECTION
-		}
-
-		savedPeerv, ok := savedStatev.(map[string]interface{})["peer"]
-		if !ok {
-			return nil, fmt.Errorf("garbage stored in wireguard_state in config (under peer)")
-		}
-
-		savedState := savedStatev.(map[string]interface{})
-		savedPeer := savedPeerv.(map[string]interface{})
-
-		// if we get this far and the config is garbled, i'm fine
-		// with a panic
-		return &WireGuardState{
-			Org:          org.Slug,
-			Name:         savedState["name"].(string),
-			Region:       savedState["region"].(string),
-			LocalPublic:  savedState["localpublic"].(string),
-			LocalPrivate: savedState["localprivate"].(string),
-			Peer: api.CreatedWireGuardPeer{
-				Peerip:     savedPeer["peerip"].(string),
-				Endpointip: savedPeer["endpointip"].(string),
-				Pubkey:     savedPeer["pubkey"].(string),
-			},
-		}, nil
-	} else {
-		svm = map[string]interface{}{}
-	}
-
-NEW_CONNECTION:
-	terminal.Debugf("Can't find matching WireGuard configuration; creating new one\n")
-
-	user, err := ctx.Client.API().GetCurrentUser()
-	if err != nil {
-		return nil, err
-	}
-
-	rx := regexp.MustCompile("[^a-zA-Z0-9\\-]")
-
-	host, _ := os.Hostname()
-
-	wgName := fmt.Sprintf("interactive-%s-%s-%d",
-		strings.Split(host, ".")[0],
-		rx.ReplaceAllString(user.Email, "-"), badrand.Intn(1000))
-
-	region := ctx.Config.GetString("region")
-
-	terminal.Debugf("Creating new WireGuard connection for %s in %s named %s\n", org.Slug, region, wgName)
-
-	stateb, err := wireGuardCreate(ctx, org, &region, &wgName)
-	if err != nil {
-		return nil, err
-	}
-
-	svm[stateb.Org] = stateb
-
-	viper.Set(flyctl.ConfigWireGuardState, &svm)
-	if err := flyctl.SaveConfig(); err != nil {
-		return nil, err
-	}
-
-	return stateb, err
 }

--- a/cmd/wireguard.go
+++ b/cmd/wireguard.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"crypto/rand"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -21,7 +19,6 @@ import (
 	"github.com/superfly/flyctl/docstrings"
 	"github.com/superfly/flyctl/internal/client"
 	"github.com/superfly/flyctl/internal/wireguard"
-	"golang.org/x/crypto/curve25519"
 )
 
 func newWireGuardCommand(client *client.Client) *Command {
@@ -190,22 +187,6 @@ func resolveOutputWriter(ctx *cmdctx.CmdContext, idx int, prompt string) (w io.W
 
 		fmt.Printf("Can't create '%s': %s\n", filename, err)
 	}
-}
-
-func c25519pair() (string, string) {
-	var private [32]byte
-	_, err := rand.Read(private[:])
-	if err != nil {
-		panic(fmt.Sprintf("reading from random: %s", err))
-	}
-
-	public, err := curve25519.X25519(private[:], curve25519.Basepoint)
-	if err != nil {
-		panic(fmt.Sprintf("can't mult: %s", err))
-	}
-
-	return base64.StdEncoding.EncodeToString(public[:]),
-		base64.StdEncoding.EncodeToString(private[:])
 }
 
 func runWireGuardCreate(ctx *cmdctx.CmdContext) error {
@@ -487,7 +468,7 @@ func runWireGuardTokenStartPeer(ctx *cmdctx.CmdContext) error {
 		return err
 	}
 
-	pubkey, privatekey := c25519pair()
+	pubkey, privatekey := wireguard.C25519pair()
 
 	body := &StartPeerJson{
 		Name:   name,
@@ -532,7 +513,7 @@ func runWireGuardTokenUpdatePeer(ctx *cmdctx.CmdContext) error {
 		return err
 	}
 
-	pubkey, privatekey := c25519pair()
+	pubkey, privatekey := wireguard.C25519pair()
 
 	body := &StartPeerJson{
 		Pubkey: pubkey,

--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -103,8 +103,6 @@ func Create(apiClient *api.Client, org *api.Organization, regionCode, name strin
 			cleanEmailPattern.ReplaceAllString(user.Email, "-"), badrand.Intn(1000))
 	}
 
-	fmt.Println(name)
-
 	if regionCode == "" {
 		region, err := apiClient.ClosestWireguardGatewayRegion()
 		if err != nil {
@@ -119,7 +117,7 @@ func Create(apiClient *api.Client, org *api.Organization, regionCode, name strin
 
 	fmt.Printf("Creating WireGuard peer \"%s\" in region \"%s\" for organization %s\n", name, regionCode, org.Slug)
 
-	pubkey, privatekey := c25519pair()
+	pubkey, privatekey := C25519pair()
 
 	data, err := apiClient.CreateWireGuardPeer(org, regionCode, name, pubkey)
 	if err != nil {
@@ -136,7 +134,7 @@ func Create(apiClient *api.Client, org *api.Organization, regionCode, name strin
 	}, nil
 }
 
-func c25519pair() (string, string) {
+func C25519pair() (string, string) {
 	var private [32]byte
 	_, err := rand.Read(private[:])
 	if err != nil {

--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -1,0 +1,153 @@
+package wireguard
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	badrand "math/rand"
+
+	"github.com/spf13/viper"
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/flyctl"
+	"github.com/superfly/flyctl/pkg/wg"
+	"github.com/superfly/flyctl/terminal"
+	"golang.org/x/crypto/curve25519"
+)
+
+func StateForOrg(apiClient *api.Client, org *api.Organization, regionCode string, name string) (*wg.WireGuardState, error) {
+	var (
+		svm map[string]interface{}
+		ok  bool
+	)
+
+	sv := viper.Get(flyctl.ConfigWireGuardState)
+	if sv != nil {
+		terminal.Debugf("Found WireGuard state in local configuration\n")
+
+		svm, ok = sv.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("garbage stored in wireguard_state in config")
+		}
+
+		// no state saved for this org
+		savedStatev, ok := svm[org.Slug]
+		if !ok {
+			goto NEW_CONNECTION
+		}
+
+		savedPeerv, ok := savedStatev.(map[string]interface{})["peer"]
+		if !ok {
+			return nil, fmt.Errorf("garbage stored in wireguard_state in config (under peer)")
+		}
+
+		savedState := savedStatev.(map[string]interface{})
+		savedPeer := savedPeerv.(map[string]interface{})
+
+		// if we get this far and the config is garbled, i'm fine
+		// with a panic
+		return &wg.WireGuardState{
+			Org:          org.Slug,
+			Name:         savedState["name"].(string),
+			Region:       savedState["region"].(string),
+			LocalPublic:  savedState["localpublic"].(string),
+			LocalPrivate: savedState["localprivate"].(string),
+			Peer: api.CreatedWireGuardPeer{
+				Peerip:     savedPeer["peerip"].(string),
+				Endpointip: savedPeer["endpointip"].(string),
+				Pubkey:     savedPeer["pubkey"].(string),
+			},
+		}, nil
+	} else {
+		svm = map[string]interface{}{}
+	}
+
+NEW_CONNECTION:
+	terminal.Debugf("Can't find matching WireGuard configuration; creating new one\n")
+
+	stateb, err := Create(apiClient, org, regionCode, name)
+	if err != nil {
+		return nil, err
+	}
+
+	svm[stateb.Org] = stateb
+
+	viper.Set(flyctl.ConfigWireGuardState, &svm)
+	if err := flyctl.SaveConfig(); err != nil {
+		return nil, err
+	}
+
+	return stateb, err
+}
+
+func Create(apiClient *api.Client, org *api.Organization, regionCode, name string) (*wg.WireGuardState, error) {
+	var (
+		err error
+		rx  = regexp.MustCompile("^[a-zA-Z0-9\\-]+$")
+	)
+
+	if name == "" {
+		user, err := apiClient.GetCurrentUser()
+		if err != nil {
+			return nil, err
+		}
+		host, _ := os.Hostname()
+
+		cleanEmailPattern := regexp.MustCompile("[^a-zA-Z0-9\\-]")
+		name = fmt.Sprintf("interactive-%s-%s-%d",
+			strings.Split(host, ".")[0],
+			cleanEmailPattern.ReplaceAllString(user.Email, "-"), badrand.Intn(1000))
+	}
+
+	fmt.Println(name)
+
+	if regionCode == "" {
+		region, err := apiClient.ClosestWireguardGatewayRegion()
+		if err != nil {
+			return nil, err
+		}
+		regionCode = region.Code
+	}
+
+	if !rx.MatchString(name) {
+		return nil, errors.New("name must consist solely of letters, numbers, and the dash character")
+	}
+
+	fmt.Printf("Creating WireGuard peer \"%s\" in region \"%s\" for organization %s\n", name, regionCode, org.Slug)
+
+	pubkey, privatekey := c25519pair()
+
+	data, err := apiClient.CreateWireGuardPeer(org, regionCode, name, pubkey)
+	if err != nil {
+		return nil, err
+	}
+
+	return &wg.WireGuardState{
+		Name:         name,
+		Region:       regionCode,
+		Org:          org.Slug,
+		LocalPublic:  pubkey,
+		LocalPrivate: privatekey,
+		Peer:         *data,
+	}, nil
+}
+
+func c25519pair() (string, string) {
+	var private [32]byte
+	_, err := rand.Read(private[:])
+	if err != nil {
+		panic(fmt.Sprintf("reading from random: %s", err))
+	}
+
+	public, err := curve25519.X25519(private[:], curve25519.Basepoint)
+	if err != nil {
+		panic(fmt.Sprintf("can't mult: %s", err))
+	}
+
+	return base64.StdEncoding.EncodeToString(public[:]),
+		base64.StdEncoding.EncodeToString(private[:])
+}

--- a/pkg/wg/state.go
+++ b/pkg/wg/state.go
@@ -1,0 +1,68 @@
+package wg
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/superfly/flyctl/api"
+)
+
+type WireGuardState struct {
+	Org          string
+	Name         string
+	Region       string
+	LocalPublic  string
+	LocalPrivate string
+	DNS          string
+	Peer         api.CreatedWireGuardPeer
+}
+
+// BUG(tqbf): Obviously all this needs to go, and I should just
+// make my code conform to the marshal/unmarshal protocol wireguard-go
+// uses, but in the service of landing this feature, I'm just going
+// to apply a layer of spackle for now.
+func (s *WireGuardState) TunnelConfig() *Config {
+	skey := PrivateKey{}
+	if err := skey.UnmarshalText([]byte(s.LocalPrivate)); err != nil {
+		panic(fmt.Sprintf("martian local private key: %s", err))
+	}
+
+	pkey := PublicKey{}
+	if err := pkey.UnmarshalText([]byte(s.Peer.Pubkey)); err != nil {
+		panic(fmt.Sprintf("martian local public key: %s", err))
+	}
+
+	_, lnet, err := net.ParseCIDR(fmt.Sprintf("%s/120", s.Peer.Peerip))
+	if err != nil {
+		panic(fmt.Sprintf("martian local public: %s/120: %s", s.Peer.Peerip, err))
+	}
+
+	raddr := net.ParseIP(s.Peer.Peerip).To16()
+	for i := 6; i < 16; i++ {
+		raddr[i] = 0
+	}
+
+	// BUG(tqbf): for now, we never manage tunnels for different
+	// organizations, and while this comment is eating more space
+	// than the code I'd need to do this right, it's more fun to
+	// type, so we just hardcode.
+	_, rnet, _ := net.ParseCIDR(fmt.Sprintf("%s/48", raddr))
+
+	raddr[15] = 3
+	dns := net.ParseIP(raddr.String())
+
+	// BUG(tqbf): I think this dance just because these needed to
+	// parse for Ben's TOML code.
+	wgl := IPNet(*lnet)
+	wgr := IPNet(*rnet)
+
+	return &Config{
+		LocalPrivateKey: skey,
+		LocalNetwork:    &wgl,
+		RemotePublicKey: pkey,
+		RemoteNetwork:   &wgr,
+		Endpoint:        s.Peer.Endpointip + ":51820",
+		DNS:             dns,
+		// LogLevel:        9999999,
+	}
+}


### PR DESCRIPTION
- remote builder connects directly to dockerd via an on-demand wireguard tunnel, just like `ssh console`, bypassing the problematic proxy
- move `wireGuardCreate` & `wireGuardForOrg` from `cmd` to `internal/wireguard` so docker code can reach it
- automatically pick the closest gateway region and auto-generate a peer name instead of prompting if region or name are blank
