### PR TITLE
Use new Postgres attach in launchers

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -167,7 +167,11 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 				article += "n"
 			}
 
-			appType := srcInfo.Family + " " + srcInfo.Version
+			appType := srcInfo.Family
+
+			if srcInfo.Version != "" {
+				appType = " " + srcInfo.Version
+			}
 			fmt.Printf("Detected %s %s app\n", article, aurora.Green(appType))
 
 			if srcInfo.Builder != "" {
@@ -428,20 +432,18 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 		payload, err := runApiCreatePostgresCluster(cmdCtx, org.Slug, &clusterInput)
 
 		if err != nil {
+			err = fmt.Errorf("failed creating the Postgres cluster %s: %w", clusterAppName, err)
 			return err
 		}
-
-		attachInput := api.AttachPostgresClusterInput{
-			AppID:                app.ID,
-			PostgresClusterAppID: clusterAppName,
-		}
-
-		_, err = cmdCtx.Client.API().AttachPostgresCluster(cmdCtx.Command.Context(), attachInput)
 
 		// Reset the app name here beacuse AttachPostgresCluster sets it on the cmdCtx :/
 		cmdCtx.AppName = app.ID
 
+		cmdCtx.Config.Set("postgres-app", clusterAppName)
+		err = runAttachPostgresCluster(cmdCtx)
+
 		if err != nil {
+			err = fmt.Errorf("failed attaching %s to the Postgres cluster %s: %w", clusterAppName, app.Name, err)
 			return err
 		}
 

--- a/flyctl/config.go
+++ b/flyctl/config.go
@@ -28,6 +28,7 @@ type Config interface {
 	GetStringSlice(key string) []string
 	GetInt(key string) int
 	IsSet(key string) bool
+	Set(key string, value interface{})
 }
 
 type config struct {
@@ -73,6 +74,11 @@ func (cfg *config) IsSet(key string) bool {
 
 func ConfigNS(ns string) Config {
 	return &config{ns}
+}
+
+func (cfg *config) Set(key string, value interface{}) {
+	fullKey := cfg.nsKey(key)
+	viper.Set(fullKey, value)
 }
 
 var FlyConfig Config = ConfigNS(NSRoot)


### PR DESCRIPTION
To quality for merge, this branch needs to be tested in different regions to ensure there's no race condition when trying to attach to a recently-created cluster.