### PR TITLE
Create volume/pg from snapshot

### DIFF
--- a/cmd/volumes.go
+++ b/cmd/volumes.go
@@ -47,6 +47,11 @@ func newVolumesCommand(client *client.Client) *Command {
 		Default:     true,
 	})
 
+	createCmd.AddStringFlag(StringFlagOpts{
+		Name:        "snapshot-id",
+		Description: "Creates the volume with the contents of the snapshot",
+	})
+
 	deleteStrings := docstrings.Get("volumes.delete")
 	deleteCmd := BuildCommandKS(volumesCmd, runDeleteVolume, deleteStrings, client, requireSession)
 	deleteCmd.Args = cobra.ExactArgs(1)


### PR DESCRIPTION
Backups are restored by creating a new volume with a snapshot id. 
Postgres clusters are restored by creating a new cluster with a snapshot id. 
This PR add a snapshot id flag to flyctl volumes create and flyctl pg create.

The flag value just needs to be added to the mutation input if present. 
﻿
