### PR TITLE
Port proxy command to the new CLI format

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,6 @@ func NewRootCmd(client *client.Client) *cobra.Command {
 		newVMCommand(client),
 		newLaunchCommand(client),
 		newMachineCommand(client),
-		newProxyCommand(client),
 		newTurbokuCommand(client),
 	)
 

--- a/internal/cli/internal/command/deploy/deploy.go
+++ b/internal/cli/internal/command/deploy/deploy.go
@@ -79,6 +79,10 @@ func New() (cmd *cobra.Command) {
 			Name:        "no-cache",
 			Description: "Do not use the build cache when building the image",
 		},
+		flag.Bool{
+			Name:        "nix",
+			Description: "Build with Nix on a remote builder",
+		},
 	)
 
 	return
@@ -175,6 +179,14 @@ func determineAppConfig(ctx context.Context) (cfg *app.Config, err error) {
 
 func determineImage(ctx context.Context, appConfig *app.Config) (img *imgsrc.DeploymentImage, err error) {
 	tb := render.NewTextBlock(ctx, "Building image")
+
+	if flag.GetBool(ctx, "nix") {
+		if img, err = imgsrc.NixSourceBuild(ctx); err != nil {
+			return nil, err
+		} else {
+			return img, nil
+		}
+	}
 	daemonType := imgsrc.NewDockerDaemonType(!flag.GetRemoteOnly(ctx), !flag.GetLocalOnly(ctx))
 	appName := app.NameFromContext(ctx)
 	client := client.FromContext(ctx).API()

--- a/internal/cli/internal/command/deploy/deploy.go
+++ b/internal/cli/internal/command/deploy/deploy.go
@@ -79,10 +79,6 @@ func New() (cmd *cobra.Command) {
 			Name:        "no-cache",
 			Description: "Do not use the build cache when building the image",
 		},
-		flag.Bool{
-			Name:        "nix",
-			Description: "Build with Nix on a remote builder",
-		},
 	)
 
 	return
@@ -180,13 +176,6 @@ func determineAppConfig(ctx context.Context) (cfg *app.Config, err error) {
 func determineImage(ctx context.Context, appConfig *app.Config) (img *imgsrc.DeploymentImage, err error) {
 	tb := render.NewTextBlock(ctx, "Building image")
 
-	if flag.GetBool(ctx, "nix") {
-		if img, err = imgsrc.NixSourceBuild(ctx); err != nil {
-			return nil, err
-		} else {
-			return img, nil
-		}
-	}
 	daemonType := imgsrc.NewDockerDaemonType(!flag.GetRemoteOnly(ctx), !flag.GetLocalOnly(ctx))
 	appName := app.NameFromContext(ctx)
 	client := client.FromContext(ctx).API()

--- a/internal/cli/internal/command/proxy/proxy.go
+++ b/internal/cli/internal/command/proxy/proxy.go
@@ -1,0 +1,57 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/cli/internal/app"
+	"github.com/superfly/flyctl/internal/cli/internal/command"
+	"github.com/superfly/flyctl/internal/cli/internal/flag"
+	"github.com/superfly/flyctl/internal/client"
+	"github.com/superfly/flyctl/pkg/proxy"
+)
+
+func New() *cobra.Command {
+	var (
+		long  = strings.Trim(`Proxies connections to a fly VM through a Wireguard tunnel`, "\n")
+		short = `Proxies connections to a fly VM"`
+	)
+
+	cmd := command.New("proxy <local:remote>", short, long, run,
+		command.RequireSession, command.RequireAppName)
+
+	cmd.Args = cobra.ExactArgs(1)
+
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+		flag.Org(),
+		flag.Bool{
+			Name:        "select",
+			Shorthand:   "s",
+			Default:     false,
+			Description: "Prompt to select from available instances from the current application",
+		},
+	)
+
+	return cmd
+}
+
+func run(ctx context.Context) error {
+	client := client.FromContext(ctx).API()
+	appName := app.NameFromContext(ctx)
+
+	args := flag.Args(ctx)
+
+	app, err := client.GetApp(ctx, appName)
+	if err != nil {
+		return fmt.Errorf("get app: %w", err)
+	}
+
+	ports := strings.Split(args[0], ":")
+
+	proxy.Connect(ctx, ports, app, flag.GetBool(ctx, "select"))
+	return nil
+}

--- a/internal/cli/internal/command/root/root.go
+++ b/internal/cli/internal/command/root/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/superfly/flyctl/internal/cli/internal/command/orgs"
 	"github.com/superfly/flyctl/internal/cli/internal/command/ping"
 	"github.com/superfly/flyctl/internal/cli/internal/command/platform"
+	"github.com/superfly/flyctl/internal/cli/internal/command/proxy"
 	"github.com/superfly/flyctl/internal/cli/internal/command/releases"
 	"github.com/superfly/flyctl/internal/cli/internal/command/restart"
 	"github.com/superfly/flyctl/internal/cli/internal/command/resume"
@@ -138,6 +139,7 @@ func New() *cobra.Command {
 		agent.New(),
 		image.New(),
 		ping.New(),
+		proxy.New(),
 	}
 
 	if os.Getenv("DEV") != "" {

--- a/pkg/proxy/server.go
+++ b/pkg/proxy/server.go
@@ -18,7 +18,7 @@ type Server struct {
 	Dial      func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
-func (srv *Server) Proxy(ctx context.Context) error {
+func (srv *Server) ProxyServer(ctx context.Context) error {
 
 	ls, ok := srv.Listener.(*net.TCPListener)
 	if !ok {


### PR DESCRIPTION
This port has a few specific goals:

* Pave the way for extracting common agent tunnel behavior to a package
* Extract most proxy behavior to a package to be able to use it from other commands, like the upcoming nix rsync experiment