### PR TITLE
'fly releases --image' now displays the deployed Docker image reference

### DIFF
--- a/api/resource_releases.go
+++ b/api/resource_releases.go
@@ -13,6 +13,7 @@ func (c *Client) GetAppReleases(ctx context.Context, appName string, limit int) 
 						description
 						reason
 						status
+						imageRef
 						stable
 						user {
 							id

--- a/api/types.go
+++ b/api/types.go
@@ -616,6 +616,7 @@ type Release struct {
 	User               User
 	EvaluationID       string
 	CreatedAt          time.Time
+	ImageRef           string
 }
 
 type Build struct {

--- a/internal/cli/internal/command/apps/releases.go
+++ b/internal/cli/internal/command/apps/releases.go
@@ -39,7 +39,7 @@ including type, when, success/fail and which user triggered the release.
 		flag.AppConfig(),
 		flag.Bool{
 			Name:        "image",
-			Description: "Display the Docker image reference of the release.",
+			Description: "Display the Docker image reference of the release",
 		},
 	)
 


### PR DESCRIPTION
This is useful for doing manual rollbacks.