### PR TITLE
Bug fix: Custom passwords not being sent to backend on Postgres create

### DIFF
--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -128,6 +128,10 @@ func runCreatePostgresCluster(ctx *cmdctx.CmdContext) error {
 		input.ImageRef = api.StringPointer(imageRef)
 	}
 
+	if password := ctx.Config.GetString("password"); password != "" {
+		input.Password = api.StringPointer(password)
+	}
+
 	snapshot := ctx.Config.GetString("snapshot-id")
 	if snapshot != "" {
 		input.SnapshotID = api.StringPointer(snapshot)


### PR DESCRIPTION
Fixes issue where passwords were being generated regardless of whether --password was specified with `flyctl postgres create`