### PR TITLE
Move logs command to the new command format

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,6 @@ func NewRootCmd(client *client.Client) *cobra.Command {
 		newInfoCommand(client),
 		newIPAddressesCommand(client),
 		newListCommand(client),
-		newLogsCommand(client),
 		newMonitorCommand(client),
 		newOpenCommand(client),
 		newPlatformCommand(client),

--- a/internal/cli/internal/command/root/root.go
+++ b/internal/cli/internal/command/root/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/superfly/flyctl/internal/cli/internal/command/builds"
 	"github.com/superfly/flyctl/internal/cli/internal/command/create"
 	"github.com/superfly/flyctl/internal/cli/internal/command/destroy"
+	"github.com/superfly/flyctl/internal/cli/internal/command/logs"
 	"github.com/superfly/flyctl/internal/cli/internal/command/move"
 	"github.com/superfly/flyctl/internal/cli/internal/command/orgs"
 	"github.com/superfly/flyctl/internal/cli/internal/command/restart"
@@ -92,6 +93,7 @@ func New() *cobra.Command {
 		orgs.New(),
 		auth.New(),
 		builds.New(),
+		logs.New(),
 	}
 
 	if os.Getenv("DEV") != "" {


### PR DESCRIPTION
A few doubts to resolve:

* How should the log presenter be ported to the new system? This presenter is used by three different packages currently.
* What should we do with `terminal.Debug`?