### PR TITLE
Update Remix dockerignores to match the Remix Indie Stack

### DIFF
--- a/internal/sourcecode/templates/remix/.dockerignore
+++ b/internal/sourcecode/templates/remix/.dockerignore
@@ -1,5 +1,7 @@
-/.cache
-/.env
-/build
 /node_modules
+*.log
+.DS_Store
+.env
+/.cache
 /public/build
+/build

--- a/internal/sourcecode/templates/remix_prisma/.dockerignore
+++ b/internal/sourcecode/templates/remix_prisma/.dockerignore
@@ -1,1 +1,7 @@
-node_modules
+/node_modules
+*.log
+.DS_Store
+.env
+/.cache
+/public/build
+/build


### PR DESCRIPTION
This fixes issues with build artifacts in `public` getting uploaded in Docker contexts.