### PR TITLE
Launch Rails apps with default production environment variables

### DIFF
--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -202,6 +202,11 @@ func configureRails(sourceDir string) (*SourceInfo, error) {
 				Value: string(masterKey),
 			},
 		}
+
+		s.Env = map[string]string{
+			"RAILS_ENV":           "production",
+			"RAILS_LOG_TO_STDOUT": "true",
+		}
 	}
 
 	s.ReleaseCmd = "bundle exec rails db:migrate"


### PR DESCRIPTION
`RAILS_ENV` and `RAILS_LOG_TO_STDOUT` should probably be set up front.