### PR TITLE
Wait for tunnels & hosts up to 4 minutes

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -235,10 +235,8 @@ func newRemoteDockerClient(ctx context.Context, apiClient *api.Client, appName s
 				return errors.Wrapf(err, "error establishing wireguard connection for %s organization", app.Organization.Slug)
 			}
 
-			tunnelCtx, cancel := context.WithTimeout(errCtx, 4*time.Minute)
-			defer cancel()
 			// wait for the tunnel to be ready
-			if err = agentclient.WaitForTunnel(tunnelCtx, app.Organization.Slug); err != nil {
+			if err = agentclient.WaitForTunnel(errCtx, app.Organization.Slug); err != nil {
 				return errors.Wrap(err, "unable to connect WireGuard tunnel")
 			}
 

--- a/pkg/logs/nats.go
+++ b/pkg/logs/nats.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"net"
-	"time"
 
 	"github.com/nats-io/nats.go"
 
@@ -36,10 +35,7 @@ func NewNatsStream(ctx context.Context, apiClient *api.Client, opts *LogOptions)
 		return nil, fmt.Errorf("failed establishing wireguard connection for %s organization: %w", app.Organization.Slug, err)
 	}
 
-	tunnelCtx, cancel := context.WithTimeout(ctx, 4*time.Minute)
-	defer cancel()
-
-	if err = agentclient.WaitForTunnel(tunnelCtx, app.Organization.Slug); err != nil {
+	if err = agentclient.WaitForTunnel(ctx, app.Organization.Slug); err != nil {
 		return nil, fmt.Errorf("failed connecting to WireGuard tunnel: %w", err)
 	}
 


### PR DESCRIPTION
This PR refactors `WaitForTunnel` and `WaitForHost` so that they block for up to 4 minutes.