### PR TITLE
Ensure app config definition is loaded

### DIFF
--- a/internal/cli/internal/app/config_test.go
+++ b/internal/cli/internal/app/config_test.go
@@ -1,0 +1,61 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadTOMLAppConfigWithAppName(t *testing.T) {
+	const path = "./testdata/app-name.toml"
+
+	p, err := LoadConfig(path)
+	assert.NoError(t, err)
+	assert.Equal(t, p.AppName, "test-app")
+}
+
+func TestLoadTOMLAppConfigWithBuilderName(t *testing.T) {
+	const path = "./testdata/build.toml"
+
+	p, err := LoadConfig(path)
+	assert.NoError(t, err)
+	assert.Equal(t, p.Build.Builder, "builder/name")
+}
+
+func TestLoadTOMLAppConfigWithImage(t *testing.T) {
+	const path = "./testdata/image.toml"
+
+	p, err := LoadConfig(path)
+	assert.NoError(t, err)
+	assert.Equal(t, p.Build.Image, "image/name")
+}
+
+func TestLoadTOMLAppConfigWithDockerfile(t *testing.T) {
+	const path = "./testdata/docker.toml"
+
+	p, err := LoadConfig(path)
+	assert.NoError(t, err)
+	assert.Equal(t, p.Build.Dockerfile, "./Dockerfile")
+}
+
+func TestLoadTOMLAppConfigWithBuilderNameAndArgs(t *testing.T) {
+	const path = "./testdata/build-with-args.toml"
+
+	p, err := LoadConfig(path)
+	assert.NoError(t, err)
+	assert.Equal(t, p.Build.Args, map[string]string{"A": "B", "C": "D"})
+}
+
+func TestLoadTOMLAppConfigWithServices(t *testing.T) {
+	const path = "./testdata/services.toml"
+	p, err := LoadConfig(path)
+
+	rawData := map[string]interface{}{}
+	toml.DecodeFile("./testdata/services.toml", &rawData)
+	delete(rawData, "app")
+	delete(rawData, "build")
+
+	assert.NoError(t, err)
+	assert.Equal(t, p.Definition, rawData)
+}

--- a/internal/cli/internal/app/testdata/app-name.toml
+++ b/internal/cli/internal/app/testdata/app-name.toml
@@ -1,0 +1,1 @@
+app = "test-app"

--- a/internal/cli/internal/app/testdata/build-with-args.toml
+++ b/internal/cli/internal/app/testdata/build-with-args.toml
@@ -1,0 +1,7 @@
+app = "build-with-args"
+
+[build]
+builder = "builder/name"
+  [build.args]
+  A = "B"
+  C = "D"

--- a/internal/cli/internal/app/testdata/build.toml
+++ b/internal/cli/internal/app/testdata/build.toml
@@ -1,0 +1,4 @@
+app = "build"
+
+[build]
+  builder = "builder/name"

--- a/internal/cli/internal/app/testdata/docker.toml
+++ b/internal/cli/internal/app/testdata/docker.toml
@@ -1,0 +1,4 @@
+app = "image"
+
+[build]
+  dockerfile = "./Dockerfile"

--- a/internal/cli/internal/app/testdata/image.toml
+++ b/internal/cli/internal/app/testdata/image.toml
@@ -1,0 +1,4 @@
+app = "image"
+
+[build]
+  image = "image/name"

--- a/internal/cli/internal/app/testdata/services.toml
+++ b/internal/cli/internal/app/testdata/services.toml
@@ -1,0 +1,9 @@
+app = "services"
+
+[[service]]
+  protocol = "tcp"
+  internal_port = 8080
+  [service.port.80]
+    handlers = ["http"]
+  [service.port.443]
+    handlers = ["tls", "http"]

--- a/internal/cli/internal/command/deploy/deploy.go
+++ b/internal/cli/internal/command/deploy/deploy.go
@@ -344,7 +344,7 @@ func createRelease(ctx context.Context, appConfig *app.Config, img *imgsrc.Deplo
 		input.Strategy = api.StringPointer(strings.ToUpper(val))
 	}
 
-	if appConfig != nil && len(appConfig.Definition) > 0 {
+	if len(appConfig.Definition) > 0 {
 		input.Definition = api.DefinitionPtr(appConfig.Definition)
 	}
 


### PR DESCRIPTION
This fixes a regression causing the app config to only contain build data at deploy time.