### PR TITLE
do not display warning when the config file is not found

### DIFF
--- a/internal/cli/internal/command/command.go
+++ b/internal/cli/internal/command/command.go
@@ -211,12 +211,7 @@ func loadConfig(ctx context.Context) (context.Context, error) {
 
 	// Apply config from the config file, if it exists
 	path := filepath.Join(state.ConfigDirectory(ctx), config.FileName)
-	switch err := cfg.ApplyFile(path); {
-	case err == nil:
-		// config file loaded
-	case errors.Is(err, fs.ErrNotExist):
-		logger.Warnf("no config file found at %s", path)
-	default:
+	if err := cfg.ApplyFile(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}
 

--- a/internal/cli_test/cli_test.go
+++ b/internal/cli_test/cli_test.go
@@ -22,7 +22,7 @@ func TestVersion(t *testing.T) {
 
 	assert.Equal(t, 0, code)
 	assert.NotEmpty(t, stdout)
-	assert.NotEmpty(t, stderr) // [33mWARN[0m no config file found at /home/azazeal/.fly/config.yml
+	assert.Empty(t, stderr)
 }
 
 func capture(ctx context.Context, t *testing.T, args ...string) (stdout, stderr string, code int) {


### PR DESCRIPTION
This PR refactors the configuration loading process so that it no longer warns the user when a config file isn't found.

Fixes #741.