### PR TITLE
remove redundant defaults in flag descriptions

### DIFF
--- a/cmd/volumes.go
+++ b/cmd/volumes.go
@@ -35,13 +35,13 @@ func newVolumesCommand(client *client.Client) *Command {
 
 	createCmd.AddIntFlag(IntFlagOpts{
 		Name:        "size",
-		Description: "Size of volume in gigabytes, default 10GB",
+		Description: "Size of volume in gigabytes",
 		Default:     10,
 	})
 
 	createCmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "encrypted",
-		Description: "Encrypt the volume (default: true)",
+		Description: "Encrypt the volume",
 		Default:     true,
 	})
 


### PR DESCRIPTION
`flyctl volumes --help` lists defaults twice:

Create new volume for app. --region flag must be included to specify
region the volume exists in. --size flag is optional, defaults to 10,
sets the size as the number of gigabytes the volume will consume.

Usage:
  flyctl volumes create <volumename> [flags]

Flags:
  -a, --app string      App name to operate on
  -c, --config string   Path to an app config file or directory containing one (default "./fly.toml")
      --encrypted       Encrypt the volume **(default: true)** (default true)
  -h, --help            help for create
      --region string   Set region for new volume
      --size int        Size of volume in gigabytes**, default 10GB** (default 10)

Global Flags:
  -t, --access-token string   Fly API Access Token
  -j, --json                  json output
  -v, --verbose               verbose output
