### PR TITLE
Add CI-friendly options and name prompting to 'fly launch' 

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	"github.com/superfly/flyctl/cmdctx"
-
-	"github.com/AlecAivazis/survey/v2"
 )
 
 //TODO: Move all output to status styled begin/done updates
@@ -19,9 +17,11 @@ func runCreate(cmdCtx *cmdctx.CmdContext) error {
 
 	name := ""
 
+	// If we aren't generating the name automatically, get the name from the command line or from a prompt
 	if !cmdCtx.Config.GetBool("generate-name") {
 		name = cmdCtx.Config.GetString("name")
 
+		// App name was specified as a command argument and via the --name option
 		if name != "" && appName != "" {
 			return fmt.Errorf(`two app names specified %s and %s. Select and specify only one`, appName, name)
 		}
@@ -33,14 +33,15 @@ func runCreate(cmdCtx *cmdctx.CmdContext) error {
 		fmt.Println()
 
 		if name == "" {
-			prompt := &survey.Input{
-				Message: "App Name (leave blank to use an auto-generated name)",
+
+			// Prompt the user for the app name
+			inputName, err := inputAppName("", true)
+
+			if err != nil {
+				return err
 			}
-			if err := survey.AskOne(prompt, &name); err != nil {
-				if isInterrupt(err) {
-					return nil
-				}
-			}
+
+			name = inputName
 		} else {
 			fmt.Printf("Selected App Name: %s\n", name)
 		}

--- a/cmd/input.go
+++ b/cmd/input.go
@@ -153,11 +153,20 @@ func selectVMSize(client *api.Client, vmSizeName string) (*api.VMSize, error) {
 	return &vmSizes[selectedVMSize], nil
 }
 
-func inputAppName(defaultName string) (name string, err error) {
+func inputAppName(defaultName string, autoGenerate bool) (name string, err error) {
+	message := "App Name"
+
+	if autoGenerate {
+		message += " (leave blank to use an auto-generated name)"
+	}
+
+	message += ":"
+
 	prompt := &survey.Input{
-		Message: "App name:",
+		Message: message,
 		Default: defaultName,
 	}
+
 	if err := survey.AskOne(prompt, &name); err != nil {
 		return name, err
 	}

--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -82,7 +82,7 @@ func runPostgresList(ctx *cmdctx.CmdContext) error {
 func runCreatePostgresCluster(ctx *cmdctx.CmdContext) error {
 	name := ctx.Config.GetString("name")
 	if name == "" {
-		n, err := inputAppName("")
+		n, err := inputAppName("", false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
\`no-deploy\` and \`generate-name\` are useful for CI. And, we now prompt for an app name like 'fly init' did when these options are not used.