### PR TITLE
Add a Dockerfile-based Deno launcher with fly.toml processes and grep support

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -179,6 +179,10 @@ func runLaunch(cmdctx *cmdctx.CmdContext) error {
 		if len(srcInfo.Statics) > 0 {
 			appConfig.SetStatics(srcInfo.Statics)
 		}
+
+		for procName, procCommand := range srcInfo.Processes {
+			appConfig.SetProcess(procName, procCommand)
+		}
 	}
 
 	fmt.Printf("Created app %s in organization %s\n", app.Name, org.Slug)

--- a/flyctl/app_config.go
+++ b/flyctl/app_config.go
@@ -313,6 +313,7 @@ func (ac *AppConfig) SetEnvVariable(name, value string) {
 			env = castEnv
 		}
 	}
+
 	if env == nil {
 		env = map[string]string{}
 	}
@@ -320,6 +321,24 @@ func (ac *AppConfig) SetEnvVariable(name, value string) {
 	env[name] = value
 
 	ac.Definition["env"] = env
+}
+
+func (ac *AppConfig) SetProcess(name, value string) {
+	var processes map[string]string
+
+	if rawProcesses, ok := ac.Definition["processes"]; ok {
+		if castProcesses, ok := rawProcesses.(map[string]string); ok {
+			processes = castProcesses
+		}
+	}
+
+	if processes == nil {
+		processes = map[string]string{}
+	}
+
+	processes[name] = value
+
+	ac.Definition["processes"] = processes
 }
 
 func (ac *AppConfig) SetStatics(statics []sourcecode.Static) {

--- a/internal/sourcecode/templates/deno/Dockerfile
+++ b/internal/sourcecode/templates/deno/Dockerfile
@@ -1,0 +1,27 @@
+# Based on https://github.com/denoland/deno_docker/blob/main/alpine.dockerfile
+
+ARG DENO_VERSION=1.14.0
+ARG BIN_IMAGE=denoland/deno:bin-${DENO_VERSION}
+FROM ${BIN_IMAGE} AS bin
+
+FROM frolvlad/alpine-glibc:alpine-3.13
+
+RUN apk --no-cache add ca-certificates
+
+RUN addgroup --gid 1000 deno \
+  && adduser --uid 1000 --disabled-password deno --ingroup deno \
+  && mkdir /deno-dir/ \
+  && chown deno:deno /deno-dir/
+
+ENV DENO_DIR /deno-dir/
+ENV DENO_INSTALL_ROOT /usr/local
+
+ARG DENO_VERSION
+ENV DENO_VERSION=${DENO_VERSION}
+COPY --from=bin /deno /bin/deno
+
+WORKDIR /deno-dir
+COPY . .
+
+ENTRYPOINT ["/bin/deno"]
+CMD ["run", "--allow-net", "https://deno.land/std/examples/echo_server.ts"]

--- a/internal/sourcecode/templates/deno/example.ts
+++ b/internal/sourcecode/templates/deno/example.ts
@@ -1,0 +1,14 @@
+import {
+  app,
+  get,
+  post,
+  redirect,
+  contentType,
+} from "https://denopkg.com/syumai/dinatra/mod.ts";
+
+const greeting = "<h1>Hello From Deno on Fly!</h1>";
+
+app(
+  get("/", () => greeting),
+  get("/:id", ({ params }) => greeting + `</br>and hello to ${params.id}`),
+);


### PR DESCRIPTION
This PR adds a new Deno app launcher with a Dockerfile. The Deno launcher required a few new scanner features. They are:

*   Matching strings present in a given set of files in the source directory, since Deno apps have no filename conventions yet
*   Adding 'processes' to `fly.toml` (web, worker, etc), since developers should have a path to override the run command to point to their JS entrypoint