### PR TITLE
Improve error handling for remote builds

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -229,7 +229,7 @@ func newRemoteDockerClient(ctx context.Context, apiClient *api.Client, appName s
 	case !up:
 		streams.StopProgressIndicator()
 
-		terminal.Warnf("Remote builder did not start on time. Check remote builder logs with `flyctl logs -a %s`\n", remoteBuilderAppName)
+		terminal.Warnf("Remote builder did not start in time. Check remote builder logs with `flyctl logs -a %s`\n", remoteBuilderAppName)
 
 		return nil, errors.New("remote builder app unavailable")
 	default:


### PR DESCRIPTION
This PR now issues more accurate errors for failures during attempts to connect to remote builders. These errors should be more helpful both to users and to those monitoring exceptions. Also, each step has its own timer, with appropriate values for the step.