### PR TITLE
Display os and arch in build output

### DIFF
--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -50,7 +50,7 @@ func (s *buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClient
 		terminal.Debug("failed to fetch docker server info %s", err)
 	}
 
-	msg := fmt.Sprintf("Building image with Docker (%s %s)", serverInfo.OSType, serverInfo.Architecture)
+	msg := fmt.Sprintf("Building image with Buildpacks (%s %s)", serverInfo.OSType, serverInfo.Architecture)
 	cmdfmt.PrintBegin(streams.ErrOut, msg)
 
 	err = packClient.Build(ctx, pack.BuildOptions{

--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -47,7 +47,7 @@ func (s *buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClient
 
 	serverInfo, err := docker.Info(ctx)
 	if err != nil {
-		terminal.Debug("failed to fetch docker server info %s", err)
+		terminal.Debug("error fetching docker server info:", err)
 	}
 
 	msg := fmt.Sprintf("Building image with Buildpacks (%s %s)", serverInfo.OSType, serverInfo.Architecture)

--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 
 	"github.com/buildpacks/pack"
 	"github.com/superfly/flyctl/flyctl"
@@ -46,7 +45,12 @@ func (s *buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClient
 		return nil, err
 	}
 
-	msg := fmt.Sprintf("Building image with Buildpacks (%s %s)", runtime.GOOS, runtime.GOARCH)
+	serverInfo, err := docker.Info(ctx)
+	if err != nil {
+		terminal.Debug("failed to fetch docker server info %s", err)
+	}
+
+	msg := fmt.Sprintf("Building image with Docker (%s %s)", serverInfo.OSType, serverInfo.Architecture)
 	cmdfmt.PrintBegin(streams.ErrOut, msg)
 
 	err = packClient.Build(ctx, pack.BuildOptions{

--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 
 	"github.com/buildpacks/pack"
 	"github.com/superfly/flyctl/flyctl"
@@ -45,7 +46,8 @@ func (s *buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClient
 		return nil, err
 	}
 
-	cmdfmt.PrintBegin(streams.ErrOut, "Building image with Buildpacks")
+	msg := fmt.Sprintf("Building image with Buildpacks (%s %s)", runtime.GOOS, runtime.GOARCH)
+	cmdfmt.PrintBegin(streams.ErrOut, msg)
 
 	err = packClient.Build(ctx, pack.BuildOptions{
 		AppPath:        opts.WorkingDir,

--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -50,8 +50,9 @@ func (s *buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClient
 		terminal.Debug("error fetching docker server info:", err)
 	}
 
-	msg := fmt.Sprintf("Building image with Buildpacks (%s %s)", serverInfo.OSType, serverInfo.Architecture)
-	cmdfmt.PrintBegin(streams.ErrOut, msg)
+	cmdfmt.PrintBegin(streams.ErrOut, "Building image with Buildpacks")
+	msg := fmt.Sprintf("docker host: %s %s %s", serverInfo.ServerVersion, serverInfo.OSType, serverInfo.Architecture)
+	cmdfmt.PrintDone(streams.ErrOut, msg)
 
 	err = packClient.Build(ctx, pack.BuildOptions{
 		AppPath:        opts.WorkingDir,

--- a/internal/build/imgsrc/builtin_builder.go
+++ b/internal/build/imgsrc/builtin_builder.go
@@ -75,8 +75,9 @@ func (ds *builtinBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 		terminal.Debug("error fetching docker server info:", err)
 	}
 
-	msg := fmt.Sprintf("Building image with Docker (%s %s)", serverInfo.OperatingSystem, serverInfo.Architecture)
-	cmdfmt.PrintBegin(streams.ErrOut, msg)
+	cmdfmt.PrintBegin(streams.ErrOut, "Building image with Docker")
+	msg := fmt.Sprintf("docker host: %s %s %s", serverInfo.ServerVersion, serverInfo.OSType, serverInfo.Architecture)
+	cmdfmt.PrintDone(streams.ErrOut, msg)
 
 	buildArgs := normalizeBuildArgsForDocker(opts.AppConfig, opts.ExtraBuildArgs)
 	imageID, err = runClassicBuild(ctx, streams, docker, r, opts, "", buildArgs)

--- a/internal/build/imgsrc/builtin_builder.go
+++ b/internal/build/imgsrc/builtin_builder.go
@@ -2,7 +2,6 @@ package imgsrc
 
 import (
 	"fmt"
-	"runtime"
 
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/internal/build/imgsrc/builtins"
@@ -71,7 +70,12 @@ func (ds *builtinBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 
 	var imageID string
 
-	msg := fmt.Sprintf("Building image with Docker (%s %s)", runtime.GOOS, runtime.GOARCH)
+	serverInfo, err := docker.Info(ctx)
+	if err != nil {
+		terminal.Debug("failed to fetch docker server info %s", err)
+	}
+
+	msg := fmt.Sprintf("Building image with Docker (%s %s)", serverInfo.OperatingSystem, serverInfo.Architecture)
 	cmdfmt.PrintBegin(streams.ErrOut, msg)
 
 	buildArgs := normalizeBuildArgsForDocker(opts.AppConfig, opts.ExtraBuildArgs)

--- a/internal/build/imgsrc/builtin_builder.go
+++ b/internal/build/imgsrc/builtin_builder.go
@@ -72,7 +72,7 @@ func (ds *builtinBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 
 	serverInfo, err := docker.Info(ctx)
 	if err != nil {
-		terminal.Debug("failed to fetch docker server info %s", err)
+		terminal.Debug("error fetching docker server info:", err)
 	}
 
 	msg := fmt.Sprintf("Building image with Docker (%s %s)", serverInfo.OperatingSystem, serverInfo.Architecture)

--- a/internal/build/imgsrc/builtin_builder.go
+++ b/internal/build/imgsrc/builtin_builder.go
@@ -2,6 +2,7 @@ package imgsrc
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/internal/build/imgsrc/builtins"
@@ -70,7 +71,8 @@ func (ds *builtinBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 
 	var imageID string
 
-	cmdfmt.PrintBegin(streams.ErrOut, "Building image with Docker")
+	msg := fmt.Sprintf("Building image with Docker (%s %s)", runtime.GOOS, runtime.GOARCH)
+	cmdfmt.PrintBegin(streams.ErrOut, msg)
 
 	buildArgs := normalizeBuildArgsForDocker(opts.AppConfig, opts.ExtraBuildArgs)
 	imageID, err = runClassicBuild(ctx, streams, docker, r, opts, "", buildArgs)

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -129,7 +129,7 @@ func (ds *dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClien
 
 	serverInfo, err := docker.Info(ctx)
 	if err != nil {
-		terminal.Debug("failed to fetch docker server info %s", err)
+		terminal.Debug("error fetching docker server info:", err)
 	}
 
 	msg := fmt.Sprintf("Building image with Docker (%s %s)", serverInfo.OSType, serverInfo.Architecture)

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -132,8 +132,9 @@ func (ds *dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClien
 		terminal.Debug("error fetching docker server info:", err)
 	}
 
-	msg := fmt.Sprintf("Building image with Docker (%s %s)", serverInfo.OSType, serverInfo.Architecture)
-	cmdfmt.PrintBegin(streams.ErrOut, msg)
+	cmdfmt.PrintBegin(streams.ErrOut, "Building image with Docker")
+	msg := fmt.Sprintf("docker host: %s %s %s", serverInfo.ServerVersion, serverInfo.OSType, serverInfo.Architecture)
+	cmdfmt.PrintDone(streams.ErrOut, msg)
 
 	buildArgs := normalizeBuildArgsForDocker(opts.AppConfig, opts.ExtraBuildArgs)
 

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/containerd/console"
 	"github.com/docker/docker/api/types"
@@ -128,7 +127,12 @@ func (ds *dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClien
 
 	var imageID string
 
-	msg := fmt.Sprintf("Building image with Docker (%s %s)", runtime.GOOS, runtime.GOARCH)
+	serverInfo, err := docker.Info(ctx)
+	if err != nil {
+		terminal.Debug("failed to fetch docker server info %s", err)
+	}
+
+	msg := fmt.Sprintf("Building image with Docker (%s %s)", serverInfo.OSType, serverInfo.Architecture)
 	cmdfmt.PrintBegin(streams.ErrOut, msg)
 
 	buildArgs := normalizeBuildArgsForDocker(opts.AppConfig, opts.ExtraBuildArgs)

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/containerd/console"
 	"github.com/docker/docker/api/types"
@@ -127,7 +128,8 @@ func (ds *dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClien
 
 	var imageID string
 
-	cmdfmt.PrintBegin(streams.ErrOut, "Building image with Docker")
+	msg := fmt.Sprintf("Building image with Docker (%s %s)", runtime.GOOS, runtime.GOARCH)
+	cmdfmt.PrintBegin(streams.ErrOut, msg)
 
 	buildArgs := normalizeBuildArgsForDocker(opts.AppConfig, opts.ExtraBuildArgs)
 


### PR DESCRIPTION
Changed the build output to help debugging, particularly on M1

```
==> Building image with Docker (darwin arm64)
```