### PR TITLE
[WIP] Close invalid tunnels without restarting agent

### DIFF
--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -111,7 +111,7 @@ func C25519pair() (string, string) {
 
 type WireGuardStates map[string]*wg.WireGuardState
 
-func getWireGuardState() (WireGuardStates, error) {
+func GetWireGuardState() (WireGuardStates, error) {
 	states := WireGuardStates{}
 
 	if err := viper.UnmarshalKey(flyctl.ConfigWireGuardState, &states); err != nil {
@@ -122,7 +122,7 @@ func getWireGuardState() (WireGuardStates, error) {
 }
 
 func getWireGuardStateForOrg(orgSlug string) (*wg.WireGuardState, error) {
-	states, err := getWireGuardState()
+	states, err := GetWireGuardState()
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func setWireGuardState(s WireGuardStates) error {
 }
 
 func setWireGuardStateForOrg(orgSlug string, s *wg.WireGuardState) error {
-	states, err := getWireGuardState()
+	states, err := GetWireGuardState()
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func setWireGuardStateForOrg(orgSlug string, s *wg.WireGuardState) error {
 }
 
 func PruneInvalidPeers(apiClient *api.Client) error {
-	state, err := getWireGuardState()
+	state, err := GetWireGuardState()
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
@rugwirobaker This stubs out what (_I think_) we can do to remove invalid tunnels from the agent without restarting. When we detect the WireGuard state has changed in the handler, run `validateTunnels` on the server to close any invalid tunnels. New tunnels will be created as needed after that. 