### PR TITLE
Fixing machine status so it only needs an id

### DIFF
--- a/internal/cli/internal/command/machine/kill.go
+++ b/internal/cli/internal/command/machine/kill.go
@@ -70,11 +70,8 @@ func runMachineKill(ctx context.Context) (err error) {
 		}
 
 		// check if machine even exists //
-		machineBody := api.V1Machine{
-			ID:    machineID,
-			AppID: appName,
-		}
-		currentMachine, err := flapsClient.Get(ctx, &machineBody)
+		machineBody := api.V1Machine{}
+		currentMachine, err := flapsClient.Get(ctx, machineID)
 		if err != nil {
 			return fmt.Errorf("could not retrieve machine %s", machineID)
 		}

--- a/internal/cli/internal/command/machine/run.go
+++ b/internal/cli/internal/command/machine/run.go
@@ -319,7 +319,7 @@ func runMachineRun(ctx context.Context) error {
 			fmt.Fprintf(io.Out, "You can connect to your machine via the following private ip\n")
 			fmt.Fprintf(io.Out, "  %s\n", machineBody.PrivateIP)
 		}()
-		newMachineBody, _ := flapsClient.Get(ctx, &machineBody)
+		newMachineBody, _ := flapsClient.Get(ctx, machineBody.ID)
 		err = json.Unmarshal(newMachineBody, &machineBody)
 	}()
 	_, err = flapsClient.Wait(ctx, &machineBody)

--- a/pkg/flaps/flaps.go
+++ b/pkg/flaps/flaps.go
@@ -81,8 +81,8 @@ func (f *Client) Stop(ctx context.Context, machineStop api.V1MachineStop) ([]byt
 	return f.sendRequest(ctx, nil, http.MethodPost, stopEndpoint, body)
 }
 
-func (f *Client) Get(ctx context.Context, machine *api.V1Machine) ([]byte, error) {
-	getEndpoint := fmt.Sprintf("/%s", machine.ID)
+func (f *Client) Get(ctx context.Context, machineID string) ([]byte, error) {
+	getEndpoint := fmt.Sprintf("/%s", machineID)
 
 	return f.sendRequest(ctx, nil, http.MethodGet, getEndpoint, nil)
 }


### PR DESCRIPTION
Currently, we create a new machine struct and pass that in when we want to get the status of a machine. Because of [logic here](https://github.com/superfly/flyctl/blob/6d74903bcd71bde6864df1e4d77f744750bda5ff/pkg/flaps/flaps.go#L92), the newly created machine (which doesn't have a private ip) panics on resolve and fails. 

It's unnecessary to create a machine struct when retrieving a machine since you can just curl with an id like so 
`curl -i -XGET -u "APP:TOKEN" -H "Content-Type:application/json" "http://[fdaa:0:3e9b::3]:4280/v1/machines/MACHINEID"`

To test, run:
`go run . machine status MACHINEID --app APPNAME`
![Screen Shot 2022-04-04 at 2 28 03 PM](https://user-images.githubusercontent.com/3229484/161635281-1035d604-37ce-4ef5-91da-791a05ca8858.png)

