### PR TITLE
Create volumes in unique zones

### DIFF
--- a/api/resource_volumes.go
+++ b/api/resource_volumes.go
@@ -14,6 +14,9 @@ func (c *Client) GetVolumes(ctx context.Context, appName string) ([]Volume, erro
 					region
 					encrypted
 					createdAt
+					host{
+						id
+					}
 					attachedAllocation {
 						idShort
 						taskName
@@ -50,6 +53,9 @@ func (c *Client) CreateVolume(ctx context.Context, input CreateVolumeInput) (*Vo
 					sizeGb
 					encrypted
 					createdAt
+					host {
+						id
+					}
 				}
 			}
 		}
@@ -103,6 +109,9 @@ func (c *Client) GetVolume(ctx context.Context, volID string) (Volume *Volume, e
 				region
 				encrypted
 				createdAt
+				host {
+					id
+				}
 			}
 		}
 	}`

--- a/api/types.go
+++ b/api/types.go
@@ -342,12 +342,13 @@ type Volume struct {
 }
 
 type CreateVolumeInput struct {
-	AppID      string  `json:"appId"`
-	Name       string  `json:"name"`
-	Region     string  `json:"region"`
-	SizeGb     int     `json:"sizeGb"`
-	Encrypted  bool    `json:"encrypted"`
-	SnapshotID *string `json:"snapshotId,omitempty"`
+	AppID             string  `json:"appId"`
+	Name              string  `json:"name"`
+	Region            string  `json:"region"`
+	SizeGb            int     `json:"sizeGb"`
+	Encrypted         bool    `json:"encrypted"`
+	SnapshotID        *string `json:"snapshotId,omitempty"`
+	RequireUniqueZone bool    `json:"requireUniqueZone"`
 }
 
 type CreateVolumePayload struct {

--- a/api/types.go
+++ b/api/types.go
@@ -339,6 +339,9 @@ type Volume struct {
 	Encrypted          bool
 	CreatedAt          time.Time
 	AttachedAllocation *AllocationStatus
+	Host               struct {
+		ID string
+	}
 }
 
 type CreateVolumeInput struct {

--- a/cmd/volumes.go
+++ b/cmd/volumes.go
@@ -91,7 +91,7 @@ func runListVolumes(cmdCtx *cmdctx.CmdContext) error {
 		return nil
 	}
 
-	table := helpers.MakeSimpleTable(cmdCtx.Out, []string{"ID", "Name", "Size", "Region", "Attached VM", "Created At"})
+	table := helpers.MakeSimpleTable(cmdCtx.Out, []string{"ID", "Name", "Size", "Region", "Zone", "Attached VM", "Created At"})
 
 	for _, v := range volumes {
 		var attachedAllocID string
@@ -101,7 +101,7 @@ func runListVolumes(cmdCtx *cmdctx.CmdContext) error {
 				attachedAllocID = fmt.Sprintf("%s (%s)", v.AttachedAllocation.IDShort, v.AttachedAllocation.TaskName)
 			}
 		}
-		table.Append([]string{v.ID, v.Name, strconv.Itoa(v.SizeGb) + "GB", v.Region, attachedAllocID, humanize.Time(v.CreatedAt)})
+		table.Append([]string{v.ID, v.Name, strconv.Itoa(v.SizeGb) + "GB", v.Region, v.Host.ID, attachedAllocID, humanize.Time(v.CreatedAt)})
 	}
 
 	table.Render()
@@ -148,6 +148,7 @@ func runCreateVolume(cmdCtx *cmdctx.CmdContext) error {
 	fmt.Printf("%10s: %s\n", "ID", volume.ID)
 	fmt.Printf("%10s: %s\n", "Name", volume.Name)
 	fmt.Printf("%10s: %s\n", "Region", volume.Region)
+	fmt.Printf("%10s: %s\n", "Zone", volume.Host.ID)
 	fmt.Printf("%10s: %d\n", "Size GB", volume.SizeGb)
 	fmt.Printf("%10s: %t\n", "Encrypted", volume.Encrypted)
 	fmt.Printf("%10s: %s\n", "Created at", volume.CreatedAt.Format(time.RFC822))
@@ -208,6 +209,7 @@ func runShowVolume(cmdCtx *cmdctx.CmdContext) error {
 	fmt.Printf("%10s: %s\n", "ID", volume.ID)
 	fmt.Printf("%10s: %s\n", "Name", volume.Name)
 	fmt.Printf("%10s: %s\n", "Region", volume.Region)
+	fmt.Printf("%10s: %s\n", "Zone", volume.Host.ID)
 	fmt.Printf("%10s: %d\n", "Size GB", volume.SizeGb)
 	fmt.Printf("%10s: %t\n", "Encrypted", volume.Encrypted)
 	fmt.Printf("%10s: %s\n", "Created at", volume.CreatedAt.Format(time.RFC822))

--- a/cmd/volumes.go
+++ b/cmd/volumes.go
@@ -47,6 +47,12 @@ func newVolumesCommand(client *client.Client) *Command {
 		Default:     true,
 	})
 
+	createCmd.AddBoolFlag(BoolFlagOpts{
+		Name:        "require-unique-zone",
+		Description: "Require volume to be placed in separate hardware zone from existing volumes",
+		Default:     true,
+	})
+
 	deleteStrings := docstrings.Get("volumes.delete")
 	deleteCmd := BuildCommandKS(volumesCmd, runDeleteVolume, deleteStrings, client, requireSession)
 	deleteCmd.Args = cobra.ExactArgs(1)
@@ -125,11 +131,12 @@ func runCreateVolume(cmdCtx *cmdctx.CmdContext) error {
 	sizeGb := cmdCtx.Config.GetInt("size")
 
 	input := api.CreateVolumeInput{
-		AppID:     appid,
-		Name:      volName,
-		Region:    region,
-		SizeGb:    sizeGb,
-		Encrypted: cmdCtx.Config.GetBool("encrypted"),
+		AppID:             appid,
+		Name:              volName,
+		Region:            region,
+		SizeGb:            sizeGb,
+		Encrypted:         cmdCtx.Config.GetBool("encrypted"),
+		RequireUniqueZone: cmdCtx.Config.GetBool("require-unique-zone"),
 	}
 
 	volume, err := cmdCtx.Client.API().CreateVolume(ctx, input)


### PR DESCRIPTION
This adds a `--require-unique-zone` argument to `fly volumes create`. When users create a volume with this flag, we ensure that the new volume is on different hardware than existing volumes of the same name. It defaults to `true`, this is almost always what people want.

It also adds a `zone` to the volume show/list output.