### PR TITLE
Support 'fly launch' with a Dockerfile for Remix apps

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -253,9 +253,15 @@ func runLaunch(cmdctx *cmdctx.CmdContext) error {
 		return nil
 	}
 
-	fmt.Println("Your app is ready. Deploy with `flyctl deploy`")
+	if srcInfo.SkipDeploy && srcInfo.Docs == "" {
+		fmt.Println("Your app is ready. Deploy with `flyctl deploy`")
+	} else if srcInfo.Docs != "" {
+		fmt.Println(srcInfo.Docs)
+	}
 
-	if !cmdctx.Config.GetBool("no-deploy") && (cmdctx.Config.GetBool("now") || confirm("Would you like to deploy now?")) {
+	if !cmdctx.Config.GetBool("no-deploy") &&
+		!srcInfo.SkipDeploy &&
+		(cmdctx.Config.GetBool("now") || confirm("Would you like to deploy now?")) {
 		return runDeploy(cmdctx)
 	}
 

--- a/internal/sourcecode/templates/remix/.dockerignore
+++ b/internal/sourcecode/templates/remix/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/internal/sourcecode/templates/remix/Dockerfile
+++ b/internal/sourcecode/templates/remix/Dockerfile
@@ -1,0 +1,66 @@
+# base node image
+FROM node:16-bullseye-slim as base
+
+ARG REMIX_TOKEN
+ENV REMIX_TOKEN=$REMIX_TOKEN
+
+# Install openssl for Prisma
+RUN apt-get update && apt-get install -y openssl
+
+# Install all node_modules, including dev dependencies
+FROM base as deps
+
+RUN mkdir /app
+WORKDIR /app
+
+ADD package.json package-lock.json .npmrc ./
+RUN npm install --production=false
+
+# Setup production node_modules
+FROM base as production-deps
+
+ARG REMIX_TOKEN
+ENV REMIX_TOKEN=$REMIX_TOKEN
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY --from=deps /app/node_modules /app/node_modules
+ADD package.json package-lock.json .npmrc ./
+RUN npm prune --production
+
+# Build the app
+FROM base as build
+
+ARG REMIX_TOKEN
+ENV REMIX_TOKEN=$REMIX_TOKEN
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY --from=deps /app/node_modules /app/node_modules
+
+# If we're using Prisma, uncomment to cache the prisma schema
+# ADD prisma .
+# RUN npx prisma generate
+
+ADD . .
+RUN npm run build
+
+# Finally, build the production image with minimal footprint
+FROM base
+
+ENV NODE_ENV=production
+
+RUN mkdir /app
+WORKDIR /app
+
+# Uncomment if using Prisma
+# COPY --from=build /app/node_modules/.prisma /app/node_modules/.prisma
+
+COPY --from=production-deps /app/node_modules /app/node_modules
+COPY --from=build /app/build /app/build
+COPY --from=build /app/public /app/public
+ADD . .
+
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
This PR adds scanner support for `fly launch` for Remix apps. To do this correctly, the PR introduces two new keys.

`SourceInfo.Docs` will be printed out at the end of a successful launch step. It's useful here since `fly deploy` won't work on an app that requires build arguments.

`SourceInfo.SkipDeploy` prevents `fly deploy` from running for the same reason.