### PR TITLE
Improve agent error handling

### DIFF
--- a/api/resource_remote_builders.go
+++ b/api/resource_remote_builders.go
@@ -7,6 +7,9 @@ func (client *Client) EnsureRemoteBuilderForApp(appName string) (string, *App, e
 				url,
 				app {
 					name
+					organization {
+						slug
+					}
 				}
 			}
 		}

--- a/cmd/fly_agent.go
+++ b/cmd/fly_agent.go
@@ -44,7 +44,7 @@ func newAgentCommand(client *client.Client) *Command {
 }
 
 func runFlyAgentDaemonStart(ctx *cmdctx.CmdContext) error {
-	agent, err := agent.DefaultServer(ctx)
+	agent, err := agent.DefaultServer(ctx.Client.API())
 	if err != nil {
 		log.Fatalf("can't start daemon: %s", err)
 	}

--- a/cmd/ssh_terminal.go
+++ b/cmd/ssh_terminal.go
@@ -56,10 +56,12 @@ func runSSHConsole(cc *cmdctx.CmdContext) error {
 		return fmt.Errorf("ssh: can't build tunnel for %s: %s\n", app.Organization.Slug, err)
 	}
 
+	cc.IO.StartProgressIndicatorMsg("Connecting to tunnel")
 	if err := agentclient.WaitForTunnel(ctx, &app.Organization); err != nil {
 		captureError(err)
 		return errors.Wrapf(err, "tunnel unavailable")
 	}
+	cc.IO.StopProgressIndicator()
 
 	var addr string
 
@@ -85,11 +87,14 @@ func runSSHConsole(cc *cmdctx.CmdContext) error {
 		addr = cc.Args[0]
 	} else {
 		addr = fmt.Sprintf("%s.internal", cc.AppName)
-
+		fmt.Println("wait for host")
+		cc.IO.StartProgressIndicatorMsg("Waiting for host")
 		if err := agentclient.WaitForHost(ctx, &app.Organization, addr); err != nil {
+			fmt.Println("wait for host error", err)
 			captureError(err)
 			return errors.Wrapf(err, "host unavailable")
 		}
+		cc.IO.StopProgressIndicator()
 	}
 
 	err = sshConnect(&SSHParams{

--- a/cmd/ssh_terminal.go
+++ b/cmd/ssh_terminal.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"time"
 
@@ -91,7 +90,7 @@ func runSSHConsole(cc *cmdctx.CmdContext) error {
 	}
 
 	// wait for the addr to be resolved in dns unless it's an ip address
-	if n := net.ParseIP(addr); n == nil {
+	if !agent.IsIPv6(addr) {
 		cc.IO.StartProgressIndicatorMsg("Waiting for host")
 		if err := agentclient.WaitForHost(ctx, &app.Organization, addr); err != nil {
 			captureError(err)

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/mattn/go-colorable v0.1.8
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
+	github.com/miekg/dns v1.1.43 // indirect
 	github.com/moby/buildkit v0.8.1
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635
 	github.com/morikuni/aec v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -910,6 +910,8 @@ github.com/michaeldwan/toml v0.3.2-0.20191213213541-3c5ced72b6f3 h1:fO9bKICUp3uS
 github.com/michaeldwan/toml v0.3.2-0.20191213213541-3c5ced72b6f3/go.mod h1:zs/AcS/gLJIa42aCC4p6n7sJIQIAV5LNLBu79EjGjt4=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/dns v1.1.43 h1:JKfpVSCB84vrAmHzyrsxB5NAr5kLoMXZArPSw7Qlgyg=
+github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -1558,6 +1560,7 @@ golang.org/x/sys v0.0.0-20201202213521-69691e467435/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225014209-683adc9d29d7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210303074136-134d130e1a04/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -31,7 +31,7 @@ chmod +x "$exe"
 rm "$exe.tar.gz"
 
 # stop the agent if it's running before updating
-flyctl agent stop &> /dev/null
+flyctl agent stop &> /dev/null || true
 ln -sf $exe $simexe
 
 if [ "${1}" = "prerel" ] || [ "${1}" = "pre" ]; then

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -13,13 +13,13 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	dockerclient "github.com/docker/docker/client"
-	"github.com/getsentry/sentry-go"
 	"github.com/jpillora/backoff"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/helpers"
+	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/internal/monitor"
 	"github.com/superfly/flyctl/pkg/agent"
 	"github.com/superfly/flyctl/pkg/iostreams"
@@ -152,21 +152,13 @@ func newLocalDockerClient() (*dockerclient.Client, error) {
 	return c, nil
 }
 
-type remoteBuilderError struct {
-	RemoteBuilderName string
-	Err               error
-}
-
-func (e *remoteBuilderError) Error() string {
-	return fmt.Sprintf("remote builder %s error %s", e.RemoteBuilderName, e.Err)
-}
-
 func newRemoteDockerClient(ctx context.Context, apiClient *api.Client, appName string, streams *iostreams.IOStreams) (*dockerclient.Client, error) {
 	host, app, err := remoteBuilderURL(apiClient, appName)
 	if err != nil {
 		return nil, err
 	}
 	remoteBuilderAppName := app.Name
+	remoteBuilderOrg := app.Organization.Slug
 
 	terminal.Debugf("Remote Docker builder host: %s\n", host)
 
@@ -180,6 +172,22 @@ func newRemoteDockerClient(ctx context.Context, apiClient *api.Client, appName s
 	defer cancel()
 
 	eg, errCtx := errgroup.WithContext(ctx)
+
+	captureError := func(err error) {
+		// ignore cancelled errors
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+
+		flyerr.CaptureException(err,
+			flyerr.WithTag("feature", "remote-build"),
+			flyerr.WithContexts(map[string]interface{}{
+				"app":          appName,
+				"builder":      remoteBuilderAppName,
+				"organization": remoteBuilderOrg,
+			}),
+		)
+	}
 
 	eg.Go(func() error {
 		defer streams.ChangeProgressIndicatorMsg(fmt.Sprintf("Waiting for remote builder %s... connecting", remoteBuilderAppName))
@@ -242,13 +250,13 @@ func newRemoteDockerClient(ctx context.Context, apiClient *api.Client, appName s
 	})
 
 	if err = eg.Wait(); err != nil {
-		captureRemoteBuilderError(err, remoteBuilderAppName)
+		captureError(err)
 
 		return nil, err
 	}
 
 	if err := ctx.Err(); err != nil {
-		captureRemoteBuilderError(err, remoteBuilderAppName)
+		captureError(err)
 
 		streams.StopProgressIndicator()
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -262,14 +270,6 @@ func newRemoteDockerClient(ctx context.Context, apiClient *api.Client, appName s
 	streams.StopProgressIndicatorMsg(fmt.Sprintf("Remote builder %s ready", remoteBuilderAppName))
 
 	return <-clientCh, nil
-}
-
-func captureRemoteBuilderError(err error, builderAppName string) {
-	if errors.Is(err, context.Canceled) {
-		return
-	}
-
-	sentry.CaptureException(&remoteBuilderError{RemoteBuilderName: builderAppName, Err: err})
 }
 
 func remoteBuilderURL(apiClient *api.Client, appName string) (string, *api.App, error) {

--- a/internal/flyerr/sentry.go
+++ b/internal/flyerr/sentry.go
@@ -1,0 +1,41 @@
+package flyerr
+
+import "github.com/getsentry/sentry-go"
+
+type CaptureOption func(scope *sentry.Scope)
+
+func WithContext(key string, val interface{}) CaptureOption {
+	return func(scope *sentry.Scope) {
+		scope.SetContext(key, val)
+	}
+}
+
+func WithContexts(contexts map[string]interface{}) CaptureOption {
+	return func(scope *sentry.Scope) {
+		scope.SetContexts(contexts)
+	}
+}
+
+func WithTag(key, value string) CaptureOption {
+	return func(scope *sentry.Scope) {
+		scope.SetTag(key, value)
+	}
+}
+
+func CaptureException(err error, opts ...CaptureOption) {
+	sentry.WithScope(func(scope *sentry.Scope) {
+		for _, opt := range opts {
+			opt(scope)
+		}
+		sentry.CaptureException(err)
+	})
+}
+
+func CaptureMessage(msg string, opts ...CaptureOption) {
+	sentry.WithScope(func(scope *sentry.Scope) {
+		for _, opt := range opts {
+			opt(scope)
+		}
+		sentry.CaptureMessage(msg)
+	})
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -312,8 +312,7 @@ func fetchInstances(tunnel *wg.Tunnel, app string) (*Instances, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	regionsv, err := tunnel.Resolver().
-		LookupTXT(ctx, fmt.Sprintf("regions.%s.internal", app))
+	regionsv, err := tunnel.LookupTXT(ctx, fmt.Sprintf("regions.%s.internal", app))
 	if err != nil {
 		return nil, fmt.Errorf("look up regions for %s: %w", app, err)
 	}
@@ -327,7 +326,7 @@ func fetchInstances(tunnel *wg.Tunnel, app string) (*Instances, error) {
 
 	for _, region := range strings.Split(regions, ",") {
 		name := fmt.Sprintf("%s.%s.internal", region, app)
-		addrs, err := tunnel.Resolver().LookupHost(ctx, name)
+		addrs, err := tunnel.LookupAAAA(ctx, name)
 		if err != nil {
 			log.Printf("can't lookup records for %s: %s", name, err)
 			continue
@@ -335,13 +334,13 @@ func fetchInstances(tunnel *wg.Tunnel, app string) (*Instances, error) {
 
 		if len(addrs) == 1 {
 			ret.Labels = append(ret.Labels, name)
-			ret.Addresses = append(ret.Addresses, addrs[0])
+			ret.Addresses = append(ret.Addresses, addrs[0].String())
 			continue
 		}
 
 		for _, addr := range addrs {
 			ret.Labels = append(ret.Labels, fmt.Sprintf("%s (%s)", region, addr))
-			ret.Addresses = append(ret.Addresses, addrs[0])
+			ret.Addresses = append(ret.Addresses, addrs[0].String())
 		}
 	}
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -491,7 +491,6 @@ func (s *Server) clean() {
 }
 
 func resolve(tunnel *wg.Tunnel, addr string) (string, error) {
-	log.Printf("Resolving %v %s", tunnel, addr)
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		if strings.Contains(err.Error(), "missing port") {

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/api"
@@ -161,4 +162,10 @@ type clientProvider interface {
 
 type Dialer interface {
 	DialContext(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
+func IsIPv6(addr string) bool {
+	addr = strings.Trim(addr, "[]")
+	ip := net.ParseIP(addr)
+	return ip != nil && ip.To16() != nil
 }

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -1,139 +1,71 @@
-// +build !windows
-
 package agent
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"os"
-	"strconv"
-	"strings"
-	"time"
 
+	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/internal/wireguard"
 )
 
-type Client struct {
-	path string
-}
-
-const (
-	defaultTimeout = 1500 * time.Millisecond
-)
-
-var (
-	ErrUnreachable = errors.New("can't connect to agent")
-)
-
-func NewClient(path string) (*Client, error) {
-	c := &Client{
-		path: path,
+/// Establish starts the daemon if necessary and returns a client
+func Establish(ctx context.Context, apiClient *api.Client) (*Client, error) {
+	if err := wireguard.PruneInvalidPeers(apiClient); err != nil {
+		return nil, err
 	}
 
-	testConn, err := c.connect()
+	c, err := DefaultClient(apiClient)
+	if err == nil {
+		_, err := c.Ping(ctx)
+		if err == nil {
+			return c, nil
+		}
+	}
+
+	return StartDaemon(ctx, apiClient, os.Args[0])
+}
+
+func NewClient(path string, apiClient *api.Client) (*Client, error) {
+	provider, err := newClientProvider(path, apiClient)
 	if err != nil {
 		return nil, err
 	}
 
-	testConn.Close()
-
-	return c, nil
+	return &Client{provider: provider}, nil
 }
 
-func DefaultClient(*api.Client) (*Client, error) {
-	return NewClient(fmt.Sprintf("%s/.fly/fly-agent.sock", os.Getenv("HOME")))
+func DefaultClient(apiClient *api.Client) (*Client, error) {
+	path := fmt.Sprintf("%s/.fly/fly-agent.sock", os.Getenv("HOME"))
+	return NewClient(path, apiClient)
 }
 
-func (c *Client) connect() (net.Conn, error) {
-	d := net.Dialer{
-		Timeout: defaultTimeout,
-	}
-
-	conn, err := d.Dial("unix", c.path)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %s", ErrUnreachable, err)
-	}
-
-	return conn, nil
-}
-
-func (c *Client) withConnection(ctx context.Context, f func(conn net.Conn) error) error {
-	errCh := make(chan error, 1)
-
-	go func() {
-		conn, err := c.connect()
-		if err != nil {
-			errCh <- err
-		}
-		defer conn.Close()
-
-		errCh <- f(conn)
-	}()
-
-	select {
-	case <-ctx.Done():
-		<-errCh
-		return ctx.Err()
-	case err := <-errCh:
-		return err
-	}
+type Client struct {
+	provider clientProvider
 }
 
 func (c *Client) Kill(ctx context.Context) error {
-	return c.withConnection(ctx, func(conn net.Conn) error {
-		return writef(conn, "kill")
-	})
+	if err := c.provider.Kill(ctx); err != nil {
+		return errors.Wrap(err, "kill failed")
+	}
+	return nil
 }
 
 func (c *Client) Ping(ctx context.Context) (int, error) {
-	var pid int
-
-	err := c.withConnection(ctx, func(conn net.Conn) error {
-		writef(conn, "ping")
-
-		conn.SetReadDeadline(time.Now().Add(defaultTimeout))
-
-		pong, err := read(conn)
-		if err != nil {
-			return err
-		}
-
-		tup := strings.Split(string(pong), " ")
-		if len(tup) != 2 {
-			return fmt.Errorf("malformed response (no pid)")
-		}
-
-		pid, err = strconv.Atoi(tup[1])
-		if err != nil {
-			return fmt.Errorf("malformed response (bad pid: %w)", err)
-		}
-
-		return nil
-	})
-
-	return pid, err
+	n, err := c.provider.Ping(ctx)
+	if err != nil {
+		return n, errors.Wrap(err, "ping failed")
+	}
+	return n, nil
 }
 
 func (c *Client) Establish(ctx context.Context, slug string) error {
-	return c.withConnection(ctx, func(conn net.Conn) error {
-		writef(conn, "establish %s", slug)
-
-		// this goes out to the API; don't time it out aggressively
-		reply, err := read(conn)
-		if err != nil {
-			return err
-		}
-
-		if string(reply) != "ok" {
-			return fmt.Errorf("establish failed: %s", string(reply))
-		}
-
-		return nil
-	})
+	if err := c.provider.Establish(ctx, slug); err != nil {
+		return errors.Wrap(err, "establish failed")
+	}
+	return nil
 }
 
 func (c *Client) WaitForTunnel(ctx context.Context, o *api.Organization) error {
@@ -142,97 +74,73 @@ func (c *Client) WaitForTunnel(ctx context.Context, o *api.Organization) error {
 		switch {
 		case err == nil:
 			return nil
-		case err == context.Canceled || err == context.DeadlineExceeded:
-			return err
-		case errors.Is(err, &ErrProbeFailed{}):
+		case IsTunnelError(err):
 			continue
+		default:
+			return err
+		}
+	}
+}
+
+func (c *Client) WaitForHost(ctx context.Context, o *api.Organization, host string) error {
+	for {
+		_, err := c.Resolve(ctx, o, host)
+		switch {
+		case err == nil:
+			return nil
+		case IsHostNotFoundError(err), IsTunnelError(err):
+			continue
+		default:
+			return err
 		}
 	}
 }
 
 func (c *Client) Probe(ctx context.Context, o *api.Organization) error {
-	return c.withConnection(ctx, func(conn net.Conn) error {
-		writef(conn, "probe %s", o.Slug)
+	if err := c.provider.Probe(ctx, o); err != nil {
+		err = mapResolveError(err, o.Slug, "")
+		return errors.Wrap(err, "probe failed")
+	}
+	return nil
+}
 
-		reply, err := read(conn)
-		if err != nil {
-			return err
-		}
-
-		if string(reply) != "ok" {
-			return &ErrProbeFailed{Msg: string(reply)}
-		}
-
-		return nil
-	})
+func (c *Client) Resolve(ctx context.Context, o *api.Organization, host string) (string, error) {
+	addr, err := c.provider.Resolve(ctx, o, host)
+	if err != nil {
+		err = mapResolveError(err, o.Slug, host)
+		return "", errors.Wrap(err, "resolve failed")
+	}
+	return addr, nil
 }
 
 func (c *Client) Instances(ctx context.Context, o *api.Organization, app string) (*Instances, error) {
-	var instances *Instances
-
-	err := c.withConnection(ctx, func(conn net.Conn) error {
-		writef(conn, "instances %s %s", o.Slug, app)
-
-		// this goes out to the network; don't time it out aggressively
-		reply, err := read(conn)
-		if err != nil {
-			return err
-		}
-
-		if string(reply[0:3]) != "ok " {
-			return fmt.Errorf("failed to retrieve instances: %s", string(reply))
-		}
-
-		reply = reply[3:]
-
-		inst := &Instances{}
-
-		if err = json.NewDecoder(bytes.NewReader(reply)).Decode(inst); err != nil {
-			return fmt.Errorf("failed to retrieve instances: malformed response: %s", err)
-		}
-
-		instances = inst
-
-		return nil
-	})
-
-	return instances, err
-}
-
-type Dialer struct {
-	Org     *api.Organization
-	Timeout time.Duration
-
-	client *Client
-}
-
-func (c *Client) Dialer(ctx context.Context, o *api.Organization) (*Dialer, error) {
-	if err := c.Establish(ctx, o.Slug); err != nil {
-		return nil, err
-	}
-
-	return &Dialer{
-		Org:    o,
-		client: c,
-	}, nil
-}
-
-func (d *Dialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	conn, err := d.client.connect()
+	instances, err := c.provider.Instances(ctx, o, app)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "list instances failed")
 	}
+	return instances, nil
+}
 
-	writef(conn, "connect %s %s %d", d.Org.Slug, addr, d.Timeout)
-
-	res, err := read(conn)
+func (c *Client) Dialer(ctx context.Context, o *api.Organization) (Dialer, error) {
+	dialer, err := c.provider.Dialer(ctx, o)
 	if err != nil {
-		return nil, err
+		err = mapResolveError(err, o.Slug, "")
+		return nil, errors.Wrap(err, "error fetching dialer")
 	}
+	return dialer, nil
+}
 
-	if string(res) != "ok" {
-		return nil, fmt.Errorf("got error reply from agent: %s", string(res))
-	}
+// clientProvider is an interface for client functions backed by either the agent or in-process on Windows
+type clientProvider interface {
+	Dialer(ctx context.Context, o *api.Organization) (Dialer, error)
+	Establish(ctx context.Context, slug string) error
+	Instances(ctx context.Context, o *api.Organization, app string) (*Instances, error)
+	Kill(ctx context.Context) error
+	Ping(ctx context.Context) (int, error)
+	Probe(ctx context.Context, o *api.Organization) error
+	Resolve(ctx context.Context, o *api.Organization, name string) (string, error)
+}
 
-	return conn, nil
+type Dialer interface {
+	DialContext(ctx context.Context, network, addr string) (net.Conn, error)
 }

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -85,6 +85,7 @@ func (c *Client) WaitForTunnel(ctx context.Context, o *api.Organization) error {
 func (c *Client) WaitForHost(ctx context.Context, o *api.Organization, host string) error {
 	for {
 		_, err := c.Resolve(ctx, o, host)
+		fmt.Println("got resolve error", host, err, IsHostNotFoundError(err), IsTunnelError(err))
 		switch {
 		case err == nil:
 			return nil
@@ -98,6 +99,7 @@ func (c *Client) WaitForHost(ctx context.Context, o *api.Organization, host stri
 
 func (c *Client) Probe(ctx context.Context, o *api.Organization) error {
 	if err := c.provider.Probe(ctx, o); err != nil {
+		fmt.Println("probe err: ", err, errors.Is(err, context.DeadlineExceeded))
 		err = mapResolveError(err, o.Slug, "")
 		return errors.Wrap(err, "probe failed")
 	}
@@ -106,6 +108,7 @@ func (c *Client) Probe(ctx context.Context, o *api.Organization) error {
 
 func (c *Client) Resolve(ctx context.Context, o *api.Organization, host string) (string, error) {
 	addr, err := c.provider.Resolve(ctx, o, host)
+	// fmt.Printf("got resolve response '%s' '%s'\n", addr, err)
 	if err != nil {
 		err = mapResolveError(err, o.Slug, host)
 		return "", errors.Wrap(err, "resolve failed")

--- a/pkg/agent/client_agent.go
+++ b/pkg/agent/client_agent.go
@@ -1,0 +1,236 @@
+// +build !windows
+
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/superfly/flyctl/api"
+)
+
+type agentClientProvider struct {
+	path string
+}
+
+const (
+	defaultTimeout = 1500 * time.Millisecond
+)
+
+var (
+	ErrUnreachable = errors.New("can't connect to agent")
+)
+
+func newClientProvider(path string, api *api.Client) (clientProvider, error) {
+	session := &agentClientProvider{path: path}
+
+	testConn, err := session.connect()
+	if err != nil {
+		return nil, err
+	}
+	testConn.Close()
+
+	return session, nil
+}
+
+func (c *agentClientProvider) connect() (net.Conn, error) {
+	d := net.Dialer{
+		Timeout: defaultTimeout,
+	}
+
+	conn, err := d.Dial("unix", c.path)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrUnreachable, err)
+	}
+
+	return conn, nil
+}
+
+func (c *agentClientProvider) withConnection(ctx context.Context, f func(conn net.Conn) error) error {
+	errCh := make(chan error, 1)
+
+	go func() {
+		conn, err := c.connect()
+		if err != nil {
+			errCh <- err
+		}
+		defer conn.Close()
+
+		errCh <- f(conn)
+	}()
+
+	select {
+	case <-ctx.Done():
+		<-errCh
+		return ctx.Err()
+	case err := <-errCh:
+		return err
+	}
+}
+
+func (c *agentClientProvider) Kill(ctx context.Context) error {
+	return c.withConnection(ctx, func(conn net.Conn) error {
+		return writef(conn, "kill")
+	})
+}
+
+func (c *agentClientProvider) Ping(ctx context.Context) (int, error) {
+	var pid int
+
+	err := c.withConnection(ctx, func(conn net.Conn) error {
+		writef(conn, "ping")
+
+		conn.SetReadDeadline(time.Now().Add(defaultTimeout))
+
+		pong, err := read(conn)
+		if err != nil {
+			return err
+		}
+
+		tup := strings.Split(string(pong), " ")
+		if len(tup) != 2 {
+			return fmt.Errorf("malformed response (no pid)")
+		}
+
+		pid, err = strconv.Atoi(tup[1])
+		if err != nil {
+			return fmt.Errorf("malformed response (bad pid: %w)", err)
+		}
+
+		return nil
+	})
+
+	return pid, err
+}
+
+func (c *agentClientProvider) Establish(ctx context.Context, slug string) error {
+	return c.withConnection(ctx, func(conn net.Conn) error {
+		writef(conn, "establish %s", slug)
+
+		// this goes out to the API; don't time it out aggressively
+		reply, err := read(conn)
+		if err != nil {
+			return err
+		}
+
+		if string(reply) != "ok" {
+			return fmt.Errorf("establish failed: %s", string(reply))
+		}
+
+		return nil
+	})
+}
+
+func (c *agentClientProvider) Probe(ctx context.Context, o *api.Organization) error {
+	return c.withConnection(ctx, func(conn net.Conn) error {
+		writef(conn, "probe %s", o.Slug)
+
+		reply, err := read(conn)
+		if err != nil {
+			return err
+		}
+
+		if string(reply) != "ok" {
+			return fmt.Errorf("probe failed: %s", string(reply))
+		}
+
+		return nil
+	})
+}
+
+func (c *agentClientProvider) Resolve(ctx context.Context, o *api.Organization, addr string) (resp string, err error) {
+	err = c.withConnection(ctx, func(conn net.Conn) error {
+		writef(conn, "resolve %s %s", o.Slug, addr)
+
+		reply, err := read(conn)
+		if err != nil {
+			return err
+		}
+
+		if string(reply) != "ok" {
+			resp = string(reply)
+			// return &ErrProbeFailed{Msg: string(reply)}
+		}
+
+		return nil
+	})
+
+	return
+}
+
+func (c *agentClientProvider) Instances(ctx context.Context, o *api.Organization, app string) (*Instances, error) {
+	var instances *Instances
+
+	err := c.withConnection(ctx, func(conn net.Conn) error {
+		writef(conn, "instances %s %s", o.Slug, app)
+
+		// this goes out to the network; don't time it out aggressively
+		reply, err := read(conn)
+		if err != nil {
+			return err
+		}
+
+		if string(reply[0:3]) != "ok " {
+			return fmt.Errorf("failed to retrieve instances: %s", string(reply))
+		}
+
+		reply = reply[3:]
+
+		inst := &Instances{}
+
+		if err = json.NewDecoder(bytes.NewReader(reply)).Decode(inst); err != nil {
+			return fmt.Errorf("failed to retrieve instances: malformed response: %s", err)
+		}
+
+		instances = inst
+
+		return nil
+	})
+
+	return instances, err
+}
+
+func (c *agentClientProvider) Dialer(ctx context.Context, o *api.Organization) (Dialer, error) {
+	if err := c.Establish(ctx, o.Slug); err != nil {
+		return nil, err
+	}
+
+	return &agentDialer{
+		Org:     o,
+		session: c,
+	}, nil
+}
+
+type agentDialer struct {
+	Org     *api.Organization
+	Timeout time.Duration
+
+	session *agentClientProvider
+}
+
+func (d *agentDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	conn, err := d.session.connect()
+	if err != nil {
+		return nil, err
+	}
+
+	writef(conn, "connect %s %s %d", d.Org.Slug, addr, d.Timeout)
+
+	res, err := read(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	if string(res) != "ok" {
+		return nil, mapResolveError(errors.New(string(res)), d.Org.Slug, addr)
+	}
+
+	return conn, nil
+}

--- a/pkg/agent/client_agent.go
+++ b/pkg/agent/client_agent.go
@@ -154,11 +154,11 @@ func (c *agentClientProvider) Resolve(ctx context.Context, o *api.Organization, 
 			return err
 		}
 
-		if string(reply) != "ok" {
-			resp = string(reply)
-			// return &ErrProbeFailed{Msg: string(reply)}
+		if !strings.HasPrefix(string(reply), "ok ") {
+			return fmt.Errorf("resolve failed: %s", reply)
 		}
 
+		resp = string(reply[3:])
 		return nil
 	})
 

--- a/pkg/agent/client_noagent.go
+++ b/pkg/agent/client_noagent.go
@@ -13,13 +13,20 @@ import (
 	"github.com/superfly/flyctl/pkg/wg"
 )
 
-type Client struct {
+func newClientProvider(path string, api *api.Client) (clientProvider, error) {
+	return &noAgentClientProvider{
+		tunnels: map[string]*wg.Tunnel{},
+		Client:  api,
+	}, nil
+}
+
+type noAgentClientProvider struct {
 	Client  *api.Client
 	tunnels map[string]*wg.Tunnel
 	lock    sync.Mutex
 }
 
-func (c *Client) tunnelFor(slug string) (*wg.Tunnel, error) {
+func (c *noAgentClientProvider) tunnelFor(slug string) (*wg.Tunnel, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -31,30 +38,15 @@ func (c *Client) tunnelFor(slug string) (*wg.Tunnel, error) {
 	return tunnel, nil
 }
 
-func NewClient(path string) (*Client, error) {
-	return &Client{
-		tunnels: map[string]*wg.Tunnel{},
-	}, nil
-}
-
-func DefaultClient(c *api.Client) (*Client, error) {
-	client, err := NewClient("")
-	if err != nil {
-		return nil, err
-	}
-	client.Client = c
-	return client, nil
-}
-
-func (c *Client) Kill(ctx context.Context) error {
+func (c *noAgentClientProvider) Kill(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) Ping(ctx context.Context) (int, error) {
+func (c *noAgentClientProvider) Ping(ctx context.Context) (int, error) {
 	return 0, nil
 }
 
-func (c *Client) Establish(ctx context.Context, slug string) error {
+func (c *noAgentClientProvider) Establish(ctx context.Context, slug string) error {
 	if c.Client == nil {
 		return fmt.Errorf("no client set for stub agent")
 	}
@@ -80,7 +72,7 @@ func (c *Client) Establish(ctx context.Context, slug string) error {
 	return nil
 }
 
-func (c *Client) Probe(ctx context.Context, o *api.Organization) error {
+func (c *noAgentClientProvider) Probe(ctx context.Context, o *api.Organization) error {
 	tunnel, err := c.tunnelFor(o.Slug)
 	if err != nil {
 		return fmt.Errorf("probe: can't build tunnel: %s", err)
@@ -93,21 +85,16 @@ func (c *Client) Probe(ctx context.Context, o *api.Organization) error {
 	return nil
 }
 
-func (c *Client) WaitForTunnel(ctx context.Context, o *api.Organization) error {
-	for {
-		err := c.Probe(ctx, o)
-		switch {
-		case err == nil:
-			return nil
-		case err == context.Canceled || err == context.DeadlineExceeded:
-			return err
-		case errors.Is(err, &ErrProbeFailed{}):
-			continue
-		}
+func (c *noAgentClientProvider) Resolve(ctx context.Context, o *api.Organization, host string) (string, error) {
+	tunnel, err := c.tunnelFor(o.Slug)
+	if err != nil {
+		return fmt.Errorf("probe: can't build tunnel: %s", err)
 	}
+
+	return resolve(tunnel, host)
 }
 
-func (c *Client) Instances(ctx context.Context, o *api.Organization, app string) (*Instances, error) {
+func (c *noAgentClientProvider) Instances(ctx context.Context, o *api.Organization, app string) (*Instances, error) {
 	tunnel, err := c.tunnelFor(o.Slug)
 	if err != nil {
 		return nil, fmt.Errorf("can't build tunnel: %s", err)

--- a/pkg/agent/errors.go
+++ b/pkg/agent/errors.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func IsTunnelError(err error) bool {
+	return errors.Is(err, &TunnelError{})
+}
+
+type TunnelError struct {
+	OrgSlug string
+	Err     error
+}
+
+func (e *TunnelError) Error() string {
+	return fmt.Sprintf("tunnel %s error: %s", e.OrgSlug, e.Err)
+}
+
+func (e *TunnelError) Unwrap() error {
+	return e.Err
+}
+
+func (e *TunnelError) Cause() error {
+	return e.Err
+}
+
+func IsHostNotFoundError(err error) bool {
+	return errors.Is(err, &HostNotFoundError{})
+}
+
+type HostNotFoundError struct {
+	OrgSlug string
+	Host    string
+	Err     error
+}
+
+func (e *HostNotFoundError) Error() string {
+	return fmt.Sprintf("host %s not found on tunnel %s", e.Host, e.OrgSlug)
+}
+
+func (e *HostNotFoundError) Unwrap() error {
+	return e.Err
+}
+
+func (e *HostNotFoundError) Cause() error {
+	return e.Err
+}
+
+func mapResolveError(err error, orgSlug string, host string) error {
+	msg := err.Error()
+	if strings.Contains(msg, "i/o timeout") {
+		return &TunnelError{Err: err, OrgSlug: orgSlug}
+	}
+	if strings.Contains(msg, "no such host") {
+		return &HostNotFoundError{Err: err, OrgSlug: orgSlug, Host: host}
+	}
+	return err
+}

--- a/pkg/agent/errors.go
+++ b/pkg/agent/errors.go
@@ -54,6 +54,9 @@ func mapResolveError(err error, orgSlug string, host string) error {
 	if strings.Contains(msg, "i/o timeout") {
 		return &TunnelError{Err: err, OrgSlug: orgSlug}
 	}
+	if strings.Contains(msg, "DNS name does not exist") {
+		return &TunnelError{Err: err, OrgSlug: orgSlug}
+	}
 	if strings.Contains(msg, "no such host") {
 		return &HostNotFoundError{Err: err, OrgSlug: orgSlug, Host: host}
 	}

--- a/pkg/agent/errors.go
+++ b/pkg/agent/errors.go
@@ -7,7 +7,8 @@ import (
 )
 
 func IsTunnelError(err error) bool {
-	return errors.Is(err, &TunnelError{})
+	var tunnelError *TunnelError
+	return errors.As(err, &tunnelError)
 }
 
 type TunnelError struct {
@@ -23,12 +24,13 @@ func (e *TunnelError) Unwrap() error {
 	return e.Err
 }
 
-func (e *TunnelError) Cause() error {
-	return e.Err
-}
+// func (e *TunnelError) Cause() error {
+// 	return e.Err
+// }
 
 func IsHostNotFoundError(err error) bool {
-	return errors.Is(err, &HostNotFoundError{})
+	var notfoundError *HostNotFoundError
+	return errors.As(err, &notfoundError)
 }
 
 type HostNotFoundError struct {
@@ -45,13 +47,16 @@ func (e *HostNotFoundError) Unwrap() error {
 	return e.Err
 }
 
-func (e *HostNotFoundError) Cause() error {
-	return e.Err
-}
+// func (e *HostNotFoundError) Cause() error {
+// 	return e.Err
+// }
 
 func mapResolveError(err error, orgSlug string, host string) error {
 	msg := err.Error()
 	if strings.Contains(msg, "i/o timeout") {
+		return &TunnelError{Err: err, OrgSlug: orgSlug}
+	}
+	if strings.Contains(msg, "tunnel unavailable") {
 		return &TunnelError{Err: err, OrgSlug: orgSlug}
 	}
 	if strings.Contains(msg, "DNS name does not exist") {

--- a/pkg/wg/tunnel.go
+++ b/pkg/wg/tunnel.go
@@ -8,15 +8,17 @@ import (
 	"math/rand"
 	"net"
 
+	"github.com/miekg/dns"
 	"golang.zx2c4.com/wireguard/device"
 	"golang.zx2c4.com/wireguard/tun"
 	"golang.zx2c4.com/wireguard/tun/netstack"
 )
 
 type Tunnel struct {
-	dev *device.Device
-	tun tun.Device
-	net *netstack.Net
+	dev   *device.Device
+	tun   tun.Device
+	net   *netstack.Net
+	dnsIP net.IP
 
 	resolv *net.Resolver
 }
@@ -63,13 +65,15 @@ func Connect(cfg Config) (*Tunnel, error) {
 	wgDev.Up()
 
 	return &Tunnel{
-		dev: wgDev,
-		tun: tunDev,
-		net: gNet,
+		dev:   wgDev,
+		tun:   tunDev,
+		net:   gNet,
+		dnsIP: dnsIP,
 
 		resolv: &net.Resolver{
 			PreferGo: true,
 			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				fmt.Println("resolver.Dial", network, address)
 				return gNet.DialContext(ctx, "tcp", net.JoinHostPort(dnsIP.String(), "53"))
 			},
 		},
@@ -91,4 +95,63 @@ func (t *Tunnel) DialContext(ctx context.Context, network, addr string) (net.Con
 
 func (t *Tunnel) Resolver() *net.Resolver {
 	return t.resolv
+}
+
+func (t *Tunnel) queryDNS(ctx context.Context, msg *dns.Msg) (*dns.Msg, error) {
+	client := dns.Client{
+		Net: "tcp",
+		Dialer: &net.Dialer{
+			Resolver: t.resolv,
+		},
+	}
+
+	c, err := t.DialContext(ctx, "tcp", net.JoinHostPort(t.dnsIP.String(), "53"))
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+
+	conn := &dns.Conn{Conn: c}
+	defer conn.Close()
+
+	r, _, err := client.ExchangeWithConn(msg, conn)
+	return r, err
+}
+
+func (t *Tunnel) LookupTXT(ctx context.Context, name string) ([]string, error) {
+	m := &dns.Msg{}
+	m.SetQuestion(dns.Fqdn(name), dns.TypeTXT)
+
+	r, err := t.queryDNS(ctx, m)
+	if err != nil {
+		return nil, err
+	}
+
+	results := []string{}
+
+	for _, a := range r.Answer {
+		txtRecord := a.(*dns.TXT)
+		results = append(results, txtRecord.Txt...)
+	}
+
+	return results, nil
+}
+
+func (t *Tunnel) LookupAAAA(ctx context.Context, name string) ([]net.IP, error) {
+	m := &dns.Msg{}
+	m.SetQuestion(dns.Fqdn(name), dns.TypeAAAA)
+
+	r, err := t.queryDNS(ctx, m)
+	if err != nil {
+		return nil, err
+	}
+
+	results := []net.IP{}
+
+	for _, a := range r.Answer {
+		aaaaRecord := a.(*dns.AAAA)
+		results = append(results, aaaaRecord.AAAA)
+	}
+
+	return results, nil
 }


### PR DESCRIPTION
This is a little refactor of the client code to better catch and propagate errors to the caller. The functionality is the same, but `Client` now references an interface which is conditionally set to be an agent client or non-agent client depending on build flags. `Client` handles errors and adds functions to test a tunnel or host and leaves the rest to the individual implementations. 

highlights:
- refactor agent & non-agent clients so shared logic & error handling is in `agent.Client` and the platform dependent code is behind an interface
- map string errors (eg `i/o timeout` or `no such host`) to types to make detecting tunnel and resolution faults easier. Propagate stack and context for everything else
- new `WaitForTunnel` and `WaitForHost` functions on client that blocks until the tunnel is healthy and the host is reachable
- call `WaitForTunnel` and `WaitForHost` before connecting to a vm for ssh or remote build
- move sentry error capturing to the flyctl side of the client since errors happen regularly (and are handled with the new error types). Should get better errors and stack traces in sentry with wrapped errors 