### PR TITLE
fix: prompt.Select

### DIFF
--- a/internal/cli/internal/prompt/prompt.go
+++ b/internal/cli/internal/prompt/prompt.go
@@ -64,8 +64,11 @@ func Select(ctx context.Context, index *int, msg, def string, options ...string)
 	p := &survey.Select{
 		Message:  msg,
 		Options:  options,
-		Default:  def,
 		PageSize: 15,
+	}
+
+	if def != "" {
+		p.Default = def
 	}
 
 	return survey.AskOne(p, index, opt)


### PR DESCRIPTION
This PR changes the behavior of `prompt.Select` so that the default value is considered only if non-empty.

Closes #680 