### PR TITLE
PG Config Management for Machines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,6 +118,7 @@ require (
 	github.com/opencontainers/selinux v1.8.0 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/r3labs/diff v1.1.0 // indirect
 	github.com/rivo/tview v0.0.0-20210624165335-29d673af0ce2 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20201211074657-223ce5d391b0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	github.com/opencontainers/selinux v1.8.0 // indirect
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/r3labs/diff v1.1.0 // indirect
+	github.com/r3labs/diff v1.1.0
 	github.com/rivo/tview v0.0.0-20210624165335-29d673af0ce2 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20201211074657-223ce5d391b0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1193,6 +1193,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.1.2-0.20200318202121-b00d7a75d3d8/go.mod h1:CGFX09Ci3pq9QZdj86B+VGIdNj4VyCo2iPOGS9esB/k=
+github.com/r3labs/diff v1.1.0 h1:V53xhrbTHrWFWq3gI4b94AjgEJOerO1+1l0xyHOBi8M=
+github.com/r3labs/diff v1.1.0/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rivo/tview v0.0.0-20210624165335-29d673af0ce2 h1:I5N0WNMgPSq5NKUFspB4jMJ6n2P0ipz5FlOlB4BXviQ=

--- a/internal/cli/internal/command/services/postgres/commands.go
+++ b/internal/cli/internal/command/services/postgres/commands.go
@@ -56,7 +56,7 @@ type postgresCreateDatabaseRequest struct {
 	Name string `json:"name"`
 }
 
-type postgresUpdateRequest struct {
+type updateRequest struct {
 	PGParameters map[string]string `json:"pgParameters,omitempty"`
 }
 
@@ -113,7 +113,7 @@ func newPostgresCmd(ctx context.Context, app *api.App) (*postgresCmd, error) {
 	}, nil
 }
 
-func (pc *postgresCmd) viewPGSettings(s []string) (*pgSettings, error) {
+func (pc *postgresCmd) viewSettings(s []string) (*pgSettings, error) {
 	settingsStr := strings.Join(s, ",")
 
 	cmd := fmt.Sprintf("pg-settings %s", encodeCommand(settingsStr))
@@ -142,9 +142,8 @@ func (pc *postgresCmd) viewPGSettings(s []string) (*pgSettings, error) {
 	return &settings, nil
 }
 
-func (pc *postgresCmd) updatePostgresConfig(config map[string]string) error {
-	payload := postgresUpdateRequest{PGParameters: config}
-
+func (pc *postgresCmd) updateSettings(config map[string]string) error {
+	payload := updateRequest{PGParameters: config}
 	configBytes, err := json.Marshal(payload)
 	if err != nil {
 		return err

--- a/internal/cli/internal/command/services/postgres/commands.go
+++ b/internal/cli/internal/command/services/postgres/commands.go
@@ -77,13 +77,17 @@ type pgSettings struct {
 }
 
 type pgSetting struct {
-	Name           string `json:"name,omitempty"`
-	Setting        string `json:"setting,omitempty"`
-	Context        string `json:"context,omitempty"`
-	Unit           string `json:"unit,omitempty"`
-	Desc           string `json:"short_desc,omitempty"`
-	PendingChange  string `json:"pending_change,omitempty"`
-	PendingRestart bool   `json:"pending_restart,omitempty"`
+	Name           string   `json:"name,omitempty"`
+	Setting        string   `json:"setting,omitempty"`
+	VarType        string   `json:"vartype,omitempty"`
+	MinVal         string   `json:"min_val,omitempty"`
+	MaxVal         string   `json:"max_val,omitempty"`
+	EnumVals       []string `json:"enumvals,omitempty"`
+	Context        string   `json:"context,omitempty"`
+	Unit           string   `json:"unit,omitempty"`
+	Desc           string   `json:"short_desc,omitempty"`
+	PendingChange  string   `json:"pending_change,omitempty"`
+	PendingRestart bool     `json:"pending_restart,omitempty"`
 }
 
 type postgresCmd struct {

--- a/internal/cli/internal/command/services/postgres/commands.go
+++ b/internal/cli/internal/command/services/postgres/commands.go
@@ -82,6 +82,7 @@ type pgSetting struct {
 	Context        string `json:"context,omitempty"`
 	Unit           string `json:"unit,omitempty"`
 	Desc           string `json:"short_desc,omitempty"`
+	PendingChange  string `json:"pending_change,omitempty"`
 	PendingRestart bool   `json:"pending_restart,omitempty"`
 }
 

--- a/internal/cli/internal/command/services/postgres/config.go
+++ b/internal/cli/internal/command/services/postgres/config.go
@@ -252,15 +252,15 @@ func runConfigUpdate(ctx context.Context) error {
 
 	if restartRequired {
 		fmt.Fprintln(io.Out, colorize.Bold("Please note that some of your changes will require a cluster restart before they will be applied."))
-		fmt.Fprintln(io.Out, colorize.Bold("To review the state of your changes, please run: 'DEV=1 fly services postgres config view'"))
+		fmt.Fprintln(io.Out, colorize.Bold("To review the state of your changes, please run: `DEV=1 fly services postgres config view`"))
 	}
 
 	return nil
 }
 
-func isRestartRequired(pgSettings *pgSettings, setting string) bool {
+func isRestartRequired(pgSettings *pgSettings, name string) bool {
 	for _, s := range pgSettings.Settings {
-		if s.Name == setting {
+		if s.Name == name {
 			if s.Context == "postmaster" {
 				return true
 			}

--- a/internal/cli/internal/command/services/postgres/config.go
+++ b/internal/cli/internal/command/services/postgres/config.go
@@ -86,7 +86,7 @@ func runConfigView(ctx context.Context) error {
 		settings = append(settings, k)
 	}
 
-	resp, err := pgCmd.viewPGSettings(settings)
+	resp, err := pgCmd.viewSettings(settings)
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,6 @@ func runConfigUpdate(ctx context.Context) error {
 	}
 
 	io := iostreams.FromContext(ctx)
-	out := io.Out
 	colorize := io.ColorScheme()
 
 	// Identify requested configuration changes.
@@ -180,7 +179,7 @@ func runConfigUpdate(ctx context.Context) error {
 	}
 
 	// Pull existing configuration
-	settings, err := pgCmd.viewPGSettings(keys)
+	settings, err := pgCmd.viewSettings(keys)
 	if err != nil {
 		return err
 	}
@@ -211,7 +210,7 @@ func runConfigUpdate(ctx context.Context) error {
 			fmt.Sprint(r),
 		})
 	}
-	_ = render.Table(out, "", rows, "Name", "Value", "Target value", "Restart Required")
+	_ = render.Table(io.Out, "", rows, "Name", "Value", "Target value", "Restart Required")
 
 	if !flag.GetBool(ctx, "auto-confirm") {
 		const msg = "Are you sure you want to apply these changes?"
@@ -228,8 +227,8 @@ func runConfigUpdate(ctx context.Context) error {
 		}
 	}
 
-	fmt.Fprintln(out, "Performing update...")
-	err = pgCmd.updatePostgresConfig(rChanges)
+	fmt.Fprintln(io.Out, "Performing update...")
+	err = pgCmd.updateSettings(rChanges)
 	if err != nil {
 		return err
 	}
@@ -241,8 +240,8 @@ func runConfigUpdate(ctx context.Context) error {
 		runRestart(ctx)
 	}
 
-	fmt.Fprintln(out, "Update complete!")
-	fmt.Fprintln(out, colorize.Bold("Run `DEV=1 fly services postgres config view` to see your changes."))
+	fmt.Fprintln(io.Out, "Update complete!")
+	fmt.Fprintln(io.Out, colorize.Bold("Run `DEV=1 fly services postgres config view` to see your changes."))
 
 	return nil
 }

--- a/internal/cli/internal/command/services/postgres/config.go
+++ b/internal/cli/internal/command/services/postgres/config.go
@@ -103,7 +103,7 @@ func runConfigView(ctx context.Context) error {
 			restart = colorize.Bold(restart)
 		}
 		if setting.PendingChange != "" {
-			p := colorize.Bold(fmt.Sprintf("(%s)", setting.PendingChange))
+			p := colorize.Bold(fmt.Sprintf("-> (%s)", setting.PendingChange))
 			value = fmt.Sprintf("%s %s", value, p)
 		}
 		rows = append(rows, []string{

--- a/internal/cli/internal/command/services/postgres/config.go
+++ b/internal/cli/internal/command/services/postgres/config.go
@@ -1,0 +1,255 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/r3labs/diff"
+	"github.com/spf13/cobra"
+
+	"github.com/superfly/flyctl/internal/cli/internal/app"
+	"github.com/superfly/flyctl/internal/cli/internal/command"
+	"github.com/superfly/flyctl/internal/cli/internal/flag"
+	"github.com/superfly/flyctl/internal/cli/internal/prompt"
+	"github.com/superfly/flyctl/internal/cli/internal/render"
+	"github.com/superfly/flyctl/internal/client"
+	"github.com/superfly/flyctl/pkg/iostreams"
+)
+
+func newConfig() (cmd *cobra.Command) {
+	// TODO - Add better top level docs.
+	const (
+		long = `
+`
+		short = ""
+	)
+
+	cmd = command.New("config", short, long, nil)
+
+	cmd.AddCommand(
+		newConfigView(),
+		newConfigUpdate(),
+	)
+
+	return
+}
+
+func newConfigView() (cmd *cobra.Command) {
+	const (
+		long = `Configure postgres cluster
+`
+		short = "Configure postgres cluster"
+		usage = "view"
+	)
+
+	cmd = command.New(usage, short, long, runConfigView,
+		command.RequireSession,
+		command.RequireAppName,
+	)
+
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+	)
+
+	return
+}
+
+func runConfigView(ctx context.Context) error {
+	client := client.FromContext(ctx).API()
+	appName := app.NameFromContext(ctx)
+
+	app, err := client.GetApp(ctx, appName)
+	if err != nil {
+		return fmt.Errorf("get app: %w", err)
+	}
+
+	pgCmd, err := newPostgresCmd(ctx, app)
+	if err != nil {
+		return err
+	}
+
+	resp, err := pgCmd.viewStolonConfig()
+	if err != nil {
+		return err
+	}
+
+	str, err := json.MarshalIndent(resp, "", "\t")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(str))
+
+	return nil
+}
+
+func newConfigUpdate() (cmd *cobra.Command) {
+	const (
+		long = `Manage Stolon and Postgres configuration.  Configure postgres cluster
+`
+		short = "Configure postgres cluster"
+		usage = "update"
+	)
+
+	cmd = command.New(usage, short, long, runConfigUpdate,
+		command.RequireSession,
+		command.RequireAppName,
+	)
+
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+		flag.String{
+			Name:        "max-connections",
+			Description: "Sets the maximum number of concurrent connections.",
+		},
+		flag.String{
+			Name:        "wal-level",
+			Description: "Sets the level of information written to the WAL. (minimal, replica, logical).",
+		},
+		flag.String{
+			Name:        "log-statement",
+			Description: "Sets the type of statements logged. (none, ddl, mod, all)",
+		},
+		flag.String{
+			Name:        "log-min-duration-statement",
+			Description: "Sets the minimum execution time above which all statements will be logged. (ms)",
+		},
+	)
+
+	return
+}
+
+func runConfigUpdate(ctx context.Context) error {
+	client := client.FromContext(ctx).API()
+	appName := app.NameFromContext(ctx)
+
+	app, err := client.GetApp(ctx, appName)
+	if err != nil {
+		return fmt.Errorf("get app: %w", err)
+	}
+
+	pgCmd, err := newPostgresCmd(ctx, app)
+	if err != nil {
+		return err
+	}
+
+	// Original stolon configuration
+	oCfg, err := pgCmd.viewStolonConfig()
+	if err != nil {
+		return err
+	}
+
+	// New stolon configuration
+	var nCfg *stolonSpec
+
+	// Duplicate original configuration.
+	oCfgJSON, err := json.Marshal(oCfg)
+	if err != nil {
+		return err
+	}
+	json.Unmarshal(oCfgJSON, &nCfg)
+
+	var requiresRestart []string
+
+	maxConnections := flag.GetString(ctx, "max-connections")
+	if maxConnections != "" {
+		nCfg.PGParameters.MaxConnections = maxConnections
+		requiresRestart = append(requiresRestart, "max-connections")
+	}
+
+	walLevel := flag.GetString(ctx, "wal-level")
+	if walLevel != "" {
+		requiresRestart = append(requiresRestart, "wal-level")
+		nCfg.PGParameters.WalLevel = walLevel
+	}
+
+	logStatement := flag.GetString(ctx, "log-statement")
+	if logStatement != "" {
+		nCfg.PGParameters.LogStatement = logStatement
+	}
+
+	logMinDurationStatement := flag.GetString(ctx, "log-min-duration-statement")
+	if logMinDurationStatement != "" {
+		nCfg.PGParameters.LogMinDurationStatement = logMinDurationStatement
+	}
+
+	out := iostreams.FromContext(ctx).Out
+
+	// Verify that we actually have changes to apply
+	changelog, _ := diff.Diff(oCfg, nCfg)
+	if len(changelog) == 0 {
+		return fmt.Errorf("no changes to apply")
+	}
+
+	rows := make([][]string, 0, len(changelog))
+	for _, change := range changelog {
+		rows = append(rows, []string{
+			change.Path[len(change.Path)-1],
+			fmt.Sprint(change.From),
+			fmt.Sprint(change.To),
+			restartRequired(change.Path[len(change.Path)-1]),
+		})
+	}
+	_ = render.Table(out, "", rows, "Configuration option", "Current", "Target", "Restart")
+
+	msg := ""
+	if len(requiresRestart) > 0 {
+		msg = " (Restart required)"
+	}
+
+	confirm, err := prompt.Confirm(ctx, fmt.Sprintf("Are you sure you want to apply these changes?%s", msg))
+	if err != nil {
+		return err
+	}
+	if !confirm {
+		return nil
+	}
+
+	fmt.Fprintln(out, "Performing update...")
+	err = pgCmd.updateStolonConfig(nCfg)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(out, "Confirming changes have been applied...")
+	cfg, err := pgCmd.viewStolonConfig()
+	if err != nil {
+		return err
+	}
+
+	// Diff newly pulled configuration with what was expected.
+	changelog, _ = diff.Diff(cfg, &nCfg)
+	if len(changelog) != 0 {
+		return fmt.Errorf(("Update failed to apply changes..."))
+	}
+
+	if len(requiresRestart) > 0 {
+		fmt.Fprintln(out, "Restarting cluster...")
+		// Sleep for a second or two to give Stolon time to propagate changes to
+		// the registered keepers.
+		time.Sleep(time.Second * 2)
+		if err := runRestart(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func restartRequired(option string) string {
+	// List of options that require restarts
+	cfgOpts := []string{
+		"WalLevel",
+		"MaxConnections",
+	}
+	for _, cfgOpt := range cfgOpts {
+		if option == cfgOpt {
+			return "true"
+		}
+	}
+
+	return "false"
+}

--- a/internal/cli/internal/command/services/postgres/config.go
+++ b/internal/cli/internal/command/services/postgres/config.go
@@ -306,7 +306,7 @@ func validateConfigValue(setting pgSetting, key, val string) error {
 				return nil
 			}
 		}
-		return fmt.Errorf("invalid value specified for %s: %s. available options: %s", key, val, setting.EnumVals)
+		return fmt.Errorf("Invalid value specified for %s. Received: %s, Accepted values: [%s]", key, val, strings.Join(setting.EnumVals, ", "))
 	case "integer":
 		min, err := strconv.Atoi(setting.MinVal)
 		if err != nil {
@@ -317,13 +317,9 @@ func validateConfigValue(setting pgSetting, key, val string) error {
 			return err
 		}
 
-		val, err := strconv.Atoi(val)
-		if err != nil {
-			return err
-		}
-
-		if val < min || val > max {
-			return fmt.Errorf("invalid value specified for %s: %d. accepted range: (%s, %s)", key, val, setting.MinVal, setting.MaxVal)
+		v, err := strconv.Atoi(val)
+		if err != nil || v < min || v > max {
+			return fmt.Errorf("Invalid value specified for %s. (Received: %s, Accepted range: (%s, %s)", key, val, setting.MinVal, setting.MaxVal)
 		}
 	}
 

--- a/internal/cli/internal/command/services/postgres/config.go
+++ b/internal/cli/internal/command/services/postgres/config.go
@@ -20,9 +20,9 @@ import (
 func newConfig() (cmd *cobra.Command) {
 	// TODO - Add better top level docs.
 	const (
-		long = `
+		long = `View and manage Postgres configuration.
 `
-		short = ""
+		short = "View and manage Postgres configuration."
 	)
 
 	cmd = command.New("config", short, long, nil)
@@ -35,10 +35,9 @@ func newConfig() (cmd *cobra.Command) {
 	return
 }
 
-// pgSettingMap maps the command-line arguments to the actual pgParameter
-// and also acts as a whitelist as far as what's configurable via flyctl.
-// To support additional configuration, just add the commandline-argument
-// and the value must be a Postgres compatible
+// pgSettingMap maps the command-line argument to the actual pgParameter.
+// This also acts as a whitelist as far as what's configurable via flyctl and
+// can be expanded on as needed.
 var pgSettingMap = map[string]string{
 	"wal-level":                  "wal_level",
 	"max-connections":            "max_connections",
@@ -48,9 +47,9 @@ var pgSettingMap = map[string]string{
 
 func newConfigView() (cmd *cobra.Command) {
 	const (
-		long = `Configure postgres cluster
+		long = `View your Postgres configuration
 `
-		short = "Configure postgres cluster"
+		short = "View your Postgres configuration"
 		usage = "view"
 	)
 
@@ -129,9 +128,9 @@ func runConfigView(ctx context.Context) error {
 
 func newConfigUpdate() (cmd *cobra.Command) {
 	const (
-		long = `Manage Stolon and Postgres configuration.
+		long = `Update Postgres configuration.
 `
-		short = "Configure postgres cluster"
+		short = "Update Postgres configuration."
 		usage = "update"
 	)
 

--- a/internal/cli/internal/command/services/postgres/config.go
+++ b/internal/cli/internal/command/services/postgres/config.go
@@ -93,9 +93,6 @@ func runConfigView(ctx context.Context) error {
 		return err
 	}
 
-	// TODO - Auto-generate this URL from the image tag
-	colorize.Bold("For additional information on these settings, please refer to:")
-
 	pendingRestart := false
 	rows := make([][]string, 0, len(resp.Settings))
 	for _, setting := range resp.Settings {

--- a/internal/cli/internal/command/services/postgres/launch.go
+++ b/internal/cli/internal/command/services/postgres/launch.go
@@ -122,10 +122,12 @@ func runLaunch(ctx context.Context) error {
 
 	client := client.FromContext(ctx).API()
 
-	imageRef, err := client.GetLatestImageTag(ctx, "flyio/postgres")
-	if err != nil {
-		return err
-	}
+	// imageRef, err := client.GetLatestImageTag(ctx, "flyio/postgres")
+	// if err != nil {
+	// 	return err
+	// }
+
+	imageRef := "registry.fly.io/shaun-pg-config-test:deployment-1643921185"
 
 	config := LaunchConfig{
 		AppName:            name,

--- a/internal/cli/internal/command/services/postgres/launch.go
+++ b/internal/cli/internal/command/services/postgres/launch.go
@@ -122,12 +122,10 @@ func runLaunch(ctx context.Context) error {
 
 	client := client.FromContext(ctx).API()
 
-	// imageRef, err := client.GetLatestImageTag(ctx, "flyio/postgres")
-	// if err != nil {
-	// 	return err
-	// }
-
-	imageRef := "registry.fly.io/shaun-pg-config-test:deployment-1643921185"
+	imageRef, err := client.GetLatestImageTag(ctx, "flyio/postgres")
+	if err != nil {
+		return err
+	}
 
 	config := LaunchConfig{
 		AppName:            name,

--- a/internal/cli/internal/command/services/postgres/postgres.go
+++ b/internal/cli/internal/command/services/postgres/postgres.go
@@ -24,6 +24,7 @@ func New() (cmd *cobra.Command) {
 		newAttach(),
 		newDetach(),
 		newRestart(),
+		newConfig(),
 	)
 
 	return


### PR DESCRIPTION
Exposes a basic way to view/update common Postgres specific configuration settings.  

```
Manage Postgres configuration.

Usage:
  flyctl services postgres config update [flags]

Flags:
  -a, --app string                          Application name
  -c, --config string                       Path to application configuration file
  -h, --help                                help for update
      --log-min-duration-statement string   Sets the minimum execution time above which all statements will be logged. (ms)
      --log-statement string                Sets the type of statements logged. (none, ddl, mod, all)
      --max-connections string              Sets the maximum number of concurrent connections.
      --wal-level string                    Sets the level of information written to the WAL. (minimal, replica, logical).

Global Flags:
  -t, --access-token string   Fly API Access Token
  -j, --json                  json output
      --verbose               verbose output
```

**View 
<img width="1164" alt="Screen Shot 2022-02-04 at 11 45 08 AM" src="https://user-images.githubusercontent.com/423038/152577335-2e5a0c5b-af7f-4882-9877-6e8e11370821.png">
example - With Pending Changes**


**Update example:**

<img width="1019" alt="Screen Shot 2022-02-03 at 5 09 57 PM" src="https://user-images.githubusercontent.com/423038/152444558-5dbae10f-0547-4b6e-9f8c-4349a46ac5bf.png">


Available settings can be managed here:
https://github.com/superfly/flyctl/blob/52b3fbeeeb4acf78be2a09f3275a05666cdd5d13/internal/cli/internal/command/services/postgres/config.go#L41


**Input validations**
<img width="1049" alt="Screen Shot 2022-02-04 at 12 11 31 PM" src="https://user-images.githubusercontent.com/423038/152581047-9847b131-e24e-4f47-9574-5ba1702bd29f.png">

