### PR TITLE
fix: work directory swap

### DIFF
--- a/internal/cli/internal/command/deploy/deploy.go
+++ b/internal/cli/internal/command/deploy/deploy.go
@@ -34,8 +34,8 @@ func New() (cmd *cobra.Command) {
 
 	cmd = command.New("deploy [WORKING_DIRECTORY]", short, long, run,
 		command.RequireSession,
-		command.RequireAppName,
 		command.ChangeWorkingDirectoryToFirstArgIfPresent,
+		command.RequireAppName,
 	)
 
 	cmd.Args = cobra.MaximumNArgs(1)


### PR DESCRIPTION
This PR fixes a regression via which we couldn't specific another working directory in `flyctl deploy`.