### PR TITLE
helpful errors when the daemon fails to start

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/client"
+	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/terminal"
 )
 
@@ -307,7 +308,7 @@ func requireAppName(cmd *Command) Initializer {
 				terminal.Warnf("app flag '%s' does not match app name in config file '%s'\n", ctx.AppName, ctx.AppConfig.AppName)
 
 				if !confirm(fmt.Sprintf("Continue using '%s'", ctx.AppName)) {
-					return ErrAbort
+					return flyerr.ErrAbort
 				}
 			}
 
@@ -391,7 +392,7 @@ func requireAppNameAsArg(cmd *Command) Initializer {
 				terminal.Warnf("app flag '%s' does not match app name in config file '%s'\n", ctx.AppName, ctx.AppConfig.AppName)
 
 				if !confirm(fmt.Sprintf("Continue using '%s'", ctx.AppName)) {
-					return ErrAbort
+					return flyerr.ErrAbort
 				}
 			}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -26,6 +26,7 @@ import (
 	"github.com/superfly/flyctl/internal/cmdfmt"
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/deployment"
+	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/internal/monitor"
 	"github.com/superfly/flyctl/terminal"
 	"golang.org/x/sync/errgroup"
@@ -476,7 +477,7 @@ func watchDeployment(ctx context.Context, cmdCtx *cmdctx.CmdContext) error {
 
 	if !monitor.Success() {
 		cmdCtx.Status("deploy", cmdctx.SINFO, "Troubleshooting guide at https://fly.io/docs/getting-started/troubleshooting/")
-		return ErrAbort
+		return flyerr.ErrAbort
 	}
 
 	return nil

--- a/cmd/fly_agent.go
+++ b/cmd/fly_agent.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/cmdctx"
 	"github.com/superfly/flyctl/docstrings"
 	"github.com/superfly/flyctl/internal/client"
@@ -46,7 +46,7 @@ func newAgentCommand(client *client.Client) *Command {
 func runFlyAgentDaemonStart(ctx *cmdctx.CmdContext) error {
 	agent, err := agent.DefaultServer(ctx.Client.API())
 	if err != nil {
-		log.Fatalf("can't start daemon: %s", err)
+		return errors.Wrap(err, "daemon error")
 	}
 
 	fmt.Printf("OK %d\n", os.Getpid())

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/docstrings"
 	"github.com/superfly/flyctl/internal/client"
 	"github.com/superfly/flyctl/internal/deployment"
+	"github.com/superfly/flyctl/internal/flyerr"
 )
 
 func newMonitorCommand(client *client.Client) *Command {
@@ -131,7 +132,7 @@ func monitorDeployment(ctx context.Context, commandContext *cmdctx.CmdContext) e
 	}
 
 	if !monitor.Success() {
-		return ErrAbort
+		return flyerr.ErrAbort
 	}
 
 	return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
@@ -13,10 +12,8 @@ import (
 	"github.com/superfly/flyctl/docstrings"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/client"
+	"github.com/superfly/flyctl/internal/flyerr"
 )
-
-// ErrAbort - Error generated when application aborts
-var ErrAbort = errors.New("abort")
 
 func NewRootCmd(client *client.Client) *cobra.Command {
 	rootStrings := docstrings.Get("flyctl")
@@ -111,7 +108,7 @@ func checkErr(err error) {
 }
 
 func isCancelledError(err error) bool {
-	if err == ErrAbort {
+	if err == flyerr.ErrAbort {
 		return true
 	}
 

--- a/internal/cmdutil/strings.go
+++ b/internal/cmdutil/strings.go
@@ -1,0 +1,13 @@
+package cmdutil
+
+import (
+	"regexp"
+)
+
+const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+
+var re = regexp.MustCompile(ansi)
+
+func StripANSI(str string) string {
+	return re.ReplaceAllString(str, "")
+}

--- a/internal/flyerr/flyerr.go
+++ b/internal/flyerr/flyerr.go
@@ -64,6 +64,7 @@ func PrintCLIOutput(err error) {
 		}
 		fmt.Printf("\n%s", suggestion)
 	}
+	fmt.Println()
 }
 
 func IsCancelledError(err error) bool {

--- a/internal/flyerr/flyerr.go
+++ b/internal/flyerr/flyerr.go
@@ -1,0 +1,47 @@
+package flyerr
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrAbort is an error for when the CLI aborts
+var ErrAbort = errors.New("abort")
+func PrintCLIOutput(err error) {
+	if err == nil {
+		return
+	}
+
+	if IsCancelledError(err) {
+		return
+	}
+
+	fmt.Println()
+	fmt.Println(aurora.Red("Error"), err)
+}
+
+func IsCancelledError(err error) bool {
+	if errors.Is(err, ErrAbort) {
+		return true
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	// if err == cmd.ErrAbort {
+	// 	return true
+	// }
+
+	// if err == context.Canceled {
+	// 	return true
+	// }
+
+	// if merr, ok := err.(*multierror.Error); ok {
+	// 	if len(merr.Errors) == 1 && merr.Errors[0] == context.Canceled {
+	// 		return true
+	// 	}
+	// }
+
+	return false
+}

--- a/internal/flyerr/flyerr.go
+++ b/internal/flyerr/flyerr.go
@@ -11,7 +11,7 @@ import (
 // ErrAbort is an error for when the CLI aborts
 var ErrAbort = errors.New("abort")
 
-// ErrorDescription is an error with detailed description that will be printed before the CLI exits
+// ErrorDescription is an error with a detailed description that will be printed before the CLI exits
 type ErrorDescription interface {
 	error
 	Description() string
@@ -25,7 +25,7 @@ func GetErrorDescription(err error) string {
 	return ""
 }
 
-// ErrorSuggestion is an error with a suggested next steps that will be printed before the CLI exits
+// ErrorSuggestion is an error with suggested next steps that will be printed before the CLI exits
 type ErrorSuggestion interface {
 	error
 	Suggestion() string

--- a/internal/flyerr/flyerr.go
+++ b/internal/flyerr/flyerr.go
@@ -3,10 +3,42 @@ package flyerr
 import (
 	"context"
 	"errors"
+	"fmt"
+
+	"github.com/logrusorgru/aurora"
 )
 
 // ErrAbort is an error for when the CLI aborts
 var ErrAbort = errors.New("abort")
+
+// ErrorDescription is an error with detailed description that will be printed before the CLI exits
+type ErrorDescription interface {
+	error
+	Description() string
+}
+
+func GetErrorDescription(err error) string {
+	var ferr ErrorDescription
+	if errors.As(err, &ferr) {
+		return ferr.Description()
+	}
+	return ""
+}
+
+// ErrorSuggestion is an error with a suggested next steps that will be printed before the CLI exits
+type ErrorSuggestion interface {
+	error
+	Suggestion() string
+}
+
+func GetErrorSuggestion(err error) string {
+	var ferr ErrorSuggestion
+	if errors.As(err, &ferr) {
+		return ferr.Suggestion()
+	}
+	return ""
+}
+
 func PrintCLIOutput(err error) {
 	if err == nil {
 		return
@@ -18,6 +50,20 @@ func PrintCLIOutput(err error) {
 
 	fmt.Println()
 	fmt.Println(aurora.Red("Error"), err)
+
+	description := GetErrorDescription(err)
+	suggestion := GetErrorSuggestion(err)
+
+	if description != "" {
+		fmt.Printf("\n%s", description)
+	}
+
+	if suggestion != "" {
+		if description != "" {
+			fmt.Println()
+		}
+		fmt.Printf("\n%s", suggestion)
+	}
 }
 
 func IsCancelledError(err error) bool {

--- a/main.go
+++ b/main.go
@@ -9,13 +9,13 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/hashicorp/go-multierror"
 	"github.com/logrusorgru/aurora"
 	"github.com/superfly/flyctl/cmd"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/flyname"
 	"github.com/superfly/flyctl/internal/client"
 	"github.com/superfly/flyctl/internal/cmdutil"
+	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/internal/update"
 	"github.com/superfly/flyctl/terminal"
 )
@@ -96,9 +96,20 @@ func checkErr(err error) {
 		return
 	}
 
-	if !isCancelledError(err) {
-		fmt.Println(aurora.Red("Error"), err)
-	}
+	flyerr.PrintCLIOutput(err)
+
+	// if !isCancelledError(err) {
+	// 	fmt.Println(aurora.Red("Error"), err)
+	// }
+
+	// if msg := flyerr.GetErrorDescription(err); msg != "" {
+
+	// 	fmt.Printf("\n%s\n", msg)
+	// }
+
+	// if msg := flyerr.GetErrorSuggestion(err); msg != "" {
+	// 	fmt.Printf("\n%s\n", msg)
+	// }
 
 	safeExit()
 }
@@ -108,18 +119,26 @@ func isCancelledError(err error) bool {
 		return true
 	}
 
-	if err == context.Canceled {
-		return true
-	}
+// 	if errors.Is(err, context.Canceled) {
+// 		return true
+// 	}
 
-	if merr, ok := err.(*multierror.Error); ok {
-		if len(merr.Errors) == 1 && merr.Errors[0] == context.Canceled {
-			return true
-		}
-	}
+// 	// if err == cmd.ErrAbort {
+// 	// 	return true
+// 	// }
 
-	return false
-}
+// 	// if err == context.Canceled {
+// 	// 	return true
+// 	// }
+
+// 	// if merr, ok := err.(*multierror.Error); ok {
+// 	// 	if len(merr.Errors) == 1 && merr.Errors[0] == context.Canceled {
+// 	// 		return true
+// 	// 	}
+// 	// }
+
+// 	return false
+// }
 
 func safeExit() {
 	flyctl.BackgroundTaskWG.Wait()

--- a/main.go
+++ b/main.go
@@ -114,10 +114,10 @@ func checkErr(err error) {
 	safeExit()
 }
 
-func isCancelledError(err error) bool {
-	if err == cmd.ErrAbort {
-		return true
-	}
+// func isCancelledError(err error) bool {
+// 	if errors.Is(err, cmd.ErrAbort) {
+// 		return true
+// 	}
 
 // 	if errors.Is(err, context.Canceled) {
 // 		return true

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -154,8 +154,11 @@ func (s *Server) Serve() {
 	for {
 		conn, err := s.listener.Accept()
 		if err != nil {
-			// this can't really be how i'm supposed to do this
-			if strings.Contains(err.Error(), "use of closed network connection") {
+			// // this can't really be how i'm supposed to do this
+			// if strings.Contains(err.Error(), "use of closed network connection") {
+			// 	return
+			// }
+			if errors.Is(err, net.ErrClosed) {
 				return
 			}
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -254,7 +254,6 @@ func probeTunnel(ctx context.Context, tunnel *wg.Tunnel) error {
 	results, err := tunnel.LookupTXT(ctx, "_apps.internal")
 	terminal.Debug("probe results for _apps.internal", results)
 
-	// _, err = tunnel.Resolver().LookupTXT(ctx, "_apps.internal")
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return ErrTunnelUnavailable
@@ -273,7 +272,6 @@ func (s *Server) handleProbe(c net.Conn, args []string) error {
 	}
 
 	if err := probeTunnel(context.Background(), tunnel); err != nil {
-		// captureWireguardConnErr(err, args[1])
 		return err
 	}
 
@@ -385,7 +383,6 @@ func (s *Server) handleConnect(c net.Conn, args []string) error {
 
 	address, err := resolve(tunnel, args[2])
 	if err != nil {
-		// captureWireguardConnErr(err, args[1])
 		return fmt.Errorf("connect: can't resolve address '%s': %s", args[2], err)
 	}
 
@@ -405,7 +402,6 @@ func (s *Server) handleConnect(c net.Conn, args []string) error {
 
 	outconn, err := tunnel.DialContext(ctx, "tcp", address)
 	if err != nil {
-		// captureWireguardConnErr(err, args[1])
 		cancel()
 		return fmt.Errorf("connection failed: %s", err)
 	}

--- a/pkg/agent/start.go
+++ b/pkg/agent/start.go
@@ -3,12 +3,15 @@
 package agent
 
 import (
+	"bufio"
+	"bytes"
 	"context"
-	"fmt"
 	"os/exec"
+	"regexp"
 	"syscall"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/api"
 )
 
@@ -19,23 +22,87 @@ func StartDaemon(ctx context.Context, api *api.Client, command string) (*Client,
 		Pgid:    0,
 	}
 
+	// buffer stdout and stderr from the daemon process. If it
+	// includes "OK <pid>" we know it started successfully.
+	// Otherwise we know it failed and we can include the output with the
+	// returnred error so it can be displayed to the user
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		panic(err)
+	}
+
+	startCh := make(chan error, 1)
+
+	go func() {
+		var output bytes.Buffer
+		r := regexp.MustCompile(`\AOK \d+\z`)
+
+		scanner := bufio.NewScanner(out)
+		scanner.Split(bufio.ScanLines)
+
+		var ok bool
+		for scanner.Scan() {
+			if r.Match(scanner.Bytes()) {
+				ok = true
+				break
+			}
+			if output.Len() > 0 {
+				output.WriteByte(byte('\n'))
+			}
+			output.Write(scanner.Bytes())
+		}
+
+		if ok {
+			startCh <- nil
+			return
+		}
+
+		startCh <- &AgentStartError{Output: output.String()}
+	}()
+
+	// run the command while the goroutine captures output
 	if err := cmd.Start(); err != nil {
 		return nil, err
 	}
 
-	// this is gross placeholder logic
-
-	for i := 0; i < 20; i++ {
-		time.Sleep(100 * time.Millisecond)
-
-		c, err := DefaultClient(api)
-		if err == nil {
-			_, err := c.Ping(ctx)
-			if err == nil {
-				return c, nil
-			}
-		}
+	// wait for the output to include "OK <pid>" or EOF
+	if startErr := <-startCh; startErr != nil {
+		return nil, startErr
 	}
 
-	return nil, fmt.Errorf("couldn't establish connection to Fly Agent")
+	client, err := waitForClient(ctx, api)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't establish connection to Fly Agent")
+	}
+
+	return client, nil
+}
+
+func waitForClient(ctx context.Context, api *api.Client) (*Client, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+
+	respCh := make(chan *Client, 1)
+
+	go func() {
+		for {
+			time.Sleep(100 * time.Millisecond)
+
+			c, err := DefaultClient(api)
+			if err == nil {
+				_, err := c.Ping(ctx)
+				if err == nil {
+					respCh <- c
+					break
+				}
+			}
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case client := <-respCh:
+		return client, nil
+	}
 }


### PR DESCRIPTION
It's hard to troubleshoot issues that cause the agent daemon to fail since it doesn't log to a file and is started on demand in the background. 

When a connection from flyctl to the daemon fails, the user sees this:
```
Error error establishing agent: couldn't establish connection to Fly Agent
```

Now it looks like this:

```
Error error connecting to docker: error establishing agent: Failed to start the agent daemon

Agent failed to start with the following output:
	Error daemon error: can't bind: listen unix /Users/md/.fly/fly-agent.sock: bind: address already in use

Try running the agent with 'flyctl agent daemon-start' to see more output. Once the issue preventing startup is fixed you can stop the agent and flyctl will create it as needed
exit status 1
```

There are also two new interfaces in the `flyerr` package to improve error output for users:

```go
// ErrorDescription is an error with detailed description that will be printed before the CLI exits
type ErrorDescription interface {
	error
	Description() string
}

// ErrorSuggestion is an error with a suggested next steps that will be printed before the CLI exits
type ErrorSuggestion interface {
	error
	Suggestion() string
}
```

When a command fails with an error it'll run `flyerr.PrintCLIOutput(err)` which unwraps the error stack looking for `Description` or `Suggestion` functions to print before exiting. Ideal use cases are printing a reason for an auth failure along with instructions on how to sign in, or a url to visit to correct a billing error. So just add one of those functions to your custom error and it'll be shown to the user with the right formatting. 

