### PR TITLE
Small Spelling Fix For Docstrings Gen

### DIFF
--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -237,7 +237,7 @@ ensure it is correct and meaningful to the platform.`,
 		}
 	case "curl":
 		return KeyStrings{"curl <url>", "Run a performance test against a url",
-			`Run a performance test againt a url.`,
+			`Run a performance test against a url.`,
 		}
 	case "dashboard":
 		return KeyStrings{"dashboard", "Open web browser on Fly Web UI for this app",


### PR DESCRIPTION
- small spelling adjustment on curl case KeyString from "againt" to "against" in switch
block

Resolves: docs/small-docstrings-spelling-fix