### PR TITLE
Fix agent detach logs

### DIFF
--- a/cmd/fly_agent.go
+++ b/cmd/fly_agent.go
@@ -40,6 +40,12 @@ func newAgentCommand(client *client.Client) *Command {
 		client,
 		requireSession)
 
+	_ = BuildCommandKS(cmd,
+		runFlyAgentPing,
+		docstrings.Get("agent.ping"),
+		client,
+		requireSession)
+
 	return cmd
 }
 
@@ -83,4 +89,21 @@ func runFlyAgentStop(cc *cmdctx.CmdContext) error {
 	}
 
 	return err
+}
+
+func runFlyAgentPing(cc *cmdctx.CmdContext) error {
+	api := cc.Client.API()
+	ctx := context.Background()
+
+	c, err := agent.DefaultClient(api)
+	if err != nil {
+		return err
+	}
+	resp, err := c.Ping(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Println(resp)
+
+	return nil
 }

--- a/cmd/fly_agent.go
+++ b/cmd/fly_agent.go
@@ -3,11 +3,15 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/cmdctx"
 	"github.com/superfly/flyctl/docstrings"
+	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/client"
 	"github.com/superfly/flyctl/pkg/agent"
 )
@@ -49,15 +53,37 @@ func newAgentCommand(client *client.Client) *Command {
 	return cmd
 }
 
-func runFlyAgentDaemonStart(ctx *cmdctx.CmdContext) error {
-	agent, err := agent.DefaultServer(ctx.Client.API())
+func runFlyAgentDaemonStart(cc *cmdctx.CmdContext) error {
+	ctx := createCancellableContext()
+
+	logFile, err := os.Create(filepath.Join(flyctl.ConfigDir(), "agent.log"))
 	if err != nil {
-		return errors.Wrap(err, "daemon error")
+		return errors.Wrap(err, "can't create log file")
 	}
 
-	fmt.Printf("OK %d\n", os.Getpid())
+	w := io.MultiWriter(os.Stdout, logFile)
+	log.SetOutput(w)
+	log.SetFlags(log.Lmsgprefix | log.LstdFlags)
+	log.SetPrefix(fmt.Sprintf("[%d] ", os.Getpid()))
+
+	defer log.Printf("QUIT")
+
+	agent, err := agent.DefaultServer(cc.Client.API())
+	if err != nil {
+		log.Println(err)
+		return errors.New("daemon failed to start")
+	}
+
+	log.Printf("OK %d", os.Getpid())
 
 	agent.Serve()
+
+	go func() {
+		<-ctx.Done()
+		agent.Stop()
+	}()
+
+	agent.Wait()
 
 	return nil
 }
@@ -73,7 +99,7 @@ func runFlyAgentStart(cc *cmdctx.CmdContext) error {
 
 	_, err = agent.Establish(ctx, api)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "can't start agent: %s", err)
+		return errors.Wrap(err, "failed to start agent")
 	}
 
 	return err

