### PR TITLE
Quote variables in installer.sh

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -8,7 +8,7 @@ os=$(uname -s)
 arch=$(uname -m)
 version=${1:-latest}
 
-flyctl_uri=$(curl -s https://api.fly.io/app/flyctl_releases/$os/$arch/$version)
+flyctl_uri=$(curl -s "https://api.fly.io/app/flyctl_releases/$os/$arch/$version")
 if [ ! "$flyctl_uri" ]; then
 	echo "Error: Unable to find a flyctl release for $os/$arch/$version - see github.com/superfly/flyctl/releases for all versions" 1>&2
 	exit 1
@@ -29,7 +29,7 @@ cd "$bin_dir"
 tar xzf "$exe.tar.gz"
 chmod +x "$exe"
 rm "$exe.tar.gz"
-ln -sf $exe $simexe
+ln -sf "$exe" "$simexe"
 
 if [ "${1}" = "prerel" ] || [ "${1}" = "pre" ]; then
 	"$exe" version -s "shell-prerel"


### PR DESCRIPTION
Addresses ShellCheck warnings about SC2086: Double quote to prevent
globbing and word splitting.