### PR TITLE
Use nginx for RedwoodJS apps for serving assets and proxying API requests

### DIFF
--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -382,7 +382,7 @@ func configureRedwood(sourceDir string) (*SourceInfo, error) {
 	s := &SourceInfo{
 		Family: "RedwoodJS",
 		Files:  templates("templates/redwood"),
-		Port:   8911,
+		Port:   8080,
 		Env: map[string]string{
 			"PORT": "8911",
 		},

--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -11,7 +11,7 @@ import (
 	"github.com/superfly/flyctl/helpers"
 )
 
-//go:embed templates templates/*/.dockerignore
+//go:embed templates templates/*/.dockerignore templates/*/.fly
 var content embed.FS
 
 type InitCommand struct {
@@ -386,16 +386,17 @@ func configureRedwood(sourceDir string) (*SourceInfo, error) {
 		Env: map[string]string{
 			"PORT": "8911",
 		},
-		Statics: []Static{
-			{
-				GuestPath: "/app/web/dist",
-				UrlPrefix: "/",
-			},
-		},
+		// Nginx serves statics with cache headers, so don't use statics
+		// Statics: []Static{
+		// 	{
+		// 		GuestPath: "/app/web/dist",
+		// 		UrlPrefix: "/",
+		// 	},
+		// },
 		ReleaseCmd: "npx prisma migrate deploy --schema '/app/api/db/schema.prisma'",
 		PostgresInitCommands: []InitCommand{
 			{
-				Command:     "scripts/switch_prisma_provider.sh",
+				Command:     ".fly/switch_prisma_provider.sh",
 				Description: "Switching the prisma provider to postgresql",
 				Condition:   checksPass(sourceDir, fileExists("api/db/schema.prisma")),
 			},

--- a/internal/sourcecode/templates/redwood/.fly/Dockerfile
+++ b/internal/sourcecode/templates/redwood/.fly/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:14-alpine as base
+ARG BASE_IMAGE=node:14.19.0-bullseye-slim
+FROM $BASE_IMAGE as base
 
 WORKDIR /app
 
@@ -21,7 +22,14 @@ FROM base as api_build
 COPY api api
 RUN yarn rw build api
 
-FROM node:14-alpine
+FROM $BASE_IMAGE
+RUN apt-get update && apt-get install -y nginx bash
+
+RUN curl -L https://github.com/DarthSim/overmind/releases/download/v2.2.2/overmind-v2.2.2-linux-amd64.gz -o overmind.gz \
+    && gunzip overmind.gz \
+    && mv overmind /usr/local/bin
+
+RUN chmod +x /usr/local/bin/hivemind
 
 WORKDIR /app
 
@@ -39,7 +47,6 @@ COPY --from=api_build /app/api/dist /app/api/dist
 COPY --from=api_build /app/api/db /app/api/db
 COPY --from=api_build /app/node_modules/.prisma /app/node_modules/.prisma
 
-EXPOSE 8911
-
-# Entrypoint to @redwoodjs/api-server binary
-CMD [ "yarn", "rw-api-server", "--port", "8911", "--rootPath", "/api" ]
+EXPOSE 8911 8080
+COPY .fly .fly
+CMD ["/usr/local/bin/overmind", ".fly/Procfile"]

--- a/internal/sourcecode/templates/redwood/.fly/Dockerfile
+++ b/internal/sourcecode/templates/redwood/.fly/Dockerfile
@@ -23,13 +23,13 @@ COPY api api
 RUN yarn rw build api
 
 FROM $BASE_IMAGE
-RUN apt-get update && apt-get install -y nginx bash
+RUN apt-get update && apt-get install -y nginx bash tmux curl
 
 RUN curl -L https://github.com/DarthSim/overmind/releases/download/v2.2.2/overmind-v2.2.2-linux-amd64.gz -o overmind.gz \
     && gunzip overmind.gz \
     && mv overmind /usr/local/bin
 
-RUN chmod +x /usr/local/bin/hivemind
+RUN chmod +x /usr/local/bin/overmind
 
 WORKDIR /app
 
@@ -49,4 +49,4 @@ COPY --from=api_build /app/node_modules/.prisma /app/node_modules/.prisma
 
 EXPOSE 8911 8080
 COPY .fly .fly
-CMD ["/usr/local/bin/overmind", ".fly/Procfile"]
+CMD ["/usr/local/bin/overmind", "start", "-f", "/app/.fly/Procfile"]

--- a/internal/sourcecode/templates/redwood/.fly/Procfile
+++ b/internal/sourcecode/templates/redwood/.fly/Procfile
@@ -1,0 +1,2 @@
+rw: yarn rw-server api --port 8911 --rootPath /.redwood/functions
+nginx: nginx -c .fly/nginx.conf

--- a/internal/sourcecode/templates/redwood/.fly/Procfile
+++ b/internal/sourcecode/templates/redwood/.fly/Procfile
@@ -1,2 +1,2 @@
 rw: yarn rw-server api --port 8911 --rootPath /.redwood/functions
-nginx: nginx -c .fly/nginx.conf
+nginx: nginx -c /app/.fly/nginx.conf

--- a/internal/sourcecode/templates/redwood/.fly/nginx.conf
+++ b/internal/sourcecode/templates/redwood/.fly/nginx.conf
@@ -1,0 +1,85 @@
+#user nginx;
+
+# Run in the foreground
+daemon off;
+
+# Set number of worker processes automatically based on number of CPU cores.
+worker_processes auto;
+
+# Enables the use of JIT for regular expressions to speed-up their processing.
+pcre_jit on;
+
+# Log errors to stdout
+error_log /dev/stdout info;
+
+events {
+	# The maximum number of simultaneous connections that can be opened by
+	# a worker process.
+	worker_connections 1024;
+}
+
+http {
+	# Includes mapping of file name extensions to MIME types of responses
+	# and defines the default type.
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	# Don't tell nginx version to the clients
+	server_tokens off;
+
+	# Specifies the maximum accepted body size of a client request, as
+	# indicated by the request header Content-Length. If the stated content
+	# length is greater than this size, then the client receives the HTTP
+	# error code 413. Set to 0 to disable. Default is '1m'.
+	client_max_body_size 500m;
+
+	# Sendfile copies data between one FD and other from within the kernel,
+	# which is more efficient than read() + write(). Default is off.
+	sendfile on;
+
+	# Causes nginx to attempt to send its HTTP response head in one packet,
+	# instead of using partial frames. Default is 'off'.
+	tcp_nopush on;
+
+	# Helper variable for proxying websockets.
+	map $http_upgrade $connection_upgrade {
+		default upgrade;
+		'' close;
+	}
+
+	# Specifies the main log format.
+	log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+			'$status $body_bytes_sent "$http_referer" '
+			'"$http_user_agent" "$http_x_forwarded_for"';
+
+	# Log to stdout
+  access_log /dev/stdout;
+
+  server {
+    listen [::]:8080;
+    listen 8080 default_server;
+    root /app/web/dist;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+   if ($http_x_forwarded_proto = 'http') {
+     return 301 https://<domain>$request_uri;
+     break;
+   }
+
+   location /.redwood/functions {
+       proxy_pass http://localhost:8911/.redwood/functions;
+       break;
+
+   }
+
+    location ~* \.(js|css|png|jpg)$ {
+        expires max;
+        break;
+    }
+
+    location / {
+       try_files $uri $uri/ /index.html;
+    }
+
+  }
+}

--- a/internal/sourcecode/templates/redwood/.fly/switch_prisma_provider.sh
+++ b/internal/sourcecode/templates/redwood/.fly/switch_prisma_provider.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+mv api/db/schema.prisma api/db/schema.prisma.dist
+sed s/sqlite/postgresql/ api/db/schema.prisma.dist > api/db/schema.prisma


### PR DESCRIPTION
This is required because Redwood needs all non-API requests to be rewritten to `index.html`. It has some upsides, like getting cache headers, and maybe lightweight HTTP caching out of the box if desired.