### PR TITLE
machine run UX improvements

### DIFF
--- a/internal/cli/internal/command/machine/run.go
+++ b/internal/cli/internal/command/machine/run.go
@@ -157,107 +157,61 @@ func runMachineRun(ctx context.Context) error {
 		appName = app.NameFromContext(ctx)
 		client  = client.FromContext(ctx).API()
 		io      = iostreams.FromContext(ctx)
+		err     error
+		app     *api.App
 	)
 
-	var org *api.Organization
-
-	var err error
-
-	var app *api.App
-
 	if appName == "" {
-		var message = "Running a machine without specifying an app will create one for you, is this what you want?"
-
-		confirm, err := prompt.Confirm(ctx, message)
+		app, err = createApp(ctx, "Running a machine without specifying an app will create one for you, is this what you want?", "", client)
 		if err != nil {
 			return err
 		}
-
-		if !confirm {
-			return nil
-		}
-
-		org, err = prompt.Org(ctx, nil)
-		if err != nil {
-			return err
-		}
-
-		name, err := selectAppName(ctx)
-		if err != nil {
-			return err
-		}
-
-		input := api.CreateAppInput{
-			Name:           name,
-			Runtime:        "FIRECRACKER",
-			OrganizationID: org.ID,
-		}
-
-		app, err = client.CreateApp(ctx, input)
-		if err != nil {
-			return err
-		}
-
 	} else {
 		app, err = client.GetApp(ctx, appName)
+		if err != nil && strings.Contains(err.Error(), "Could not resolve App") {
+			app, err = createApp(ctx, fmt.Sprintf("App '%s' does not exist, would you like to create it?", appName), appName, client)
+		}
 		if err != nil {
 			return err
 		}
 	}
 
-	var machineConf = new(api.MachineConfig)
+	machineConf := api.MachineConfig{
+		Guest: &api.MachineGuest{
+			CPUKind:  "shared",
+			CPUs:     1,
+			MemoryMB: 256,
+		},
+	}
+
+	if guest := api.MachinePresets[flag.GetString(ctx, "size")]; guest != nil {
+		machineConf.Guest = guest
+	} else {
+		if cpus := flag.GetInt(ctx, "cpus"); cpus != 0 {
+			machineConf.Guest.CPUs = cpus
+		}
+
+		if memory := flag.GetInt(ctx, "memory"); memory != 0 {
+			machineConf.Guest.MemoryMB = memory
+		}
+
+		if cpuKind := flag.GetString(ctx, "cpu-kind"); cpuKind != "" && cpuKind != "shared" {
+			return errors.New("unsupported cpu-kind flag, only shared allowed")
+		}
+	}
 
 	machineConf.Env, err = parseEnvVars(ctx)
 	if err != nil {
 		return err
 	}
 
-	img, err := determineImage(ctx, app.Name)
+	services, err := determineServices(ctx)
 	if err != nil {
 		return err
 	}
-
-	if flag.GetBool(ctx, "build-only") {
-		return nil
+	if len(services) > 0 {
+		machineConf.Services = services
 	}
-
-	machineConf.Image = img.Tag
-
-	guest := api.MachinePresets[flag.GetString(ctx, "size")]
-
-	if guest == nil {
-		cpuKind := flag.GetString(ctx, "cpu-kind")
-		if cpuKind == "" {
-			cpuKind = "shared"
-		}
-
-		cpus := flag.GetInt(ctx, "cpus")
-		if cpus == 0 {
-			cpus = 1
-		}
-
-		memory := flag.GetInt(ctx, "memory")
-		if memory == 0 {
-			memory = 256
-		}
-		guest = &api.MachineGuest{
-			CPUKind:  cpuKind,
-			CPUs:     cpus,
-			MemoryMB: memory,
-		}
-	} else {
-		if cpuKind := flag.GetString(ctx, "cpu-kind"); cpuKind != "" {
-			guest.CPUKind = cpuKind
-		}
-		if cpus := flag.GetInt(ctx, "cpus"); cpus != 0 {
-			guest.CPUs = cpus
-		}
-		if memory := flag.GetInt(ctx, "memory"); memory != 0 {
-			guest.MemoryMB = memory
-		}
-	}
-
-	machineConf.Guest = guest
 
 	if entrypoint := flag.GetString(ctx, "entrypoint"); entrypoint != "" {
 		splitted, err := shlex.Split(entrypoint)
@@ -271,29 +225,26 @@ func runMachineRun(ctx context.Context) error {
 		machineConf.Init.Cmd = cmd
 	}
 
-	services, err := determineServices(ctx)
-	if err != nil {
-		return err
-	}
-	if len(services) > 0 {
-		machineConf.Services = services
-	}
-
 	machineConf.Mounts, err = determineMounts(ctx)
 	if err != nil {
 		return err
 	}
 
-	input := api.LaunchMachineInput{
-		AppID:  app.Name,
-		ID:     flag.GetString(ctx, "id"),
-		Name:   flag.GetString(ctx, "name"),
-		Region: flag.GetString(ctx, "region"),
-		Config: machineConf,
+	img, err := determineImage(ctx, app.Name)
+	if err != nil {
+		return err
+	}
+	machineConf.Image = img.Tag
+
+	if flag.GetBool(ctx, "build-only") {
+		return nil
 	}
 
-	if org != nil {
-		input.OrgSlug = org.ID
+	input := api.LaunchMachineInput{
+		AppID:  app.Name,
+		Name:   flag.GetString(ctx, "name"),
+		Region: flag.GetString(ctx, "region"),
+		Config: &machineConf,
 	}
 
 	flapsClient, err := flaps.New(ctx, app)
@@ -327,6 +278,37 @@ func runMachineRun(ctx context.Context) error {
 	fmt.Fprintf(io.Out, "  %s\n", privateIP)
 
 	return nil
+}
+
+func createApp(ctx context.Context, message, name string, client *api.Client) (*api.App, error) {
+	confirm, err := prompt.Confirm(ctx, message)
+	if err != nil {
+		return nil, err
+	}
+
+	if !confirm {
+		return nil, err
+	}
+
+	org, err := prompt.Org(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if name == "" {
+		name, err = selectAppName(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	input := api.CreateAppInput{
+		Name:           name,
+		Runtime:        "FIRECRACKER",
+		OrganizationID: org.ID,
+	}
+
+	return client.CreateApp(ctx, input)
 }
 
 func waitForStart(ctx context.Context, flapsClient *flaps.Client, machine *api.V1Machine) error {


### PR DESCRIPTION
Two UX changes:
- Currently, we attempt to build the image early in the process which can take some time and if a flag was defined incorrectly the users wasted time watching the image build. Now we'll process as much as possible before trying to build the image.
- If the app flag was specified but did not exist, we would return the error `Could not resolve App`. Now we'll prompt the user if they would like to first create the app with the name specified in the flag.