### PR TITLE
Fly launch: generate fly.toml and a Dockerfile for RedwoodJS apps

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -30,6 +30,17 @@ func confirm(message string) bool {
 	return confirm
 }
 
+func confirmOverwrite(filename string) bool {
+	confirm := false
+	prompt := &survey.Confirm{
+		Message: fmt.Sprintf(`Overwrite "%s"?`, filename),
+	}
+	err := survey.AskOne(prompt, &confirm)
+	checkErr(err)
+
+	return confirm
+}
+
 func selectOrganization(client *api.Client, slug string, typeFilter *api.OrganizationType) (*api.Organization, error) {
 	orgs, err := client.GetOrganizations(typeFilter)
 	if err != nil {

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -173,6 +173,10 @@ func runLaunch(cmdctx *cmdctx.CmdContext) error {
 		for envName, envVal := range srcInfo.Env {
 			appConfig.SetEnvVariable(envName, envVal)
 		}
+
+		if len(srcInfo.Statics) > 0 {
+			appConfig.SetStatics(srcInfo.Statics)
+		}
 	}
 
 	fmt.Printf("Created app %s in organization %s\n", app.Name, org.Slug)

--- a/flyctl/app_config.go
+++ b/flyctl/app_config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/superfly/flyctl/helpers"
+	"github.com/superfly/flyctl/internal/sourcecode"
 )
 
 type ConfigFormat string
@@ -319,6 +320,10 @@ func (ac *AppConfig) SetEnvVariable(name, value string) {
 	env[name] = value
 
 	ac.Definition["env"] = env
+}
+
+func (ac *AppConfig) SetStatics(statics []sourcecode.Static) {
+	ac.Definition["statics"] = statics
 }
 
 const defaultConfigFileName = "fly.toml"

--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -30,8 +30,8 @@ type SourceFile struct {
 	Contents []byte
 }
 type Static struct {
-	GuestPath string `toml:"guest_path"`
-	UrlPrefix string `toml:"url_prefix"`
+	GuestPath string `toml:"guest_path" json:"guest_path"`
+	UrlPrefix string `toml:"url_prefix" json:"url_prefix"`
 }
 
 func Scan(sourceDir string) (*SourceInfo, error) {

--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -36,11 +36,14 @@ type Static struct {
 
 func Scan(sourceDir string) (*SourceInfo, error) {
 	scanners := []sourceScanner{
+		configureRedwood,
+		/* frameworks scanners are placed before generic scanners,
+		   since they might mix languages or have a Dockerfile that
+			 doesn't work with Fly */
 		configureDockerfile,
 		configureRuby,
 		configureGo,
 		configureElixir,
-		configureRedwood,
 		configureNode,
 	}
 

--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -191,7 +191,7 @@ func configureRedwood(sourceDir string) (*SourceInfo, error) {
 			"PORT": "8911",
 		},
 		Statics: []Static{
-			0: {
+			{
 				GuestPath: "/app/public",
 				UrlPrefix: "/",
 			},

--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -22,11 +22,16 @@ type SourceInfo struct {
 	Files          []SourceFile
 	Port           int
 	Env            map[string]string
+	Statics        []Static
 }
 
 type SourceFile struct {
 	Path     string
 	Contents []byte
+}
+type Static struct {
+	GuestPath string `toml:"guest_path"`
+	UrlPrefix string `toml:"url_prefix"`
 }
 
 func Scan(sourceDir string) (*SourceInfo, error) {
@@ -178,9 +183,15 @@ func configureRedwood(sourceDir string) (*SourceInfo, error) {
 	s := &SourceInfo{
 		Family: "Redwood",
 		Files:  templates("templates/redwood"),
-		Port:   1234,
+		Port:   8911,
 		Env: map[string]string{
-			"PORT": "1234",
+			"PORT": "8911",
+		},
+		Statics: []Static{
+			0: {
+				GuestPath: "/app/public",
+				UrlPrefix: "/",
+			},
 		},
 	}
 

--- a/internal/sourcecode/templates/redwood/Dockerfile
+++ b/internal/sourcecode/templates/redwood/Dockerfile
@@ -1,1 +1,45 @@
-FROM alpine
+FROM node:14-alpine as base
+
+WORKDIR /app
+
+COPY package.json package.json
+COPY web/package.json web/package.json
+COPY api/package.json api/package.json
+COPY yarn.lock yarn.lock
+RUN yarn install --frozen-lockfile
+
+COPY redwood.toml .
+COPY graphql.config.js .
+COPY babel.config.js .
+
+FROM base as web_build
+
+COPY web web
+RUN yarn rw build web
+
+FROM base as api_build
+
+COPY api api
+RUN yarn rw build api
+
+FROM node:14-alpine
+
+WORKDIR /app
+
+# Only install API packages to keep image small
+COPY api/package.json .
+
+RUN yarn install && yarn add react react-dom @redwoodjs/cli
+
+COPY graphql.config.js .
+COPY redwood.toml .
+COPY api api
+
+COPY --from=web_build /app/web/dist /app/web/dist
+COPY --from=api_build /app/api/dist /app/api/dist
+COPY --from=api_build /app/node_modules/.prisma /app/node_modules/.prisma
+
+EXPOSE 8911
+
+# Entrypoint to @redwoodjs/api-server binary
+CMD [ "yarn", "rw", "serve", "api", "--port", "8911", "--rootPath", "/api" ]

--- a/internal/sourcecode/templates/redwood/Dockerfile
+++ b/internal/sourcecode/templates/redwood/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine


### PR DESCRIPTION
RedwoodJS has some special deployment requirements that, for now, are most easily satisfied with a Dockerfile. It also benefits from having `statics` preconfigured since the entire clientside app is static.

This PR adds:

*   A way to generate files from templates embedded in `flyctl`
*   A way to add statics to `fly.toml` via `fly launch`
*   A Redwood-specific app detector

TODO:

*   \[x\] Fix generated TOML to format with underscores