### PR TITLE
Add wg.WireGuardState and wg.Config to agent.Dialer interface

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -282,7 +282,7 @@ func buildTunnel(client *api.Client, org *api.Organization) (*wg.Tunnel, error) 
 		return nil, fmt.Errorf("can't get wireguard state for %s: %s", org.Slug, err)
 	}
 
-	tunnel, err := wg.Connect(*state.TunnelConfig())
+	tunnel, err := wg.Connect(state)
 	if err != nil {
 		return nil, fmt.Errorf("can't connect wireguard: %w", err)
 	}
@@ -304,17 +304,22 @@ func (s *Server) handleEstablish(c net.Conn, args []string) error {
 		return err
 	}
 
-	if _, ok := s.tunnels[org.Slug]; ok {
-		return writef(c, "ok")
+	tunnel, ok := s.tunnels[org.Slug]
+	if !ok {
+		tunnel, err = buildTunnel(s.client, org)
+		if err != nil {
+			return err
+		}
+		s.tunnels[org.Slug] = tunnel
 	}
 
-	tunnel, err := buildTunnel(s.client, org)
-	if err != nil {
-		return err
+	resp := EstablishResponse{
+		WireGuardState: tunnel.State,
+		TunnelConfig:   tunnel.Config,
 	}
 
-	s.tunnels[org.Slug] = tunnel
-	return writef(c, "ok")
+	data, _ := json.Marshal(resp)
+	return writef(c, "ok %s", data)
 }
 
 func probeTunnel(ctx context.Context, tunnel *wg.Tunnel) error {

--- a/pkg/wg/tunnel.go
+++ b/pkg/wg/tunnel.go
@@ -15,15 +15,19 @@ import (
 )
 
 type Tunnel struct {
-	dev   *device.Device
-	tun   tun.Device
-	net   *netstack.Net
-	dnsIP net.IP
+	dev    *device.Device
+	tun    tun.Device
+	net    *netstack.Net
+	dnsIP  net.IP
+	State  *WireGuardState
+	Config *Config
 
 	resolv *net.Resolver
 }
 
-func Connect(cfg Config) (*Tunnel, error) {
+func Connect(state *WireGuardState) (*Tunnel, error) {
+	cfg := state.TunnelConfig()
+	fmt.Println("wg connect", cfg.DNS, cfg.Endpoint, cfg.LocalNetwork.IP, cfg.RemoteNetwork.IP)
 	localIPs := []net.IP{cfg.LocalNetwork.IP}
 	dnsIP := cfg.DNS
 
@@ -65,10 +69,12 @@ func Connect(cfg Config) (*Tunnel, error) {
 	wgDev.Up()
 
 	return &Tunnel{
-		dev:   wgDev,
-		tun:   tunDev,
-		net:   gNet,
-		dnsIP: dnsIP,
+		dev:    wgDev,
+		tun:    tunDev,
+		net:    gNet,
+		dnsIP:  dnsIP,
+		Config: cfg,
+		State:  state,
 
 		resolv: &net.Resolver{
 			PreferGo: true,


### PR DESCRIPTION
There's a few spots where we need the WireGuard tunnel state or config after establishing a connection, such as [the nats client in the logging branch](https://github.com/superfly/flyctl/pull/519/files#diff-8e884508533a33409f1abddf9a8e5525eba887e11c550f158683c948aa869963R120-R137). Instead of having callers hit the config (which has an unintuitive api since it tries to create a peer), this branch returns an `EstablishResponse` on `client.Establish` and adds the state to the Dialer interface:

```go
dialer, err := agentclient.Dialer(ctx, &app.Organization)
peerIP := dialer.State().Peer.Peerip
```

