### PR TITLE
slugify hostname when using for interactive wireguard tunnel

### DIFF
--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -67,7 +67,7 @@ func Create(apiClient *api.Client, org *api.Organization, regionCode, name strin
 		}
 		hostSlug := cleanDNSPattern.ReplaceAllString(strings.Split(host, ".")[0], "-")
 
-		name = fmt.Sprintf("interactive-%s-%s-%d", hostSlug, emailSlug, badrand.Intn(1000))
+		name = fmt.Sprintf("interactive-%s-%s-%d", hostSlug, emailSlug, badrand.Intn(1000)) // skipcq: GSC-G404
 	}
 
 	if regionCode == "" {


### PR DESCRIPTION
Currently, if a user has their hostname set to anything that is not DNS safe it will error out when trying to create the wireguard tunnel:

```
error establishing wireguard connection for personal organization: name must consist solely of letters, numbers, and the dash character
```

The following change utilizes the same regular expression for slugifying the email for the return call to `os.Hostname()`.