### PR TITLE
Make sure ENV in the config is not cleared by setting `-e`

### DIFF
--- a/flyctl/app_config.go
+++ b/flyctl/app_config.go
@@ -57,7 +57,7 @@ func LoadAppConfig(configFile string) (*AppConfig, error) {
 		return nil, err
 	}
 
-	appConfig := *NewAppConfig()
+	appConfig := NewAppConfig()
 
 	file, err := os.Open(fullConfigFilePath)
 	if err != nil {
@@ -72,7 +72,7 @@ func LoadAppConfig(configFile string) (*AppConfig, error) {
 		return nil, errors.New("Unsupported config file format")
 	}
 
-	return &appConfig, err
+	return appConfig, err
 }
 
 func (ac *AppConfig) HasDefinition() bool {

--- a/flyctl/app_config.go
+++ b/flyctl/app_config.go
@@ -25,6 +25,15 @@ const (
 
 type Environment map[string]string
 
+func (e Environment) Set(key, value string) { e[key] = value }
+func (e Environment) Get(key string) string { return e[key] }
+func (e Environment) Unset(key string)      { delete(e, key) }
+func (e Environment) MultiSet(keyValues map[string]string) {
+	for k, v := range keyValues {
+		e[k] = v
+	}
+}
+
 type AppConfig struct {
 	AppName    string
 	Build      *Build
@@ -135,7 +144,7 @@ func (ac *AppConfig) unmarshalNativeMap(data map[string]interface{}) error {
 	}
 	if env, ok := data["env"].(map[string]interface{}); ok {
 		for k, v := range env {
-			ac.Env[k] = fmt.Sprint(v)
+			ac.Env.Set(k, fmt.Sprint(v))
 		}
 	}
 	delete(data, "app")
@@ -321,13 +330,11 @@ func (ac *AppConfig) GetInternalPort() (int, error) {
 }
 
 func (ac *AppConfig) SetEnvVariables(vals map[string]string) {
-	for k, v := range vals {
-		ac.SetEnvVariable(k, v)
-	}
+	ac.Env.MultiSet(vals)
 }
 
 func (ac *AppConfig) SetEnvVariable(name, value string) {
-	ac.Env[name] = value
+	ac.Env.Set(name, value)
 }
 
 func (ac *AppConfig) SetProcess(name, value string) {

--- a/flyctl/app_config.go
+++ b/flyctl/app_config.go
@@ -23,11 +23,13 @@ const (
 	UnsupportedFormat              = ""
 )
 
+type Env map[string]string
+
 type AppConfig struct {
 	AppName    string
 	Build      *Build
 	Definition map[string]interface{}
-	Env        map[string]string
+	Env        Env
 }
 
 type Build struct {

--- a/flyctl/app_config.go
+++ b/flyctl/app_config.go
@@ -27,6 +27,7 @@ type AppConfig struct {
 	AppName    string
 	Build      *Build
 	Definition map[string]interface{}
+	Env        map[string]string
 }
 
 type Build struct {
@@ -46,6 +47,7 @@ type Build struct {
 func NewAppConfig() *AppConfig {
 	return &AppConfig{
 		Definition: map[string]interface{}{},
+		Env:        map[string]string{},
 	}
 }
 
@@ -55,9 +57,7 @@ func LoadAppConfig(configFile string) (*AppConfig, error) {
 		return nil, err
 	}
 
-	appConfig := AppConfig{
-		Definition: map[string]interface{}{},
-	}
+	appConfig := *NewAppConfig()
 
 	file, err := os.Open(fullConfigFilePath)
 	if err != nil {
@@ -131,7 +131,13 @@ func (ac *AppConfig) unmarshalNativeMap(data map[string]interface{}) error {
 	if appName, ok := (data["app"]).(string); ok {
 		ac.AppName = appName
 	}
+	if env, ok := data["env"].(map[string]interface{}); ok {
+		for k, v := range env {
+			ac.Env[k] = fmt.Sprint(v)
+		}
+	}
 	delete(data, "app")
+	delete(data, "env")
 	if buildConfig, ok := (data["build"]).(map[string]interface{}); ok {
 		insection := false
 		b := Build{
@@ -313,40 +319,13 @@ func (ac *AppConfig) GetInternalPort() (int, error) {
 }
 
 func (ac *AppConfig) SetEnvVariables(vals map[string]string) {
-	var env map[string]string
-
-	if rawEnv, ok := ac.Definition["env"]; ok {
-		if castEnv, ok := rawEnv.(map[string]string); ok {
-			env = castEnv
-		}
-	}
-	if env == nil {
-		env = map[string]string{}
-	}
-
 	for k, v := range vals {
-		env[k] = v
+		ac.SetEnvVariable(k, v)
 	}
-
-	ac.Definition["env"] = env
 }
 
 func (ac *AppConfig) SetEnvVariable(name, value string) {
-	var env map[string]string
-
-	if rawEnv, ok := ac.Definition["env"]; ok {
-		if castEnv, ok := rawEnv.(map[string]string); ok {
-			env = castEnv
-		}
-	}
-
-	if env == nil {
-		env = map[string]string{}
-	}
-
-	env[name] = value
-
-	ac.Definition["env"] = env
+	ac.Env[name] = value
 }
 
 func (ac *AppConfig) SetProcess(name, value string) {

--- a/flyctl/app_config.go
+++ b/flyctl/app_config.go
@@ -23,13 +23,13 @@ const (
 	UnsupportedFormat              = ""
 )
 
-type Env map[string]string
+type Environment map[string]string
 
 type AppConfig struct {
 	AppName    string
 	Build      *Build
 	Definition map[string]interface{}
-	Env        Env
+	Env        Environment
 }
 
 type Build struct {

--- a/flyctl/app_config_test.go
+++ b/flyctl/app_config_test.go
@@ -1,6 +1,7 @@
 package flyctl
 
 import (
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -56,9 +57,9 @@ func TestLoadTOMLAppConfigWithServices(t *testing.T) {
 }
 
 func TestLoadTOMLAppConfigWithEnvVars(t *testing.T) {
-	path := "./testdata/env-vars.toml"
+	const path = "./testdata/env-vars.toml"
 	p, err := LoadAppConfig(path)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "debug", p.Env["LOG_LEVEL"])
 	assert.Equal(t, "production", p.Env["RAILS_ENV"])
 

--- a/flyctl/app_config_test.go
+++ b/flyctl/app_config_test.go
@@ -54,3 +54,21 @@ func TestLoadTOMLAppConfigWithServices(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, p.Definition, rawData)
 }
+
+func TestLoadTOMLAppConfigWithEnvVars(t *testing.T) {
+	path := "./testdata/env-vars.toml"
+	p, err := LoadAppConfig(path)
+	assert.NoError(t, err)
+	assert.Equal(t, "debug", p.Env["LOG_LEVEL"])
+	assert.Equal(t, "production", p.Env["RAILS_ENV"])
+
+	p.SetEnvVariable("LOG_LEVEL", "info")
+
+	assert.Equal(t, "info", p.Env["LOG_LEVEL"])
+	assert.Equal(t, "production", p.Env["RAILS_ENV"])
+
+	p.SetEnvVariables(map[string]string{"RAILS_ENV": "development"})
+
+	assert.Equal(t, "info", p.Env["LOG_LEVEL"])
+	assert.Equal(t, "development", p.Env["RAILS_ENV"])
+}

--- a/flyctl/app_config_test.go
+++ b/flyctl/app_config_test.go
@@ -73,3 +73,15 @@ func TestLoadTOMLAppConfigWithEnvVars(t *testing.T) {
 	assert.Equal(t, "info", p.Env["LOG_LEVEL"])
 	assert.Equal(t, "development", p.Env["RAILS_ENV"])
 }
+
+func TestEnvironment(t *testing.T) {
+	env := Environment{}
+	env.Set("k1", "v1")
+	assert.Equal(t, "v1", env["k1"])
+	assert.Equal(t, "v1", env.Get("k1"))
+	env.Set("k2", "v2")
+	env.MultiSet(map[string]string{"k2": "v2.2", "k3": "v3"})
+	assert.Equal(t, "v1", env.Get("k1"))
+	assert.Equal(t, "v2.2", env.Get("k2"))
+	assert.Equal(t, "v3", env.Get("k3"))
+}

--- a/flyctl/testdata/env-vars.toml
+++ b/flyctl/testdata/env-vars.toml
@@ -1,0 +1,6 @@
+app = "test-app"
+
+[env]
+  LOG_LEVEL = "debug"
+  RAILS_ENV = "production"
+  S3_BUCKET = "my-app-production"


### PR DESCRIPTION
Made ENV vars a property of the AppConfig, and made sure SetEnvVariable and SetEnvVariables don't clear out the entire set of vars.

Fixes #560