### PR TITLE
New PG Attach/Detach process

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -196,6 +196,9 @@ type Query struct {
 	Machines struct {
 		Nodes []*Machine
 	}
+	PostgresAttachments struct {
+		Nodes []*PostgresClusterAttachment
+	}
 	LaunchMachine struct {
 		Machine *Machine
 		App     *App
@@ -1035,7 +1038,15 @@ type AttachPostgresClusterInput struct {
 	AppID                string  `json:"appId"`
 	PostgresClusterAppID string  `json:"postgresClusterAppId"`
 	DatabaseName         *string `json:"databaseName,omitempty"`
+	DatabaseUser         *string `json:"databaseUser,omitempty"`
 	VariableName         *string `json:"variableName,omitempty"`
+	ManualEntry          bool    `json:"manualEntry,omitempty"`
+}
+
+type DetachPostgresClusterInput struct {
+	AppID                       string `json:"appId"`
+	PostgresClusterId           string `json:"postgresClusterAppId"`
+	PostgresClusterAttachmentId string `json:"postgresClusterAttachmentId"`
 }
 
 type AttachPostgresClusterPayload struct {
@@ -1059,6 +1070,13 @@ type PostgresClusterUser struct {
 type PostgresClusterDatabase struct {
 	Name  string
 	Users []string
+}
+
+type PostgresClusterAttachment struct {
+	ID                      string
+	DatabaseName            string
+	DatabaseUser            string
+	EnvironmentVariableName string
 }
 
 type Image struct {

--- a/cmd/postgres_commands.go
+++ b/cmd/postgres_commands.go
@@ -1,0 +1,240 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/cmdctx"
+	"github.com/superfly/flyctl/pkg/agent"
+)
+
+type PostgresDatabaseListResponse struct {
+	Result []PostgresDatabase
+}
+
+type PostgresDatabase struct {
+	Name  string
+	Users []string
+}
+
+type PostgresUserListResponse struct {
+	Result []PostgresUser
+}
+
+type PostgresUser struct {
+	Username  string
+	Superuser bool
+	Databases []string
+}
+
+type PostgresRevokeAccessRequest struct {
+	Database string `json:"database"`
+	Username string `json:"username"`
+}
+
+type PostgresGrantAccessRequest struct {
+	Database string `json:"database"`
+	Username string `json:"username"`
+}
+
+type PostgresCreateUserRequest struct {
+	Username  string `json:"username"`
+	Password  string `json:"password"`
+	Superuser bool   `json:"superuser"`
+}
+
+type PostgresDeleteUserRequest struct {
+	Username string `json:"username"`
+}
+
+type PostgresCreateDatabaseRequest struct {
+	Name string `json:"name"`
+}
+
+type PostgresCommandResponse struct {
+	Result bool   `json:"result"`
+	Error  string `json:"error"`
+}
+
+type PostgresCmd struct {
+	cmdCtx *cmdctx.CmdContext
+	app    *api.App
+	dialer agent.Dialer
+}
+
+func NewPostgresCmd(cmdCtx *cmdctx.CmdContext, app *api.App, dialer agent.Dialer) *PostgresCmd {
+	return &PostgresCmd{
+		cmdCtx: cmdCtx,
+		app:    app,
+		dialer: dialer,
+	}
+}
+
+func (pc *PostgresCmd) RevokeAccess(dbName, username string) (*PostgresCommandResponse, error) {
+	fmt.Println("Running flyadmin revoke-access")
+	req := &PostgresRevokeAccessRequest{
+		Database: dbName,
+		Username: username,
+	}
+
+	reqJson, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := fmt.Sprintf("flyadmin revoke-access %s", string(reqJson))
+	createUsrBytes, err := runSSHCommand(pc.cmdCtx, pc.app, pc.dialer, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp PostgresCommandResponse
+	if err := json.Unmarshal(createUsrBytes, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (pc *PostgresCmd) GrantAccess(dbName, username string) (*PostgresCommandResponse, error) {
+	fmt.Println("Running flyadmin grant-access")
+	req := &PostgresGrantAccessRequest{
+		Database: dbName,
+		Username: username,
+	}
+
+	reqJson, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := fmt.Sprintf("flyadmin grant-access %s", string(reqJson))
+	createUsrBytes, err := runSSHCommand(pc.cmdCtx, pc.app, pc.dialer, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp PostgresCommandResponse
+	if err := json.Unmarshal(createUsrBytes, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (pc *PostgresCmd) CreateUser(userName, pwd string) (*PostgresCommandResponse, error) {
+	fmt.Println("Running flyadmin user-create")
+	req := &PostgresCreateUserRequest{
+		Username:  userName,
+		Password:  pwd,
+		Superuser: false,
+	}
+
+	reqJson, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := fmt.Sprintf("flyadmin user-create %s", string(reqJson))
+	createUsrBytes, err := runSSHCommand(pc.cmdCtx, pc.app, pc.dialer, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp PostgresCommandResponse
+	if err := json.Unmarshal(createUsrBytes, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (pc *PostgresCmd) DeleteUser(userName string) (*PostgresCommandResponse, error) {
+	fmt.Println("Running flyadmin user-delete")
+	req := &PostgresDeleteUserRequest{
+		Username: userName,
+	}
+
+	reqJson, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := fmt.Sprintf("flyadmin user-delete %s", string(reqJson))
+	createUsrBytes, err := runSSHCommand(pc.cmdCtx, pc.app, pc.dialer, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp PostgresCommandResponse
+	if err := json.Unmarshal(createUsrBytes, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (pc *PostgresCmd) CreateDatabase(dbName string) (*PostgresCommandResponse, error) {
+	fmt.Println("Running flyadmin database-create")
+	req := &PostgresCreateDatabaseRequest{Name: dbName}
+	reqJson, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := fmt.Sprintf("flyadmin database-create %s", string(reqJson))
+	createDbBytes, err := runSSHCommand(pc.cmdCtx, pc.app, pc.dialer, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp PostgresCommandResponse
+	if err := json.Unmarshal(createDbBytes, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (pc *PostgresCmd) DbExists(dbName string) (bool, error) {
+	fmt.Println("Running flyadmin database-list")
+	databaseListBytes, err := runSSHCommand(pc.cmdCtx, pc.app, pc.dialer, "flyadmin database-list")
+	if err != nil {
+		return false, err
+	}
+
+	var dbList PostgresDatabaseListResponse
+	if err := json.Unmarshal(databaseListBytes, &dbList); err != nil {
+		return false, err
+	}
+
+	for _, db := range dbList.Result {
+		if db.Name == dbName {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (pc *PostgresCmd) UserExists(userName string) (bool, error) {
+	fmt.Println("Running flyadmin user-list")
+	userListBytes, err := runSSHCommand(pc.cmdCtx, pc.app, pc.dialer, "flyadmin user-list")
+	if err != nil {
+		return false, err
+	}
+
+	var userList PostgresUserListResponse
+	if err := json.Unmarshal(userListBytes, &userList); err != nil {
+		return false, err
+	}
+
+	for _, user := range userList.Result {
+		if user.Username == userName {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
This is a rewrite of Postgres's Attach/Detach features.  The primary change includes bringing the actual orchestration of the associated commands to flyctl and leveraging SSH to call the commands directly from the client.  

This should help improve the general reliability of these commands. 

Attach
![Screen Shot 2021-12-08 at 5 42 34 PM](https://user-images.githubusercontent.com/423038/145308701-22d3728e-c903-4468-bbc3-2da35359353d.png)


Detach
![Screen Shot 2021-12-08 at 5 43 03 PM](https://user-images.githubusercontent.com/423038/145308747-45ceec1d-3b2b-48d9-a1e1-12d2a4cf7683.png)


This will also allow you to attach multiple apps to a single database and manage the individual attachments individually.

![Screen Shot 2021-12-08 at 5 46 47 PM](https://user-images.githubusercontent.com/423038/145309073-5b4fa3d4-bd94-4e21-bbe2-9bc7c01207e2.png)

