### PR TITLE
WIP: Adding flyctl postgres info subcommand

### DIFF
--- a/api/resource_postgres.go
+++ b/api/resource_postgres.go
@@ -24,6 +24,37 @@ func (client *Client) CreatePostgresCluster(input CreatePostgresClusterInput) (*
 	return data.CreatePostgresCluster, nil
 }
 
+func (client *Client) GetPostgresInfo(appName string) (*App, error) {
+	query := `
+		query($appName: String!) {
+			app(name: $appName) {
+				imageUpgradeAvailable
+				currentImageVersion {
+					repository
+					tag
+					digest
+					version
+				}
+				latestImageVersion {
+					repository
+					tag
+					digest
+					version
+				}
+			}
+		}
+	`
+	req := client.NewRequest(query)
+	req.Var("appName", appName)
+
+	data, err := client.Run(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data.App, nil
+}
+
 func (client *Client) GetTemplateDeployment(id string) (*TemplateDeployment, error) {
 	query := `
 		query($id: ID!) {

--- a/api/types.go
+++ b/api/types.go
@@ -246,6 +246,13 @@ func DefinitionPtr(in map[string]interface{}) *Definition {
 	return &x
 }
 
+type ImageVersion struct {
+	Repository string
+	Tag        string
+	Version    string
+	Digest     string
+}
+
 type App struct {
 	ID             string
 	Name           string
@@ -297,6 +304,10 @@ type App struct {
 		Users     *[]PostgresClusterUser
 	}
 	Image *Image
+
+	ImageUpgradeAvailable bool
+	CurrentImageVersion   ImageVersion
+	LatestImageVersion    ImageVersion
 }
 
 type TaskGroupCount struct {

--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -48,6 +48,9 @@ func newPostgresCommand(client *client.Client) *Command {
 	detachCmd := BuildCommandKS(cmd, runDetachPostgresCluster, detachStrngs, client, requireSession, requireAppName)
 	detachCmd.AddStringFlag(StringFlagOpts{Name: "postgres-app", Description: "the postgres cluster to detach from the app"})
 
+	infoStrings := docstrings.Get("postgres.info")
+	BuildCommandKS(cmd, runPostgresInfo, infoStrings, client, requireSession, requireAppNameAsArg)
+
 	dbStrings := docstrings.Get("postgres.db")
 	dbCmd := BuildCommandKS(cmd, nil, dbStrings, client, requireSession)
 
@@ -180,6 +183,35 @@ func runCreatePostgresCluster(ctx *cmdctx.CmdContext) error {
 	}
 
 	return err
+}
+
+func runPostgresInfo(ctx *cmdctx.CmdContext) error {
+	appName := ctx.AppName
+
+	app, err := ctx.Client.API().GetPostgresInfo(appName)
+	if err != nil {
+		return err
+	}
+
+	if app.ImageUpgradeAvailable {
+		current := fmt.Sprintf("%s:%s %s", app.CurrentImageVersion.Repository, app.CurrentImageVersion.Tag, app.CurrentImageVersion.Version)
+		latest := fmt.Sprintf("%s:%s %s", app.LatestImageVersion.Repository, app.LatestImageVersion.Tag, app.LatestImageVersion.Version)
+		fmt.Fprintln(os.Stderr, aurora.Yellow(fmt.Sprintf("Postgres update available %s -> %s", current, latest)))
+	}
+
+	err = ctx.Frender(cmdctx.PresenterOption{Presentable: &presenters.ImageVersion{ImageDetails: app.CurrentImageVersion}, HideHeader: true, Vertical: true, Title: "Image details"})
+	if err != nil {
+		return err
+	}
+
+	if app.ImageUpgradeAvailable {
+		err = ctx.Frender(cmdctx.PresenterOption{Presentable: &presenters.ImageVersion{ImageDetails: app.LatestImageVersion}, HideHeader: true, Vertical: true, Title: "Latest image details"})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func runAttachPostgresCluster(ctx *cmdctx.CmdContext) error {

--- a/cmd/presenters/imageVersion.go
+++ b/cmd/presenters/imageVersion.go
@@ -1,0 +1,32 @@
+package presenters
+
+import (
+	"github.com/superfly/flyctl/api"
+)
+
+type ImageVersion struct {
+	ImageDetails api.ImageVersion
+}
+
+func (p *ImageVersion) APIStruct() interface{} {
+	return p.ImageDetails
+}
+
+func (p *ImageVersion) FieldNames() []string {
+	return []string{"Repository", "Tag", "Version", "Digest"}
+}
+
+func (p *ImageVersion) Records() []map[string]string {
+	out := []map[string]string{}
+
+	info := map[string]string{
+		"Repository": p.ImageDetails.Repository,
+		"Tag":        p.ImageDetails.Tag,
+		"Version":    p.ImageDetails.Version,
+		"Digest":     p.ImageDetails.Digest,
+	}
+
+	out = append(out, info)
+
+	return out
+}

--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -565,6 +565,10 @@ about the Fly platform.`,
 		return KeyStrings{"detach", "Detach a postgres cluster from an app",
 			`Detach a postgres cluster from an app`,
 		}
+	case "postgres.info":
+		return KeyStrings{"info", "Show Postgres app info",
+			`Show Postgres app information`,
+		}
 	case "postgres.list":
 		return KeyStrings{"list", "list postgres clusters",
 			`list postgres clusters`,

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -504,6 +504,10 @@ usage = "status"
 longHelp = "Manage postgres clusters"
 shortHelp = "Manage postgres clusters"
 usage = "postgres"
+[postgres.info]
+longHelp = "Show Postgres app information"
+shortHelp = "Show Postgres app info"
+usage = "info"
 [postgres.attach]
 longHelp = "Attach a postgres cluster to an app"
 shortHelp = "Attach a postgres cluster to an app"


### PR DESCRIPTION
This PR achieves two things:

1. Exposes a new `flyctl postgres info` subcommand that exposes a given Postgres app's image details.  This is currently only available to PG apps provisioned via `flyctl postgres create`.

2. Notifies the user if there's a new image available.  
```
$ flyctl postgres info --app <app-name>

Image details
  Repository = flyio/postgres
  Tag        = 13.4
  Version    = v0.0.4
  Digest     = sha256:d90b1a8456d2c587ef04905269f39b89ffe3c20400095b0098757b26ad676aa5
```



If there's a new update available, there will be a notification and we will display details about the latest image.
```shell
$ flyctl postgres info --app <app-name>

Postgres update available flyio/postgres:13 v0.0.0 -> flyio/postgres:13.4 v0.0.4
Image details
  Repository = flyio/postgres
  Tag        = 13
  Version    = v0.0.0
  Digest     = sha256:fb465a3f01184606d11bbee3376b1d0de48fc890408ea9119b477c9d7f5fa221

Latest image details
  Repository = flyio/postgres
  Tag        = 13.4
  Version    = v0.0.4
  Digest     = sha256:d90b1a8456d2c587ef04905269f39b89ffe3c20400095b0098757b26ad676aa5
  
```



Screenshot:


![Screen Shot 2021-09-30 at 4 39 18 PM](https://user-images.githubusercontent.com/423038/135533776-f1c0942a-432a-49c8-ad28-555393c5f06a.png)


