### PR TITLE
Improve warning message wording when stopping an out-of-date agent

### DIFF
--- a/internal/cli/internal/command/agent/agent.go
+++ b/internal/cli/internal/command/agent/agent.go
@@ -19,8 +19,8 @@ import (
 // New initializes and returns a new agent Command.
 func New() (cmd *cobra.Command) {
 	const (
-		short = "Commands that manage the Fly agent"
-		long  = short + "\n"
+		short = "Commands that manage the Fly agent, a background process that manages flyctl wireguard connections"
+		long  = "The Fly agent is a background process that manages wireguard connections started by flyctl.\nCommands such as 'fly ssh' and 'fly proxy' use this agent.\nGenerally, the agent starts and stops automatically. These commands are useful for debugging.\n"
 		usage = "agent <command>"
 	)
 

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -43,7 +43,7 @@ func Establish(ctx context.Context, apiClient *api.Client) (*Client, error) {
 	}
 
 	// TOOD: log this instead
-	msg := fmt.Sprintf("flyctl version %s does not match agent version %s", buildinfo.Version(), res.Version)
+	msg := fmt.Sprintf("The running flyctl background agent (v%s) is older than the current flyctl (v%s).", buildinfo.Version(), res.Version)
 
 	logger := logger.MaybeFromContext(ctx)
 	if logger != nil {
@@ -56,7 +56,7 @@ func Establish(ctx context.Context, apiClient *api.Client) (*Client, error) {
 		return c, nil
 	}
 
-	const stopMessage = "stopping agent ..."
+	const stopMessage = "The out-of-date agent will be shut down along with existing wireguard connections. The new agent will start automatically as needed."
 	if logger != nil {
 		logger.Warn(stopMessage)
 	} else {


### PR DESCRIPTION
This copy change clarifies what's going on when agents are restarted. Many users won't even know an agent exists until they see this message, so it shouldn't be too scary as to trigger support messages or mislead people.

We also improve the agent command help so people know what the agent is.