### PR TITLE
flyname: cache os.Executable during init

### DIFF
--- a/flyname/flyname.go
+++ b/flyname/flyname.go
@@ -1,3 +1,8 @@
+// Package flyname implements an efficient way of resolving the name of the
+// executable.
+//
+// Importing this package will result into a runtime panic in situations where
+// os.Executable would report an error.
 package flyname
 
 import (
@@ -5,16 +10,20 @@ import (
 	"path/filepath"
 )
 
-var cachedName string
+var cachedName string // populated during init
 
-// Name - get the (cached) executable name
-func Name() string {
-	if cachedName == "" {
-		execname, err := os.Executable()
-		if err != nil {
-			panic(err)
-		}
-		cachedName = filepath.Base(execname)
+func init() {
+	var err error
+	if cachedName, err = os.Executable(); err != nil {
+		panic(err)
 	}
+	cachedName = filepath.Base(cachedName)
+}
+
+// Name returns the name for the executable that started the current
+// process.
+//
+// Name is safe for concurrent use.
+func Name() string {
 	return cachedName
 }

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/logrusorgru/aurora"
 	"github.com/superfly/flyctl/cmd"
 	"github.com/superfly/flyctl/flyctl"
+	"github.com/superfly/flyctl/flyname"
 	"github.com/superfly/flyctl/internal/client"
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/update"

--- a/main.go
+++ b/main.go
@@ -12,12 +12,10 @@ import (
 	"github.com/logrusorgru/aurora"
 	"github.com/superfly/flyctl/cmd"
 	"github.com/superfly/flyctl/flyctl"
-	"github.com/superfly/flyctl/flyname"
 	"github.com/superfly/flyctl/internal/client"
 )
 
 func main() {
-	flyname.Name() // Initialise
 	opts := sentry.ClientOptions{
 		Dsn: "https://89fa584dc19b47a6952dd94bf72dbab4@sentry.io/4492967",
 		// Debug:       true,


### PR DESCRIPTION
This PR refactors the way the `flyname` package caches the executable's name while at the same time making `flyname.Name` safe for concurrent use.

It additionally eliminates the need for calling `Name` in [main](https://github.com/superfly/flyctl/blob/4652ebd3cb70634b173e242b449f366433f55ed1/main.go#L20) as the package will now panic during the initialization process.

