### PR TITLE
Fix suspend command

### DIFF
--- a/internal/cli/internal/command/apps/suspend.go
+++ b/internal/cli/internal/command/apps/suspend.go
@@ -81,7 +81,7 @@ func RunSuspend(ctx context.Context) (err error) {
 		if status, err = client.GetAppStatus(ctx, appName, false); err != nil {
 			s.Stop()
 
-			err = fmt.Errorf("failed retrieving %s status: %w", status.Name, err)
+			err = fmt.Errorf("failed retrieving %s status: %w", appName, err)
 
 			return
 		}


### PR DESCRIPTION
Should not access status.Name when there is an error﻿
