### PR TITLE
Add a Rails launcher which can launch a Postgres database

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -323,6 +323,8 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 					fmt.Errorf("Could not generate random string: %w", err)
 				}
 
+			} else if secret.Value != "" {
+				val = secret.Value
 			} else {
 				prompt := fmt.Sprintf("Set secret %s:", secret.Key)
 

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -430,33 +430,33 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 
 		clusterAppName := app.Name + "-db"
 
-		// Create a standalone Postgres in the same region as the app and organization
-		clusterInput := api.CreatePostgresClusterInput{
-			OrganizationID: org.ID,
-			Name:           clusterAppName,
-			Region:         api.StringPointer(region.Code),
-			ImageRef:       api.StringPointer("flyio/postgres"),
-			Count:          api.IntPointer(1),
-		}
-		payload, err := runApiCreatePostgresCluster(cmdCtx, org.Slug, &clusterInput)
+		cmdCtx.Config.Set("name", clusterAppName)
+		cmdCtx.Config.Set("region", region.Code)
+		cmdCtx.Config.Set("organization", org.Slug)
+
+		err = runCreatePostgresCluster(cmdCtx)
 
 		if err != nil {
 			err = fmt.Errorf("failed creating the Postgres cluster %s: %w", clusterAppName, err)
 			return err
 		}
 
-		// Reset the app name here beacuse AttachPostgresCluster sets it on the cmdCtx :/
-		cmdCtx.AppName = app.ID
-
 		cmdCtx.Config.Set("postgres-app", clusterAppName)
+
+		// Reset the app name here beacuse runCreatePostgresCluster overrides it
+		cmdCtx.AppName = app.ID
 		err = runAttachPostgresCluster(cmdCtx)
 
+		// Reset the app name here beacuse AttachPostgresCluster overrides it
+		cmdCtx.AppName = app.ID
+
 		if err != nil {
-			err = fmt.Errorf("failed attaching %s to the Postgres cluster %s: %w", clusterAppName, app.Name, err)
+			msg := `Failed attaching %s to the Postgres cluster %s: %w.\nTry attaching manually with 'fly postgres attach --app %s --postgres-app %s'`
+			err = fmt.Errorf(msg, clusterAppName, app.ID, err, app.ID, clusterAppName)
 			return err
 		}
 
-		fmt.Printf("Postgres cluster %s is now attached to %s\n", payload.App.Name, app.Name)
+		fmt.Printf("Postgres cluster %s is now attached to %s\n", clusterAppName, app.Name)
 	}
 
 	// Notices from a launcher about its behavior that should always be displayed

--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -71,6 +71,7 @@ func Scan(sourceDir string) (*SourceInfo, error) {
 		   since they might mix languages or have a Dockerfile that
 			 doesn't work with Fly */
 		configureDockerfile,
+		configureRails,
 		configureRuby,
 		configureGo,
 		configurePhoenix,
@@ -173,6 +174,32 @@ func configureDockerfile(sourceDir string) (*SourceInfo, error) {
 	}
 
 	return s, nil
+}
+
+func configureRails(sourceDir string) (*SourceInfo, error) {
+
+	if !checksPass(sourceDir, dirContains("Gemfile", "rails")) {
+		return nil, nil
+	}
+
+	s := &SourceInfo{
+		Builder: "heroku/buildpacks:20",
+		Family:  "Rails",
+		Port:    8080,
+		Env: map[string]string{
+			"PORT": "8080",
+		},
+		InitCommands: []InitCommand{
+			{
+				Command:     "bundle",
+				Args:        []string{"lock", "--add-platform", "x86_64-linux"},
+				Description: "Preparing Gemfile.lock for x86_64 deployment",
+			},
+		},
+	}
+
+	return s, nil
+
 }
 
 func configureRuby(sourceDir string) (*SourceInfo, error) {

--- a/internal/sourcecode/templates/rails/.dockerignore
+++ b/internal/sourcecode/templates/rails/.dockerignore
@@ -1,0 +1,5 @@
+.git
+tmp
+log
+public/assets
+.bundle

--- a/internal/sourcecode/templates/rails/Dockerfile
+++ b/internal/sourcecode/templates/rails/Dockerfile
@@ -1,0 +1,65 @@
+# syntax = docker/dockerfile:experimental
+
+ARG RUBY_VERSION=3.1.0-jemalloc
+FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim as build
+
+ARG RAILS_ENV=production
+ENV RAILS_ENV=${RAILS_ENV}
+
+ARG RAILS_MASTER_KEY
+ENV RAILS_MASTER_KEY=${RAILS_MASTER_KEY}
+
+ENV PATH $PATH:/usr/local/bin
+
+ENV BUNDLE_WITHOUT development:test
+ENV BUNDLE_PATH vendor/bundle
+
+RUN mkdir /app
+WORKDIR /app
+
+# Reinstall runtime dependencies that need to be installed as packages
+
+RUN --mount=type=cache,id=apt-cache,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=apt-lib,sharing=locked,target=/var/lib/apt \
+    apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+    git build-essential libpq-dev wget vim curl gzip xz-utils \
+    && rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+RUN gem install -N bundler -v 2.2.32
+
+# Install rubygems
+COPY Gemfile* ./
+RUN bundle install
+
+COPY . .
+
+RUN bundle exec rails assets:precompile
+
+RUN rm -rf vendor/bundle/ruby/*/cache
+
+FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
+
+ARG RAILS_ENV=production
+ENV RAILS_ENV=${RAILS_ENV}
+ENV RAILS_SERVE_STATIC_FILES true
+ENV BUNDLE_PATH vendor/bundle
+ENV BUNDLE_WITHOUT development:test
+ENV RAILS_MASTER_KEY=${RAILS_MASTER_KEY}
+
+RUN --mount=type=cache,id=apt-cache,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=apt-lib,sharing=locked,target=/var/lib/apt \
+    apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+    postgresql-client file vim curl gzip \
+    && rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+COPY --from=build /app /app
+
+WORKDIR /app
+
+RUN mkdir -p tmp/pids
+
+EXPOSE 8080
+
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]


### PR DESCRIPTION
This launcher sets Rails app up for deployment using the Heroku buildpack. It also sets `RAILS_MASTER_KEY` and offers launching a Postgres database if the `postgresql` adapter is being used in `database.yml`. 

This PR also updates the inline Postgres launcher to allow developers to select the cluster size.