### PR TITLE
 Remove duplicates method requireAppNameAsArg

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -23,11 +23,11 @@ func newAppsCommand(client *client.Client) *Command {
 
 	appsListStrings := docstrings.Get("apps.list")
 
-	BuildCommand(cmd, runAppsList, appsListStrings.Usage, appsListStrings.Short, appsListStrings.Long, client, requireSession)
+	BuildCommand(cmd, runAppsList, appsListStrings.Usage, appsListStrings.Short, appsListStrings.Long, client, nil, requireSession)
 
 	appsCreateStrings := docstrings.Get("apps.create")
 
-	create := BuildCommand(cmd, runInit, appsCreateStrings.Usage, appsCreateStrings.Short, appsCreateStrings.Long, client, requireSession)
+	create := BuildCommand(cmd, runInit, appsCreateStrings.Usage, appsCreateStrings.Short, appsCreateStrings.Long, client, nil, requireSession)
 	create.Args = cobra.RangeArgs(0, 1)
 
 	// TODO: Move flag descriptions into the docStrings
@@ -58,13 +58,13 @@ func newAppsCommand(client *client.Client) *Command {
 	})
 
 	appsDestroyStrings := docstrings.Get("apps.destroy")
-	destroy := BuildCommand(cmd, runDestroy, appsDestroyStrings.Usage, appsDestroyStrings.Short, appsDestroyStrings.Long, client, requireSession)
+	destroy := BuildCommand(cmd, runDestroy, appsDestroyStrings.Usage, appsDestroyStrings.Short, appsDestroyStrings.Long, client, nil, requireSession)
 	destroy.Args = cobra.ExactArgs(1)
 	// TODO: Move flag descriptions into the docStrings
 	destroy.AddBoolFlag(BoolFlagOpts{Name: "yes", Shorthand: "y", Description: "Accept all confirmations"})
 
 	appsMoveStrings := docstrings.Get("apps.move")
-	move := BuildCommand(cmd, runMove, appsMoveStrings.Usage, appsMoveStrings.Short, appsMoveStrings.Long, client, requireSession)
+	move := BuildCommand(cmd, runMove, appsMoveStrings.Usage, appsMoveStrings.Short, appsMoveStrings.Long, client, nil, requireSession)
 	move.Args = cobra.ExactArgs(1)
 	// TODO: Move flag descriptions into the docStrings
 	move.AddBoolFlag(BoolFlagOpts{Name: "yes", Shorthand: "y", Description: "Accept all confirmations"})
@@ -73,16 +73,20 @@ func newAppsCommand(client *client.Client) *Command {
 		Description: `The organization to move the app to`,
 	})
 
+	ctxOptions := map[string]interface{}{
+		"requireAppNameAsArg": true,
+	}
+
 	appsSuspendStrings := docstrings.Get("apps.suspend")
-	appsSuspendCmd := BuildCommand(cmd, runSuspend, appsSuspendStrings.Usage, appsSuspendStrings.Short, appsSuspendStrings.Long, client, requireSession, requireAppNameAsArg)
+	appsSuspendCmd := BuildCommand(cmd, runSuspend, appsSuspendStrings.Usage, appsSuspendStrings.Short, appsSuspendStrings.Long, client, ctxOptions, requireSession, requireAppName)
 	appsSuspendCmd.Args = cobra.RangeArgs(0, 1)
 
 	appsResumeStrings := docstrings.Get("apps.resume")
-	appsResumeCmd := BuildCommand(cmd, runResume, appsResumeStrings.Usage, appsResumeStrings.Short, appsResumeStrings.Long, client, requireSession, requireAppNameAsArg)
+	appsResumeCmd := BuildCommand(cmd, runResume, appsResumeStrings.Usage, appsResumeStrings.Short, appsResumeStrings.Long, client, ctxOptions, requireSession, requireAppName)
 	appsResumeCmd.Args = cobra.RangeArgs(0, 1)
 
 	appsRestartStrings := docstrings.Get("apps.restart")
