### PR TITLE
don't prune peers when agent starts

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -190,8 +190,6 @@ func NewServer(path string, apiClient *api.Client, background bool) (*Server, er
 }
 
 func DefaultServer(apiClient *api.Client, background bool) (*Server, error) {
-	wireguard.PruneInvalidPeers(apiClient)
-
 	return NewServer(fmt.Sprintf("%s/.fly/fly-agent.sock", os.Getenv("HOME")), apiClient, background)
 }
 


### PR DESCRIPTION
removes an api call which might be slowing down agent starts and causing timeouts