### PR TITLE
Directly specify the homebrew-core fork in superfly

### DIFF
--- a/.github/workflows/homebrew_bump.yml
+++ b/.github/workflows/homebrew_bump.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: mislav/bump-homebrew-formula-action@v1
         with:
+          push-to: superfly/homebrew-core
           formula-name: flyctl
           tag-name: ${{ github.event.inputs.version }}
           commit-message: |


### PR DESCRIPTION
I believe this might circumvent what looks like an issue with fork auto-selection here: https://github.com/superfly/flyctl/runs/6118824383?check_suite_focus=true