### PR TITLE
Launchers requesting volumes should get 1GB instead of 10GB

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -366,7 +366,7 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 				AppID:     app.ID,
 				Name:      vol.Source,
 				Region:    region.Code,
-				SizeGb:    10,
+				SizeGb:    1,
 				Encrypted: true,
 			})
 


### PR DESCRIPTION
This way, a first launch will fit inside the free tier.