### PR TITLE
feat: Add status command to machines

### DIFF
--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -485,6 +485,10 @@ to all instances running in a specific region using the --region/-r flag.`,
 		return KeyStrings{"stop <id>", "Stop a Fly machine",
 			`Stop a Fly machine`,
 		}
+	case "machine.status":
+		return KeyStrings{"status <id>", "Get status on a fly machine",
+			`Get status for a Fly machine`,
+		}
 	case "monitor":
 		return KeyStrings{"monitor", "Monitor deployments",
 			`Monitor application deployments and other activities. Use --verbose/-v

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -1038,6 +1038,10 @@ usage = "kill <id>"
 longHelp = "Remove a Fly machine"
 shortHelp = "Remove a Fly machine"
 usage = "remove <id>"
+[machine.status]
+longHelp = """Show current status of a running mchine"""
+shortHelp = "Show current status of a running machine"
+usage = "status <id>"
 
 [proxy]
 longHelp = """Proxies connections to a fly app through the wireguard tunnel"""


### PR DESCRIPTION
This PR copies the status command from VM and moves it over the machines, since we haven't yet discussed what we want the output for machine status to be, this is an exact replica of what `fly vm status <image-id>` output

<img width="755" alt="terminal screen with output" src="https://user-images.githubusercontent.com/3229484/152255874-d821b4a0-2f2e-4634-8d9b-bf805fb7262a.png">
