### PR TITLE
Update app move confirmation msg

### DIFF
--- a/cmd/move.go
+++ b/cmd/move.go
@@ -51,7 +51,9 @@ func runMove(commandContext *cmdctx.CmdContext) error {
 	}
 
 	if !commandContext.Config.GetBool("yes") {
-		fmt.Println(aurora.Red("Are you sure you want to move this app?"))
+		fmt.Println(aurora.Red(`Moving an app between organizations requires a complete shutdown and restart. This will result in some app downtime.
+If the app relies on other services within the current organization, it may not come back up in a healthy manner.
+Please confirm you wish to restart this app now?`))
 
 		confirm := false
 		prompt := &survey.Confirm{


### PR DESCRIPTION
Fixes #441 

It will change the confirmation message from the following:
``` bash
 $ fly apps move icy-shadow-8099                                                                                                                 master  ✱

App 'icy-shadow-8099' is currently in organization 'personal'
? Select organization: Amal Al-khamees (personal)
Are you sure you want to move this app?
? Move icy-shadow-8099 from personal to personal? Yes
``` 
to 
``` bash
 $ fly apps move icy-shadow-8099                                                                                                                 master  ✱

App 'icy-shadow-8099' is currently in organization 'personal'
? Select organization: Amal Al-khamees (personal)
Moving an app between organizations requires a complete shutdown and restart. This will result in some app downtime.
If the app relies on other services within the current organization, it may not come back up in a healthy manner.
Please confirm you wish to restart this app now?
Move icy-shadow-8099 from personal to personal? Yes
```