### PR TITLE
Fix #560: Make sure ENV vars are not cleared

### DIFF
--- a/flyctl/app_config_test.go
+++ b/flyctl/app_config_test.go
@@ -54,3 +54,21 @@ func TestLoadTOMLAppConfigWithServices(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, p.Definition, rawData)
 }
+
+func TestLoadTOMLAppConfigWithEnvVars(t *testing.T) {
+	path := "./testdata/env-vars.toml"
+	p, err := LoadAppConfig(path)
+	assert.NoError(t, err)
+	assert.Equal(t, "debug", p.Env["LOG_LEVEL"])
+	assert.Equal(t, "production", p.Env["RAILS_ENV"])
+
+	p.SetEnvVariable("LOG_LEVEL", "info")
+
+	assert.Equal(t, "info", p.Env["LOG_LEVEL"])
+	assert.Equal(t, "production", p.Env["RAILS_ENV"])
+
+	p.SetEnvVariables(map[string]string{"RAILS_ENV": "development"})
+
+	assert.Equal(t, "info", p.Env["LOG_LEVEL"])
+	assert.Equal(t, "development", p.Env["RAILS_ENV"])
+}

--- a/flyctl/testdata/env-vars.toml
+++ b/flyctl/testdata/env-vars.toml
@@ -1,0 +1,6 @@
+app = "test-app"
+
+[env]
+  LOG_LEVEL = "debug"
+  RAILS_ENV = "production"
+  S3_BUCKET = "my-app-production"


### PR DESCRIPTION
Made ENV vars a property of the `AppConfig`, and made sure `SetEnvVariable` and `SetEnvVariables` don't clear out the entire set of vars. 

Fixes #560 