### PR TITLE
Avoid bubbling errors from intentional closure of release command logs

### DIFF
--- a/internal/cli/internal/command/deploy/deploy.go
+++ b/internal/cli/internal/command/deploy/deploy.go
@@ -410,7 +410,7 @@ func watchReleaseCommand(ctx context.Context, id string) error {
 					}
 				}
 
-				if err = ls.Err(); (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && ctx.Err() == nil {
+				if err = ls.Err(); errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					err = nil
 				}
 				return err


### PR DESCRIPTION
During deployment, we intentionally shut down log tailing after 3 seconds of inactivity. The resulting error was bubbling up and manifesting with an early exit `127` and an aborted deployment. This PR ensures the parent context error is ignored.