### PR TITLE
Updates for the Phoenix launcher: db launching and fixes to fly.toml

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -72,6 +72,11 @@ func newLaunchCommand(client *client.Client) *Command {
 		Description: "Use the configuration file if present without prompting.",
 		Default:     false,
 	})
+	launchCmd.AddBoolFlag(BoolFlagOpts{
+		Name:        "remote-only",
+		Description: "Perform builds remotely without using the local docker daemon",
+		Default:     true,
+	})
 
 	return launchCmd
 }

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -438,6 +438,9 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 
 		_, err = cmdCtx.Client.API().AttachPostgresCluster(cmdCtx.Command.Context(), attachInput)
 
+		// Reset the app name here beacuse AttachPostgresCluster sets it on the cmdCtx :/
+		cmdCtx.AppName = app.ID
+
 		if err != nil {
 			return err
 		}

--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -296,14 +296,20 @@ func runCreatePostgresCluster(cmdCtx *cmdctx.CmdContext) error {
 
 	fmt.Fprintf(cmdCtx.Out, "Creating postgres cluster %s in organization %s\n", name, org.Slug)
 
+	_, err = runApiCreatePostgresCluster(cmdCtx, org.Slug, &input)
+
+	return err
+}
+
+func runApiCreatePostgresCluster(cmdCtx *cmdctx.CmdContext, org string, input *api.CreatePostgresClusterInput) (*api.CreatePostgresClusterPayload, error) {
 	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 	s.Writer = os.Stderr
 	s.Prefix = "Launching..."
 	s.Start()
 
-	payload, err := cmdCtx.Client.API().CreatePostgresCluster(ctx, input)
+	payload, err := cmdCtx.Client.API().CreatePostgresCluster(cmdCtx.Command.Context(), *input)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	s.FinalMSG = fmt.Sprintf("Postgres cluster %s created\n", payload.App.Name)
@@ -329,14 +335,14 @@ func runCreatePostgresCluster(cmdCtx *cmdctx.CmdContext) error {
 	if err == nil {
 		fmt.Println()
 		fmt.Println(aurora.Bold("Connect to postgres"))
-		fmt.Printf("Any app within the %s organization can connect to postgres using the above credentials and the hostname \"%s.internal.\"\n", org.Slug, payload.App.Name)
+		fmt.Printf("Any app within the %s organization can connect to postgres using the above credentials and the hostname \"%s.internal.\"\n", org, payload.App.Name)
 		fmt.Printf("For example: postgres://%s:%s@%s.internal:%d\n", payload.Username, payload.Password, payload.App.Name, 5432)
 
 		fmt.Println()
 		fmt.Println("See the postgres docs for more information on next steps, managing postgres, connecting from outside fly:  https://fly.io/docs/reference/postgres/")
 	}
 
-	return err
+	return payload, err
 }
 
 func runAttachPostgresCluster(cmdCtx *cmdctx.CmdContext) error {

--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -29,19 +29,20 @@ type SourceInfo struct {
 	DockerCommand    string
 	DockerEntrypoint string
 
-	Buildpacks         []string
-	Secrets            map[string]string
-	Files              []SourceFile
-	Port               int
-	Env                map[string]string
-	Statics            []Static
-	Processes          map[string]string
-	DeployDocs         string
-	Notice             string
-	SkipDeploy         bool
-	Volumes            []Volume
-	DockerfileAppendix []string
-	InitCommands       []InitCommand
+	Buildpacks            []string
+	Secrets               map[string]string
+	Files                 []SourceFile
+	Port                  int
+	Env                   map[string]string
+	Statics               []Static
+	Processes             map[string]string
+	DeployDocs            string
+	Notice                string
+	SkipDeploy            bool
+	Volumes               []Volume
+	DockerfileAppendix    []string
+	InitCommands          []InitCommand
+	CreatePostgresCluster bool
 }
 
 type SourceFile struct {
@@ -272,12 +273,12 @@ func configurePhoenix(sourceDir string) (*SourceInfo, error) {
 		},
 		Port: 8080,
 		Env: map[string]string{
-			"PORT": "8080",
+			"PORT":     "8080",
+			"PHX_HOST": "APP_FQDN",
 		},
 		DockerfileAppendix: []string{
 			"ENV ECTO_IPV6 true",
 			"ENV ERL_AFLAGS \"-proto_dist inet6_tcp\"",
-			"ENV RELEASE_DISTRIBUTION name",
 		},
 		InitCommands: []InitCommand{
 			{
@@ -296,14 +297,12 @@ func configurePhoenix(sourceDir string) (*SourceInfo, error) {
 	// We found Phoenix 1.6.3 or higher, so try running the Docker generator
 	if checksPass(sourceDir, dirContains("mix.exs", "phoenix.*"+regexp.QuoteMeta("1.6.3"))) {
 		s.Version = "1.6.3"
-		s.SkipDeploy = true
 		s.DeployDocs = `
-Your Phoenix app should be ready for deployment!. If you need a Postgres database, see
-https://fly.io/docs/reference/postgres/ and attach it to your app before deployment.
+Your Phoenix app should be ready for deployment!.
 
 If you need something else, post on our community forum at https://community.fly.io.
 
-When you're ready to deploy, use 'fly deploy'.
+When you're ready to deploy, use 'fly deploy --remote-only'.
 `
 	}
 	// We found Phoenix 1.6.0 - 1.6.2
@@ -323,6 +322,15 @@ a Postgresql database.
 `
 	}
 
+	// Add migration task if we find ecto
+	if checksPass(sourceDir, dirContains("mix.exs", "ecto")) {
+		s.ReleaseCmd = "/app/bin/migrate"
+	}
+
+	// Ask to create a postgres database if we find the postgres adapter
+	if checksPass(sourceDir, dirContains("mix.lock", "postgrex")) {
+		s.CreatePostgresCluster = true
+	}
 	return s, nil
 }
 

--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -295,8 +295,7 @@ func configurePhoenix(sourceDir string) (*SourceInfo, error) {
 	}
 
 	// We found Phoenix 1.6.3 or higher, so try running the Docker generator
-	if checksPass(sourceDir, dirContains("mix.exs", "phoenix.*"+regexp.QuoteMeta("1.6.3"))) {
-		s.Version = "1.6.3"
+	if checksPass(sourceDir, dirContains("mix.exs", "phoenix.*"+regexp.QuoteMeta("1.6"))) {
 		s.DeployDocs = `
 Your Phoenix app should be ready for deployment!.
 
@@ -307,8 +306,6 @@ When you're ready to deploy, use 'fly deploy --remote-only'.
 	}
 	// We found Phoenix 1.6.0 - 1.6.2
 	if checksPass(sourceDir, dirContains("mix.exs", "phoenix.*"+regexp.QuoteMeta("1.6.")+"[0-2]")) {
-		s.Version = "1.6"
-		s.Files = templates("templates/phoenix")
 		s.SkipDeploy = true
 		s.DeployDocs = `
 We recommend upgrading to Phoenix 1.6.3 which includes a release configuration for Docker-based deployment.


### PR DESCRIPTION
This PR updates the Phoenix launcher with some fixes and enhancements.

* Set `PHX_ENV` to the `appname.fly.dev`
* Remove `RELEASE_DISTRIBUTION` from Dockerfile
* Add the Ecto migration release command to `fly.toml`
* Ask to launch a minimal standalone postgres cluster