### PR TITLE
Add windows powershell install script to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ brew upgrade flyctl
 
 ## Install Script
 
-Download `flyctl` and install into 
+Download `flyctl` and install into a local bin directory.
+
+#### MacOS, Linux, WSL
 
 Installing the latest version:
 
@@ -41,6 +43,15 @@ Installing a specific version:
 ```bash
 curl -L https://fly.io/install.sh | sh -s 0.0.200
 ```
+
+#### Windows
+
+Run the Powershell install script:
+
+```
+iwr https://fly.io/install.ps1 -useb | iex
+```
+
 
 ## Downloading from GitHub
 


### PR DESCRIPTION

I develop on windows and usually come to this repo first, but it's missing the windows powershell instructions found in the docs: https://fly.io/docs/getting-started/installing-flyctl/

