### PR TITLE
Postgres connect

### DIFF
--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -91,6 +91,10 @@ func (client *Client) GetApp(ctx context.Context, appName string) (*App, error) 
 						createdAt
 					}
 				}
+				imageDetails {
+					repository
+					version
+				}
 			}
 		}
 	`

--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -648,7 +648,7 @@ func runPostgresConnect(cmdCtx *cmdctx.CmdContext) error {
 	if imageVersion.LessThan(requiredVersion) {
 		return fmt.Errorf(
 			"Image version is not compatible. (Current: %s, Required: >= %s)\n"+
-				"Please run 'flyctl image show' and update to the latest image version.",
+				"Please run 'flyctl image show' and update to the latest available version.",
 			imageVersion, requiredVersion.String())
 	}
 

--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -617,7 +617,7 @@ func runPostgresConnect(cmdCtx *cmdctx.CmdContext) error {
 		return fmt.Errorf("get app: %w", err)
 	}
 
-	// Validate image version and ensure it's compatible with this feature.
+	// Validate image version to ensure it's compatible with this feature.
 	imageVersionStr := app.ImageDetails.Version[1:]
 	imageVersion, err := version.NewVersion(imageVersionStr)
 	if err != nil {
@@ -627,12 +627,14 @@ func runPostgresConnect(cmdCtx *cmdctx.CmdContext) error {
 	// Specify compatible versions per repo.
 	requiredVersion := &version.Version{}
 	if app.ImageDetails.Repository == "flyio/postgres-standalone" {
+		// https://github.com/fly-apps/postgres-standalone/releases/tag/v0.0.4
 		requiredVersion, err = version.NewVersion("0.0.4")
 		if err != nil {
 			return err
 		}
 	}
 	if app.ImageDetails.Repository == "flyio/postgres" {
+		// https://github.com/fly-apps/postgres-ha/releases/tag/v0.0.9
 		requiredVersion, err = version.NewVersion("0.0.9")
 		if err != nil {
 			return err

--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -608,8 +608,11 @@ func runDetachPostgresCluster(cmdCtx *cmdctx.CmdContext) error {
 }
 
 func runPostgresConnect(cmdCtx *cmdctx.CmdContext) error {
-	ctx := cmdCtx.Command.Context()
+	// Minimum image version requirements
+	MinPostgresStandaloneVersion := "0.0.4"
+	MinPostgresHaVersion := "0.0.9"
 
+	ctx := cmdCtx.Command.Context()
 	client := cmdCtx.Client.API()
 
 	app, err := client.GetApp(ctx, cmdCtx.AppName)
@@ -628,14 +631,14 @@ func runPostgresConnect(cmdCtx *cmdctx.CmdContext) error {
 	requiredVersion := &version.Version{}
 	if app.ImageDetails.Repository == "flyio/postgres-standalone" {
 		// https://github.com/fly-apps/postgres-standalone/releases/tag/v0.0.4
-		requiredVersion, err = version.NewVersion("0.0.4")
+		requiredVersion, err = version.NewVersion(MinPostgresStandaloneVersion)
 		if err != nil {
 			return err
 		}
 	}
 	if app.ImageDetails.Repository == "flyio/postgres" {
 		// https://github.com/fly-apps/postgres-ha/releases/tag/v0.0.9
-		requiredVersion, err = version.NewVersion("0.0.9")
+		requiredVersion, err = version.NewVersion(MinPostgresHaVersion)
 		if err != nil {
 			return err
 		}

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -561,6 +561,10 @@ about the Fly platform.`,
 		return KeyStrings{"attach", "Attach a postgres cluster to an app",
 			`Attach a postgres cluster to an app`,
 		}
+	case "postgres.connect":
+		return KeyStrings{"connect", "Connect to postgres cluster",
+			`Connect to a postgres cluster`,
+		}
 	case "postgres.create":
 		return KeyStrings{"create", "Create a postgres cluster",
 			`Create a postgres cluster`,

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -563,7 +563,7 @@ about the Fly platform.`,
 		}
 	case "postgres.connect":
 		return KeyStrings{"connect", "Connect to postgres cluster",
-			`Connect to a postgres cluster`,
+			`Connect to postgres cluster`,
 		}
 	case "postgres.create":
 		return KeyStrings{"create", "Create a postgres cluster",

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/gofrs/flock v0.7.3
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/heroku/heroku-go/v5 v5.4.0
 	github.com/inancgumus/screen v0.0.0-20190314163918-06e984b86ed3
 	github.com/jpillora/backoff v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gofrs/flock v0.7.3
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/go-version v1.3.0 // indirect
+	github.com/hashicorp/go-version v1.3.0
 	github.com/heroku/heroku-go/v5 v5.4.0
 	github.com/inancgumus/screen v0.0.0-20190314163918-06e984b86ed3
 	github.com/jpillora/backoff v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -789,6 +789,8 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
+github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -516,6 +516,10 @@ usage = "attach"
 [postgres.create]
 longHelp = "Create a postgres cluster"
 shortHelp = "Create a postgres cluster"
+[postgres.connect]
+usage     = "connect"
+shortHelp = "Connect to postgres cluster"
+longHelp  = "Connect to a postgres cluster"
 usage = "create"
 [postgres.db]
 longHelp = "manage databases in a cluster"

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -513,13 +513,13 @@ usage = "postgres"
 longHelp = "Attach a postgres cluster to an app"
 shortHelp = "Attach a postgres cluster to an app"
 usage = "attach"
+[postgres.connect]
+shortHelp = "Connect to postgres cluster"
+longHelp  = "Connect to a postgres cluster"
+usage     = "connect"
 [postgres.create]
 longHelp = "Create a postgres cluster"
 shortHelp = "Create a postgres cluster"
-[postgres.connect]
-usage     = "connect"
-shortHelp = "Connect to postgres cluster"
-longHelp  = "Connect to a postgres cluster"
 usage = "create"
 [postgres.db]
 longHelp = "manage databases in a cluster"

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -515,7 +515,7 @@ shortHelp = "Attach a postgres cluster to an app"
 usage = "attach"
 [postgres.connect]
 shortHelp = "Connect to postgres cluster"
-longHelp  = "Connect to a postgres cluster"
+longHelp  = "Connect to postgres cluster"
 usage     = "connect"
 [postgres.create]
 longHelp = "Create a postgres cluster"


### PR DESCRIPTION
Postgres connect allows you to quickly connect to a specified Postgres cluster.  

```
Connect to a postgres cluster

Usage:
  flyctl postgres connect [flags]

Flags:
  -a, --app string        App name to operate on
  -c, --config string     Path to an app config file or directory containing one (default "./fly.toml")
      --database string   The postgres database to connect to
  -h, --help              help for connect
      --password string   The postgres user password
      --user string       The postgres user to connect with

Global Flags:
  -t, --access-token string   Fly API Access Token
  -j, --json                  json output
      --verbose               verbose output
 ```
 
 