### PR TITLE
Pass the new logger to the HTTP client

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -37,7 +37,7 @@ type Client struct {
 }
 
 // NewClient - creates a new Client, takes an access token
-func NewClient(accessToken string, name, version string, logger Logger) *Client {
+func NewClient(accessToken, name, version string, logger Logger) *Client {
 
 	httpClient, _ := newHTTPClient(logger)
 

--- a/api/client.go
+++ b/api/client.go
@@ -33,13 +33,13 @@ type Client struct {
 	client      *graphql.Client
 	accessToken string
 	userAgent   string
-	logger Logger
+	logger      Logger
 }
 
 // NewClient - creates a new Client, takes an access token
 func NewClient(accessToken string, name, version string, logger Logger) *Client {
 
-	httpClient, _ := newHTTPClient()
+	httpClient, _ := newHTTPClient(logger)
 
 	url := fmt.Sprintf("%s/graphql", baseURL)
 

--- a/api/http.go
+++ b/api/http.go
@@ -13,7 +13,7 @@ import (
 
 var retryErrors = []string{"INTERNAL_ERROR", "read: connection reset by peer"}
 
-func newHTTPClient() (*http.Client, error) {
+func newHTTPClient(logger Logger) (*http.Client, error) {
 	retryTransport := rehttp.NewTransport(
 		http.DefaultTransport,
 		rehttp.RetryAll(
@@ -28,6 +28,7 @@ func newHTTPClient() (*http.Client, error) {
 
 	transport := &LoggingTransport{
 		innerTransport: retryTransport,
+		logger:         logger,
 	}
 
 	httpClient := &http.Client{


### PR DESCRIPTION
This fixes a panic caused by the missing logger.