### PR TITLE
update fly machine kill to send sigkill to signal API endpoint

### DIFF
--- a/pkg/flaps/flaps.go
+++ b/pkg/flaps/flaps.go
@@ -102,10 +102,8 @@ func (f *Client) Destroy(ctx context.Context, input api.RemoveMachineInput) ([]b
 	return f.sendRequest(ctx, nil, http.MethodDelete, destroyEndpoint, nil)
 }
 
-func (f *Client) Kill(ctx context.Context, machineKillInput api.KillMachineInput) ([]byte, error) {
-	killEndpoint := fmt.Sprintf("/%s?kill=%t", machineKillInput.ID, machineKillInput.Force)
-
-	return f.sendRequest(ctx, nil, http.MethodDelete, killEndpoint, nil)
+func (f *Client) Kill(ctx context.Context, machineID string) ([]byte, error) {
+	return f.sendRequest(ctx, nil, http.MethodPost, fmt.Sprintf("/%s/signal", machineID), []byte(`{"signal":9}`))
 }
 
 func (f *Client) sendRequest(ctx context.Context, machine *api.V1Machine, method, endpoint string, data []byte) ([]byte, error) {


### PR DESCRIPTION
Updates `fly machine kill` to not take any additional flags and uses the `/v1/{machine_id}/signal` endpoint to send a `sigkill`.