### PR TITLE
Add app runtime environment command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/superfly/flyctl/cmd/presenters"
 	"github.com/superfly/flyctl/cmdctx"
 	"github.com/superfly/flyctl/internal/client"
 
@@ -29,6 +30,9 @@ func newConfigCommand(client *client.Client) *Command {
 
 	configValidateStrings := docstrings.Get("config.validate")
 	BuildCommandKS(cmd, runValidateConfig, configValidateStrings, client, requireSession, requireAppName)
+
+	configEnvStrings := docstrings.Get("config.env")
+	BuildCommandKS(cmd, runEnvConfig, configEnvStrings, client, requireSession, requireAppName)
 
 	return cmd
 }
@@ -100,6 +104,30 @@ func runValidateConfig(commandContext *cmdctx.CmdContext) error {
 	printAppConfigErrors(*serverCfg)
 
 	return errors.New("App configuration is not valid")
+}
+
+func runEnvConfig(ctx *cmdctx.CmdContext) error {
+	secrets, err := ctx.Client.API().GetAppSecrets(ctx.AppName)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := ctx.Client.API().GetConfig(ctx.AppName)
+	if err != nil {
+		return err
+	}
+
+	vars := cfg.Definition["env"].(map[string]interface{})
+	// if !ok {
+	// 	return fmt.Errorf("can not parse environment variables")
+	// }
+
+	env := &presenters.Environment{
+		Secrets: secrets,
+		Envs:    vars,
+	}
+
+	return ctx.Render(env)
 }
 
 func printAppConfigErrors(cfg api.AppConfig) {

--- a/cmd/presenters/env.go
+++ b/cmd/presenters/env.go
@@ -1,0 +1,40 @@
+package presenters
+
+import (
+	"fmt"
+
+	"github.com/superfly/flyctl/api"
+)
+
+type Environment struct {
+	Secrets []api.Secret
+	Envs    map[string]interface{}
+}
+
+func (p *Environment) APIStruct() interface{} {
+	return nil
+}
+func (p *Environment) FieldNames() []string {
+	return []string{"Name", "Type", "Value"}
+}
+
+func (p *Environment) Records() []map[string]string {
+	out := []map[string]string{}
+
+	for _, secret := range p.Secrets {
+		out = append(out, map[string]string{
+			"Name":  secret.Name,
+			"Type":  "Secret",
+			"Value": "REDACTED",
+		})
+	}
+
+	for key, value := range p.Envs {
+		out = append(out, map[string]string{
+			"Name":  key,
+			"Type":  "Variable",
+			"Value": fmt.Sprintf("%v", value),
+		})
+	}
+	return out
+}

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -220,6 +220,11 @@ Takes hostname as a parameter to locate the certificate.`,
 			`Display an application's configuration. The configuration is presented 
 in JSON format. The configuration data is retrieved from the Fly service.`,
 		}
+	case "config.env":
+		return KeyStrings{"env", "Display an app's runtime environment variables",
+			`Display a running app's runtime environment with config file in the
+form of NAME:VALUE while secrets being retracted are the form of SECRET_NAME:DIGEST`,
+		}
 	case "config.save":
 		return KeyStrings{"save", "Save an app's config file",
 			`Save an application's configuration locally. The configuration data is 

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -297,6 +297,12 @@ retrieved from the Fly service and saved in TOML format.
     longHelp  = """Validates an application's config file against the Fly platform to 
 ensure it is correct and meaningful to the platform. 
 """
+    [config.env]
+    usage =  "env"
+    shortHelp = "Display an app's runtime environment variables"
+    longHelp = """Display a running app's runtime environment with config file in the
+form of NAME:VALUE while secrets being retracted are the form of SECRET_NAME:DIGEST
+"""
 
 [dashboard]
 usage     = "dashboard"


### PR DESCRIPTION
This PR adds a new config subcommand `flyctl config env` that displays
an app's environment variables as seen by the app at runtime.

Example:
```sh
$ flyctl config env --app database
NAME           TYPE     VALUE
REPL_PASSWORD  Secret   REDACTED
SU_PASSWORD    Secret   REDACTED
PRIMARY_REGION Variable lhr
```

Notes:
* It redacts the values of secrets since they are not available throug the API.
