### PR TITLE
Expose useful build-only and no-cache deploy arguments

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -45,8 +45,7 @@ func newDeployCommand(client *client.Client) *Command {
 		Description: "Return immediately instead of monitoring deployment progress",
 	})
 	cmd.AddBoolFlag(BoolFlagOpts{
-		Name:   "build-only",
-		Hidden: true,
+		Name: "build-only",
 	})
 	cmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "remote-only",
@@ -84,7 +83,6 @@ func newDeployCommand(client *client.Client) *Command {
 	cmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "no-cache",
 		Description: "Do not use the cache when building the image",
-		Hidden:      true,
 	})
 
 	cmd.Command.Args = cobra.MaximumNArgs(1)

--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -319,8 +319,7 @@ func newMachineRunCommand(parent *Command, client *client.Client) {
 	})
 
 	cmd.AddBoolFlag(BoolFlagOpts{
-		Name:   "build-only",
-		Hidden: true,
+		Name: "build-only",
 	})
 	cmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "build-remote-only",
@@ -349,7 +348,6 @@ func newMachineRunCommand(parent *Command, client *client.Client) {
 	cmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "no-build-cache",
 		Description: "Do not use the cache when building the image",
-		Hidden:      true,
 	})
 
 	cmd.Command.Args = cobra.MinimumNArgs(1)


### PR DESCRIPTION
Partially addresses #386. A separate `build` command could be added later if we want.