### PR TITLE
Restore from snapshot

### DIFF
--- a/api/resource_volumes.go
+++ b/api/resource_volumes.go
@@ -116,3 +116,32 @@ func (c *Client) GetVolume(volID string) (Volume *Volume, err error) {
 
 	return &data.Volume, nil
 }
+
+func (c *Client) GetVolumeSnapshots(appName, volName string) ([]Snapshot, error) {
+	query := `
+	query($id: ID!) {
+		volume: node(id: $id) {
+			... on Volume {
+				encrypted
+				snapshots {
+					nodes {
+						id
+						size
+						createdAt
+					}
+				}
+			}
+		}
+	}`
+
+	req := c.NewRequest(query)
+
+	req.Var("id", volName)
+
+	data, err := c.Run(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.Volume.Snapshots.Nodes, nil
+}

--- a/api/resource_volumes.go
+++ b/api/resource_volumes.go
@@ -34,7 +34,7 @@ func (c *Client) GetVolumes(appName string) ([]Volume, error) {
 	return data.App.Volumes.Nodes, nil
 }
 
-func (c *Client) CreateVolume(appName string, volname string, region string, sizeGb int, encrypted bool) (*Volume, error) {
+func (c *Client) CreateVolume(input CreateVolumeInput) (*Volume, error) {
 	query := `
 		mutation($input: CreateVolumeInput!) {
 			createVolume(input: $input) {
@@ -52,8 +52,6 @@ func (c *Client) CreateVolume(appName string, volname string, region string, siz
 			}
 		}
 	`
-
-	input := CreateVolumeInput{AppID: appName, Name: volname, Region: region, SizeGb: sizeGb, Encrypted: encrypted}
 
 	req := c.NewRequest(query)
 

--- a/api/resource_volumes.go
+++ b/api/resource_volumes.go
@@ -117,11 +117,12 @@ func (c *Client) GetVolume(volID string) (Volume *Volume, err error) {
 	return &data.Volume, nil
 }
 
-func (c *Client) GetVolumeSnapshots(appName, volName string) ([]Snapshot, error) {
+func (c *Client) GetVolumeSnapshots(volName string) ([]Snapshot, error) {
 	query := `
 	query($id: ID!) {
 		volume: node(id: $id) {
 			... on Volume {
+				name
 				encrypted
 				snapshots {
 					nodes {

--- a/api/types.go
+++ b/api/types.go
@@ -277,11 +277,22 @@ type TaskGroupCount struct {
 	Count int
 }
 
+type Snapshot struct {
+	ID        string `json:"id"`
+	Key       string
+	Region    string
+	Size      string
+	CreatedAt time.Time
+}
+
 type Volume struct {
-	ID                 string `json:"id"`
-	App                string
-	Name               string
-	SizeGb             int
+	ID        string `json:"id"`
+	App       string
+	Name      string
+	SizeGb    int
+	Snapshots struct {
+		Nodes []Snapshot
+	}
 	Region             string
 	Encrypted          bool
 	CreatedAt          time.Time

--- a/api/types.go
+++ b/api/types.go
@@ -289,11 +289,12 @@ type Volume struct {
 }
 
 type CreateVolumeInput struct {
-	AppID     string `json:"appId"`
-	Name      string `json:"name"`
-	Region    string `json:"region"`
-	SizeGb    int    `json:"sizeGb"`
-	Encrypted bool   `json:"encrypted"`
+	AppID      string  `json:"appId"`
+	Name       string  `json:"name"`
+	Region     string  `json:"region"`
+	SizeGb     int     `json:"sizeGb"`
+	Encrypted  bool    `json:"encrypted"`
+	SnapshotID *string `json:"snapshot_id,omitempty"`
 }
 
 type CreateVolumePayload struct {
@@ -950,6 +951,7 @@ type CreatePostgresClusterInput struct {
 	VMSize         *string `json:"vmSize,omitempty"`
 	VolumeSizeGB   *int    `json:"volumeSizeGb,omitempty"`
 	ImageRef       *string `json:"imageRef,omitempty"`
+	SnapshotID     *string `json:"snapshot_id,omitempty"`
 }
 
 type CreatePostgresClusterPayload struct {

--- a/api/types.go
+++ b/api/types.go
@@ -294,7 +294,7 @@ type CreateVolumeInput struct {
 	Region     string  `json:"region"`
 	SizeGb     int     `json:"sizeGb"`
 	Encrypted  bool    `json:"encrypted"`
-	SnapshotID *string `json:"snapshot_id,omitempty"`
+	SnapshotID *string `json:"snapshotId,omitempty"`
 }
 
 type CreateVolumePayload struct {
@@ -951,7 +951,7 @@ type CreatePostgresClusterInput struct {
 	VMSize         *string `json:"vmSize,omitempty"`
 	VolumeSizeGB   *int    `json:"volumeSizeGb,omitempty"`
 	ImageRef       *string `json:"imageRef,omitempty"`
-	SnapshotID     *string `json:"snapshot_id,omitempty"`
+	SnapshotID     *string `json:"snapshotId,omitempty"`
 }
 
 type CreatePostgresClusterPayload struct {

--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -128,6 +128,11 @@ func runCreatePostgresCluster(ctx *cmdctx.CmdContext) error {
 		input.ImageRef = api.StringPointer(imageRef)
 	}
 
+	snapshot := ctx.Config.GetString("snapshot-id")
+	if snapshot != "" {
+		input.SnapshotID = api.StringPointer(snapshot)
+	}
+
 	fmt.Fprintf(ctx.Out, "Creating postgres cluster %s in organization %s\n", name, org.Slug)
 
 	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)

--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -36,6 +36,7 @@ func newPostgresCommand(client *client.Client) *Command {
 	createCmd.AddStringFlag(StringFlagOpts{Name: "volume-size", Description: "the size in GB for volumes"})
 	createCmd.AddStringFlag(StringFlagOpts{Name: "vm-size", Description: "the size of the VM"})
 	createCmd.AddStringFlag(StringFlagOpts{Name: "image-ref", Hidden: true})
+	createCmd.AddStringFlag(StringFlagOpts{Name: "snapshot-id", Description: "Creates the volume with the contents of the snapshot"})
 
 	attachStrngs := docstrings.Get("postgres.attach")
 	attachCmd := BuildCommandKS(cmd, runAttachPostgresCluster, attachStrngs, client, requireSession, requireAppName)

--- a/cmd/volumes.go
+++ b/cmd/volumes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/cmdctx"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/client"
@@ -118,7 +119,21 @@ func runCreateVolume(ctx *cmdctx.CmdContext) error {
 
 	sizeGb := ctx.Config.GetInt("size")
 
-	volume, err := ctx.Client.API().CreateVolume(appid, volName, region, sizeGb, ctx.Config.GetBool("encrypted"))
+	snapshot := ctx.Config.GetString("snapshot-id")
+
+	input := api.CreateVolumeInput{
+		AppID:     appid,
+		Name:      volName,
+		Region:    region,
+		SizeGb:    sizeGb,
+		Encrypted: ctx.Config.GetBool("encrypted"),
+	}
+
+	if snapshot != "" {
+		input.SnapshotID = api.StringPointer(snapshot)
+	}
+
+	volume, err := ctx.Client.API().CreateVolume(input)
 
 	if err != nil {
 		return err

--- a/cmd/volumes.go
+++ b/cmd/volumes.go
@@ -45,6 +45,11 @@ func newVolumesCommand(client *client.Client) *Command {
 		Default:     true,
 	})
 
+	createCmd.AddStringFlag(StringFlagOpts{
+		Name:        "snapshot-id",
+		Description: "Creates the volume with the contents of the snapshot",
+	})
+
 	deleteStrings := docstrings.Get("volumes.delete")
 	deleteCmd := BuildCommandKS(volumesCmd, runDeleteVolume, deleteStrings, client, requireSession)
 	deleteCmd.Args = cobra.ExactArgs(1)

--- a/cmd/volumes.go
+++ b/cmd/volumes.go
@@ -47,11 +47,6 @@ func newVolumesCommand(client *client.Client) *Command {
 		Default:     true,
 	})
 
-	createCmd.AddStringFlag(StringFlagOpts{
-		Name:        "snapshot-id",
-		Description: "Creates the volume with the contents of the snapshot",
-	})
-
 	deleteStrings := docstrings.Get("volumes.delete")
 	deleteCmd := BuildCommandKS(volumesCmd, runDeleteVolume, deleteStrings, client, requireSession)
 	deleteCmd.Args = cobra.ExactArgs(1)
@@ -127,18 +122,12 @@ func runCreateVolume(ctx *cmdctx.CmdContext) error {
 
 	sizeGb := ctx.Config.GetInt("size")
 
-	snapshot := ctx.Config.GetString("snapshot-id")
-
 	input := api.CreateVolumeInput{
 		AppID:     appid,
 		Name:      volName,
 		Region:    region,
 		SizeGb:    sizeGb,
 		Encrypted: ctx.Config.GetBool("encrypted"),
-	}
-
-	if snapshot != "" {
-		input.SnapshotID = api.StringPointer(snapshot)
 	}
 
 	volume, err := ctx.Client.API().CreateVolume(input)

--- a/cmd/volumes.go
+++ b/cmd/volumes.go
@@ -232,7 +232,7 @@ func runListVolumeSnapshots(ctx *cmdctx.CmdContext) error {
 		return nil
 	}
 
-	table := helpers.MakeSimpleTable(ctx.Out, []string{"id", "size", "created at", "encrypted"})
+	table := helpers.MakeSimpleTable(ctx.Out, []string{"id", "size", "created at"})
 
 	// Sort snapshots from newest to oldest
 	sort.SliceStable(snapshots, func(i, j int) bool {

--- a/cmd/volumes.go
+++ b/cmd/volumes.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -232,6 +233,11 @@ func runListVolumeSnapshots(ctx *cmdctx.CmdContext) error {
 	}
 
 	table := helpers.MakeSimpleTable(ctx.Out, []string{"id", "size", "created at"})
+
+	// Sort snapshots from newest to oldest
+	sort.SliceStable(snapshots, func(i, j int) bool {
+		return snapshots[i].CreatedAt.After(snapshots[j].CreatedAt)
+	})
 
 	for _, s := range snapshots {
 		size, _ := strconv.Atoi(s.Size)

--- a/cmd/volumes.go
+++ b/cmd/volumes.go
@@ -30,13 +30,6 @@ func newVolumesCommand(client *client.Client) *Command {
 	createCmd := BuildCommandKS(volumesCmd, runCreateVolume, createStrings, client, requireAppName, requireSession)
 	createCmd.Args = cobra.ExactArgs(1)
 
-	snapshotStrings := docstrings.Get("volumes.snapshots")
-	snapshotCmd := BuildCommandKS(volumesCmd, nil, snapshotStrings, client, requireSession)
-
-	snapshotListStrings := docstrings.Get("volumes.snapshots.list")
-	snapshotListCmd := BuildCommandKS(snapshotCmd, runListVolumeSnapshots, snapshotListStrings, client, requireAppName, requireSession)
-	snapshotListCmd.Args = cobra.ExactArgs(1)
-
 	createCmd.AddStringFlag(StringFlagOpts{
 		Name:        "region",
 		Description: "Set region for new volume",
@@ -67,6 +60,13 @@ func newVolumesCommand(client *client.Client) *Command {
 	showStrings := docstrings.Get("volumes.show")
 	showCmd := BuildCommandKS(volumesCmd, runShowVolume, showStrings, client, requireSession)
 	showCmd.Args = cobra.ExactArgs(1)
+
+	snapshotStrings := docstrings.Get("volumes.snapshots")
+	snapshotCmd := BuildCommandKS(volumesCmd, nil, snapshotStrings, client, requireSession)
+
+	snapshotListStrings := docstrings.Get("volumes.snapshots.list")
+	snapshotListCmd := BuildCommandKS(snapshotCmd, runListVolumeSnapshots, snapshotListStrings, client, requireSession)
+	snapshotListCmd.Args = cobra.ExactArgs(1)
 
 	return volumesCmd
 }
@@ -217,7 +217,7 @@ func runShowVolume(ctx *cmdctx.CmdContext) error {
 func runListVolumeSnapshots(ctx *cmdctx.CmdContext) error {
 	volName := ctx.Args[0]
 
-	snapshots, err := ctx.Client.API().GetVolumeSnapshots(ctx.AppName, volName)
+	snapshots, err := ctx.Client.API().GetVolumeSnapshots(volName)
 	if err != nil {
 		return err
 	}
@@ -232,7 +232,7 @@ func runListVolumeSnapshots(ctx *cmdctx.CmdContext) error {
 		return nil
 	}
 
-	table := helpers.MakeSimpleTable(ctx.Out, []string{"id", "size", "created at"})
+	table := helpers.MakeSimpleTable(ctx.Out, []string{"id", "size", "created at", "encrypted"})
 
 	// Sort snapshots from newest to oldest
 	sort.SliceStable(snapshots, func(i, j int) bool {

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -760,6 +760,14 @@ number to operate. This can be found through the volumes list command`,
 			`Show details of an app's volume. Requires the volume's ID
 number to operate. This can be found through the volumes list command`,
 		}
+	case "volumes.snapshots":
+		return KeyStrings{"snapshots", "manage volume snapshots",
+			`manage volume snapshots`,
+		}
+	case "volumes.snapshots.list":
+		return KeyStrings{"list <volume-id>", "list volume snapshots associated with the specified volume id",
+			`list snapshots associated with cluster`,
+		}
 	case "wireguard":
 		return KeyStrings{"wireguard <command>", "Commands that manage WireGuard peer connections",
 			`Commands that manage WireGuard peer connections`,

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -761,12 +761,12 @@ number to operate. This can be found through the volumes list command`,
 number to operate. This can be found through the volumes list command`,
 		}
 	case "volumes.snapshots":
-		return KeyStrings{"snapshots", "manage volume snapshots",
-			`manage volume snapshots`,
+		return KeyStrings{"snapshots", "Manage volume snapshots",
+			`Commands for managing volume snapshots`,
 		}
 	case "volumes.snapshots.list":
-		return KeyStrings{"list <volume-id>", "list volume snapshots associated with the specified volume id",
-			`list snapshots associated with cluster`,
+		return KeyStrings{"list <volume-id>", "list snapshots associated with the specified volume",
+			`list snapshots associated with the specified volume`,
 		}
 	case "wireguard":
 		return KeyStrings{"wireguard <command>", "Commands that manage WireGuard peer connections",

--- a/helpers/bytes.go
+++ b/helpers/bytes.go
@@ -1,0 +1,67 @@
+package helpers
+
+import (
+	"fmt"
+	"strconv"
+)
+
+const (
+	TB = 1099511627776
+	GB = 1073741824
+	MB = 1048576
+	KB = 1024
+)
+
+func BytesToHumanReadable(bytes, decimals int) string {
+	var unit string
+	var val int
+	var remainder int
+
+	if bytes > TB {
+		unit = "TB"
+		val = bytes / TB
+		remainder = bytes - (val * TB)
+	} else if bytes > GB {
+		unit = "GB"
+		val = bytes / GB
+		remainder = bytes - (val * GB)
+	} else if bytes > MB {
+		unit = "MB"
+		val = bytes / MB
+		remainder = bytes - (val * MB)
+	} else if bytes > KB {
+		unit = "KB"
+		val = val / KB
+		remainder = bytes - (val * KB)
+	} else {
+		unit = "B"
+		val = bytes
+	}
+
+	if decimals == 0 {
+		return strconv.Itoa(val) + " " + unit
+	}
+
+	// This is to calculate missing leading zeroes
+	width := 0
+	if remainder > GB {
+		width = 12
+	} else if remainder > MB {
+		width = 9
+	} else if remainder > KB {
+		width = 6
+	} else {
+		width = 3
+	}
+
+	// Insert missing leading zeroes
+	remainderString := strconv.Itoa(remainder)
+	for iter := len(remainderString); iter < width; iter++ {
+		remainderString = "0" + remainderString
+	}
+	if decimals > len(remainderString) {
+		decimals = len(remainderString)
+	}
+
+	return fmt.Sprintf("%d.%s %s", val, remainderString[:decimals], unit)
+}

--- a/helpers/bytes.go
+++ b/helpers/bytes.go
@@ -63,5 +63,5 @@ func BytesToHumanReadable(bytes, decimals int) string {
 		decimals = len(remainderString)
 	}
 
-	return fmt.Sprintf("%d.%s %s", val, remainderString[:decimals], unit)
+	return fmt.Sprintf("%d.%s%s", val, remainderString[:decimals], unit)
 }

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -863,12 +863,12 @@ number to operate. This can be found through the volumes list command"""
 
     [volumes.snapshots]
     usage     = "snapshots"
-    shortHelp = "manage volume snapshots"
-    longHelp  = "manage volume snapshots"
+    shortHelp = "Manage volume snapshots"
+    longHelp  = "Commands for managing volume snapshots"
         [volumes.snapshots.list]
         usage     = "list <volume-id>"
-        shortHelp = "list volume snapshots associated with the specified volume id"
-        longHelp  = "list snapshots associated with cluster"
+        shortHelp = "list snapshots associated with the specified volume"
+        longHelp  = "list snapshots associated with the specified volume"
 
 [ssh]
 usage     = "ssh <command>"

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -861,6 +861,15 @@ number to operate. This can be found through the volumes list command"""
     longHelp  = """Show details of an app's volume. Requires the volume's ID
 number to operate. This can be found through the volumes list command"""
 
+    [volumes.snapshots]
+    usage     = "snapshots"
+    shortHelp = "manage volume snapshots"
+    longHelp  = "manage volume snapshots"
+        [volumes.snapshots.list]
+        usage     = "list <volume-id>"
+        shortHelp = "list volume snapshots associated with the specified volume id"
+        longHelp  = "list snapshots associated with cluster"
+
 [ssh]
 usage     = "ssh <command>"
 shortHelp = "Commands that manage SSH credentials"
@@ -870,7 +879,7 @@ longHelp  = """Commands that manage SSH credentials"""
     usage     = "console [<host>]"
     shortHelp = "Connect to a running instance of the current app."
     longHelp  = """Connect to a running instance of the current app; with -select, choose instance from list."""
-  
+
     [ssh.log]
     usage     = "log"
     shortHelp = "Log of all issued certs"


### PR DESCRIPTION
Noteworthy changes:

* Volume snapshots can now be viewed via `flyctl volumes snapshots list <volume-id>`
* Remote restores are now available for Postgres. 

```
Commands for managing volume snapshots

Usage:
  flyctl volumes snapshots [command]

Available Commands:
  list        list snapshots associated with the specified volume

Flags:
  -h, --help   help for snapshots

Global Flags:
  -t, --access-token string   Fly API Access Token
  -j, --json                  json output
  -v, --verbose               verbose output

Use "flyctl volumes snapshots [command] --help" for more information about a command.
```

Example output:
```
flyctl volumes snapshots list vol_x915gr2008vn70qy
ID                  SIZE    CREATED AT 
vs_5p0e4D7Mqnjj0hjm 34.75MB 4 hours ago
vs_3KxgDxb4x3BAVsDN 34.72MB 1 day ago
vs_OlOvv3Gy50z0Dcq8 34.70MB 2 days ago
vs_1A542NBV5ppJYcV  34.35MB 3 days ago
vs_q9xZ8AD3N74KeCz0 34.15MB 4 days ago
vs_0RPg1JGj4DYewcBw 34.15MB 5 days ago
```

Example of how to restore a Postgres from a snapshot:
`flyctl postgres create --snapshot-id vs_3KxgDxb4x3BAVsDN`

