### PR TITLE
add flag to auto-generate the app name when running apps create

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -57,6 +57,11 @@ func newAppsCommand(client *client.Client) *Command {
 		Description: "Never write a fly.toml file",
 	})
 
+	create.AddBoolFlag(BoolFlagOpts{
+		Name:        "generatename",
+		Description: "Always generate a name for the app",
+	})
+
 	appsDestroyStrings := docstrings.Get("apps.destroy")
 	destroy := BuildCommand(cmd, runDestroy, appsDestroyStrings.Usage, appsDestroyStrings.Short, appsDestroyStrings.Long, client, requireSession)
 	destroy.Args = cobra.ExactArgs(1)


### PR DESCRIPTION
Fixes #510 

Add flag to auto-generate the app name when running `flyctl apps create`

```
$ flyctl  apps   create  --generatename
***An existing configuration file has been found.
? Overwrite file '/Users/fly.toml' Yes

? Select organization: org2 (org2)

? Select builder: go
    Go Builtin
Builtins use port 8080
New app created
  Name         = cold-haze-2358
  Organization = org2
  Version      = 0
  Status       =
  Hostname     = <empty>

App will initially deploy to cdg (Paris, France) region

Wrote config file fly.toml
```