### PR TITLE
[windows] detach the agent process

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/net v0.0.0-20211008194852-3b03d305991f
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 	golang.zx2c4.com/wireguard v0.0.20201118
 	golang.zx2c4.com/wireguard/tun/netstack v0.0.0-20210402170708-10533c3e73cd
@@ -142,7 +143,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.0.0-RC1 // indirect
 	go.opentelemetry.io/proto/otlp v0.9.0 // indirect
 	golang.org/x/mod v0.5.0 // indirect
-	golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
 	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect

--- a/pkg/agent/cmd_unix.go
+++ b/pkg/agent/cmd_unix.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 )
 
-func setCommandFlags(cmd *exec.Cmd) {
+func setSysProcAttributes(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
 		Pgid:    0,

--- a/pkg/agent/cmd_windows.go
+++ b/pkg/agent/cmd_windows.go
@@ -6,11 +6,13 @@ package agent
 import (
 	"os/exec"
 	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
 func setCommandFlags(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		HideWindow:    true,
-		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+		CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP,
 	}
 }

--- a/pkg/agent/cmd_windows.go
+++ b/pkg/agent/cmd_windows.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func setCommandFlags(cmd *exec.Cmd) {
+func setSysProcAttributes(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		HideWindow:    true,
 		CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP,

--- a/pkg/agent/start.go
+++ b/pkg/agent/start.go
@@ -36,7 +36,7 @@ func StartDaemon(ctx context.Context) (*Client, error) {
 
 	cmd := exec.Command(os.Args[0], "agent", "run", logFile)
 	cmd.Env = append(os.Environ(), "FLY_NO_UPDATE_CHECK=1")
-	setCommandFlags(cmd)
+	setSysProcAttributes(cmd)
 
 	if err := cmd.Start(); err != nil {
 		err = forkError{err}


### PR DESCRIPTION
This PR ensures the agent process is detached when started in the background on Windows. This solves the problem of both `cmd` and `Powershel` being unable to comply to `exit` after `fly agent start`.