### PR TITLE
fix: Use `rw-server` for RedwoodJS apps

### DIFF
--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -382,15 +382,9 @@ func configureRedwood(sourceDir string) (*SourceInfo, error) {
 	s := &SourceInfo{
 		Family: "RedwoodJS",
 		Files:  templates("templates/redwood"),
-		Port:   8911,
+		Port:   8910,
 		Env: map[string]string{
-			"PORT": "8911",
-		},
-		Statics: []Static{
-			{
-				GuestPath: "/app/web/dist",
-				UrlPrefix: "/",
-			},
+			"PORT": "8910",
 		},
 		ReleaseCmd: "npx prisma migrate deploy --schema '/app/api/db/schema.prisma'",
 		PostgresInitCommands: []InitCommand{

--- a/internal/sourcecode/templates/redwood/Dockerfile
+++ b/internal/sourcecode/templates/redwood/Dockerfile
@@ -39,7 +39,5 @@ COPY --from=api_build /app/api/dist /app/api/dist
 COPY --from=api_build /app/api/db /app/api/db
 COPY --from=api_build /app/node_modules/.prisma /app/node_modules/.prisma
 
-EXPOSE 8910
-
 # Entrypoint to @redwoodjs/api-server binary
 CMD [ "yarn", "rw-server", "--port", "8910" ]

--- a/internal/sourcecode/templates/redwood/Dockerfile
+++ b/internal/sourcecode/templates/redwood/Dockerfile
@@ -39,7 +39,7 @@ COPY --from=api_build /app/api/dist /app/api/dist
 COPY --from=api_build /app/api/db /app/api/db
 COPY --from=api_build /app/node_modules/.prisma /app/node_modules/.prisma
 
-EXPOSE 8911
+EXPOSE 8910
 
 # Entrypoint to @redwoodjs/api-server binary
-CMD [ "yarn", "rw-api-server", "--port", "8911", "--rootPath", "/api" ]
+CMD [ "yarn", "rw-server", "--port", "8910" ]


### PR DESCRIPTION
Related: #836 

This PR replaces the usage of `rw-api-server` with `rw-server` (on port 8910) which serves both API and Web side of a Redwood app with fastify. `rw-server` is configured to redirect the unknown requests to index.html.

Internal discussion: https://redwoodjs.slack.com/archives/C01R3RYH4LW/p1646076378318309 Gist is: Running fastify for the web side may not be ideal for all cases but it keeps things simple as a start config. For advanced use cases, individual projects can configure ngnix.

Looping in: @dthyresson @dac09 @jsierles