### PR TITLE
Add lucky as a fly launch plan

### DIFF
--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -74,6 +74,7 @@ func Scan(sourceDir string) (*SourceInfo, error) {
 		   since they might mix languages or have a Dockerfile that
 			 doesn't work with Fly */
 		configureDockerfile,
+		configureLucky,
 		configureRails,
 		configureRuby,
 		configureGo,
@@ -109,6 +110,44 @@ func configureDockerfile(sourceDir string) (*SourceInfo, error) {
 	s := &SourceInfo{
 		DockerfilePath: filepath.Join(sourceDir, "Dockerfile"),
 		Family:         "Dockerfile",
+	}
+
+	return s, nil
+}
+
+func configureLucky(sourceDir string) (*SourceInfo, error) {
+	if !checksPass(sourceDir, dirContains("shard.yml", "lucky")) {
+		return nil, nil
+	}
+
+	s := &SourceInfo{
+		Family:     "Lucky",
+		Files:      templates("templates/lucky"),
+		Port:       8080,
+		ReleaseCmd: "lucky db.migrate",
+		Env: map[string]string{
+			"PORT":       "8080",
+			"LUCKY_ENV":  "production",
+			"APP_DOMAIN": "APP_FQDN",
+		},
+		Secrets: []Secret{
+			{
+				Key:      "SECRET_KEY_BASE",
+				Help:     "Lucky needs a random, secret key. Use the random default we've generated, or generate your own.",
+				Generate: true,
+			},
+			{
+				Key:   "SEND_GRID_KEY",
+				Help:  "Lucky needs a SendGrid API key. For now, we're setting this to unused. You can generate one at https://docs.sendgrid.com/for-developers/sending-email/api-getting-started",
+				Value: "unused",
+			},
+		},
+		Statics: []Static{
+			{
+				GuestPath: "/app/public",
+				UrlPrefix: "/",
+			},
+		},
 	}
 
 	return s, nil

--- a/internal/sourcecode/templates/lucky/Dockerfile
+++ b/internal/sourcecode/templates/lucky/Dockerfile
@@ -1,0 +1,40 @@
+FROM crystallang/crystal:1.3.2-alpine as crystal_dependencies
+ENV LUCKY_ENV=production
+ENV SKIP_LUCKY_TASK_PRECOMPILATION=1
+WORKDIR /shards
+COPY shard.* ./
+RUN  shards install --production
+
+FROM node:alpine as asset_build
+WORKDIR /assets
+COPY . .
+RUN yarn install
+RUN yarn prod
+
+FROM crystallang/crystal:1.3.2-alpine as lucky_tasks_build
+ENV LUCKY_ENV=production
+RUN apk --no-cache add yaml-static
+COPY . .
+COPY --from=crystal_dependencies /shards/lib lib
+COPY --from=asset_build /assets/public public
+RUN crystal build --static --release tasks.cr -o /usr/local/bin/lucky
+
+FROM crystallang/crystal:1.3.2-alpine as lucky_webserver_build
+WORKDIR /webserver_build
+RUN apk --no-cache add yaml-static coreutils
+ENV LUCKY_ENV=production
+COPY . .
+COPY --from=crystal_dependencies /shards/lib lib
+COPY --from=asset_build /assets/public public
+RUN shards build --production --static --release
+RUN mv ./bin/`ls ./bin/ | head -1` /usr/local/bin/webserver
+
+FROM alpine as webserver
+WORKDIR /app
+RUN apk --no-cache add postgresql-client tzdata
+COPY --from=lucky_tasks_build /usr/local/bin/lucky /usr/local/bin/lucky
+COPY --from=lucky_webserver_build /usr/local/bin/webserver webserver
+COPY --from=asset_build /assets/public public
+
+ENV PORT 8080
+CMD ["./webserver"]


### PR DESCRIPTION
To test:
1. [Install Lucky](https://luckyframework.org/guides/getting-started/starting-project)
2. `lucky init`
3. `cd project-name` (selected in `lucky init`)
4. `dfly launch`
5. Visit freshly deployed lucky app

One thing I'm running into is that the postgres isn't auto-connecting:
```
➜  fresh-fly git:(main) ✗ dfly launch
Creating app in /app
Scanning source code
Detected a Lucky app
? App Name (leave blank to use an auto-generated name):
? Select organization: Alex Piechowski (personal)
? Select region: ams (Amsterdam, Netherlands)
Created app damp-water-8350 in organization personal
Set secrets on damp-water-8350: SECRET_KEY_BASE, SEND_GRID_KEY
Wrote config file fly.toml
? Would you like to setup a Postgresql database now? Yes
For pricing information visit: https://fly.io/docs/about/pricing/#postgresql-clusters
? Select configuration: Development - Single node, 1x shared CPU, 256MB RAM, 1GB disk
Creating postgres cluster damp-water-8350-db in organization personal
Postgres cluster damp-water-8350-db created
  Username:    postgres
  Password:    xxx
  Hostname:    damp-water-8350-db.internal
  Proxy Port:  5432
  PG Port: 5433
Save your credentials in a secure place, you won't be able to see them again!

Monitoring Deployment

1 desired, 1 placed, 1 healthy, 0 unhealthy [health checks: 3 total, 3 passing]
--> v0 deployed successfully

Connect to postgres
Any app within the personal organization can connect to postgres using the above credentials and the hostname "damp-water-8350-db.internal."
For example: postgres://xxx@damp-water-8350-db.internal:5432

See the postgres docs for more information on next steps, managing postgres, connecting from outside fly:  https://fly.io/docs/reference/postgres/
Running flyadmin database-list
Error Failed attaching damp-water-8350-db to the Postgres cluster damp-water-8350: unexpected end of JSON input.\nTry attaching manually with 'fly postgres attach --app damp-water-8350 --postgres-app damp-water-8350-db'
```

TODO:
- [x] Add statics export for `public` dir

Add as new issue:
- [ ] Add http check
- [ ] add "ping" lucky action