### PR TITLE
Handle cancelation while establishing ssh connection

### DIFF
--- a/cmd/ssh_terminal.go
+++ b/cmd/ssh_terminal.go
@@ -224,7 +224,8 @@ func sshConnect(p *SSHParams, addr string) error {
 		defer endSpin()
 	}
 
-	if err := sshClient.Connect(context.Background()); err != nil {
+	ctx := p.Ctx.Command.Context()
+	if err := sshClient.Connect(ctx); err != nil {
 		return errors.Wrap(err, "error connecting to SSH server")
 	}
 	defer sshClient.Close()
@@ -242,7 +243,7 @@ func sshConnect(p *SSHParams, addr string) error {
 		Mode:   "xterm",
 	}
 
-	if err := sshClient.Shell(context.Background(), term, p.Cmd); err != nil {
+	if err := sshClient.Shell(ctx, term, p.Cmd); err != nil {
 		return errors.Wrap(err, "ssh shell")
 	}
 


### PR DESCRIPTION
Fixes #830 

Possibly relevant issue https://github.com/golang/go/issues/20288

Seems like cancelation isn't being handled in `ssh.NewClientConn`. Comments on that issue indicate that cancelation will happen if the `net.Conn` being passed in is correctly closed on cancel. This is _likely_ not happening as needed due to the way we pass in a connection from the agent's dialer. 

Handling cancelation independently solves the issue for now.