### PR TITLE
WIP: DNS Fixes and Ping All Apps

### DIFF
--- a/internal/cli/internal/command/dig/dig.go
+++ b/internal/cli/internal/command/dig/dig.go
@@ -250,7 +250,7 @@ func ResolverForOrg(ctx context.Context, c *agent.Client, org *api.Organization)
 	return &net.Resolver{
 		PreferGo: true,
 		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-			d, err := c.Dialer(ctx, org.Slug)
+			d, err := c.DecafDialer(ctx, org.Slug)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/cli/internal/command/ping/ping.go
+++ b/internal/cli/internal/command/ping/ping.go
@@ -18,7 +18,6 @@ import (
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/internal/cli/internal/app"
 	"github.com/superfly/flyctl/internal/cli/internal/command"
-	"github.com/superfly/flyctl/internal/cli/internal/command/dig"
 	"github.com/superfly/flyctl/internal/cli/internal/flag"
 	"github.com/superfly/flyctl/internal/client"
 	"github.com/superfly/flyctl/pkg/agent"
@@ -76,7 +75,7 @@ The target argument can be either a ".internal" DNS name in our network
 	return cmd
 }
 
-func FindApps(ctx context.Context, r *net.Resolver) (map[string]string, error) {
+func FindApps(ctx context.Context, r *agent.Resolver) (map[string]string, error) {
 	txts, err := r.LookupTXT(ctx, "_apps.internal")
 	if err != nil {
 		return nil, fmt.Errorf("find apps: %w", err)
@@ -184,10 +183,12 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	r, ns, err := dig.ResolverForOrg(ctx, aClient, org)
+	r, err := aClient.Resolver(ctx, org.Slug)
 	if err != nil {
 		return err
 	}
+
+	ns := r.NSAddr()
 
 	var mu sync.RWMutex
 	targets := map[string]string{}

--- a/internal/cli/internal/command/ping/ping.go
+++ b/internal/cli/internal/command/ping/ping.go
@@ -88,8 +88,8 @@ func FindApps(ctx context.Context, r *agent.Resolver) (map[string]string, error)
 	wg := sync.WaitGroup{}
 
 	for _, app := range strings.Split(strings.Join(txts, ""), ",") {
+		wg.Add(1)
 		go func(app string) {
-			wg.Add(1)
 			defer wg.Done()
 
 			hostname := fmt.Sprintf("top1.nearest.of.%s.internal", app)
@@ -238,8 +238,8 @@ func run(ctx context.Context) error {
 			wg := sync.WaitGroup{}
 
 			for _, region := range strings.Split(regions, ",") {
+				wg.Add(1)
 				go func(region string) {
-					wg.Add(1)
 					defer wg.Done()
 
 					regHost := fmt.Sprintf("%s.%s.internal", region, app)
@@ -388,6 +388,8 @@ func run(ctx context.Context) error {
 	signal.Notify(stp, syscall.SIGINT, syscall.SIGTERM)
 
 	for i := 0; count == 0 || i < count; i++ {
+		fmt.Printf("loop tick: %d\n", i)
+
 		select {
 		case <-stp:
 			cancel()

--- a/internal/cli/internal/command/ping/ping.go
+++ b/internal/cli/internal/command/ping/ping.go
@@ -187,6 +187,7 @@ func run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer r.Close()
 
 	ns := r.NSAddr()
 

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -399,6 +399,13 @@ func unmarshal(dst interface{}, data []byte) (err error) {
 	return
 }
 
+func (c *Client) DecafDialer(ctx context.Context, slug string) (d Dialer, err error) {
+	return &dialer{
+		slug:   slug,
+		client: c,
+	}, nil
+}
+
 func (c *Client) Dialer(ctx context.Context, slug string) (d Dialer, err error) {
 	var er *EstablishResponse
 	if er, err = c.Establish(ctx, slug); err == nil {

--- a/pkg/agent/server/session.go
+++ b/pkg/agent/server/session.go
@@ -412,6 +412,11 @@ func (s *session) resolver(ctx context.Context, args ...string) {
 		return nil
 	}
 
+	if err := respond(fmt.Sprintf("ok %s", tunnel.Config.DNS)); err != nil {
+		s.error(err)
+		return
+	}
+
 	for {
 		if ctx.Err() != nil {
 			return

--- a/pkg/wg/dns.go
+++ b/pkg/wg/dns.go
@@ -1,0 +1,181 @@
+package wg
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"net"
+	"os"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+type Resolver struct {
+	t  *Tunnel
+	ns *net.UDPAddr
+}
+
+var (
+	ErrDNSTransient = errors.New("transient error")
+)
+
+func NewResolver(t *Tunnel, nsaddr string) (*Resolver, error) {
+	addr, err := net.ResolveUDPAddr("udp", nsaddr+":53")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Resolver{
+		t:  t,
+		ns: addr,
+	}, nil
+}
+
+func (r *Resolver) LookupHost(ctx context.Context, name string) ([]string, error) {
+	var m dns.Msg
+	m.SetQuestion(dns.Fqdn(name), dns.TypeAAAA)
+
+	reply, err := r.roundTrip(ctx, &m)
+	if err != nil {
+		return nil, fmt.Errorf("lookup: %w", err)
+	}
+
+	results := []string{}
+
+	for _, a := range reply.Answer {
+		results = append(results, a.(*dns.AAAA).AAAA.String())
+	}
+
+	return results, nil
+}
+
+func (r *Resolver) LookupAAAA(ctx context.Context, name string) ([]net.IP, error) {
+	var m dns.Msg
+	m.SetQuestion(dns.Fqdn(name), dns.TypeAAAA)
+
+	reply, err := r.roundTrip(ctx, &m)
+	if err != nil {
+		return nil, fmt.Errorf("lookup: %w", err)
+	}
+
+	results := []net.IP{}
+
+	for _, a := range reply.Answer {
+		results = append(results, a.(*dns.AAAA).AAAA)
+	}
+
+	return results, nil
+}
+
+func (r *Resolver) LookupTXT(ctx context.Context, name string) ([]string, error) {
+	var m dns.Msg
+	m.SetQuestion(dns.Fqdn(name), dns.TypeTXT)
+
+	reply, err := r.roundTrip(ctx, &m)
+	if err != nil {
+		return nil, fmt.Errorf("lookup: %w", err)
+	}
+
+	results := []string{}
+
+	for _, a := range reply.Answer {
+		results = append(results, a.(*dns.TXT).Txt...)
+	}
+
+	return nil, nil
+}
+
+func qid() uint16 {
+	var buf [2]byte
+
+	_, err := rand.Read(buf[:])
+	if err != nil {
+		log.Panicf("read from random: %s", err)
+	}
+
+	return binary.LittleEndian.Uint16(buf[:])
+}
+
+func (r *Resolver) roundTrip(ctx context.Context, msg *dns.Msg) (*dns.Msg, error) {
+	reply, err := r.roundTripUDP(ctx, msg)
+	if err == nil || !errors.Is(err, ErrDNSTransient) {
+		return reply, err
+	}
+
+	client := dns.Client{
+		Net: "tcp",
+		Dialer: &net.Dialer{
+			Resolver: r.t.resolv,
+		},
+	}
+
+	c, err := r.t.DialContext(ctx, "tcp", net.JoinHostPort(r.t.dnsIP.String(), "53"))
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+
+	conn := &dns.Conn{Conn: c}
+	defer conn.Close()
+
+	reply, _, err = client.ExchangeWithConn(msg, conn)
+	return reply, err
+}
+
+// returns ErrDNSTransient on truncated UDP plus routine network
+// I/O issues and timeout; other errors aren't transient, and don't
+// fall back
+func (r *Resolver) roundTripUDP(ctx context.Context, msg *dns.Msg) (*dns.Msg, error) {
+	uc, err := r.t.net.DialUDP(nil, r.ns)
+	if err != nil {
+		return nil, fmt.Errorf("dns round trip: contact %s: %w", r.ns, err)
+	}
+
+	defer uc.Close()
+
+	msg.Id = qid()
+
+	raw, err := msg.Pack()
+	if err != nil {
+		return nil, fmt.Errorf("dns round trip: marshal: %w", err)
+	}
+
+	// 50, 150, 450
+	deadline := time.Duration(50 * time.Millisecond)
+
+	for attempt := 0; attempt < 3; attempt++ {
+		_, err := uc.Write(raw)
+		if err != nil {
+			return nil, fmt.Errorf("dns round trip: send to %s: %s (%w)", r.ns, err, ErrDNSTransient)
+		}
+
+		var replyBuf [1500]byte
+
+		deadline *= time.Duration(attempt + 1)
+		uc.SetReadDeadline(time.Now().Add(deadline))
+		n64, err := uc.Read(replyBuf[:])
+		if err != nil && errors.Is(err, os.ErrDeadlineExceeded) {
+			continue
+		} else if err != nil {
+			return nil, fmt.Errorf("dns round trip: read from %s: %s (%w)", r.ns, err, ErrDNSTransient)
+		}
+
+		rb := replyBuf[:n64]
+		reply := &dns.Msg{}
+		if err = reply.Unpack(rb); err != nil || reply.Id != msg.Id {
+			return nil, fmt.Errorf("dns round trip: unpack: %s (%w)", r.ns, err, ErrDNSTransient)
+		}
+
+		if reply.MsgHdr.Truncated {
+			return nil, fmt.Errorf("dns round trip: udp message truncated (%w)", ErrDNSTransient)
+		}
+
+		return reply, nil
+	}
+
+	return nil, fmt.Errorf("dns round trip: timed out reading from %s (%w)", r.ns, ErrDNSTransient)
+}

--- a/pkg/wg/dns.go
+++ b/pkg/wg/dns.go
@@ -173,7 +173,7 @@ func (r *Resolver) roundTripUDP(ctx context.Context, msg *dns.Msg) (*dns.Msg, er
 		rb := replyBuf[:n64]
 		reply := &dns.Msg{}
 		if err = reply.Unpack(rb); err != nil || reply.Id != msg.Id {
-			return nil, fmt.Errorf("dns round trip: unpack: %s (%w)", r.ns, err, ErrDNSTransient)
+			return nil, fmt.Errorf("dns round trip: unpack: %s (%w)", err, ErrDNSTransient)
 		}
 
 		if reply.MsgHdr.Truncated {

--- a/pkg/wg/dns.go
+++ b/pkg/wg/dns.go
@@ -87,10 +87,12 @@ func (r *Resolver) LookupTXT(ctx context.Context, name string) ([]string, error)
 	results := []string{}
 
 	for _, a := range reply.Answer {
-		results = append(results, a.(*dns.TXT).Txt...)
+		txt := a.(*dns.TXT)
+
+		results = append(results, txt.Txt...)
 	}
 
-	return nil, nil
+	return results, nil
 }
 
 func qid() uint16 {

--- a/pkg/wg/dns.go
+++ b/pkg/wg/dns.go
@@ -24,15 +24,19 @@ var (
 )
 
 func NewResolver(t *Tunnel, nsaddr string) (*Resolver, error) {
-	addr, err := net.ResolveUDPAddr("udp", nsaddr+":53")
-	if err != nil {
-		return nil, err
+	r := &Resolver{
+		t: t,
+		ns: &net.UDPAddr{
+			IP:   net.ParseIP(nsaddr),
+			Port: 53,
+		},
 	}
 
-	return &Resolver{
-		t:  t,
-		ns: addr,
-	}, nil
+	if r.ns.IP == nil {
+		return nil, fmt.Errorf("resolver: bad ns addr")
+	}
+
+	return r, nil
 }
 
 func (r *Resolver) LookupHost(ctx context.Context, name string) ([]string, error) {


### PR DESCRIPTION
This PR really got away from me.

tl;dr: you can ostensibly `flyctl ping apps` and ping the nearest 6PN address of every app in your org. It almost works!

Something I'm doing here is seriously confusing netstack's ICMP code now, so I'm still noodling.

The important bit of this PR is what I did with DNS.

Previously, all our DNS requests were done over TCP, with individual TCP connections. This makes sense 99% of the time, when you're probably just doing 1-2 DNS lookups over the life of the whole command you're running. It makes less sense when you're making _a bunch_ of DNS requests, which my ping code does, to look up app addresses and to resolve 6PN addresses back to regions. 

The new code in this branch provides a pkg/wg.Resolver, which attempts lookups over UDP (waiting 50, 150, and 450ms for 3 attempts), and falls back to TCP if UDP doesn't work or if the DNS response has the `truncated` bit set, which indicates a response too long for UDP. 

This seems to be a lot faster than the previous DNS code and is "the right" thing, but it's a lot of sorta gnarly code, and it'll take some time to debug. 

The other thing this PR adds is `DialerDecaf`, which creates an agent Dialer without running the `Establish` command. Once in awhile, you want the Dialer to `Establish` so you can get the WireGuard configuration from the client side (it's a PITA to get otherwise), but you don't want to constantly be `Establish`-ing on every DNS lookup; the `dig` DNS code uses the decaf interface, and probably a bunch of other places should too, I don't know. 
