### PR TITLE
Don't ask to set a Remix authentication token, now it's no longer required

### DIFF
--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -271,9 +271,6 @@ func configureRemix(sourceDir string) (*SourceInfo, error) {
 		Family: "Remix",
 		Files:  templates("templates/remix"),
 		Port:   8080,
-		Secrets: map[string]string{
-			"REMIX_TOKEN": "Your Remix authentication token.",
-		},
 		Env: map[string]string{
 			"PORT": "8080",
 		},

--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -274,8 +274,6 @@ func configureRemix(sourceDir string) (*SourceInfo, error) {
 		Env: map[string]string{
 			"PORT": "8080",
 		},
-		SkipDeploy: true,
-		DeployDocs: `To deploy this app, run 'npm run deploy'`,
 	}
 
 	return s, nil

--- a/internal/sourcecode/templates/remix/Dockerfile
+++ b/internal/sourcecode/templates/remix/Dockerfile
@@ -1,9 +1,6 @@
 # base node image
 FROM node:16-bullseye-slim as base
 
-ARG REMIX_TOKEN
-ENV REMIX_TOKEN=$REMIX_TOKEN
-
 # Install openssl for Prisma
 RUN apt-get update && apt-get install -y openssl
 
@@ -19,9 +16,6 @@ RUN npm install --production=false
 # Setup production node_modules
 FROM base as production-deps
 
-ARG REMIX_TOKEN
-ENV REMIX_TOKEN=$REMIX_TOKEN
-
 RUN mkdir /app
 WORKDIR /app
 
@@ -31,9 +25,6 @@ RUN npm prune --production
 
 # Build the app
 FROM base as build
-
-ARG REMIX_TOKEN
-ENV REMIX_TOKEN=$REMIX_TOKEN
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
In preparation for open-sourcing, Remix no longer requires an authentication token to run. So, remove everything related to auth tokens from the Remix launcher.