### PR TITLE
use lstat when removing the old socket

### DIFF
--- a/pkg/agent/server/server.go
+++ b/pkg/agent/server/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"log"
 	"net"
 	"os"
@@ -355,22 +354,4 @@ func (s *server) print(v ...interface{}) {
 
 func (s *server) printf(format string, v ...interface{}) {
 	s.Logger.Printf(format, v...)
-}
-
-func removeSocket(path string) (err error) {
-	var stat os.FileInfo
-	switch stat, err = os.Stat(path); {
-	case errors.Is(err, fs.ErrNotExist):
-		err = nil
-	case err != nil:
-		break
-	case stat.Mode()&os.ModeSocket == 0:
-		err = errors.New("not a socket")
-	default:
-		if err = os.Remove(path); errors.Is(err, fs.ErrNotExist) {
-			err = nil
-		}
-	}
-
-	return
 }

--- a/pkg/agent/server/server_unix.go
+++ b/pkg/agent/server/server_unix.go
@@ -1,0 +1,28 @@
+//go:build !windows
+// +build !windows
+
+package server
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+)
+
+func removeSocket(path string) (err error) {
+	var stat os.FileInfo
+	switch stat, err = os.Lstat(path); {
+	case errors.Is(err, fs.ErrNotExist):
+		err = nil
+	case err != nil:
+		break
+	case stat.Mode()&os.ModeSocket == 0:
+		err = errors.New("not a socket")
+	default:
+		if err = os.Remove(path); errors.Is(err, fs.ErrNotExist) {
+			err = nil
+		}
+	}
+
+	return
+}

--- a/pkg/agent/server/server_windows.go
+++ b/pkg/agent/server/server_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+// +build windows
+
+package server
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+)
+
+func removeSocket(path string) (err error) {
+	switch _, err = os.Lstat(path); {
+	case errors.Is(err, fs.ErrNotExist):
+		err = nil
+	case err != nil:
+		break
+	default:
+		if err = os.Remove(path); errors.Is(err, fs.ErrNotExist) {
+			err = nil
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
This PR alters the agent boot process so that it uses `lstat` instead of `stat` and so that it does not check whether the file is actually a socket on Windows.