### PR TITLE
Add `--availability` flag, ability to bypass interactive prompts on `pg create`

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -203,6 +203,35 @@ func inputAppName(defaultName string, autoGenerate bool) (name string, err error
 	return name, nil
 }
 
+const (
+	highAvailability       = "high"
+	standaloneAvailability = "standalone"
+)
+
+func postgresClusteringOptionsInput(availability string) (PostgresClusterOption, error) {
+	if availability == highAvailability {
+		return highlyAvailablePostgres(), nil
+	}
+	if availability == standaloneAvailability {
+		return standalonePostgres(), nil
+	}
+	selected := 0
+	options := []string{}
+	for _, opt := range postgresClusteringOptions() {
+		options = append(options, opt.Name)
+	}
+	prompt := &survey.Select{
+		Message:  "Select configuration:",
+		Options:  options,
+		PageSize: 2,
+	}
+	if err := survey.AskOne(prompt, &selected); err != nil {
+		return PostgresClusterOption{}, err
+	}
+	option := postgresClusteringOptions()[selected]
+	return option, nil
+}
+
 func volumeSizeInput(defaultVal int) (int, error) {
 	var volumeSize int
 	prompt := &survey.Input{

--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -123,6 +123,7 @@ func newPostgresCommand(client *client.Client) *Command {
 	createCmd.AddStringFlag(StringFlagOpts{Name: "password", Description: "the superuser password. one will be generated for you if you leave this blank"})
 	createCmd.AddStringFlag(StringFlagOpts{Name: "volume-size", Description: "the size in GB for volumes"})
 	createCmd.AddStringFlag(StringFlagOpts{Name: "vm-size", Description: "the size of the VM"})
+	createCmd.AddStringFlag(StringFlagOpts{Name: "availability", Description: "either 'standalone' for development or 'high' for production"})
 
 	createCmd.AddStringFlag(StringFlagOpts{Name: "image-ref", Hidden: true})
 	createCmd.AddStringFlag(StringFlagOpts{Name: "snapshot-id", Description: "Creates the volume with the contents of the snapshot"})
@@ -206,14 +207,11 @@ func runCreatePostgresCluster(cmdCtx *cmdctx.CmdContext) error {
 		Region:         api.StringPointer(region.Code),
 	}
 
-	customConfig := false
-
 	volumeSize := cmdCtx.Config.GetInt("volume-size")
 	vmSizeName := cmdCtx.Config.GetString("vm-size")
+	availability := cmdCtx.Config.GetString("availability")
 
-	if volumeSize != 0 || vmSizeName != "" {
-		customConfig = true
-	}
+	customConfig := volumeSize != 0 || vmSizeName != "" || availability != ""
 
 	var pgConfig *PostgresConfiguration
 	var vmSize *api.VMSize
@@ -244,20 +242,10 @@ func runCreatePostgresCluster(cmdCtx *cmdctx.CmdContext) error {
 	}
 
 	if customConfig {
-		selected := 0
-		options := []string{}
-		for _, opt := range postgresClusteringOptions() {
-			options = append(options, opt.Name)
-		}
-		prompt := &survey.Select{
-			Message:  "Select configuration:",
-			Options:  options,
-			PageSize: 2,
-		}
-		if err := survey.AskOne(prompt, &selected); err != nil {
+		option, err := postgresClusteringOptionsInput(availability)
+		if err != nil {
 			return err
 		}
-		option := postgresClusteringOptions()[selected]
 
 		input.Count = &option.Count
 		input.ImageRef = &option.ImageRef
@@ -286,6 +274,7 @@ func runCreatePostgresCluster(cmdCtx *cmdctx.CmdContext) error {
 		}
 		input.VMSize = api.StringPointer(vmSize.Name)
 		input.VolumeSizeGB = api.IntPointer(pgConfig.DiskGb)
+
 		input.Count = api.IntPointer(pgConfig.ClusteringOption.Count)
 
 		if imageRef := cmdCtx.Config.GetString("image-ref"); imageRef != "" {


### PR DESCRIPTION
closes #645

Added `--availability` flag with possible values `high` and `standalone`. Will prompt if neither value, nil, or some other string.

This API might be a little wordy, so open to suggestions. I also considered something like `--development`, but I believe this is more explicit.

<3 fly keep up the good work!