### PR TITLE
Add tooling to publish releases from branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           path: dist/checksums.txt
 
   dev_release:
-    if: startsWith(github.ref, 'refs/tags/dev')
+    if: startsWith(github.ref, 'refs/tags/d')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
   release:
     needs: test
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -129,7 +129,7 @@ jobs:
           path: dist/checksums.txt
 
   dev_release:
-    if: startsWith(github.ref, 'refs/tags/d')
+    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, 'dev-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,52 @@ jobs:
           name: checksums
           path: dist/checksums.txt
 
+  dev_release:
+    if: startsWith(github.ref, 'refs/tags/dev')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Get go version
+        id: go-version
+        run: echo "::set-output name=version::$(go env GOVERSION)"
+      - uses: actions/cache@v2
+        with:
+          # In order:
+          # * Module download cache
+          # * Build cache (Linux)
+          # * Build cache (Mac)
+          # * Build cache (Windows)
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            %LocalAppData%\go-build
+          key: ${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ steps.go-version.outputs.version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-${{ runner.os }}-go
+      - name: Place wintun.dll
+        run: cp -r deps/wintun/bin/amd64/wintun.dll ./
+      - name: generate release notes
+        run: |
+          mkdir -p ./tmp
+          ./scripts/changelog.sh > ./tmp/changelog.txt
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --config .goreleaser.dev.yml --rm-dist --release-notes=./tmp/changelog.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+      - name: Upload checksums as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: checksums
+          path: dist/checksums.txt
   aur-publish:
     name: Build & publish to AUR
     needs: release

--- a/.goreleaser.dev.yml
+++ b/.goreleaser.dev.yml
@@ -58,7 +58,6 @@ archives:
     format: tar.gz
 
 release:
-  name_template: "{{.Branch}}-{{.ShortCommit}}"
   github:
     owner: superfly
     name: flyctl-dev

--- a/.goreleaser.dev.yml
+++ b/.goreleaser.dev.yml
@@ -1,0 +1,64 @@
+before:
+  hooks:
+    - go mod download
+    - go generate ./...
+
+builds:
+  - id: default
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    ignore:
+      - goos: darwin
+        goarch: 386
+      - goos: linux
+        goarch: 386
+    ldflags:
+      - -X github.com/superfly/flyctl/internal/buildinfo.environment=production
+      - -X github.com/superfly/flyctl/internal/buildinfo.buildDate={{ .Date }}
+      - -X github.com/superfly/flyctl/internal/buildinfo.version={{ .Version }}
+      - -X github.com/superfly/flyctl/internal/buildinfo.commit={{ .ShortCommit }}
+  - id: windows
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+    ignore:
+      - goos: windows
+        goarch: 386
+    ldflags:
+      - -X github.com/superfly/flyctl/internal/buildinfo.environment=production
+      - -X github.com/superfly/flyctl/internal/buildinfo.buildDate={{ .Date }}
+      - -X github.com/superfly/flyctl/internal/buildinfo.version={{ .Version }}
+      - -X github.com/superfly/flyctl/internal/buildinfo.commit={{ .ShortCommit }}
+
+archives:
+  - id: windows
+    replacements:
+      windows: Windows
+      amd64: x86_64
+    builds:
+      - windows
+    files:
+      - wintun.dll
+    wrap_in_directory: false
+    format: zip
+  - id: default
+    replacements:
+      darwin: macOS
+      linux: Linux
+      windows: Windows
+      amd64: x86_64
+    builds:
+      - default
+    files: [only-the-binary*]
+    wrap_in_directory: false
+    format: tar.gz
+
+release:
+  name_template: "{{.Branch}}-{{.ShortCommit}}"
+  github:
+    owner: superfly
+    repo: flyctl-dev

--- a/.goreleaser.dev.yml
+++ b/.goreleaser.dev.yml
@@ -61,4 +61,4 @@ release:
   name_template: "{{.Branch}}-{{.ShortCommit}}"
   github:
     owner: superfly
-    repo: flyctl-dev
+    name: flyctl-dev

--- a/scripts/dev_release.sh
+++ b/scripts/dev_release.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ORIGIN=${ORIGIN:-origin}
+
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+previous_version="$("$dir"/../scripts/version.sh -s)"
+
+if [[ $(git status --porcelain) != "" ]]; then
+  echo "Error: repo is dirty. Run git status, clean repo and try again."
+  exit 1
+elif [[ $(git status --porcelain -b | grep -e "ahead" -e "behind") != "" ]]; then
+  echo "Error: repo has unpushed commits. Push commits to remote and try again."
+  exit 1
+fi
+
+revision=$(git rev-parse --short HEAD)
+branch=$(git rev-parse --abbrev-ref HEAD)
+version="d${previous_version}-${branch}-${revision}"
+echo "Publishing development release: $version"
+
+read -p "Are you sure? " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+  git tag -m "release ${version}" -a "$version" && git push "${ORIGIN}" tag "$version"
+  echo "done"
+fi
+

--- a/scripts/dev_release.sh
+++ b/scripts/dev_release.sh
@@ -17,7 +17,7 @@ fi
 
 revision=$(git rev-parse --short HEAD)
 branch=$(git rev-parse --abbrev-ref HEAD)
-version="d${previous_version}-${branch}-${revision}"
+version="v${previous_version}-dev-${branch}-${revision}"
 echo "Publishing development release: $version"
 
 read -p "Are you sure? " -n 1 -r

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,5 +1,5 @@
 ORIGIN=${ORIGIN:-origin}
 
-version=$(git fetch --tags "${ORIGIN}" &>/dev/null |  git -c "versionsort.prereleasesuffix=-pre" tag -l --sort=version:refname | tail -n1 | cut -c 2-)
+version=$(git fetch --tags "${ORIGIN}" &>/dev/null |  git -c "versionsort.prereleasesuffix=-pre" tag -l --sort=version:refname | grep -v dev | tail -n1 | cut -c 2-)
 
 echo "$version"


### PR DESCRIPTION
This PR adds `scripts/dev_release.sh`. It generates a tag with the current commit and branch name, then publishes a release in a [repo dedicated to development releases](https://github.com/superfly/flyctl-dev/releases).

This approach is simpler than publishing to S3 and means we don't have to make changes to filter out development releases on the main repository. If we want releases there, we could do this filtering on the backend, of course.

