### PR TITLE
Feat: machine update via run

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -1225,7 +1225,10 @@ type V1Machine struct {
 
 	// PrivateIP is the internal 6PN address of the machine.
 	PrivateIP string `json:"private_ip"`
+
 	CreatedAt string `json:"created_at"`
+
+	Config *MachineConfig `json:"config"`
 }
 
 type V1MachineStop struct {

--- a/internal/cli/internal/command/machine/run.go
+++ b/internal/cli/internal/command/machine/run.go
@@ -184,6 +184,12 @@ func runMachineRun(ctx context.Context) error {
 		},
 	}
 
+	input := api.LaunchMachineInput{
+		AppID:  app.Name,
+		Name:   flag.GetString(ctx, "name"),
+		Region: flag.GetString(ctx, "region"),
+	}
+
 	flapsClient, err := flaps.New(ctx, app)
 	if err != nil {
 		return fmt.Errorf("could not make API client: %w", err)
@@ -201,6 +207,9 @@ func runMachineRun(ctx context.Context) error {
 			return fmt.Errorf("could not read machine body %s: %w", machineID, err)
 		}
 		fmt.Fprintf(io.Out, "machine %s was found and is currently in a %s state, attempting to update...\n", machineID, machine.State)
+		input.ID = machineID
+		input.Name = machine.Name
+		input.Region = ""
 		machineConf = *machine.Config
 	}
 
@@ -260,13 +269,7 @@ func runMachineRun(ctx context.Context) error {
 		return nil
 	}
 
-	input := api.LaunchMachineInput{
-		ID:     machineID,
-		AppID:  app.Name,
-		Name:   flag.GetString(ctx, "name"),
-		Region: flag.GetString(ctx, "region"),
-		Config: &machineConf,
-	}
+	input.Config = &machineConf
 
 	mach, err := flapsClient.Launch(ctx, input)
 	if err != nil {

--- a/internal/cli/internal/command/machine/status.go
+++ b/internal/cli/internal/command/machine/status.go
@@ -77,6 +77,7 @@ func runMachineStatus(ctx context.Context) error {
 	fmt.Fprintf(io.Out, " Machine ID: %s\n", machine.ID)
 	fmt.Fprintf(io.Out, " Instance ID: %s\n", machine.InstanceID)
 	fmt.Fprintf(io.Out, " State: %s\n", machine.State)
+	fmt.Fprintf(io.Out, " Image: %s\n", machine.Config.Image)
 
 	return nil
 }

--- a/pkg/flaps/flaps.go
+++ b/pkg/flaps/flaps.go
@@ -59,7 +59,12 @@ func (f *Client) Launch(ctx context.Context, builder api.LaunchMachineInput) ([]
 		return nil, fmt.Errorf("machine failed to launch, %w", err)
 	}
 
-	return f.sendRequest(ctx, nil, http.MethodPost, "", body)
+	var endpoint string
+	if builder.ID != "" {
+		endpoint = fmt.Sprintf("/%s", builder.ID)
+	}
+
+	return f.sendRequest(ctx, nil, http.MethodPost, endpoint, body)
 }
 
 func (f *Client) Start(ctx context.Context, machineID string) ([]byte, error) {


### PR DESCRIPTION
The following changes support updating an existing machine via `machine run` by including the `--id` flag. It will first get the latest machine config and apply any changes.