-	appsRestartCmd := BuildCommand(cmd, runRestart, appsRestartStrings.Usage, appsRestartStrings.Short, appsRestartStrings.Long, client, requireSession, requireAppNameAsArg)
+	appsRestartCmd := BuildCommand(cmd, runRestart, appsRestartStrings.Usage, appsRestartStrings.Short, appsRestartStrings.Long, client, ctxOptions, requireSession, requireAppName)
 	appsRestartCmd.Args = cobra.RangeArgs(0, 1)
 
 	return cmd

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -26,19 +26,19 @@ func newAuthCommand(client *client.Client) *Command {
 
 	authStrings := docstrings.Get("auth")
 
-	cmd := BuildCommandKS(nil, nil, authStrings, client)
+	cmd := BuildCommandKS(nil, nil, authStrings, client, nil)
 
 	authWhoamiStrings := docstrings.Get("auth.whoami")
-	BuildCommand(cmd, runWhoami, authWhoamiStrings.Usage, authWhoamiStrings.Short, authWhoamiStrings.Long, client, requireSession)
+	BuildCommand(cmd, runWhoami, authWhoamiStrings.Usage, authWhoamiStrings.Short, authWhoamiStrings.Long, client, nil, requireSession)
 
 	authTokenStrings := docstrings.Get("auth.token")
-	BuildCommand(cmd, runAuthToken, authTokenStrings.Usage, authTokenStrings.Short, authTokenStrings.Long, client, requireSession)
+	BuildCommand(cmd, runAuthToken, authTokenStrings.Usage, authTokenStrings.Short, authTokenStrings.Long, client, nil, requireSession)
 
 	authLoginStrings := docstrings.Get("auth.login")
-	login := BuildCommand(cmd, runLogin, authLoginStrings.Usage, authLoginStrings.Short, authLoginStrings.Long, client)
+	login := BuildCommand(cmd, runLogin, authLoginStrings.Usage, authLoginStrings.Short, authLoginStrings.Long, client, nil)
 
 	authDockerStrings := docstrings.Get("auth.docker")
-	BuildCommand(cmd, runAuthDocker, authDockerStrings.Usage, authDockerStrings.Short, authDockerStrings.Long, client)
+	BuildCommand(cmd, runAuthDocker, authDockerStrings.Usage, authDockerStrings.Short, authDockerStrings.Long, client, nil)
 
 	// TODO: Move flag descriptions into the docStrings
 	login.AddBoolFlag(BoolFlagOpts{
@@ -60,10 +60,10 @@ func newAuthCommand(client *client.Client) *Command {
 	})
 
 	authLogoutStrings := docstrings.Get("auth.logout")
-	BuildCommand(cmd, runLogout, authLogoutStrings.Usage, authLogoutStrings.Short, authLogoutStrings.Long, client, requireSession)
+	BuildCommand(cmd, runLogout, authLogoutStrings.Usage, authLogoutStrings.Short, authLogoutStrings.Long, client, nil, requireSession)
 
 	authSignupStrings := docstrings.Get("auth.signup")
-	BuildCommand(cmd, runSignup, authSignupStrings.Usage, authSignupStrings.Short, authSignupStrings.Long, client)
+	BuildCommand(cmd, runSignup, authSignupStrings.Usage, authSignupStrings.Short, authSignupStrings.Long, client, nil)
 
 	return cmd
 }

--- a/cmd/autoscaling.go
+++ b/cmd/autoscaling.go
@@ -18,27 +18,27 @@ import (
 func newAutoscaleCommand(client *client.Client) *Command {
 	autoscaleStrings := docstrings.Get("autoscale")
 
-	cmd := BuildCommandKS(nil, nil, autoscaleStrings, client, requireSession, requireAppName)
+	cmd := BuildCommandKS(nil, nil, autoscaleStrings, client, nil, requireSession, requireAppName)
 	//cmd.Deprecated = "use `flyctl scale` instead"
 
 	disableCmdStrings := docstrings.Get("autoscale.disable")
-	disableCmd := BuildCommand(cmd, runDisableAutoscaling, disableCmdStrings.Usage, disableCmdStrings.Short, disableCmdStrings.Long, client, requireSession, requireAppName)
+	disableCmd := BuildCommand(cmd, runDisableAutoscaling, disableCmdStrings.Usage, disableCmdStrings.Short, disableCmdStrings.Long, client, nil, requireSession, requireAppName)
 	disableCmd.Args = cobra.RangeArgs(0, 2)
 
 	balanceCmdStrings := docstrings.Get("autoscale.balanced")
-	balanceCmd := BuildCommand(cmd, runBalanceScale, balanceCmdStrings.Usage, balanceCmdStrings.Short, balanceCmdStrings.Long, client, requireSession, requireAppName)
+	balanceCmd := BuildCommand(cmd, runBalanceScale, balanceCmdStrings.Usage, balanceCmdStrings.Short, balanceCmdStrings.Long, client, nil, requireSession, requireAppName)
 	balanceCmd.Args = cobra.RangeArgs(0, 2)
 
 	standardCmdStrings := docstrings.Get("autoscale.standard")
-	standardCmd := BuildCommand(cmd, runStandardScale, standardCmdStrings.Usage, standardCmdStrings.Short, standardCmdStrings.Long, client, requireSession, requireAppName)
+	standardCmd := BuildCommand(cmd, runStandardScale, standardCmdStrings.Usage, standardCmdStrings.Short, standardCmdStrings.Long, client, nil, requireSession, requireAppName)
 	standardCmd.Args = cobra.RangeArgs(0, 2)
 
 	setCmdStrings := docstrings.Get("autoscale.set")
-	setCmd := BuildCommand(cmd, runSetParamsOnly, setCmdStrings.Usage, setCmdStrings.Short, setCmdStrings.Long, client, requireSession, requireAppName)
+	setCmd := BuildCommand(cmd, runSetParamsOnly, setCmdStrings.Usage, setCmdStrings.Short, setCmdStrings.Long, client, nil, requireSession, requireAppName)
 	setCmd.Args = cobra.RangeArgs(0, 2)
 
 	showCmdStrings := docstrings.Get("autoscale.show")
-	BuildCommand(cmd, runAutoscalingShow, showCmdStrings.Usage, showCmdStrings.Short, showCmdStrings.Long, client, requireSession, requireAppName)
+	BuildCommand(cmd, runAutoscalingShow, showCmdStrings.Usage, showCmdStrings.Short, showCmdStrings.Long, client, nil, requireSession, requireAppName)
 
 	return cmd
 }

--- a/cmd/builds.go
+++ b/cmd/builds.go
@@ -16,12 +16,12 @@ import (
 func newBuildsCommand(client *client.Client) *Command {
 	buildsStrings := docstrings.Get("builds")
 
-	cmd := BuildCommandKS(nil, nil, buildsStrings, client, requireSession, requireAppName)
+	cmd := BuildCommandKS(nil, nil, buildsStrings, client, nil, requireSession, requireAppName)
 
 	buildsListStrings := docstrings.Get("builds.list")
-	BuildCommandKS(cmd, runListBuilds, buildsListStrings, client, requireSession, requireAppName)
+	BuildCommandKS(cmd, runListBuilds, buildsListStrings, client, nil, requireSession, requireAppName)
 	buildsLogsStrings := docstrings.Get("builds.logs")
-	logs := BuildCommandKS(cmd, runBuildLogs, buildsLogsStrings, client, requireSession, requireAppName)
+	logs := BuildCommandKS(cmd, runBuildLogs, buildsLogsStrings, client, nil, requireSession, requireAppName)
 	logs.Command.Args = cobra.ExactArgs(1)
 
 	return cmd

--- a/cmd/certificates.go
+++ b/cmd/certificates.go
@@ -20,28 +20,28 @@ import (
 func newCertificatesCommand(client *client.Client) *Command {
 	certsStrings := docstrings.Get("certs")
 
-	cmd := BuildCommandKS(nil, nil, certsStrings, client, requireAppName, requireSession)
+	cmd := BuildCommandKS(nil, nil, certsStrings, client, nil, requireAppName, requireSession)
 
 	certsListStrings := docstrings.Get("certs.list")
-	BuildCommandKS(cmd, runCertsList, certsListStrings, client, requireSession, requireAppName)
+	BuildCommandKS(cmd, runCertsList, certsListStrings, client, nil, requireSession, requireAppName)
 
 	certsCreateStrings := docstrings.Get("certs.add")
-	createCmd := BuildCommandKS(cmd, runCertAdd, certsCreateStrings, client, requireSession, requireAppName)
+	createCmd := BuildCommandKS(cmd, runCertAdd, certsCreateStrings, client, nil, requireSession, requireAppName)
 	createCmd.Aliases = []string{"create"}
 	createCmd.Command.Args = cobra.ExactArgs(1)
 
 	certsDeleteStrings := docstrings.Get("certs.remove")
-	deleteCmd := BuildCommandKS(cmd, runCertDelete, certsDeleteStrings, client, requireSession, requireAppName)
+	deleteCmd := BuildCommandKS(cmd, runCertDelete, certsDeleteStrings, client, nil, requireSession, requireAppName)
 	deleteCmd.Aliases = []string{"delete"}
 	deleteCmd.Command.Args = cobra.ExactArgs(1)
 	deleteCmd.AddBoolFlag(BoolFlagOpts{Name: "yes", Shorthand: "y", Description: "accept all confirmations"})
 
 	certsShowStrings := docstrings.Get("certs.show")
-	show := BuildCommandKS(cmd, runCertShow, certsShowStrings, client, requireSession, requireAppName)
+	show := BuildCommandKS(cmd, runCertShow, certsShowStrings, client, nil, requireSession, requireAppName)
 	show.Command.Args = cobra.ExactArgs(1)
 
 	certsCheckStrings := docstrings.Get("certs.check")
-	check := BuildCommandKS(cmd, runCertCheck, certsCheckStrings, client, requireSession, requireAppName)
+	check := BuildCommandKS(cmd, runCertCheck, certsCheckStrings, client, nil, requireSession, requireAppName)
 	check.Command.Args = cobra.ExactArgs(1)
 
 	return cmd

--- a/cmd/checks.go
+++ b/cmd/checks.go
@@ -15,26 +15,26 @@ import (
 
 func newChecksCommand(client *client.Client) *Command {
 	checksStrings := docstrings.Get("checks")
-	cmd := BuildCommandKS(nil, nil, checksStrings, client)
+	cmd := BuildCommandKS(nil, nil, checksStrings, client, nil)
 
 	handlersStrings := docstrings.Get("checks.handlers")
-	handlersCmd := BuildCommandKS(cmd, nil, handlersStrings, client)
+	handlersCmd := BuildCommandKS(cmd, nil, handlersStrings, client, nil)
 
 	handlersListStrings := docstrings.Get("checks.handlers.list")
-	listHandlersCmd := BuildCommandKS(handlersCmd, runListChecksHandlers, handlersListStrings, client, requireSession)
+	listHandlersCmd := BuildCommandKS(handlersCmd, runListChecksHandlers, handlersListStrings, client, nil, requireSession)
 	listHandlersCmd.Args = cobra.ExactArgs(1)
 
 	handlersCreateStrings := docstrings.Get("checks.handlers.create")
-	createHandlersCmd := BuildCommandKS(handlersCmd, runCreateChecksHandler, handlersCreateStrings, client, requireSession)
+	createHandlersCmd := BuildCommandKS(handlersCmd, runCreateChecksHandler, handlersCreateStrings, client, nil, requireSession)
 	createHandlersCmd.AddStringFlag(StringFlagOpts{Name: "type", Description: "The type of handler to create, can be slack or pagerduty"})
 	createHandlersCmd.AddStringFlag(StringFlagOpts{Name: "organization", Shorthand: "o", Description: "The organization to add the handler to"})
 
 	handlersDeleteStrings := docstrings.Get("checks.handlers.delete")
-	deleteHandlerCmd := BuildCommandKS(handlersCmd, runDeleteChecksHandler, handlersDeleteStrings, client, requireSession)
+	deleteHandlerCmd := BuildCommandKS(handlersCmd, runDeleteChecksHandler, handlersDeleteStrings, client, nil, requireSession)
 	deleteHandlerCmd.Args = cobra.ExactArgs(2)
 
 	checksListStrings := docstrings.Get("checks.list")
-	listChecksCmd := BuildCommandKS(cmd, runAppCheckList, checksListStrings, client, requireSession, requireAppName)
+	listChecksCmd := BuildCommandKS(cmd, runAppCheckList, checksListStrings, client, nil, requireSession, requireAppName)
 	listChecksCmd.AddStringFlag(StringFlagOpts{Name: "check-name", Description: "Filter checks by name"})
 
 	return cmd

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -20,19 +20,19 @@ func newConfigCommand(client *client.Client) *Command {
 
 	configStrings := docstrings.Get("config")
 
-	cmd := BuildCommandKS(nil, nil, configStrings, client, requireSession, requireAppName)
+	cmd := BuildCommandKS(nil, nil, configStrings, client, nil, requireSession, requireAppName)
 
 	configDisplayStrings := docstrings.Get("config.display")
-	BuildCommandKS(cmd, runDisplayConfig, configDisplayStrings, client, requireSession, requireAppName)
+	BuildCommandKS(cmd, runDisplayConfig, configDisplayStrings, client, nil, requireSession, requireAppName)
 
 	configSaveStrings := docstrings.Get("config.save")
-	BuildCommandKS(cmd, runSaveConfig, configSaveStrings, client, requireSession, requireAppName)
+	BuildCommandKS(cmd, runSaveConfig, configSaveStrings, client, nil, requireSession, requireAppName)
 
 	configValidateStrings := docstrings.Get("config.validate")
-	BuildCommandKS(cmd, runValidateConfig, configValidateStrings, client, requireSession, requireAppName)
+	BuildCommandKS(cmd, runValidateConfig, configValidateStrings, client, nil, requireSession, requireAppName)
 
 	configEnvStrings := docstrings.Get("config.env")
-	BuildCommandKS(cmd, runEnvConfig, configEnvStrings, client, requireSession, requireAppName)
+	BuildCommandKS(cmd, runEnvConfig, configEnvStrings, client, nil, requireSession, requireAppName)
 
 	return cmd
 }

--- a/cmd/curl.go
+++ b/cmd/curl.go
@@ -25,7 +25,7 @@ import (
 
 func newCurlCommand(client *client.Client) *Command {
 	curlStrings := docstrings.Get("curl")
-	cmd := BuildCommandKS(nil, runCurl, curlStrings, client, requireSession)
+	cmd := BuildCommandKS(nil, runCurl, curlStrings, client, nil, requireSession)
 	cmd.Args = cobra.ExactArgs(1)
 	cmd.Hidden = true
 	return cmd

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -13,11 +13,11 @@ import (
 
 func newDashboardCommand(client *client.Client) *Command {
 	dashboardStrings := docstrings.Get("dashboard")
-	dashboardCmd := BuildCommandKS(nil, runDashboard, dashboardStrings, client, requireSession, requireAppName)
+	dashboardCmd := BuildCommandKS(nil, runDashboard, dashboardStrings, client, nil, requireSession, requireAppName)
 	dashboardCmd.Aliases = []string{"dash"}
 
 	dashMetricsStrings := docstrings.Get("dashboard.metrics")
-	BuildCommandKS(dashboardCmd, runDashboardMetrics, dashMetricsStrings, client, requireSession, requireAppName)
+	BuildCommandKS(dashboardCmd, runDashboardMetrics, dashMetricsStrings, client, nil, requireSession, requireAppName)
 
 	return dashboardCmd
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -33,7 +33,7 @@ import (
 
 func newDeployCommand(client *client.Client) *Command {
 	deployStrings := docstrings.Get("deploy")
-	cmd := BuildCommandKS(nil, runDeploy, deployStrings, client, workingDirectoryFromArg(0), requireSession, requireAppName)
+	cmd := BuildCommandKS(nil, runDeploy, deployStrings, client, nil, workingDirectoryFromArg(0), requireSession, requireAppName)
 	cmd.AddStringFlag(StringFlagOpts{
 		Name:        "image",
 		Shorthand:   "i",

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -18,7 +18,7 @@ func newDestroyCommand(client *client.Client) *Command {
 
 	destroyStrings := docstrings.Get("destroy")
 
-	destroy := BuildCommand(nil, runDestroy, destroyStrings.Usage, destroyStrings.Short, destroyStrings.Long, client, requireSession)
+	destroy := BuildCommand(nil, runDestroy, destroyStrings.Usage, destroyStrings.Short, destroyStrings.Long, client, nil, requireSession)
 
 	destroy.Args = cobra.ExactArgs(1)
 

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -15,14 +15,14 @@ import (
 
 func newDNSCommand(client *client.Client) *Command {
 	dnsStrings := docstrings.Get("dns-records")
-	cmd := BuildCommandKS(nil, nil, dnsStrings, client, requireSession)
+	cmd := BuildCommandKS(nil, nil, dnsStrings, client, nil, requireSession)
 
 	listStrings := docstrings.Get("dns-records.list")
-	listCmd := BuildCommandKS(cmd, runRecordsList, listStrings, client, requireSession)
+	listCmd := BuildCommandKS(cmd, runRecordsList, listStrings, client, nil, requireSession)
 	listCmd.Args = cobra.ExactArgs(1)
 
 	recordsExportStrings := docstrings.Get("dns-records.export")
-	recordsExportCmd := BuildCommandKS(cmd, runRecordsExport, recordsExportStrings, client, requireSession)
+	recordsExportCmd := BuildCommandKS(cmd, runRecordsExport, recordsExportStrings, client, nil, requireSession)
 	recordsExportCmd.Args = cobra.MinimumNArgs(1)
 	recordsExportCmd.Args = cobra.MaximumNArgs(3)
 	recordsExportCmd.AddBoolFlag(BoolFlagOpts{
@@ -30,7 +30,7 @@ func newDNSCommand(client *client.Client) *Command {
 	})
 
 	recordsImportStrings := docstrings.Get("dns-records.import")
-	recordsImportCmd := BuildCommandKS(cmd, runRecordsImport, recordsImportStrings, client, requireSession)
+	recordsImportCmd := BuildCommandKS(cmd, runRecordsImport, recordsImportStrings, client, nil, requireSession)
 	recordsImportCmd.Args = cobra.MaximumNArgs(3)
 	recordsImportCmd.Args = cobra.MinimumNArgs(1)
 

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -13,7 +13,7 @@ import (
 
 func newDocsCommand(client *client.Client) *Command {
 	docsStrings := docstrings.Get("docs")
-	return BuildCommand(nil, runLaunchDocs, docsStrings.Usage, docsStrings.Short, docsStrings.Long, client)
+	return BuildCommand(nil, runLaunchDocs, docsStrings.Usage, docsStrings.Short, docsStrings.Long, client, nil)
 }
 
 const docsURL = "https://fly.io/docs/"

--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -18,19 +18,19 @@ import (
 
 func newDomainsCommand(client *client.Client) *Command {
 	domainsStrings := docstrings.Get("domains")
-	cmd := BuildCommandKS(nil, nil, domainsStrings, client, requireSession)
+	cmd := BuildCommandKS(nil, nil, domainsStrings, client, nil, requireSession)
 
 	listStrings := docstrings.Get("domains.list")
-	listCmd := BuildCommandKS(cmd, runDomainsList, listStrings, client, requireSession)
+	listCmd := BuildCommandKS(cmd, runDomainsList, listStrings, client, nil, requireSession)
 	listCmd.Args = cobra.MaximumNArgs(1)
 
-	showCmd := BuildCommandKS(cmd, runDomainsShow, docstrings.Get("domains.show"), client, requireSession)
+	showCmd := BuildCommandKS(cmd, runDomainsShow, docstrings.Get("domains.show"), client, nil, requireSession)
 	showCmd.Args = cobra.ExactArgs(1)
 
-	addCmd := BuildCommandKS(cmd, runDomainsCreate, docstrings.Get("domains.add"), client, requireSession)
+	addCmd := BuildCommandKS(cmd, runDomainsCreate, docstrings.Get("domains.add"), client, nil, requireSession)
 	addCmd.Args = cobra.MaximumNArgs(2)
 
-	registerCmd := BuildCommandKS(cmd, runDomainsRegister, docstrings.Get("domains.register"), client, requireSession)
+	registerCmd := BuildCommandKS(cmd, runDomainsRegister, docstrings.Get("domains.register"), client, nil, requireSession)
 	registerCmd.Args = cobra.MaximumNArgs(2)
 
 	return cmd

--- a/cmd/fly_agent.go
+++ b/cmd/fly_agent.go
@@ -13,31 +13,35 @@ import (
 )
 
 func newAgentCommand(client *client.Client) *Command {
-	cmd := BuildCommandKS(nil, nil, docstrings.Get("agent"), client, requireSession)
+	cmd := BuildCommandKS(nil, nil, docstrings.Get("agent"), client, nil, requireSession)
 	cmd.Hidden = true
 
 	_ = BuildCommandKS(cmd,
 		runFlyAgentDaemonStart,
 		docstrings.Get("agent.daemon-start"),
 		client,
+		nil,
 		requireSession)
 
 	_ = BuildCommandKS(cmd,
 		runFlyAgentStart,
 		docstrings.Get("agent.start"),
 		client,
+		nil,
 		requireSession)
 
 	_ = BuildCommandKS(cmd,
 		runFlyAgentStart,
 		docstrings.Get("agent.restart"),
 		client,
+		nil,
 		requireSession)
 
 	_ = BuildCommandKS(cmd,
 		runFlyAgentStop,
 		docstrings.Get("agent.stop"),
 		client,
+		nil,
 		requireSession)
 
 	return cmd

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -11,7 +11,7 @@ import (
 
 func newHistoryCommand(client *client.Client) *Command {
 	historyStrings := docstrings.Get("history")
-	return BuildCommand(nil, runHistory, historyStrings.Usage, historyStrings.Short, historyStrings.Long, client, requireSession, requireAppName)
+	return BuildCommand(nil, runHistory, historyStrings.Usage, historyStrings.Short, historyStrings.Long, client, nil, requireSession, requireAppName)
 }
 
 func runHistory(commandContext *cmdctx.CmdContext) error {

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -12,7 +12,7 @@ import (
 
 func newInfoCommand(client *client.Client) *Command {
 	ks := docstrings.Get("info")
-	appInfoCmd := BuildCommandKS(nil, runInfo, ks, client, requireSession, requireAppName)
+	appInfoCmd := BuildCommandKS(nil, runInfo, ks, client, nil, requireSession, requireAppName)
 
 	appInfoCmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "name",

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -21,7 +21,7 @@ func newInitCommand(client *client.Client) *Command {
 
 	initStrings := docstrings.Get("init")
 
-	cmd := BuildCommandKS(nil, runInit, initStrings, client, requireSession)
+	cmd := BuildCommandKS(nil, runInit, initStrings, client, nil, requireSession)
 
 	cmd.Args = cobra.RangeArgs(0, 1)
 

--- a/cmd/ips.go
+++ b/cmd/ips.go
@@ -18,22 +18,22 @@ import (
 func newIPAddressesCommand(client *client.Client) *Command {
 
 	ipsStrings := docstrings.Get("ips")
-	cmd := BuildCommandKS(nil, nil, ipsStrings, client, requireSession, requireAppName)
+	cmd := BuildCommandKS(nil, nil, ipsStrings, client, nil, requireSession, requireAppName)
 
 	ipsListStrings := docstrings.Get("ips.list")
-	BuildCommandKS(cmd, runIPAddressesList, ipsListStrings, client, requireSession, requireAppName)
+	BuildCommandKS(cmd, runIPAddressesList, ipsListStrings, client, nil, requireSession, requireAppName)
 
 	ipsPrivateListStrings := docstrings.Get("ips.private")
-	BuildCommandKS(cmd, runPrivateIPAddressesList, ipsPrivateListStrings, client, requireSession, requireAppName)
+	BuildCommandKS(cmd, runPrivateIPAddressesList, ipsPrivateListStrings, client, nil, requireSession, requireAppName)
 
 	ipsAllocateV4Strings := docstrings.Get("ips.allocate-v4")
-	BuildCommandKS(cmd, runAllocateIPAddressV4, ipsAllocateV4Strings, client, requireSession, requireAppName)
+	BuildCommandKS(cmd, runAllocateIPAddressV4, ipsAllocateV4Strings, client, nil, requireSession, requireAppName)
 
 	ipsAllocateV6Strings := docstrings.Get("ips.allocate-v6")
-	BuildCommandKS(cmd, runAllocateIPAddressV6, ipsAllocateV6Strings, client, requireSession, requireAppName)
+	BuildCommandKS(cmd, runAllocateIPAddressV6, ipsAllocateV6Strings, client, nil, requireSession, requireAppName)
 
 	ipsReleaseStrings := docstrings.Get("ips.release")
-	release := BuildCommandKS(cmd, runReleaseIPAddress, ipsReleaseStrings, client, requireSession, requireAppName)
+	release := BuildCommandKS(cmd, runReleaseIPAddress, ipsReleaseStrings, client, nil, requireSession, requireAppName)
 	release.Args = cobra.ExactArgs(1)
 
 	return cmd

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -19,7 +19,7 @@ import (
 
 func newLaunchCommand(client *client.Client) *Command {
 	launchStrings := docstrings.Get("launch")
-	launchCmd := BuildCommandKS(nil, runLaunch, launchStrings, client, requireSession)
+	launchCmd := BuildCommandKS(nil, runLaunch, launchStrings, client, nil, requireSession)
 	launchCmd.Args = cobra.NoArgs
 	launchCmd.AddStringFlag(StringFlagOpts{Name: "path", Description: `path to app code and where a fly.toml file will be saved.`, Default: "."})
 	launchCmd.AddStringFlag(StringFlagOpts{Name: "org", Description: `the organization that will own the app`})

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -16,11 +16,11 @@ import (
 func newListCommand(client *client.Client) *Command {
 	ks := docstrings.Get("list")
 
-	listCmd := BuildCommandKS(nil, nil, ks, client, requireSession)
+	listCmd := BuildCommandKS(nil, nil, ks, client, nil, requireSession)
 	listCmd.Aliases = []string{"ls"}
 
 	laks := docstrings.Get("list.apps")
-	listAppsCmd := BuildCommandKS(listCmd, runListApps, laks, client, requireSession)
+	listAppsCmd := BuildCommandKS(listCmd, runListApps, laks, client, nil, requireSession)
 
 	listAppsCmd.AddStringFlag(StringFlagOpts{
 		Name:        "org",
@@ -48,7 +48,7 @@ func newListCommand(client *client.Client) *Command {
 	})
 
 	loks := docstrings.Get("list.orgs")
-	BuildCommandKS(listCmd, runListOrgs, loks, client, requireSession)
+	BuildCommandKS(listCmd, runListOrgs, loks, client, nil, requireSession)
 
 	return listCmd
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -10,7 +10,7 @@ import (
 
 func newLogsCommand(client *client.Client) *Command {
 	logsStrings := docstrings.Get("logs")
-	cmd := BuildCommandKS(nil, runLogs, logsStrings, client, requireSession, requireAppName)
+	cmd := BuildCommandKS(nil, runLogs, logsStrings, client, nil, requireSession, requireAppName)
 
 	// TODO: Move flag descriptions into the docStrings
 	cmd.AddStringFlag(StringFlagOpts{

--- a/cmd/monitor.go
+++ b/cmd/monitor.go
@@ -16,7 +16,7 @@ import (
 
 func newMonitorCommand(client *client.Client) *Command {
 	ks := docstrings.Get("monitor")
-	return BuildCommandKS(nil, runMonitor, ks, client, requireSession, requireAppName)
+	return BuildCommandKS(nil, runMonitor, ks, client, nil, requireSession, requireAppName)
 }
 
 func runMonitor(commandContext *cmdctx.CmdContext) error {

--- a/cmd/move.go
+++ b/cmd/move.go
@@ -18,7 +18,7 @@ import (
 func newMoveCommand(client *client.Client) *Command {
 
 	moveStrings := docstrings.Get("move")
-	moveCmd := BuildCommandKS(nil, runMove, moveStrings, client, requireSession)
+	moveCmd := BuildCommandKS(nil, runMove, moveStrings, client, nil, requireSession)
 	moveCmd.Args = cobra.ExactArgs(1)
 	// TODO: Move flag descriptions into the docStrings
 	moveCmd.AddBoolFlag(BoolFlagOpts{Name: "yes", Shorthand: "y", Description: "Accept all confirmations"})

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -14,7 +14,7 @@ import (
 
 func newOpenCommand(client *client.Client) *Command {
 	ks := docstrings.Get("open")
-	opencommand := BuildCommandKS(nil, runOpen, ks, client, requireSession, requireAppName)
+	opencommand := BuildCommandKS(nil, runOpen, ks, client, nil, requireSession, requireAppName)
 	return opencommand
 }
 

--- a/cmd/orgs.go
+++ b/cmd/orgs.go
@@ -15,33 +15,33 @@ import (
 
 func newOrgsCommand(client *client.Client) *Command {
 	orgsStrings := docstrings.Get("orgs")
-	orgscmd := BuildCommandKS(nil, nil, orgsStrings, client, requireSession)
+	orgscmd := BuildCommandKS(nil, nil, orgsStrings, client, nil, requireSession)
 
 	orgsListStrings := docstrings.Get("orgs.list")
-	BuildCommandKS(orgscmd, runOrgsList, orgsListStrings, client, requireSession)
+	BuildCommandKS(orgscmd, runOrgsList, orgsListStrings, client, nil, requireSession)
 
 	orgsShowStrings := docstrings.Get("orgs.show")
-	orgsShowCommand := BuildCommandKS(orgscmd, runOrgsShow, orgsShowStrings, client, requireSession)
+	orgsShowCommand := BuildCommandKS(orgscmd, runOrgsShow, orgsShowStrings, client, nil, requireSession)
 	orgsShowCommand.Args = cobra.ExactArgs(1)
 
 	orgsInviteStrings := docstrings.Get("orgs.invite")
-	orgsInviteCommand := BuildCommandKS(orgscmd, runOrgsInvite, orgsInviteStrings, client, requireSession)
+	orgsInviteCommand := BuildCommandKS(orgscmd, runOrgsInvite, orgsInviteStrings, client, nil, requireSession)
 	orgsInviteCommand.Args = cobra.MaximumNArgs(2)
 
 	orgsRevokeStrings := docstrings.Get("orgs.revoke")
-	orgsRevokeCommand := BuildCommandKS(orgscmd, runOrgsRevoke, orgsRevokeStrings, client, requireSession)
+	orgsRevokeCommand := BuildCommandKS(orgscmd, runOrgsRevoke, orgsRevokeStrings, client, nil, requireSession)
 	orgsRevokeCommand.Args = cobra.MaximumNArgs(2)
 
 	orgsRemoveStrings := docstrings.Get("orgs.remove")
-	orgsRemoveCommand := BuildCommandKS(orgscmd, runOrgsRemove, orgsRemoveStrings, client, requireSession)
+	orgsRemoveCommand := BuildCommandKS(orgscmd, runOrgsRemove, orgsRemoveStrings, client, nil, requireSession)
 	orgsRemoveCommand.Args = cobra.MaximumNArgs(2)
 
 	orgsCreateStrings := docstrings.Get("orgs.create")
-	orgsCreateCommand := BuildCommandKS(orgscmd, runOrgsCreate, orgsCreateStrings, client, requireSession)
+	orgsCreateCommand := BuildCommandKS(orgscmd, runOrgsCreate, orgsCreateStrings, client, nil, requireSession)
 	orgsCreateCommand.Args = cobra.RangeArgs(0, 1)
 
 	orgsDeleteStrings := docstrings.Get("orgs.delete")
-	orgsDeleteCommand := BuildCommandKS(orgscmd, runOrgsDelete, orgsDeleteStrings, client, requireSession)
+	orgsDeleteCommand := BuildCommandKS(orgscmd, runOrgsDelete, orgsDeleteStrings, client, nil, requireSession)
 	orgsDeleteCommand.Args = cobra.ExactArgs(1)
 
 	return orgscmd

--- a/cmd/platform.go
+++ b/cmd/platform.go
@@ -15,16 +15,16 @@ import (
 func newPlatformCommand(client *client.Client) *Command {
 	platformStrings := docstrings.Get("platform")
 
-	cmd := BuildCommandKS(nil, nil, platformStrings, client, requireAppName)
+	cmd := BuildCommandKS(nil, nil, platformStrings, client, nil, requireAppName)
 
 	regionsStrings := docstrings.Get("platform.regions")
-	BuildCommandKS(cmd, runPlatformRegions, regionsStrings, client, requireSession)
+	BuildCommandKS(cmd, runPlatformRegions, regionsStrings, client, nil, requireSession)
 
 	vmSizesStrings := docstrings.Get("platform.vmsizes")
-	BuildCommandKS(cmd, runPlatformVMSizes, vmSizesStrings, client, requireSession)
+	BuildCommandKS(cmd, runPlatformVMSizes, vmSizesStrings, client, nil, requireSession)
 
 	statusStrings := docstrings.Get("platform.status")
-	BuildCommandKS(cmd, runPlatformStatus, statusStrings, client, requireSession, requireAppName)
+	BuildCommandKS(cmd, runPlatformStatus, statusStrings, client, nil, requireSession, requireAppName)
 
 	return cmd
 }

--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -20,15 +20,15 @@ import (
 
 func newPostgresCommand(client *client.Client) *Command {
 	domainsStrings := docstrings.Get("postgres")
-	cmd := BuildCommandKS(nil, nil, domainsStrings, client, requireSession)
+	cmd := BuildCommandKS(nil, nil, domainsStrings, client, nil, requireSession)
 	cmd.Aliases = []string{"pg"}
 
 	listStrings := docstrings.Get("postgres.list")
-	listCmd := BuildCommandKS(cmd, runPostgresList, listStrings, client, requireSession)
+	listCmd := BuildCommandKS(cmd, runPostgresList, listStrings, client, nil, requireSession)
 	listCmd.Args = cobra.MaximumNArgs(1)
 
 	createStrings := docstrings.Get("postgres.create")
-	createCmd := BuildCommandKS(cmd, runCreatePostgresCluster, createStrings, client, requireSession)
+	createCmd := BuildCommandKS(cmd, runCreatePostgresCluster, createStrings, client, nil, requireSession)
 	createCmd.AddStringFlag(StringFlagOpts{Name: "organization", Description: "the organization that will own the app"})
 	createCmd.AddStringFlag(StringFlagOpts{Name: "name", Description: "the name of the new app"})
 	createCmd.AddStringFlag(StringFlagOpts{Name: "region", Description: "the region to launch the new app in"})
@@ -38,27 +38,30 @@ func newPostgresCommand(client *client.Client) *Command {
 	createCmd.AddStringFlag(StringFlagOpts{Name: "image-ref", Hidden: true})
 
 	attachStrngs := docstrings.Get("postgres.attach")
-	attachCmd := BuildCommandKS(cmd, runAttachPostgresCluster, attachStrngs, client, requireSession, requireAppName)
+	attachCmd := BuildCommandKS(cmd, runAttachPostgresCluster, attachStrngs, client, nil, requireSession, requireAppName)
 	attachCmd.AddStringFlag(StringFlagOpts{Name: "postgres-app", Description: "the postgres cluster to attach to the app"})
 	attachCmd.AddStringFlag(StringFlagOpts{Name: "database-name", Description: "database to use, defaults to a new database with the same name as the app"})
 	attachCmd.AddStringFlag(StringFlagOpts{Name: "variable-name", Description: "the env variable name that will be added to the app. Defaults to DATABASE_URL"})
 
 	detachStrngs := docstrings.Get("postgres.detach")
-	detachCmd := BuildCommandKS(cmd, runDetachPostgresCluster, detachStrngs, client, requireSession, requireAppName)
+	detachCmd := BuildCommandKS(cmd, runDetachPostgresCluster, detachStrngs, client, nil, requireSession, requireAppName)
 	detachCmd.AddStringFlag(StringFlagOpts{Name: "postgres-app", Description: "the postgres cluster to detach from the app"})
 
 	dbStrings := docstrings.Get("postgres.db")
-	dbCmd := BuildCommandKS(cmd, nil, dbStrings, client, requireSession)
+	dbCmd := BuildCommandKS(cmd, nil, dbStrings, client, nil, requireSession)
 
+	ctxOptions := map[string]interface{}{
+		"requireAppNameAsArg": true,
+	}
 	listDBStrings := docstrings.Get("postgres.db.list")
-	listDBCmd := BuildCommandKS(dbCmd, runListPostgresDatabases, listDBStrings, client, requireSession, requireAppNameAsArg)
+	listDBCmd := BuildCommandKS(dbCmd, runListPostgresDatabases, listDBStrings, client, ctxOptions, requireSession, requireAppName)
 	listDBCmd.Args = cobra.ExactArgs(1)
 
 	usersStrings := docstrings.Get("postgres.users")
-	usersCmd := BuildCommandKS(cmd, nil, usersStrings, client, requireSession)
+	usersCmd := BuildCommandKS(cmd, nil, usersStrings, client, nil, requireSession)
 
 	usersListStrings := docstrings.Get("postgres.users.list")
-	usersListCmd := BuildCommandKS(usersCmd, runListPostgresUsers, usersListStrings, client, requireSession, requireAppNameAsArg)
+	usersListCmd := BuildCommandKS(usersCmd, runListPostgresUsers, usersListStrings, client, ctxOptions, requireSession, requireAppName)
 	usersListCmd.Args = cobra.ExactArgs(1)
 
 	return cmd

--- a/cmd/regions.go
+++ b/cmd/regions.go
@@ -13,26 +13,26 @@ import (
 func newRegionsCommand(client *client.Client) *Command {
 	regionsStrings := docstrings.Get("regions")
 
-	cmd := BuildCommandKS(nil, nil, regionsStrings, client, requireAppName, requireSession)
+	cmd := BuildCommandKS(nil, nil, regionsStrings, client, nil, requireAppName, requireSession)
 
 	addStrings := docstrings.Get("regions.add")
-	addCmd := BuildCommandKS(cmd, runRegionsAdd, addStrings, client, requireSession, requireAppName)
+	addCmd := BuildCommandKS(cmd, runRegionsAdd, addStrings, client, nil, requireSession, requireAppName)
 	addCmd.Args = cobra.MinimumNArgs(1)
 
 	removeStrings := docstrings.Get("regions.remove")
-	removeCmd := BuildCommandKS(cmd, runRegionsRemove, removeStrings, client, requireSession, requireAppName)
+	removeCmd := BuildCommandKS(cmd, runRegionsRemove, removeStrings, client, nil, requireSession, requireAppName)
 	removeCmd.Args = cobra.MinimumNArgs(1)
 
 	setStrings := docstrings.Get("regions.set")
-	setCmd := BuildCommandKS(cmd, runRegionsSet, setStrings, client, requireSession, requireAppName)
+	setCmd := BuildCommandKS(cmd, runRegionsSet, setStrings, client, nil, requireSession, requireAppName)
 	setCmd.Args = cobra.MinimumNArgs(1)
 
 	setBackupStrings := docstrings.Get("regions.backup")
-	setBackupCmd := BuildCommand(cmd, runBackupRegionsSet, setBackupStrings.Usage, setBackupStrings.Short, setBackupStrings.Long, client, requireSession, requireAppName)
+	setBackupCmd := BuildCommand(cmd, runBackupRegionsSet, setBackupStrings.Usage, setBackupStrings.Short, setBackupStrings.Long, client, nil, requireSession, requireAppName)
 	setBackupCmd.Args = cobra.MinimumNArgs(1)
 
 	listStrings := docstrings.Get("regions.list")
-	BuildCommand(cmd, runRegionsList, listStrings.Usage, listStrings.Short, listStrings.Long, client, requireSession, requireAppName)
+	BuildCommand(cmd, runRegionsList, listStrings.Usage, listStrings.Short, listStrings.Long, client, nil, requireSession, requireAppName)
 
 	return cmd
 }

--- a/cmd/releases.go
+++ b/cmd/releases.go
@@ -11,7 +11,7 @@ import (
 
 func newReleasesCommand(client *client.Client) *Command {
 	releasesStrings := docstrings.Get("releases")
-	cmd := BuildCommandKS(nil, runReleases, releasesStrings, client, requireSession, requireAppName)
+	cmd := BuildCommandKS(nil, runReleases, releasesStrings, client, nil, requireSession, requireAppName)
 	return cmd
 }
 

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -13,8 +13,11 @@ import (
 //TODO: Move all output to status styled begin/done updates
 
 func newRestartCommand(client *client.Client) *Command {
+	ctxOptions := map[string]interface{}{
+		"requireAppNameAsArg": true,
+	}
 	restartStrings := docstrings.Get("restart")
-	restartCmd := BuildCommandKS(nil, runRestart, restartStrings, client, requireSession, requireAppNameAsArg)
+	restartCmd := BuildCommandKS(nil, runRestart, restartStrings, client, ctxOptions, requireSession, requireAppName)
 	restartCmd.Args = cobra.RangeArgs(0, 1)
 
 	return restartCmd

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -16,9 +16,11 @@ import (
 //TODO: Move all output to status styled begin/done updates
 
 func newResumeCommand(client *client.Client) *Command {
-
+	ctxOptions := map[string]interface{}{
+		"requireAppNameAsArg": true,
+	}
 	resumeStrings := docstrings.Get("resume")
-	resumeCmd := BuildCommandKS(nil, runResume, resumeStrings, client, requireSession, requireAppNameAsArg)
+	resumeCmd := BuildCommandKS(nil, runResume, resumeStrings, client, ctxOptions, requireSession, requireAppName)
 	resumeCmd.Args = cobra.RangeArgs(0, 1)
 
 	return resumeCmd

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -17,10 +17,10 @@ import (
 func newScaleCommand(client *client.Client) *Command {
 	scaleStrings := docstrings.Get("scale")
 
-	cmd := BuildCommandKS(nil, nil, scaleStrings, client, requireSession, requireAppName)
+	cmd := BuildCommandKS(nil, nil, scaleStrings, client, nil, requireSession, requireAppName)
 
 	vmCmdStrings := docstrings.Get("scale.vm")
-	vmCmd := BuildCommand(cmd, runScaleVM, vmCmdStrings.Usage, vmCmdStrings.Short, vmCmdStrings.Long, client, requireSession, requireAppName)
+	vmCmd := BuildCommand(cmd, runScaleVM, vmCmdStrings.Usage, vmCmdStrings.Short, vmCmdStrings.Long, client, nil, requireSession, requireAppName)
 	vmCmd.Args = cobra.ExactArgs(1)
 	vmCmd.AddIntFlag(IntFlagOpts{
 		Name:        "memory",
@@ -29,11 +29,11 @@ func newScaleCommand(client *client.Client) *Command {
 	})
 
 	memoryCmdStrings := docstrings.Get("scale.memory")
-	memoryCmd := BuildCommandKS(cmd, runScaleMemory, memoryCmdStrings, client, requireSession, requireAppName)
+	memoryCmd := BuildCommandKS(cmd, runScaleMemory, memoryCmdStrings, client, nil, requireSession, requireAppName)
 	memoryCmd.Args = cobra.ExactArgs(1)
 
 	countCmdStrings := docstrings.Get("scale.count")
-	countCmd := BuildCommand(cmd, runScaleCount, countCmdStrings.Usage, countCmdStrings.Short, countCmdStrings.Long, client, requireSession, requireAppName)
+	countCmd := BuildCommand(cmd, runScaleCount, countCmdStrings.Usage, countCmdStrings.Short, countCmdStrings.Long, client, nil, requireSession, requireAppName)
 	countCmd.Args = cobra.ExactArgs(1)
 	countCmd.AddIntFlag((IntFlagOpts{
 		Name:        "max-per-region",
@@ -42,7 +42,7 @@ func newScaleCommand(client *client.Client) *Command {
 	}))
 
 	showCmdStrings := docstrings.Get("scale.show")
-	BuildCommand(cmd, runScaleShow, showCmdStrings.Usage, showCmdStrings.Short, showCmdStrings.Long, client, requireSession, requireAppName)
+	BuildCommand(cmd, runScaleShow, showCmdStrings.Usage, showCmdStrings.Short, showCmdStrings.Long, client, nil, requireSession, requireAppName)
 
 	return cmd
 }

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -21,13 +21,13 @@ import (
 func newSecretsCommand(client *client.Client) *Command {
 
 	secretsStrings := docstrings.Get("secrets")
-	cmd := BuildCommandKS(nil, nil, secretsStrings, client, requireSession, requireAppName)
+	cmd := BuildCommandKS(nil, nil, secretsStrings, client, nil, requireSession, requireAppName)
 
 	secretsListStrings := docstrings.Get("secrets.list")
-	BuildCommandKS(cmd, runListSecrets, secretsListStrings, client, requireSession, requireAppName)
+	BuildCommandKS(cmd, runListSecrets, secretsListStrings, client, nil, requireSession, requireAppName)
 
 	secretsSetStrings := docstrings.Get("secrets.set")
-	set := BuildCommandKS(cmd, runSetSecrets, secretsSetStrings, client, requireSession, requireAppName)
+	set := BuildCommandKS(cmd, runSetSecrets, secretsSetStrings, client, nil, requireSession, requireAppName)
 
 	//TODO: Move examples into docstrings
 	set.Command.Example = `flyctl secrets set FLY_ENV=production LOG_LEVEL=info
@@ -41,14 +41,14 @@ func newSecretsCommand(client *client.Client) *Command {
 	})
 
 	secretsImportStrings := docstrings.Get("secrets.import")
-	importCmd := BuildCommandKS(cmd, runImportSecrets, secretsImportStrings, client, requireSession, requireAppName)
+	importCmd := BuildCommandKS(cmd, runImportSecrets, secretsImportStrings, client, nil, requireSession, requireAppName)
 	importCmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "detach",
 		Description: "Return immediately instead of monitoring deployment progress",
 	})
 
 	secretsUnsetStrings := docstrings.Get("secrets.unset")
-	unset := BuildCommandKS(cmd, runSecretsUnset, secretsUnsetStrings, client, requireSession, requireAppName)
+	unset := BuildCommandKS(cmd, runSecretsUnset, secretsUnsetStrings, client, nil, requireSession, requireAppName)
 	unset.Command.Args = cobra.MinimumNArgs(1)
 
 	unset.AddBoolFlag(BoolFlagOpts{

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -26,10 +26,10 @@ import (
 )
 
 func newSSHCommand(client *client.Client) *Command {
-	cmd := BuildCommandKS(nil, nil, docstrings.Get("ssh"), client, requireSession)
+	cmd := BuildCommandKS(nil, nil, docstrings.Get("ssh"), client, nil, requireSession)
 
 	child := func(parent *Command, fn RunFn, ds string) *Command {
-		return BuildCommandKS(parent, fn, docstrings.Get(ds), client, requireSession)
+		return BuildCommandKS(parent, fn, docstrings.Get(ds), client, nil, requireSession)
 	}
 
 	child(cmd, runSSHLog, "ssh.log").Args = cobra.MaximumNArgs(1)
@@ -39,6 +39,7 @@ func newSSHCommand(client *client.Client) *Command {
 		runSSHConsole,
 		docstrings.Get("ssh.console"),
 		client,
+		nil,
 		requireSession,
 		requireAppName)
 	console.Args = cobra.MaximumNArgs(1)

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -19,8 +19,11 @@ import (
 )
 
 func newStatusCommand(client *client.Client) *Command {
+	ctxOptions := map[string]interface{}{
+		"requireAppNameAsArg": true,
+	}
 	statusStrings := docstrings.Get("status")
-	cmd := BuildCommandKS(nil, runStatus, statusStrings, client, requireSession, requireAppNameAsArg)
+	cmd := BuildCommandKS(nil, runStatus, statusStrings, client, ctxOptions, requireSession, requireAppName)
 
 	//TODO: Move flag descriptions to docstrings
 	cmd.AddBoolFlag(BoolFlagOpts{Name: "all", Description: "Show completed instances"})
@@ -32,7 +35,7 @@ func newStatusCommand(client *client.Client) *Command {
 	// cmd.Command.Flag()
 
 	allocStatusStrings := docstrings.Get("status.instance")
-	allocStatusCmd := BuildCommand(cmd, runAllocStatus, allocStatusStrings.Usage, allocStatusStrings.Short, allocStatusStrings.Long, client, requireSession, requireAppName)
+	allocStatusCmd := BuildCommand(cmd, runAllocStatus, allocStatusStrings.Usage, allocStatusStrings.Short, allocStatusStrings.Long, client, nil, requireSession, requireAppName)
 	allocStatusCmd.Args = cobra.ExactArgs(1)
 	return cmd
 }

--- a/cmd/suspend.go
+++ b/cmd/suspend.go
@@ -16,10 +16,12 @@ import (
 //TODO: Move all output to status styled begin/done updates
 
 func newSuspendCommand(client *client.Client) *Command {
-
+	ctxOptions := map[string]interface{}{
+		"requireAppNameAsArg": true,
+	}
 	suspendStrings := docstrings.Get("suspend")
 
-	suspendCmd := BuildCommandKS(nil, runSuspend, suspendStrings, client, requireSession, requireAppNameAsArg)
+	suspendCmd := BuildCommandKS(nil, runSuspend, suspendStrings, client, ctxOptions, requireSession, requireAppName)
 	suspendCmd.Args = cobra.RangeArgs(0, 1)
 
 	return suspendCmd

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,7 +18,7 @@ import (
 
 func newVersionCommand(client *client.Client) *Command {
 	versionStrings := docstrings.Get("version")
-	version := BuildCommandKS(nil, runVersion, versionStrings, client)
+	version := BuildCommandKS(nil, runVersion, versionStrings, client, nil)
 	version.AddStringFlag(StringFlagOpts{
 		Name:        "saveinstall",
 		Shorthand:   "s",
@@ -27,9 +27,9 @@ func newVersionCommand(client *client.Client) *Command {
 	version.Flag("saveinstall").Hidden = true
 
 	updateStrings := docstrings.Get("version.update")
-	BuildCommandKS(version, runUpdate, updateStrings, client)
+	BuildCommandKS(version, runUpdate, updateStrings, client, nil)
 
-	initStateCmd := BuildCommand(version, runInitState, "init-state", "init-state", "Initialize installation state", client)
+	initStateCmd := BuildCommand(version, runInitState, "init-state", "init-state", "Initialize installation state", client, nil)
 	initStateCmd.Hidden = true
 	initStateCmd.Args = cobra.ExactArgs(1)
 

--- a/cmd/vm.go
+++ b/cmd/vm.go
@@ -10,15 +10,15 @@ import (
 )
 
 func newVMCommand(client *client.Client) *Command {
-	vmCmd := BuildCommandKS(nil, nil, docstrings.Get("vm"), client)
+	vmCmd := BuildCommandKS(nil, nil, docstrings.Get("vm"), client, nil)
 
-	vmRestartCmd := BuildCommandKS(vmCmd, runVMRestart, docstrings.Get("vm.restart"), client, requireSession, requireAppName)
+	vmRestartCmd := BuildCommandKS(vmCmd, runVMRestart, docstrings.Get("vm.restart"), client, nil, requireSession, requireAppName)
 	vmRestartCmd.Args = cobra.ExactArgs(1)
 
-	vmStopCmd := BuildCommandKS(vmCmd, runVMStop, docstrings.Get("vm.stop"), client, requireSession, requireAppName)
+	vmStopCmd := BuildCommandKS(vmCmd, runVMStop, docstrings.Get("vm.stop"), client, nil, requireSession, requireAppName)
 	vmStopCmd.Args = cobra.ExactArgs(1)
 
-	vmStatusCmd := BuildCommandKS(vmCmd, runAllocStatus, docstrings.Get("vm.status"), client, requireSession, requireAppName)
+	vmStatusCmd := BuildCommandKS(vmCmd, runAllocStatus, docstrings.Get("vm.status"), client, nil, requireSession, requireAppName)
 	vmStatusCmd.Args = cobra.ExactArgs(1)
 
 	return vmCmd

--- a/cmd/volumes.go
+++ b/cmd/volumes.go
@@ -18,14 +18,14 @@ import (
 
 func newVolumesCommand(client *client.Client) *Command {
 	volumesStrings := docstrings.Get("volumes")
-	volumesCmd := BuildCommandKS(nil, nil, volumesStrings, client, requireAppName, requireSession)
+	volumesCmd := BuildCommandKS(nil, nil, volumesStrings, client, nil, requireAppName, requireSession)
 	volumesCmd.Aliases = []string{"vol"}
 
 	listStrings := docstrings.Get("volumes.list")
-	BuildCommandKS(volumesCmd, runListVolumes, listStrings, client, requireAppName, requireSession)
+	BuildCommandKS(volumesCmd, runListVolumes, listStrings, client, nil, requireAppName, requireSession)
 
 	createStrings := docstrings.Get("volumes.create")
-	createCmd := BuildCommandKS(volumesCmd, runCreateVolume, createStrings, client, requireAppName, requireSession)
+	createCmd := BuildCommandKS(volumesCmd, runCreateVolume, createStrings, client, nil, requireAppName, requireSession)
 	createCmd.Args = cobra.ExactArgs(1)
 
 	createCmd.AddStringFlag(StringFlagOpts{
@@ -46,12 +46,12 @@ func newVolumesCommand(client *client.Client) *Command {
 	})
 
 	deleteStrings := docstrings.Get("volumes.delete")
-	deleteCmd := BuildCommandKS(volumesCmd, runDeleteVolume, deleteStrings, client, requireSession)
+	deleteCmd := BuildCommandKS(volumesCmd, runDeleteVolume, deleteStrings, client, nil, requireSession)
 	deleteCmd.Args = cobra.ExactArgs(1)
 	deleteCmd.AddBoolFlag(BoolFlagOpts{Name: "yes", Shorthand: "y", Description: "Accept all confirmations"})
 
 	showStrings := docstrings.Get("volumes.show")
-	showCmd := BuildCommandKS(volumesCmd, runShowVolume, showStrings, client, requireSession)
+	showCmd := BuildCommandKS(volumesCmd, runShowVolume, showStrings, client, nil, requireSession)
 	showCmd.Args = cobra.ExactArgs(1)
 
 	return volumesCmd

--- a/cmd/wireguard.go
+++ b/cmd/wireguard.go
@@ -22,11 +22,11 @@ import (
 )
 
 func newWireGuardCommand(client *client.Client) *Command {
-	cmd := BuildCommandKS(nil, nil, docstrings.Get("wireguard"), client, requireSession)
+	cmd := BuildCommandKS(nil, nil, docstrings.Get("wireguard"), client, nil, requireSession)
 	cmd.Aliases = []string{"wg"}
 
 	child := func(parent *Command, fn RunFn, ds string) *Command {
-		return BuildCommandKS(parent, fn, docstrings.Get(ds), client, requireSession)
+		return BuildCommandKS(parent, fn, docstrings.Get(ds), client, nil, requireSession)
 	}
 
 	child(cmd, runWireGuardList, "wireguard.list").Args = cobra.MaximumNArgs(1)

--- a/cmdctx/cmdcontext.go
+++ b/cmdctx/cmdcontext.go
@@ -30,6 +30,7 @@ type CmdContext struct {
 	ConfigFile   string
 	AppName      string
 	AppConfig    *flyctl.AppConfig
+	Options      map[string]interface{}
 }
 
 // PresenterOption - options for RenderEx, RenderView, render etc...
@@ -53,7 +54,7 @@ const SBEGIN = "begin"
 const SDONE = "done"
 const SERROR = "error"
 
-func NewCmdContext(flyctlClient *client.Client, ns string, args []string) (*CmdContext, error) {
+func NewCmdContext(flyctlClient *client.Client, ns string, args []string, options map[string]interface{}) (*CmdContext, error) {
 	ctx := &CmdContext{
 		IO:           flyctlClient.IO,
 		Client:       flyctlClient,
@@ -62,6 +63,7 @@ func NewCmdContext(flyctlClient *client.Client, ns string, args []string) (*CmdC
 		GlobalConfig: flyctl.FlyConfig,
 		Args:         args,
 		Out:          flyctlClient.IO.Out,
+		Options:      options,
 	}
 
 	cwd, err := os.Getwd()


### PR DESCRIPTION
This change will remove the duplicates method `requireAppNameAsArg` and replace it with options; it will allow control of which places to consider.

Also, it will help solve issues like #57 by just adding option for example `ctx.Options["mismatch confirmation"]`

