### PR TITLE
Revert "Prevent local builds on Apple M1 devices"

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -33,12 +32,9 @@ type dockerClientFactory struct {
 
 func newDockerClientFactory(daemonType DockerDaemonType, apiClient *api.Client, appName string, streams *iostreams.IOStreams) *dockerClientFactory {
 	if daemonType.AllowLocal() {
-		terminal.Debug("Trying local docker daemon")
+		terminal.Debug("trying local docker daemon")
 		c, err := newLocalDockerClient()
-
-		if localBuildUnsupported() {
-			terminal.Warn("Local docker builds are not supported on Apple M1 devices.")
-		} else if c != nil && err == nil {
+		if c != nil && err == nil {
 			return &dockerClientFactory{
 				mode: DockerDaemonTypeLocal,
 				buildFn: func(ctx context.Context) (*dockerclient.Client, error) {
@@ -53,7 +49,7 @@ func newDockerClientFactory(daemonType DockerDaemonType, apiClient *api.Client, 
 	}
 
 	if daemonType.AllowRemote() {
-		terminal.Debug("Trying remote docker daemon")
+		terminal.Debug("trying remote docker daemon")
 		var cachedDocker *dockerclient.Client
 
 		return &dockerClientFactory{
@@ -108,11 +104,6 @@ const (
 	DockerDaemonTypeRemote
 	DockerDaemonTypeNone
 )
-
-func localBuildUnsupported() bool {
-	terminal.Debug("Running on OS " + runtime.GOOS + " with architecture " + runtime.GOARCH)
-	return (runtime.GOOS == "darwin" && runtime.GOARCH == "arm64")
-}
 
 func (t DockerDaemonType) AllowLocal() bool {
 	return (t & DockerDaemonTypeLocal) != 0


### PR DESCRIPTION
Reverts #536. Local builds do not _always_ fail on M1 devices, and the build issues may be fixed by a recent Buildkit upgrade to cross-compilation tooling in #542.

We can rework this to print warnings for M1 users if the issues persist.