### PR TITLE
Add app runtime environment command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -112,14 +112,16 @@ func runEnvConfig(ctx *cmdctx.CmdContext) error {
 		return err
 	}
 
-	cfg, err := ctx.Client.API().GetConfig(ctx.AppName)
-	if err != nil {
-		return err
+	if len(secrets) > 0 {
+		err = ctx.Frender(cmdctx.PresenterOption{Presentable: &presenters.Secrets{Secrets: secrets},
+			Title: "Secrets",
+		})
+		if err != nil {
+			return err
+		}
 	}
 
-	err = ctx.Frender(cmdctx.PresenterOption{Presentable: &presenters.Secrets{Secrets: secrets},
-		Title: "Secrets",
-	})
+	cfg, err := ctx.Client.API().GetConfig(ctx.AppName)
 	if err != nil {
 		return err
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/superfly/flyctl/cmd/presenters"
 	"github.com/superfly/flyctl/cmdctx"
 	"github.com/superfly/flyctl/internal/client"
 
@@ -29,6 +30,9 @@ func newConfigCommand(client *client.Client) *Command {
 
 	configValidateStrings := docstrings.Get("config.validate")
 	BuildCommandKS(cmd, runValidateConfig, configValidateStrings, client, requireSession, requireAppName)
+
+	configEnvStrings := docstrings.Get("config.env")
+	BuildCommandKS(cmd, runEnvConfig, configEnvStrings, client, requireSession, requireAppName)
 
 	return cmd
 }
@@ -100,6 +104,30 @@ func runValidateConfig(commandContext *cmdctx.CmdContext) error {
 	printAppConfigErrors(*serverCfg)
 
 	return errors.New("App configuration is not valid")
+}
+
+func runEnvConfig(ctx *cmdctx.CmdContext) error {
+	secrets, err := ctx.Client.API().GetAppSecrets(ctx.AppName)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := ctx.Client.API().GetConfig(ctx.AppName)
+	if err != nil {
+		return err
+	}
+
+	vars := cfg.Definition["env"].(map[string]interface{})
+	// if !ok {
+	// 	return fmt.Errorf("can not parse environment variables")
+	// }
+
+	env := &presenters.Environment{
+		Secrets: secrets,
+		Envs:    vars,
+	}
+
+	return ctx.Render(env)
 }
 
 func printAppConfigErrors(cfg api.AppConfig) {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -117,17 +117,28 @@ func runEnvConfig(ctx *cmdctx.CmdContext) error {
 		return err
 	}
 
-	vars := cfg.Definition["env"].(map[string]interface{})
-	// if !ok {
-	// 	return fmt.Errorf("can not parse environment variables")
-	// }
-
-	env := &presenters.Environment{
-		Secrets: secrets,
-		Envs:    vars,
+	err = ctx.Frender(cmdctx.PresenterOption{Presentable: &presenters.Secrets{Secrets: secrets},
+		Title: "Secrets",
+	})
+	if err != nil {
+		return err
 	}
 
-	return ctx.Render(env)
+	if cfg.Definition != nil {
+		vars, ok := cfg.Definition["env"].(map[string]interface{})
+		if !ok {
+			return nil
+		}
+
+		err = ctx.Frender(cmdctx.PresenterOption{Presentable: &presenters.Environment{
+			Envs: vars,
+		}, Title: "Environment variables"})
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func printAppConfigErrors(cfg api.AppConfig) {

--- a/cmd/presenters/env.go
+++ b/cmd/presenters/env.go
@@ -1,0 +1,40 @@
+package presenters
+
+import (
+	"fmt"
+
+	"github.com/superfly/flyctl/api"
+)
+
+type Environment struct {
+	Secrets []api.Secret
+	Envs    map[string]interface{}
+}
+
+func (p *Environment) APIStruct() interface{} {
+	return nil
+}
+func (p *Environment) FieldNames() []string {
+	return []string{"Name", "Type", "Value"}
+}
+
+func (p *Environment) Records() []map[string]string {
+	out := []map[string]string{}
+
+	for _, secret := range p.Secrets {
+		out = append(out, map[string]string{
+			"Name":  secret.Name,
+			"Type":  "Secret",
+			"Value": "REDACTED",
+		})
+	}
+
+	for key, value := range p.Envs {
+		out = append(out, map[string]string{
+			"Name":  key,
+			"Type":  "Variable",
+			"Value": fmt.Sprintf("%v", value),
+		})
+	}
+	return out
+}

--- a/cmd/presenters/env.go
+++ b/cmd/presenters/env.go
@@ -2,37 +2,25 @@ package presenters
 
 import (
 	"fmt"
-
-	"github.com/superfly/flyctl/api"
 )
 
 type Environment struct {
-	Secrets []api.Secret
-	Envs    map[string]interface{}
+	Envs map[string]interface{}
 }
 
 func (p *Environment) APIStruct() interface{} {
 	return nil
 }
 func (p *Environment) FieldNames() []string {
-	return []string{"Name", "Type", "Value"}
+	return []string{"Name", "Value"}
 }
 
 func (p *Environment) Records() []map[string]string {
 	out := []map[string]string{}
 
-	for _, secret := range p.Secrets {
-		out = append(out, map[string]string{
-			"Name":  secret.Name,
-			"Type":  "Secret",
-			"Value": "REDACTED",
-		})
-	}
-
 	for key, value := range p.Envs {
 		out = append(out, map[string]string{
 			"Name":  key,
-			"Type":  "Variable",
 			"Value": fmt.Sprintf("%v", value),
 		})
 	}

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -222,8 +222,8 @@ in JSON format. The configuration data is retrieved from the Fly service.`,
 		}
 	case "config.env":
 		return KeyStrings{"env", "Display an app's runtime environment variables",
-			`Display a running app's runtime environment with config file in the
-form of NAME:VALUE while secrets being retracted are the form of SECRET_NAME:DIGEST`,
+			`Display an app's runtime environment variables. It displays a section for
+secrets and another for config file defined environment variables.`,
 		}
 	case "config.save":
 		return KeyStrings{"save", "Save an app's config file",

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -220,6 +220,11 @@ Takes hostname as a parameter to locate the certificate.`,
 			`Display an application's configuration. The configuration is presented 
 in JSON format. The configuration data is retrieved from the Fly service.`,
 		}
+	case "config.env":
+		return KeyStrings{"env", "Display an app's runtime environment variables",
+			`Display a running app's runtime environment with config file in the
+form of NAME:VALUE while secrets being retracted are the form of SECRET_NAME:DIGEST`,
+		}
 	case "config.save":
 		return KeyStrings{"save", "Save an app's config file",
 			`Save an application's configuration locally. The configuration data is 

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -297,6 +297,12 @@ retrieved from the Fly service and saved in TOML format.
     longHelp  = """Validates an application's config file against the Fly platform to 
 ensure it is correct and meaningful to the platform. 
 """
+    [config.env]
+    usage =  "env"
+    shortHelp = "Display an app's runtime environment variables"
+    longHelp = """Display a running app's runtime environment with config file in the
+form of NAME:VALUE while secrets being retracted are the form of SECRET_NAME:DIGEST
+"""
 
 [dashboard]
 usage     = "dashboard"

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -300,8 +300,8 @@ ensure it is correct and meaningful to the platform.
     [config.env]
     usage =  "env"
     shortHelp = "Display an app's runtime environment variables"
-    longHelp = """Display a running app's runtime environment with config file in the
-form of NAME:VALUE while secrets being retracted are the form of SECRET_NAME:DIGEST
+    longHelp = """Display an app's runtime environment variables. It displays a section for
+secrets and another for config file defined environment variables.
 """
 
 [dashboard]


### PR DESCRIPTION
Renaming the branch(had a typo) removed the PR entirely.  

 This PR adds a new config subcommand `flyctl config env` that displays
    an app's runtime environment variables as seen by the app at runtime.
    
    Example:
    ```sh
    $ flyctl config env --app database
    NAME           TYPE     VALUE
    REPL_PASSWORD  Secret   REDACTED
    SU_PASSWORD    Secret   REDACTED
    PRIMARY_REGION Variable lhr
    ```
    
    Notes:
    * It redacts the values of secrets since they are not available through the API.
