### PR TITLE
Add distinct name for WireGuard connections generated by the agent

### DIFF
--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -24,6 +24,23 @@ var (
 	cleanDNSPattern = regexp.MustCompile(`[^a-zA-Z0-9\\-]`)
 )
 
+func gernateConnectionnName(apiClient *api.Client, ctx context.Context) (string, error) {
+	user, err := apiClient.GetCurrentUser(ctx)
+	if err != nil {
+		return "", err
+	}
+	emailSlug := cleanDNSPattern.ReplaceAllString(user.Email, "-")
+
+	host, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+	hostSlug := cleanDNSPattern.ReplaceAllString(strings.Split(host, ".")[0], "-")
+
+	name := fmt.Sprintf("%s-%s-%d", hostSlug, emailSlug, badrand.Intn(1000)) // skipcq: GSC-G404
+	return name, nil
+}
+
 func StateForOrg(apiClient *api.Client, org *api.Organization, regionCode string, name string) (*wg.WireGuardState, error) {
 	state, err := getWireGuardStateForOrg(org.Slug)
 	if err != nil {
@@ -34,6 +51,16 @@ func StateForOrg(apiClient *api.Client, org *api.Organization, regionCode string
 	}
 
 	terminal.Debugf("Can't find matching WireGuard configuration; creating new one\n")
+
+	ctx := context.TODO()
+	if name == "" {
+		n, err := gernateConnectionnName(apiClient, ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		name = fmt.Sprintf("agent-%s", n)
+	}
 
 	stateb, err := Create(apiClient, org, regionCode, name)
 	if err != nil {
@@ -55,19 +82,12 @@ func Create(apiClient *api.Client, org *api.Organization, regionCode, name strin
 	)
 
 	if name == "" {
-		user, err := apiClient.GetCurrentUser(ctx)
+		n, err := gernateConnectionnName(apiClient, ctx)
 		if err != nil {
 			return nil, err
 		}
-		emailSlug := cleanDNSPattern.ReplaceAllString(user.Email, "-")
 
-		host, err := os.Hostname()
-		if err != nil {
-			return nil, err
-		}
-		hostSlug := cleanDNSPattern.ReplaceAllString(strings.Split(host, ".")[0], "-")
-
-		name = fmt.Sprintf("interactive-%s-%s-%d", hostSlug, emailSlug, badrand.Intn(1000)) // skipcq: GSC-G404
+		name = fmt.Sprintf("interactive-%s", n)
 	}
 
 	if regionCode == "" {

--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -24,7 +24,7 @@ var (
 	cleanDNSPattern = regexp.MustCompile(`[^a-zA-Z0-9\\-]`)
 )
 
-func gernateConnectionnName(apiClient *api.Client, ctx context.Context) (string, error) {
+func generatePeerName(ctx context.Context, apiClient *api.Client) (string, error) {
 	user, err := apiClient.GetCurrentUser(ctx)
 	if err != nil {
 		return "", err
@@ -54,7 +54,7 @@ func StateForOrg(apiClient *api.Client, org *api.Organization, regionCode string
 
 	ctx := context.TODO()
 	if name == "" {
-		n, err := gernateConnectionnName(apiClient, ctx)
+		n, err := generatePeerName(ctx, apiClient)
 		if err != nil {
 			return nil, err
 		}
@@ -82,7 +82,7 @@ func Create(apiClient *api.Client, org *api.Organization, regionCode, name strin
 	)
 
 	if name == "" {
-		n, err := gernateConnectionnName(apiClient, ctx)
+		n, err := generatePeerName(ctx, apiClient)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -59,7 +59,7 @@ func StateForOrg(apiClient *api.Client, org *api.Organization, regionCode string
 			return nil, err
 		}
 
-		name = fmt.Sprintf("agent-%s", n)
+		name = fmt.Sprintf("interactive-agent-%s", n)
 	}
 
 	stateb, err := Create(apiClient, org, regionCode, name)


### PR DESCRIPTION
Fixes #465 

it will add the word "agent" to WireGuard connections generated by the agent, for example:
``` shell 
#  host-native WireGuard connections
$ interactive-amals-MacBook-amalkms5-gmail-com-724    

# agent WireGuard connections
$ agent-interactive-amals-MacBook-amalkms5-gmail-com-714
```