### PR TITLE
Remix: exclude local builds from the Docker build context

### DIFF
--- a/internal/sourcecode/templates/remix/.dockerignore
+++ b/internal/sourcecode/templates/remix/.dockerignore
@@ -1,1 +1,5 @@
-node_modules
+/.cache
+/.env
+/build
+/node_modules
+/public/build


### PR DESCRIPTION
Based on a report in https://github.com/remix-run/remix/issues/1622.

Local builds should be excluded from Docker context to avoid painfully large/slow deploys.