### PR TITLE
implementation of file-based mutexes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/ejcx/sshcert v1.0.1
 	github.com/getsentry/sentry-go v0.11.0
+	github.com/gofrs/flock v0.7.3
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/inancgumus/screen v0.0.0-20190314163918-06e984b86ed3

--- a/internal/cli/internal/cache/cache.go
+++ b/internal/cli/internal/cache/cache.go
@@ -3,13 +3,16 @@ package cache
 
 import (
 	"bytes"
+	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/superfly/flyctl/internal/filemu"
 	"github.com/superfly/flyctl/internal/update"
 )
 
@@ -138,6 +141,8 @@ type wrapper struct {
 	LatestRelease *update.Release `yaml:"latest_release,omitempty"`
 }
 
+var lockPath = filepath.Join(os.TempDir(), "flyctl.cache.lock")
+
 // Save writes the YAML-encoded representation of c to the named file path via
 // os.WriteFile.
 func (c *cache) Save(path string) (err error) {
@@ -152,21 +157,42 @@ func (c *cache) Save(path string) (err error) {
 		LatestRelease: c.latestRelease,
 	}
 
-	if err = yaml.NewEncoder(&b).Encode(w); err == nil {
-		// TODO: this is prone to race conditions and os.WriteFile does not flush
-		err = os.WriteFile(path, b.Bytes(), 0600)
+	if err = yaml.NewEncoder(&b).Encode(w); err != nil {
+		return
 	}
+
+	var unlocker filemu.Unlocker
+	if unlocker, err = filemu.Lock(context.Background(), lockPath); err != nil {
+		return
+	}
+	defer func() {
+		if e := unlocker.Unlock(); err == nil {
+			err = e
+		}
+	}()
+
+	// TODO: os.WriteFile does NOT flush
+	err = os.WriteFile(path, b.Bytes(), 0600)
 
 	return
 }
 
 // Load loads the YAML-encoded cache file at the given path.
 func Load(path string) (c Cache, err error) {
+	var unlocker filemu.Unlocker
+	if unlocker, err = filemu.RLock(context.Background(), lockPath); err != nil {
+		return
+	}
+	defer func() {
+		if e := unlocker.Unlock(); err == nil {
+			err = e
+		}
+	}()
+
 	var f *os.File
 	if f, err = os.Open(path); err != nil {
 		return
 	}
-
 	defer func() {
 		if e := f.Close(); err == nil {
 			err = e

--- a/internal/filemu/filemu.go
+++ b/internal/filemu/filemu.go
@@ -1,0 +1,56 @@
+// Package filemu implements file-based mutexes.
+package filemu
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/gofrs/flock"
+)
+
+// Unlocker is the interface that wraps the basic Unlock method.
+type Unlocker interface {
+	Unlock() error
+}
+
+const (
+	timeout    = time.Second
+	retryDelay = timeout / 10
+)
+
+// Lock attempts to acquire an exclusive lock on the named file.
+func Lock(ctx context.Context, path string) (Unlocker, error) {
+	return try(ctx, path, (*flock.Flock).TryLockContext)
+}
+
+// RLock attempts to acquire a shared lock on the named file.
+func RLock(ctx context.Context, path string) (Unlocker, error) {
+	return try(ctx, path, (*flock.Flock).TryRLockContext)
+}
+
+var errFailed = errors.New("failed acquiring lock")
+
+type unlockFunc func() error
+
+func (fn unlockFunc) Unlock() error {
+	return fn()
+}
+
+type lockFunc func(*flock.Flock, context.Context, time.Duration) (bool, error)
+
+func try(parent context.Context, path string, fn lockFunc) (Unlocker, error) {
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
+	mu := flock.New(path)
+
+	switch locked, err := fn(mu, ctx, retryDelay); {
+	case err != nil:
+		return nil, err
+	case !locked:
+		return nil, errFailed
+	default:
+		return unlockFunc(mu.Unlock), nil
+	}
+}


### PR DESCRIPTION
This PR implements the `filemu` package via which one can now acquire file-based locks (exclusive and shared). It additionally refactors the `cache` package to demonstrate usage.