--- a/cmd/fly_agent.go
+++ b/cmd/fly_agent.go
@@ -66,7 +66,15 @@ func runFlyAgentDaemonStart(cc *cmdctx.CmdContext) error {
 	log.SetFlags(log.Lmsgprefix | log.LstdFlags)
 	log.SetPrefix(fmt.Sprintf("[%d] ", os.Getpid()))
 
+	if err := agent.StopRunningAgent(); err != nil {
+		log.Printf("failed to stop existing agent: %v", err)
+	}
+	if err := agent.CreatePidFile(); err != nil {
+		log.Printf("failed to create pid file: %v", err)
+	}
+
 	defer log.Printf("QUIT")
+	defer agent.RemovePidFile()
 
 	agent, err := agent.DefaultServer(cc.Client.API())
 	if err != nil {

--- a/cmd/ssh_terminal.go
+++ b/cmd/ssh_terminal.go
@@ -47,7 +47,7 @@ func runSSHConsole(cc *cmdctx.CmdContext) error {
 	agentclient, err := agent.Establish(ctx, client)
 	if err != nil {
 		captureError(err)
-		return fmt.Errorf("can't establish agent: %s\n", err)
+		return errors.Wrap(err, "can't establish agent")
 	}
 
 	dialer, err := agentclient.Dialer(ctx, &app.Organization)

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -11,6 +11,10 @@ func Get(key string) KeyStrings {
 		return KeyStrings{"daemon-start", "Run the Fly agent as a service (manually)",
 			`Run the Fly agent as a service (manually)`,
 		}
+	case "agent.ping":
+		return KeyStrings{"ping", "ping the Fly agent",
+			`ping the Fly agent`,
+		}
 	case "agent.restart":
 		return KeyStrings{"restart", "Restart the Fly agent",
 			`Restart the Fly agent`,

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -938,6 +938,11 @@ longHelp = """Commands that manage the Fly agent"""
     shortHelp = "Stop the Fly agent"
     longHelp = "Stop the Fly agent"
 
+    [agent.ping]
+    usage     = "ping"
+    shortHelp = "ping the Fly agent"
+    longHelp  = "ping the Fly agent"
+
 [wireguard]
 usage     = "wireguard <command>"
 shortHelp = "Commands that manage WireGuard peer connections"

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -29,12 +29,12 @@ var (
 
 type Server struct {
 	listener      *net.UnixListener
-	ctx           context.Context
-	cancel        func()
 	tunnels       map[string]*wg.Tunnel
 	client        *api.Client
 	lock          sync.Mutex
 	currentChange time.Time
+	quit          chan interface{}
+	wg            sync.WaitGroup
 }
 
 type handlerFunc func(net.Conn, []string) error
@@ -109,13 +109,12 @@ func NewServer(path string, apiClient *api.Client) (*Server, error) {
 
 	addr, err := net.ResolveUnixAddr("unix", path)
 	if err != nil {
-		fmt.Printf("Failed to resolve: %v\n", err)
-		os.Exit(1)
+		return nil, errors.Wrap(err, "can't resolve unix socket")
 	}
 
 	l, err := net.ListenUnix("unix", addr)
 	if err != nil {
-		return nil, fmt.Errorf("can't bind: %w", err)
+		return nil, errors.Wrap(err, "can't bind")
 	}
 
 	l.SetUnlinkOnClose(true)
@@ -132,9 +131,8 @@ func NewServer(path string, apiClient *api.Client) (*Server, error) {
 		client:        apiClient,
 		tunnels:       map[string]*wg.Tunnel{},
 		currentChange: latestChange,
+		quit:          make(chan interface{}),
 	}
-
-	s.ctx, s.cancel = context.WithCancel(context.Background())
 
 	return s, nil
 }
@@ -145,29 +143,41 @@ func DefaultServer(apiClient *api.Client) (*Server, error) {
 	return NewServer(fmt.Sprintf("%s/.fly/fly-agent.sock", os.Getenv("HOME")), apiClient)
 }
 
-func (s *Server) Serve() {
-	defer s.listener.Close()
-	defer s.cancel()
+func (s *Server) Stop() {
+	s.listener.Close()
+	close(s.quit)
+}
 
+func (s *Server) Wait() {
+	s.wg.Wait()
+}
+
+func (s *Server) Serve() {
 	go s.clean()
 
-	for {
-		conn, err := s.listener.Accept()
-		if err != nil {
-			// // this can't really be how i'm supposed to do this
-			// if strings.Contains(err.Error(), "use of closed network connection") {
-			// 	return
-			// }
-			if errors.Is(err, net.ErrClosed) {
-				return
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		for {
+			conn, err := s.listener.Accept()
+
+			if err != nil {
+				select {
+				case <-s.quit:
+					return
+				default:
+					if errors.Is(err, net.ErrClosed) {
+						return
+					}
+					log.Printf("warning: couldn't accept connection: %s", err)
+					continue
+				}
 			}
 
-			log.Printf("warning: couldn't accept connection: %s", err)
-			continue
+			go s.handle(conn)
 		}
-
-		go s.handle(conn)
-	}
+	}()
 }
 
 func (s *Server) errLog(c net.Conn, format string, args ...interface{}) {
@@ -176,7 +186,8 @@ func (s *Server) errLog(c net.Conn, format string, args ...interface{}) {
 }
 
 func (s *Server) handleKill(c net.Conn, args []string) error {
-	s.listener.Close()
+	s.Stop()
+
 	return nil
 }
 
@@ -482,7 +493,7 @@ func (s *Server) clean() {
 				log.Printf("failed to validate tunnels: %s", err)
 			}
 			log.Printf("validated wireguard peers(stat)")
-		case <-s.ctx.Done():
+		case <-s.quit:
 			return
 		}
 	}

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/api"
@@ -99,6 +100,7 @@ func (c *Client) WaitForHost(ctx context.Context, o *api.Organization, host stri
 		for {
 			_, err := c.Resolve(ctx, o, host)
 			if err != nil && (IsHostNotFoundError(err) || IsTunnelError(err)) {
+				time.Sleep(200 * time.Millisecond)
 				continue
 			}
 

--- a/pkg/agent/errors.go
+++ b/pkg/agent/errors.go
@@ -75,7 +75,7 @@ type AgentStartError struct {
 }
 
 func (e *AgentStartError) Error() string {
-	return "Failed to start the agent daemon"
+	return "failed to start the agent daemon"
 }
 
 func (e *AgentStartError) Description() string {


### PR DESCRIPTION
The new code in #500 could cause the agent to become unresponsive on macOS. When spawning a new process, STDOUT was piped to the parent process so errors could be captured. The problem is when the parent process died the pipe would get closed, which caused the child to sometimes become unresponsive. 

This PR changes the logic a bit so instead of attaching STDOUT/STDERR to a pipe, the agent writes to a log file (`~/.fly/agent.log`) and the parent tails that file looking for `OK` or `QUIT` messages. 

While testing this out, I added a `flyctl agent ping` command and fixed an error that wasn't getting propagated.

There was also a race condition that could leave multiple agents running. I added an agent.pid file to track the current agent, new agents kill that one before starting.