### PR TITLE
Send agent to wireguard connection failures to sentry

### DIFF
--- a/cmd/ssh_terminal.go
+++ b/cmd/ssh_terminal.go
@@ -29,7 +29,6 @@ func runSSHConsole(ctx *cmdctx.CmdContext) error {
 	agentclient, err := EstablishFlyAgent(ctx)
 	if err != nil {
 		return fmt.Errorf("can't establish agent: %s\n", err)
-		return err
 	}
 
 	dialer, err := agentclient.Dialer(&app.Organization)


### PR DESCRIPTION
* Send `wireguard.Connect` errors.
* Send `tunnel.Resolver` errors.

Closes #466
