### PR TITLE
Enable region-specific IP allocation and show the IP region in the list

### DIFF
--- a/api/resource_ip_addresses.go
+++ b/api/resource_ip_addresses.go
@@ -9,6 +9,7 @@ func (c *Client) GetIPAddresses(appName string) ([]IPAddress, error) {
 						id
 						address
 						type
+						region
 						createdAt
 					}
 				}
@@ -35,6 +36,7 @@ func (c *Client) FindIPAddress(appName string, address string) (*IPAddress, erro
 					id
 					address
 					type
+					region
 					createdAt
 				}
 			}
@@ -54,7 +56,7 @@ func (c *Client) FindIPAddress(appName string, address string) (*IPAddress, erro
 	return data.App.IPAddress, nil
 }
 
-func (c *Client) AllocateIPAddress(appName string, addrType string) (*IPAddress, error) {
+func (c *Client) AllocateIPAddress(appName string, addrType string, region string) (*IPAddress, error) {
 	query := `
 		mutation($input: AllocateIPAddressInput!) {
 			allocateIpAddress(input: $input) {
@@ -62,6 +64,7 @@ func (c *Client) AllocateIPAddress(appName string, addrType string) (*IPAddress,
 					id
 					address
 					type
+					region
 					createdAt
 				}
 			}
@@ -70,7 +73,7 @@ func (c *Client) AllocateIPAddress(appName string, addrType string) (*IPAddress,
 
 	req := c.NewRequest(query)
 
-	req.Var("input", AllocateIPAddressInput{AppID: appName, Type: addrType})
+	req.Var("input", AllocateIPAddressInput{AppID: appName, Type: addrType, Region: region})
 
 	data, err := c.Run(req)
 	if err != nil {

--- a/api/types.go
+++ b/api/types.go
@@ -486,6 +486,7 @@ type IPAddress struct {
 	ID        string
 	Address   string
 	Type      string
+	Region    string
 	CreatedAt time.Time
 }
 
@@ -700,8 +701,9 @@ type HTTPHeader struct {
 }
 
 type AllocateIPAddressInput struct {
-	AppID string `json:"appId"`
-	Type  string `json:"type"`
+	AppID  string `json:"appId"`
+	Type   string `json:"type"`
+	Region string `json:"region"`
 }
 
 type ReleaseIPAddressInput struct {

--- a/cmd/ips.go
+++ b/cmd/ips.go
@@ -27,10 +27,20 @@ func newIPAddressesCommand(client *client.Client) *Command {
 	BuildCommandKS(cmd, runPrivateIPAddressesList, ipsPrivateListStrings, client, requireSession, requireAppName)
 
 	ipsAllocateV4Strings := docstrings.Get("ips.allocate-v4")
-	BuildCommandKS(cmd, runAllocateIPAddressV4, ipsAllocateV4Strings, client, requireSession, requireAppName)
+	allocateV4Command := BuildCommandKS(cmd, runAllocateIPAddressV4, ipsAllocateV4Strings, client, requireSession, requireAppName)
+
+	allocateV4Command.AddStringFlag(StringFlagOpts{
+		Name:        "region",
+		Description: "The region where the address should be allocated",
+	})
 
 	ipsAllocateV6Strings := docstrings.Get("ips.allocate-v6")
-	BuildCommandKS(cmd, runAllocateIPAddressV6, ipsAllocateV6Strings, client, requireSession, requireAppName)
+	allocateV6Command := BuildCommandKS(cmd, runAllocateIPAddressV6, ipsAllocateV6Strings, client, requireSession, requireAppName)
+
+	allocateV6Command.AddStringFlag(StringFlagOpts{
+		Name:        "region",
+		Description: "The region where the address should be allocated.",
+	})
 
 	ipsReleaseStrings := docstrings.Get("ips.release")
 	release := BuildCommandKS(cmd, runReleaseIPAddress, ipsReleaseStrings, client, requireSession, requireAppName)
@@ -60,8 +70,9 @@ func runAllocateIPAddressV6(ctx *cmdctx.CmdContext) error {
 
 func runAllocateIPAddress(commandContext *cmdctx.CmdContext, addrType string) error {
 	appName := commandContext.AppName
+	regionCode := commandContext.Config.GetString("region")
 
-	ipAddress, err := commandContext.Client.API().AllocateIPAddress(appName, addrType)
+	ipAddress, err := commandContext.Client.API().AllocateIPAddress(appName, addrType, regionCode)
 	if err != nil {
 		return err
 	}

--- a/cmd/presenters/ipAddresses.go
+++ b/cmd/presenters/ipAddresses.go
@@ -13,7 +13,7 @@ func (p *IPAddresses) APIStruct() interface{} {
 }
 
 func (p *IPAddresses) FieldNames() []string {
-	return []string{"Type", "Address", "Created At"}
+	return []string{"Type", "Address", "Region", "Created At"}
 }
 
 func (p *IPAddresses) Records() []map[string]string {
@@ -23,6 +23,7 @@ func (p *IPAddresses) Records() []map[string]string {
 		out = append(out, map[string]string{
 			"Address":    ip.Address,
 			"Type":       ip.Type,
+			"Region":     ip.Region,
 			"Created At": FormatRelativeTime(ip.CreatedAt),
 		})
 	}


### PR DESCRIPTION
Regional IP allocation is already supported in the API, so we're exposing it here in the CLI. IP release works as expected.