### PR TITLE
Autogenerate name

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -41,6 +41,11 @@ func newAppsCommand(client *client.Client) *Command {
 		Description: `The organization that will own the app`,
 	})
 
+	create.AddBoolFlag(BoolFlagOpts{
+		Name:        "generate-name",
+		Description: "Always generate a name for the app",
+	})
+
 	appsDestroyStrings := docstrings.Get("apps.destroy")
 	destroy := BuildCommand(cmd, runDestroy, appsDestroyStrings.Usage, appsDestroyStrings.Short, appsDestroyStrings.Long, client, requireSession)
 	destroy.Args = cobra.ExactArgs(1)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -4,41 +4,11 @@ import (
 	"fmt"
 
 	"github.com/superfly/flyctl/cmdctx"
-	"github.com/superfly/flyctl/internal/client"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/spf13/cobra"
-	"github.com/superfly/flyctl/docstrings"
 )
 
 //TODO: Move all output to status styled begin/done updates
-
-func newCreateCommand(client *client.Client) *Command {
-
-	initStrings := docstrings.Get("create")
-
-	cmd := BuildCommandKS(nil, runCreate, initStrings, client, requireSession)
-
-	cmd.Args = cobra.RangeArgs(0, 1)
-
-	// TODO: Move flag descriptions into the docStrings
-	cmd.AddStringFlag(StringFlagOpts{
-		Name:        "name",
-		Description: "The app name to use",
-	})
-
-	cmd.AddStringFlag(StringFlagOpts{
-		Name:        "org",
-		Description: `The organization that will own the app`,
-	})
-
-	cmd.AddBoolFlag(BoolFlagOpts{
-		Name:        "generatename",
-		Description: "Always generate a name for the app", Hidden: true,
-	})
-
-	return cmd
-}
 
 func runCreate(cmdCtx *cmdctx.CmdContext) error {
 	var appName = ""
@@ -49,7 +19,7 @@ func runCreate(cmdCtx *cmdctx.CmdContext) error {
 
 	name := ""
 
-	if !cmdCtx.Config.GetBool("generatename") {
+	if !cmdCtx.Config.GetBool("generate-name") {
 		name = cmdCtx.Config.GetString("name")
 
 		if name != "" && appName != "" {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -45,8 +45,7 @@ func newDeployCommand(client *client.Client) *Command {
 		Description: "Return immediately instead of monitoring deployment progress",
 	})
 	cmd.AddBoolFlag(BoolFlagOpts{
-		Name:   "build-only",
-		Hidden: true,
+		Name: "build-only",
 	})
 	cmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "remote-only",
@@ -84,7 +83,6 @@ func newDeployCommand(client *client.Client) *Command {
 	cmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "no-cache",
 		Description: "Do not use the cache when building the image",
-		Hidden:      true,
 	})
 
 	cmd.Command.Args = cobra.MaximumNArgs(1)

--- a/cmd/machine.go
+++ b/cmd/machine.go
@@ -319,8 +319,7 @@ func newMachineRunCommand(parent *Command, client *client.Client) {
 	})
 
 	cmd.AddBoolFlag(BoolFlagOpts{
-		Name:   "build-only",
-		Hidden: true,
+		Name: "build-only",
 	})
 	cmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "build-remote-only",
@@ -349,7 +348,6 @@ func newMachineRunCommand(parent *Command, client *client.Client) {
 	cmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "no-build-cache",
 		Description: "Do not use the cache when building the image",
-		Hidden:      true,
 	})
 
 	cmd.Command.Args = cobra.MinimumNArgs(1)


### PR DESCRIPTION
Supersedes #513.

Expose `fly apps create --generate-name` to allow CI runners to automate app creation.