### PR TITLE
Add a static site scanner to replace the deprecated builtin

### DIFF
--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -79,6 +79,7 @@ func Scan(sourceDir string) (*SourceInfo, error) {
 		configureDeno,
 		configureRemix,
 		configureNode,
+		configureStatic,
 	}
 
 	for _, scanner := range scanners {
@@ -264,6 +265,22 @@ func configureDeno(sourceDir string) (*SourceInfo, error) {
 	}
 
 	return s, nil
+}
+
+func configureStatic(sourceDir string) (*SourceInfo, error) {
+	// No index.html detected, move on
+	if !helpers.FileExists(filepath.Join(sourceDir, "index.html")) {
+		return nil, nil
+	}
+
+	s := &SourceInfo{
+		Family: "Static",
+		Port:   8080,
+		Files:  templates("templates/static"),
+	}
+
+	return s, nil
+
 }
 
 func configurePhoenix(sourceDir string) (*SourceInfo, error) {

--- a/internal/sourcecode/templates/static/Dockerfile
+++ b/internal/sourcecode/templates/static/Dockerfile
@@ -1,0 +1,3 @@
+FROM pierrezemb/gostatic
+COPY . /srv/http/
+CMD ["-port","8080,"-https-promote", "-enable-logging"]


### PR DESCRIPTION
Also, fix an issue with empty build blocks in `fly.toml` causing a panic.