### PR TITLE
Optionally use NATS wireguard peer generation

### DIFF
--- a/api/resource_wireguard.go
+++ b/api/resource_wireguard.go
@@ -3,22 +3,23 @@ package api
 import (
 	"context"
 	"fmt"
+	"os"
 )
 
 func (c *Client) GetWireGuardPeers(ctx context.Context, slug string) ([]*WireGuardPeer, error) {
 	req := c.NewRequest(`
-query($slug: String!) { 
-  organization(slug: $slug) { 
-    wireGuardPeers { 
-      nodes { 
+query($slug: String!) {
+  organization(slug: $slug) {
+    wireGuardPeers {
+      nodes {
         id
         name
         pubkey
         region
         peerip
-      } 
+      }
     }
-  } 
+  }
 }
 `)
 	req.Var("slug", slug)
@@ -33,19 +34,27 @@ query($slug: String!) {
 
 func (c *Client) CreateWireGuardPeer(ctx context.Context, org *Organization, region, name, pubkey string) (*CreatedWireGuardPeer, error) {
 	req := c.NewRequest(`
-mutation($input: AddWireGuardPeerInput!) { 
-  addWireGuardPeer(input: $input) { 
+mutation($input: AddWireGuardPeerInput!) {
+  addWireGuardPeer(input: $input) {
     peerip
     endpointip
     pubkey
-  } 
+  }
 }
 `)
+
+	var nats bool
+
+	if os.Getenv("WG_NATS") != "" {
+		nats = true
+		fmt.Printf("Creating wiregard peer via NATS")
+	}
 
 	inputs := map[string]interface{}{
 		"organizationId": org.ID,
 		"name":           name,
 		"pubkey":         pubkey,
+		"nats":           nats,
 	}
 
 	if region != "" {
@@ -64,11 +73,11 @@ mutation($input: AddWireGuardPeerInput!) {
 
 func (c *Client) RemoveWireGuardPeer(ctx context.Context, org *Organization, name string) error {
 	req := c.NewRequest(`
-mutation($input: RemoveWireGuardPeerInput!) { 
-  removeWireGuardPeer(input: $input) { 
-    organization { 
-      id 
-    } 
+mutation($input: RemoveWireGuardPeerInput!) {
+  removeWireGuardPeer(input: $input) {
+    organization {
+      id
+    }
   }
 }
 `)
@@ -84,10 +93,10 @@ mutation($input: RemoveWireGuardPeerInput!) {
 
 func (c *Client) CreateDelegatedWireGuardToken(ctx context.Context, org *Organization, name string) (*DelegatedWireGuardToken, error) {
 	req := c.NewRequest(`
-mutation($input: CreateDelegatedWireGuardTokenInput!) { 
-  createDelegatedWireGuardToken(input: $input) { 
+mutation($input: CreateDelegatedWireGuardTokenInput!) {
+  createDelegatedWireGuardToken(input: $input) {
     token
-  } 
+  }
 }
 `)
 	req.Var("input", map[string]interface{}{
@@ -105,8 +114,8 @@ mutation($input: CreateDelegatedWireGuardTokenInput!) {
 
 func (c *Client) DeleteDelegatedWireGuardToken(ctx context.Context, org *Organization, name, token *string) error {
 	query := `
-mutation($input: DeleteDelegatedWireGuardTokenInput!) { 
-  deleteDelegatedWireGuardToken(input: $input) { 
+mutation($input: DeleteDelegatedWireGuardTokenInput!) {
+  deleteDelegatedWireGuardToken(input: $input) {
     token
   }
 }
@@ -134,14 +143,14 @@ mutation($input: DeleteDelegatedWireGuardTokenInput!) {
 
 func (c *Client) GetDelegatedWireGuardTokens(ctx context.Context, slug string) ([]*DelegatedWireGuardTokenHandle, error) {
 	req := c.NewRequest(`
-query($slug: String!) { 
-  organization(slug: $slug) { 
-    delegatedWireGuardTokens { 
-      nodes { 
+query($slug: String!) {
+  organization(slug: $slug) {
+    delegatedWireGuardTokens {
+      nodes {
         name
-      } 
+      }
     }
-  } 
+  }
 }
 `)
 	req.Var("slug", slug)
@@ -175,8 +184,8 @@ func (c *Client) ClosestWireguardGatewayRegion(ctx context.Context) (*Region, er
 
 func (c *Client) ValidateWireGuardPeers(ctx context.Context, peerIPs []string) (invalid []string, err error) {
 	req := c.NewRequest(`
-mutation($input: ValidateWireGuardPeersInput!) { 
-  validateWireGuardPeers(input: $input) { 
+mutation($input: ValidateWireGuardPeersInput!) {
+  validateWireGuardPeers(input: $input) {
 		invalidPeerIps
 	}
 }


### PR DESCRIPTION
This PR takes advantage of a change to the Fly backend allowing faster Wireguard peer creation. This may be useful in CI contexts where new peers take to long to be created.