### PR TITLE
Use machine-based remote builders exclusively

### DIFF
--- a/api/resource_remote_builders.go
+++ b/api/resource_remote_builders.go
@@ -2,7 +2,7 @@ package api
 
 import "context"
 
-func (client *Client) EnsureRemoteBuilder(ctx context.Context, orgID string, appName string) (*Machine, *App, error) {
+func (client *Client) EnsureRemoteBuilder(ctx context.Context, orgID, appName string) (*Machine, *App, error) {
 	query := `
 		mutation($input: EnsureMachineRemoteBuilderInput!) {
 			ensureMachineRemoteBuilder(input: $input) {

--- a/api/resource_remote_builders.go
+++ b/api/resource_remote_builders.go
@@ -2,7 +2,7 @@ package api
 
 import "context"
 
-func (client *Client) EnsureMachineRemoteBuilderForApp(ctx context.Context, appName string) (*Machine, *App, error) {
+func (client *Client) EnsureRemoteBuilder(ctx context.Context, orgID string, appName string) (*Machine, *App, error) {
 	query := `
 		mutation($input: EnsureMachineRemoteBuilderInput!) {
 			ensureMachineRemoteBuilder(input: $input) {
@@ -29,9 +29,16 @@ func (client *Client) EnsureMachineRemoteBuilderForApp(ctx context.Context, appN
 
 	req := client.NewRequest(query)
 
-	req.Var("input", EnsureRemoteBuilderInput{
-		AppName: StringPointer(appName),
-	})
+	if orgID != "" {
+		req.Var("input", EnsureRemoteBuilderInput{
+			OrganizationID: StringPointer(orgID),
+		})
+	} else {
+		req.Var("input", EnsureRemoteBuilderInput{
+			AppName: StringPointer(appName),
+		})
+
+	}
 
 	data, err := client.RunWithContext(ctx, req)
 	if err != nil {
@@ -39,30 +46,4 @@ func (client *Client) EnsureMachineRemoteBuilderForApp(ctx context.Context, appN
 	}
 
 	return data.EnsureMachineRemoteBuilder.Machine, data.EnsureMachineRemoteBuilder.App, nil
-}
-
-func (client *Client) EnsureRemoteBuilderForOrg(ctx context.Context, orgID string) (string, *App, error) {
-	query := `
-		mutation($input: EnsureRemoteBuilderInput!) {
-			ensureRemoteBuilder(input: $input) {
-				url,
-				app {
-					name
-				}
-			}
-		}
-	`
-
-	req := client.NewRequest(query)
-
-	req.Var("input", EnsureRemoteBuilderInput{
-		OrganizationID: StringPointer(orgID),
-	})
-
-	data, err := client.RunWithContext(ctx, req)
-	if err != nil {
-		return "", nil, err
-	}
-
-	return data.EnsureRemoteBuilder.URL, data.EnsureRemoteBuilder.App, nil
 }

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -283,7 +283,7 @@ func remoteMachine(ctx context.Context, apiClient *api.Client, appName string) (
 		return nil, nil, nil
 	}
 
-	return apiClient.EnsureMachineRemoteBuilderForApp(ctx, appName)
+	return apiClient.EnsureRemoteBuilder(ctx, "", appName)
 }
 
 func waitForDaemon(ctx context.Context, client *dockerclient.Client) error {
@@ -443,7 +443,7 @@ func EagerlyEnsureRemoteBuilder(ctx context.Context, apiClient *api.Client, orgS
 		return
 	}
 
-	_, app, err := apiClient.EnsureRemoteBuilderForOrg(ctx, org.ID)
+	_, app, err := apiClient.EnsureRemoteBuilder(ctx, org.ID, "")
 	if err != nil {
 		terminal.Debugf("error ensuring remote builder for organization: %s", err)
 		return


### PR DESCRIPTION
This is a step towards deprecating application-based remote builders.