### PR TITLE
Detect WireGuard peer changes in the agent

### DIFF
--- a/flyctl/config.go
+++ b/flyctl/config.go
@@ -15,8 +15,8 @@ const (
 	ConfigInstaller       = "installer"
 	BuildKitNodeID        = "buildkit_node_id"
 
-	ConfigWireGuardState          = "wire_guard_state"
-	ConfigWireGuardStateTimestamp = "wire_guard_state_timestamp"
+	ConfigWireGuardState = "wire_guard_state"
+	// ConfigWireGuardStateTimestamp = "wire_guard_state_timestamp"
 
 	ConfigRegistryHost = "registry_host"
 )

--- a/flyctl/config.go
+++ b/flyctl/config.go
@@ -16,7 +16,6 @@ const (
 	BuildKitNodeID        = "buildkit_node_id"
 
 	ConfigWireGuardState = "wire_guard_state"
-	// ConfigWireGuardStateTimestamp = "wire_guard_state_timestamp"
 
 	ConfigRegistryHost = "registry_host"
 )

--- a/flyctl/flyctl.go
+++ b/flyctl/flyctl.go
@@ -122,7 +122,7 @@ func GetAPIToken() string {
 
 }
 
-var writeableConfigKeys = []string{ConfigAPIToken, ConfigInstaller, ConfigWireGuardState, BuildKitNodeID, ConfigWireGuardStateTimestamp}
+var writeableConfigKeys = []string{ConfigAPIToken, ConfigInstaller, ConfigWireGuardState, BuildKitNodeID}
 
 func SaveConfig() error {
 	BackgroundTaskWG.Add(1)

--- a/flyctl/flyctl.go
+++ b/flyctl/flyctl.go
@@ -31,7 +31,8 @@ func ConfigDir() string {
 	return configDir
 }
 
-func configFilePath() string {
+// ConfigFilePath - returns the path to the config file
+func ConfigFilePath() string {
 	return path.Join(configDir, "config.yml")
 }
 
@@ -77,7 +78,7 @@ func loadConfig() error {
 		return nil
 	}
 
-	viper.SetConfigFile(configFilePath())
+	viper.SetConfigFile(ConfigFilePath())
 	viper.SetConfigType("yaml")
 
 	err := viper.ReadInConfig()
@@ -140,7 +141,7 @@ func SaveConfig() error {
 		return err
 	}
 
-	return ioutil.WriteFile(configFilePath(), data, 0600)
+	return ioutil.WriteFile(ConfigFilePath(), data, 0600)
 }
 
 func persistConfigKey(key string) bool {

--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -111,7 +111,7 @@ func C25519pair() (string, string) {
 
 type WireGuardStates map[string]*wg.WireGuardState
 
-func getWireGuardState() (WireGuardStates, error) {
+func GetWireGuardState() (WireGuardStates, error) {
 	states := WireGuardStates{}
 
 	if err := viper.UnmarshalKey(flyctl.ConfigWireGuardState, &states); err != nil {
@@ -122,7 +122,7 @@ func getWireGuardState() (WireGuardStates, error) {
 }
 
 func getWireGuardStateForOrg(orgSlug string) (*wg.WireGuardState, error) {
-	states, err := getWireGuardState()
+	states, err := GetWireGuardState()
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func setWireGuardState(s WireGuardStates) error {
 }
 
 func setWireGuardStateForOrg(orgSlug string, s *wg.WireGuardState) error {
-	states, err := getWireGuardState()
+	states, err := GetWireGuardState()
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func setWireGuardStateForOrg(orgSlug string, s *wg.WireGuardState) error {
 }
 
 func PruneInvalidPeers(apiClient *api.Client) error {
-	state, err := getWireGuardState()
+	state, err := GetWireGuardState()
 	if err != nil {
 		return nil
 	}

--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"time"
 
 	badrand "math/rand"
 
@@ -132,7 +131,7 @@ func getWireGuardStateForOrg(orgSlug string) (*wg.WireGuardState, error) {
 
 func setWireGuardState(s WireGuardStates) error {
 	viper.Set(flyctl.ConfigWireGuardState, s)
-	viper.Set(flyctl.ConfigWireGuardStateTimestamp, time.Now())
+	// viper.Set(flyctl.ConfigWireGuardStateTimestamp, time.Now())
 	if err := flyctl.SaveConfig(); err != nil {
 		return errors.Wrap(err, "error saving config file")
 	}
@@ -180,6 +179,6 @@ func PruneInvalidPeers(apiClient *api.Client) error {
 	return setWireGuardState(state)
 }
 
-func LastWireGuardStateChange() time.Time {
-	return viper.GetTime(flyctl.ConfigWireGuardStateTimestamp)
-}
+// func LastWireGuardStateChange() time.Time {
+// 	return viper.GetTime(flyctl.ConfigWireGuardStateTimestamp)
+// }

--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -131,7 +131,6 @@ func getWireGuardStateForOrg(orgSlug string) (*wg.WireGuardState, error) {
 
 func setWireGuardState(s WireGuardStates) error {
 	viper.Set(flyctl.ConfigWireGuardState, s)
-	// viper.Set(flyctl.ConfigWireGuardStateTimestamp, time.Now())
 	if err := flyctl.SaveConfig(); err != nil {
 		return errors.Wrap(err, "error saving config file")
 	}
@@ -178,7 +177,3 @@ func PruneInvalidPeers(apiClient *api.Client) error {
 
 	return setWireGuardState(state)
 }
-
-// func LastWireGuardStateChange() time.Time {
-// 	return viper.GetTime(flyctl.ConfigWireGuardStateTimestamp)
-// }


### PR DESCRIPTION
- [x] cache last wireguard state change on agent start up.`
- [x] check for any change on every `agent.handle` call.
- [x] what if `config.yml` has been manually modified?
 
Fixes #488 