### PR TITLE
fly ssh establish <arg> errors #415

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -181,7 +181,7 @@ func runSSHEstablish(ctx *cmdctx.CmdContext) error {
 	}
 
 	override := false
-	if len(ctx.Args) >= 1 && ctx.Args[1] == "override" {
+	if len(ctx.Args) >= 2 && ctx.Args[1] == "override" {
 		override = true
 	}
 


### PR DESCRIPTION
If we want to override and provide the organization name the length of args will be `2` instead of `1`.

Solves https://github.com/superfly/flyctl/issues/415

```bash
user@fun python-hellofly-flask]$ ~/fly-fun/flyctl/bin/flyctl ssh establish override
Error Could not resolve Organization
[user@fun python-hellofly-flask]$ ~/fly-fun/flyctl/bin/flyctl ssh establish personal override
Establishing SSH CA cert for organization personal
New organization root certificate:
ssh-ed25519-cert-v01@openssh.com AAAA....
.....
```