### PR TITLE
Fix map initialization panic in cli/internal/config

### DIFF
--- a/internal/cli/internal/config/file.go
+++ b/internal/cli/internal/config/file.go
@@ -18,7 +18,8 @@ func SetAccessToken(path, token string) error {
 }
 
 func set(path, key string, value interface{}) error {
-	var m map[string]interface{}
+	m := make(map[string]interface{})
+
 	switch err := unmarshal(path, &m); {
 	case err == nil, os.IsNotExist(err):
 		break


### PR DESCRIPTION
Fixes https://sentry.io/organizations/flyio/issues/2844232223/?project=4492967﻿

Initialize the map using the make function (or a map literal) before you can add any elements
