### PR TITLE
Improvements to interactions with large Docker contexts

### DIFF
--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -152,7 +152,7 @@ func (ds *dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClien
 
 	size := stat.Size()
 
-	cmdfmt.PrintBegin(streams.ErrOut, "Finished calculating build context size.")
+	cmdfmt.PrintDone(streams.ErrOut, "Finished calculating build context size.")
 
 	fmt.Printf("Your build context is %s\n\n", sourcecode.ReadableBytes(size))
 

--- a/internal/sourcecode/helpers.go
+++ b/internal/sourcecode/helpers.go
@@ -147,3 +147,17 @@ func extractBundlerVersion(gemfileLockPath string) (string, error) {
 
 	return version, nil
 }
+
+func ReadableBytes(b int64) string {
+	const unit = 1000
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB",
+		float64(b)/float64(div), "kMGTPE"[exp])
+}


### PR DESCRIPTION
This PR enables displaying the Docker context size to the user before uploading starts. It warns explicitly about contexts larger than 100MB, and prompts about continuing when over 500MB.

```
Your build context is 629.9 MB

Your build context is unusually large! Uploading it will take a while.
You may want to cancel this build and examine your source. Check that .dockerignore excludes large directories/files.
To find the biggest offenders, try: du -hs * | sort -rh

? Are you sure you want to continue deploying this large context? No
```

The only way I could figure out how to implement this was to write the context to a temporary file. For larger files, this can add some delay, but that's better than the current experience.

Also, this PR makes it possible to cancel the build context upload. This was frustrating users before who clearly started uploading a large context but could not stop the build.