### PR TITLE
fix: missing " in static Dockerfile

### DIFF
--- a/internal/sourcecode/templates/static/Dockerfile
+++ b/internal/sourcecode/templates/static/Dockerfile
@@ -1,3 +1,3 @@
 FROM pierrezemb/gostatic
 COPY . /srv/http/
-CMD ["-port","8080,"-https-promote", "-enable-logging"]
+CMD ["-port","8080","-https-promote", "-enable-logging"]


### PR DESCRIPTION
Otherwise it defaults to port 8043 and fails the default health-check.