### PR TITLE
Use the iostream package spinners

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -299,7 +299,7 @@ func watchReleaseCommand(ctx context.Context, cc *cmdctx.CmdContext, apiClient *
 
 			if !rc.InProgress && rc.Failed {
 				if rc.Succeeded && interactive {
-					cc.IO.ChangeProgressIndicatorMsg("Running release task... Done.")
+					cc.IO.StopProgressIndicatorMsg("Running release task... Done.")
 				} else if rc.Failed {
 					return errors.New("Release command failed, deployment aborted")
 				}

--- a/internal/cli/internal/watch/watch.go
+++ b/internal/cli/internal/watch/watch.go
@@ -233,7 +233,7 @@ func ReleaseCommand(ctx context.Context, id string) error {
 
 			if !rc.InProgress && rc.Failed {
 				if rc.Succeeded && interactive {
-					io.ChangeProgressIndicatorMsg("Running release task... Done.")
+					io.StopProgressIndicatorMsg("Running release task... Done.")
 				} else if rc.Failed {
 					return fmt.Errorf("release command failed, deployment aborted")
 				}

--- a/internal/spinner/spinner.go
+++ b/internal/spinner/spinner.go
@@ -1,0 +1,64 @@
+package spinner
+
+import (
+	"sync"
+
+	"github.com/superfly/flyctl/pkg/iostreams"
+)
+
+func Run(io *iostreams.IOStreams, msg string) (s *Spinner) {
+	s = &Spinner{
+		io: io,
+	}
+
+	s.StartWithMessage(msg)
+
+	return
+}
+
+type Spinner struct {
+	mu  sync.Mutex
+	io  *iostreams.IOStreams
+	msg string
+}
+
+func (s *Spinner) Set(msg string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	old := s.msg
+	s.msg = msg
+	s.io.ChangeProgressIndicatorMsg(msg)
+
+	return old
+}
+
+func (s *Spinner) Stop() string {
+	return s.StopWithMessage("")
+}
+
+func (s *Spinner) StopWithMessage(msg string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	old := s.msg
+	s.msg = msg
+	s.io.StopProgressIndicatorMsg(msg)
+
+	return old
+}
+
+func (s *Spinner) Start() {
+	s.StartWithMessage("")
+}
+
+func (s *Spinner) StartWithMessage(msg string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	old := s.msg
+	s.msg = msg
+	s.io.StartProgressIndicatorMsg(msg)
+
+	return old
+}


### PR DESCRIPTION
This PR refactors watch `deploy` & `watch` so that they utilize `iostream` spinners.

Closes #795.