### PR TITLE
Fix recognition of other apps than Django

### DIFF
--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -541,7 +541,7 @@ func configureNuxt(sourceDir string) (*SourceInfo, error) {
 
 // setup django with a postgres database
 func configureDjango(sourceDir string) (*SourceInfo, error) {
-	if !checksPass(sourceDir, fileExists("requirements.txt", "manage.py")) {
+	if !checksPass(sourceDir, fileExists("manage.py", "requirements.txt")) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Classify apps as Django, if `manage.py` exists to fix #878. This is a workaround, because the core issue is, that . This change avoids the misclassification of other Python apps, that most likely have a `requirements.txt`, but pretty sure don't have a `manage.py`.

The underlying issue is, that `fileExists` when just the first file exist. 

https://github.com/superfly/flyctl/blob/8460965950c02314a7d4d4510202b5423db44e19/internal/sourcecode/helpers.go#L10

Generally assuming a Django App, when the two files above exist, is a good enough heuristic. But for other Python frameworks you might not find such a pattern. I was actually surprised, that you are not reading the contents of `requirements.txt` and look for the name of the framework, that you want to support.