### PR TITLE
Respect terminal color capabilities

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -9,7 +9,6 @@ import (
 	"io"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/pkg/iostreams"
@@ -31,26 +30,28 @@ func Run(ctx context.Context, io *iostreams.IOStreams, args ...string) int {
 	cmd.SetErr(io.ErrOut)
 	cmd.SetArgs(args)
 
+	cs := io.ColorScheme()
+
 	switch _, err := cmd.ExecuteContextC(ctx); {
 	case err == nil:
 		return 0
 	case errors.Is(err, context.Canceled), errors.Is(err, terminal.InterruptErr):
 		return 127
 	case errors.Is(err, context.DeadlineExceeded):
-		printError(io.ErrOut, err)
+		printError(io.ErrOut, cs, err)
 
 		return 126
 	default:
-		printError(io.ErrOut, err)
+		printError(io.ErrOut, cs, err)
 
 		return 1
 	}
 }
 
-func printError(w io.Writer, err error) {
+func printError(w io.Writer, cs *iostreams.ColorScheme, err error) {
 	var b bytes.Buffer
 
-	fmt.Fprintln(&b, aurora.Red("Error"), err)
+	fmt.Fprintln(&b, cs.Red("Error"), err)
 	fmt.Fprintln(&b)
 
 	description := flyerr.GetErrorDescription(err)

--- a/internal/cli/internal/command/apps/restart.go
+++ b/internal/cli/internal/command/apps/restart.go
@@ -22,7 +22,8 @@ func newRestart() *cobra.Command {
 	)
 
 	restart := command.New(usage, short, long, RunRestart,
-		command.RequireSession)
+		command.RequireSession,
+	)
 
 	restart.Args = cobra.ExactArgs(1)
 

--- a/internal/cli/internal/command/auth/auth.go
+++ b/internal/cli/internal/command/auth/auth.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/azazeal/pause"
 	"github.com/briandowns/spinner"
-	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
@@ -64,7 +63,8 @@ func runWebLogin(ctx context.Context, signup bool) error {
 
 	logger := logger.FromContext(ctx)
 
-	fmt.Fprintf(io.Out, "Opening %s ...\n\n", aurora.Bold(auth.AuthURL))
+	colorize := io.ColorScheme()
+	fmt.Fprintf(io.Out, "Opening %s ...\n\n", colorize.Bold(auth.AuthURL))
 
 	token, err := waitForCLISession(ctx, logger, io.ErrOut, auth.ID)
 	switch {
@@ -89,7 +89,7 @@ func runWebLogin(ctx context.Context, signup bool) error {
 		return fmt.Errorf("failed retrieving current user: %w", err)
 	}
 
-	fmt.Fprintf(io.Out, "successfully logged in as %s\n", aurora.Bold(user.Email))
+	fmt.Fprintf(io.Out, "successfully logged in as %s\n", colorize.Bold(user.Email))
 
 	return nil
 }

--- a/internal/cli/internal/command/command.go
+++ b/internal/cli/internal/command/command.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/api"
@@ -365,14 +364,16 @@ func promptToUpdate(ctx context.Context) (context.Context, error) {
 		return ctx, nil
 	}
 
+	io := iostreams.FromContext(ctx)
+	colorize := io.ColorScheme()
+
 	msg := fmt.Sprintf("Update available %s -> %s.\nRun \"%s\" to upgrade.",
 		current,
 		r.Version,
-		aurora.Bold(buildinfo.Name()+" version update"),
+		colorize.Bold(buildinfo.Name()+" version update"),
 	)
 
-	stderr := iostreams.FromContext(ctx).ErrOut
-	fmt.Fprintln(stderr, aurora.Yellow(msg))
+	fmt.Fprintln(io.ErrOut, colorize.Yellow(msg))
 
 	return ctx, nil
 }

--- a/internal/cli/internal/command/doctor/doctor.go
+++ b/internal/cli/internal/command/doctor/doctor.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/azazeal/pause"
 	dockerclient "github.com/docker/docker/client"
-	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
@@ -143,25 +142,26 @@ func renderTable(ctx context.Context, errors map[string]error) error {
 	}
 	sort.Strings(keys)
 
+	io := iostreams.FromContext(ctx)
+	colorize := io.ColorScheme()
+
 	rows := make([][]string, 0, len(errors))
 	for _, key := range keys {
 		rows = append(rows, []string{
 			key,
-			toReason(errors[key]),
+			toReason(colorize, errors[key]),
 		})
 	}
 
-	out := iostreams.FromContext(ctx).Out
-
-	return render.Table(out, "", rows, "Test", "Status")
+	return render.Table(io.Out, "", rows, "Test", "Status")
 }
 
-func toReason(err error) string {
+func toReason(colorize *iostreams.ColorScheme, err error) string {
 	if err == nil {
-		return aurora.Green("PASS").String()
+		return colorize.Green("PASS")
 	}
 
-	return aurora.Red(err.Error()).String()
+	return colorize.Red(err.Error())
 }
 
 func runAuth(ctx context.Context) (err error) {

--- a/internal/cli/internal/command/image/show.go
+++ b/internal/cli/internal/command/image/show.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/pkg/iostreams"
@@ -32,8 +31,7 @@ func newShow() *cobra.Command {
 
 	cmd.Args = cobra.NoArgs
 
-	flag.Add(
-		cmd,
+	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
 	)
@@ -43,10 +41,11 @@ func newShow() *cobra.Command {
 
 func runShow(ctx context.Context) error {
 	var (
-		client  = client.FromContext(ctx).API()
-		cfg     = config.FromContext(ctx)
-		io      = iostreams.FromContext(ctx)
-		appName = app.NameFromContext(ctx)
+		client   = client.FromContext(ctx).API()
+		cfg      = config.FromContext(ctx)
+		io       = iostreams.FromContext(ctx)
+		colorize = io.ColorScheme()
+		appName  = app.NameFromContext(ctx)
 	)
 
 	app, err := client.GetImageInfo(ctx, appName)
@@ -73,7 +72,7 @@ func runShow(ctx context.Context) error {
 		var message = fmt.Sprintf("Update available! (%s -> %s)\n", current, latest)
 		message += "Run `flyctl image update` to migrate to the latest image version.\n"
 
-		fmt.Fprintln(io.ErrOut, aurora.Yellow(message))
+		fmt.Fprintln(io.ErrOut, colorize.Yellow(message))
 	}
 
 	image := app.ImageDetails

--- a/internal/cli/internal/command/orgs/delete.go
+++ b/internal/cli/internal/command/orgs/delete.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superfly/flyctl/internal/cli/internal/flag"
 	"github.com/superfly/flyctl/internal/cli/internal/prompt"
 	"github.com/superfly/flyctl/internal/client"
+	"github.com/superfly/flyctl/pkg/iostreams"
 )
 
 func newDelete() *cobra.Command {
@@ -38,7 +39,13 @@ func runDelete(ctx context.Context) error {
 		return err
 	}
 
+	io := iostreams.FromContext(ctx)
+	colorize := io.ColorScheme()
+
 	if !flag.GetYes(ctx) {
+		const msg = "Deleting an organization is not reversible."
+		fmt.Fprintln(io.ErrOut, colorize.Red(msg))
+
 		switch confirmed, err := prompt.Confirmf(ctx, "Delete organization %s?", org.Slug); {
 		case err == nil:
 			if !confirmed {

--- a/internal/cli/internal/command/orgs/show.go
+++ b/internal/cli/internal/command/orgs/show.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
@@ -26,7 +25,8 @@ associated member. Details full list of members and roles.
 	)
 
 	cmd := command.New(usage, short, long, runShow,
-		command.RequireSession)
+		command.RequireSession,
+	)
 
 	cmd.Args = cobra.MaximumNArgs(1)
 
@@ -45,22 +45,23 @@ func runShow(ctx context.Context) error {
 
 		return nil
 	}
+	colorize := io.ColorScheme()
 
 	var buf bytes.Buffer
 
-	fmt.Fprintln(&buf, aurora.Bold("Organization"))
+	fmt.Fprintln(&buf, colorize.Bold("Organization"))
 	fmt.Fprintf(&buf, "%-10s: %-20s\n", "Name", org.Name)
 	fmt.Fprintf(&buf, "%-10s: %-20s\n", "Slug", org.Slug)
 	fmt.Fprintf(&buf, "%-10s: %-20s\n", "Type", org.Type)
 	fmt.Fprintln(&buf)
 
-	fmt.Fprintln(&buf, aurora.Bold("Summary"))
+	fmt.Fprintln(&buf, colorize.Bold("Summary"))
 	fmt.Fprintf(&buf, "You have %s permissions on this organizaton\n", org.ViewerRole)
 	// fmt.Fprintf(&buf, "There are %d DNS zones associated with this organization\n", len(org.DNSZones.Nodes))
 	fmt.Fprintf(&buf, "There are %d members associated with this organization\n", len(org.Members.Edges))
 	fmt.Fprintln(&buf)
 
-	fmt.Fprintln(&buf, aurora.Bold("Organization Members"))
+	fmt.Fprintln(&buf, colorize.Bold("Organization Members"))
 
 	membertable := tablewriter.NewWriter(&buf)
 	membertable.SetHeader([]string{"Name", "Email", "Role"})

--- a/internal/cli/internal/command/status/status.go
+++ b/internal/cli/internal/command/status/status.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/azazeal/pause"
 	"github.com/inancgumus/screen"
-	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/pkg/iostreams"
@@ -179,6 +178,7 @@ func runWatch(ctx context.Context) (err error) {
 
 		return
 	}
+	colorize := streams.ColorScheme()
 
 	sleep := flag.GetInt(ctx, "rate")
 	if sleep < 1 || sleep > 3600 {
@@ -198,7 +198,7 @@ func runWatch(ctx context.Context) (err error) {
 			break
 		}
 
-		header := fmt.Sprintf("%s %s %s\n\n", aurora.Bold(appName), aurora.Italic("at:"), aurora.Bold(time.Now().UTC().Format("15:04:05")))
+		header := fmt.Sprintf("%s %s %s\n\n", colorize.Bold(appName), "at:", colorize.Bold(time.Now().UTC().Format("15:04:05")))
 
 		screen.Clear()
 		screen.MoveTopLeft()

--- a/internal/cli/internal/command/volumes/list.go
+++ b/internal/cli/internal/command/volumes/list.go
@@ -30,8 +30,7 @@ func newList() *cobra.Command {
 		command.RequireAppName,
 	)
 
-	flag.Add(
-		cmd,
+	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
 	)

--- a/internal/cli/internal/command/volumes/show.go
+++ b/internal/cli/internal/command/volumes/show.go
@@ -15,7 +15,7 @@ import (
 	"github.com/superfly/flyctl/internal/client"
 )
 
-func newShow() *cobra.Command {
+func newShow() (cmd *cobra.Command) {
 	const (
 		long = `Show details of an app's volume. Requires the volume's ID
 number to operate. This can be found through the volumes list command`
@@ -23,16 +23,12 @@ number to operate. This can be found through the volumes list command`
 		short = "Show details of an app's volume"
 	)
 
-	cmd := command.New("show <id>", short, long, runShow,
+	cmd = command.New("show <id>", short, long, runShow,
 		command.RequireSession,
 	)
 	cmd.Args = cobra.ExactArgs(1)
 
-	flag.Add(
-		cmd,
-	)
-
-	return cmd
+	return
 }
 
 func runShow(ctx context.Context) error {


### PR DESCRIPTION
This PR ensures that the new CLI respects the terminal's color capabilities. It additionally refactors all existing commands of the new CLI infrastructure accordingly.

As an added bonus, and since the opportunity presented itself, this PR also addresses some logical bugs in the way the CLI treats non-interactive confirmation prompts.

Partially addresses #687