### PR TITLE
Redefine PG Standalone setup

### DIFF
--- a/cmd/input.go
+++ b/cmd/input.go
@@ -203,33 +203,17 @@ func inputAppName(defaultName string, autoGenerate bool) (name string, err error
 	return name, nil
 }
 
-const (
-	highAvailability       = "high"
-	standaloneAvailability = "standalone"
-)
+func initialClusterSizeInput(defaultVal int) (int, error) {
+	var count int
+	prompt := &survey.Input{
+		Message: "Specify the initial cluster size:",
+		Default: strconv.Itoa(defaultVal),
+	}
+	if err := survey.AskOne(prompt, &count); err != nil {
+		return 0, err
+	}
 
-func postgresClusteringOptionsInput(availability string) (PostgresClusterOption, error) {
-	if availability == highAvailability {
-		return highlyAvailablePostgres(), nil
-	}
-	if availability == standaloneAvailability {
-		return standalonePostgres(), nil
-	}
-	selected := 0
-	options := []string{}
-	for _, opt := range postgresClusteringOptions() {
-		options = append(options, opt.Name)
-	}
-	prompt := &survey.Select{
-		Message:  "Select configuration:",
-		Options:  options,
-		PageSize: 2,
-	}
-	if err := survey.AskOne(prompt, &selected); err != nil {
-		return PostgresClusterOption{}, err
-	}
-	option := postgresClusteringOptions()[selected]
-	return option, nil
+	return count, nil
 }
 
 func volumeSizeInput(defaultVal int) (int, error) {

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -427,8 +427,6 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 			return err
 		}
 
-		options := standalonePostgres()
-
 		clusterAppName := app.Name + "-db"
 
 		// Create a standalone Postgres in the same region as the app and organization
@@ -436,7 +434,7 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 			OrganizationID: org.ID,
 			Name:           clusterAppName,
 			Region:         api.StringPointer(region.Code),
-			ImageRef:       api.StringPointer(options.ImageRef),
+			ImageRef:       api.StringPointer("flyio/postgres"),
 			Count:          api.IntPointer(1),
 		}
 		payload, err := runApiCreatePostgresCluster(cmdCtx, org.Slug, &clusterInput)


### PR DESCRIPTION
This PR redefines the standalone PG setup and allows the `initial cluster size` to be tunable on provision.

Single node, dev configurations will run Stolon.  This is not ideal, but it drastically simplifies the UX as well as the horizontal scaling story.  We may re-introduce a true standalone configuration later on.  

cc:// @jsierles 