### PR TITLE
Add events logs to status 

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -1222,6 +1222,14 @@ type machineImageRef struct {
 	Digest     string            `json:"digest"`
 	Labels     map[string]string `json:"labels"`
 }
+
+type machineEvent struct {
+	Type      string `json:"type"`
+	Status    string `json:"status"`
+	Request   any    `json:"request,omitempty"`
+	Source    string `json:"source"`
+	Timestamp uint64 `json:"timestamp"`
+}
 type V1Machine struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
@@ -1241,6 +1249,8 @@ type V1Machine struct {
 	CreatedAt string `json:"created_at"`
 
 	Config *MachineConfig `json:"config"`
+
+	Events []*machineEvent `json:"events,omitempty"`
 }
 
 type V1MachineStop struct {

--- a/api/types.go
+++ b/api/types.go
@@ -1223,12 +1223,19 @@ type machineImageRef struct {
 	Labels     map[string]string `json:"labels"`
 }
 
+type MachineEvent struct {
+	ID        string
+	Kind      string
+	Timestamp time.Time
+	Metadata  map[string]interface{}
+}
+
 type MachineEventt struct {
-	Type      string `json:"type"`
-	Status    string `json:"status"`
-	Request   any    `json:"request,omitempty"`
-	Source    string `json:"source"`
-	Timestamp uint64 `json:"timestamp"`
+	Type      string      `json:"type"`
+	Status    string      `json:"status"`
+	Request   interface{} `json:"request,omitempty"`
+	Source    string      `json:"source"`
+	Timestamp int64       `json:"timestamp"`
 }
 type V1Machine struct {
 	ID   string `json:"id"`
@@ -1351,13 +1358,6 @@ type MachineConfig struct {
 type DeleteOrganizationMembershipPayload struct {
 	Organization *Organization
 	User         *User
-}
-
-type MachineEvent struct {
-	ID        string
-	Kind      string
-	Timestamp time.Time
-	Metadata  map[string]interface{}
 }
 
 type MachineEventStop struct {

--- a/api/types.go
+++ b/api/types.go
@@ -1223,7 +1223,7 @@ type machineImageRef struct {
 	Labels     map[string]string `json:"labels"`
 }
 
-type machineEvent struct {
+type MachineEventt struct {
 	Type      string `json:"type"`
 	Status    string `json:"status"`
 	Request   any    `json:"request,omitempty"`
@@ -1250,7 +1250,7 @@ type V1Machine struct {
 
 	Config *MachineConfig `json:"config"`
 
-	Events []*machineEvent `json:"events,omitempty"`
+	Events []*MachineEventt `json:"events,omitempty"`
 }
 
 type V1MachineStop struct {

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -79,14 +79,29 @@ func runMachineStatus(ctx context.Context) error {
 		return fmt.Errorf("machine %s could not be retrieved", machineID)
 	}
 
-	machineLink := io.CreateLink("View it in the UI here:", fmt.Sprintf("https://fly.io/apps/%s/machines/%s", appName, machine.ID))
+	machine.Events = append(machine.Events, &api.MachineEventt{
+		Type:      "Exit",
+		Status:    "404",
+		Request:   "",
+		Source:    "",
+		Timestamp: 543,
+	})
+	machine.Events = append(machine.Events, &api.MachineEventt{
+		Type:      "Exit",
+		Status:    "300",
+		Request:   "",
+		Source:    "",
+		Timestamp: 345,
+	})
 
-	fmt.Fprintf(io.Out, "Success! A machine has been retrieved\n%s\n\n", machineLink)
-
+	fmt.Fprintf(io.Out, "Success! A machine has been retrieved\n")
 	fmt.Fprintf(io.Out, " Machine ID: %s\n", machine.ID)
 	fmt.Fprintf(io.Out, " Instance ID: %s\n", machine.InstanceID)
 	fmt.Fprintf(io.Out, " State: %s\n", machine.State)
-	fmt.Fprintf(io.Out, " Region: %s\n", machine.Region)
-	fmt.Fprintf(io.Out, " Image: %s\n", machine.Config.Image)
+	fmt.Fprintf(io.Out, " Event Logs \n")
+	for _, event := range machine.Events {
+		fmt.Fprintf(io.Out, " %d %s %s \n", event.Timestamp, event.Type, event.Status)
+	}
+
 	return nil
 }

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
@@ -65,7 +66,12 @@ func runMachineStatus(ctx context.Context) error {
 
 	machineBody, err := flapsClient.Get(ctx, machineID)
 	if err != nil {
-		return fmt.Errorf("machine %s could not be retrieved, %w", machineID, err)
+		switch {
+		case strings.Contains(err.Error(), "status"):
+			return fmt.Errorf("retrieve machine failed %s", err)
+		default:
+			return fmt.Errorf("machine %s could not be retrieved", machineID)
+		}
 	}
 	var machine api.V1Machine
 	err = json.Unmarshal(machineBody, &machine)

--- a/pkg/iostreams/link.go
+++ b/pkg/iostreams/link.go
@@ -1,0 +1,27 @@
+package iostreams
+
+import (
+	"fmt"
+	"os"
+)
+
+func CreateLink(text string, url string) string {
+	fmt.Println("jhello")
+	// if canMakeTextHyperlink() {
+	// 	return "\x1b]8;;" + url + "\x07" + text + "\x1b]8;;\x07"
+	// } else {
+	// 	return text + " (\u200B" + url + ")"
+	// }
+	return "\x1b]8;;" + url + "\x07" + text + "\x1b]8;;\x07"
+}
+
+func canMakeTextHyperlink() bool {
+	if os.Getenv("FORCE_HYPERLINK") != "" {
+		return true
+	}
+	if os.Getenv("DOMTERM") != "" {
+		// DomTerm
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
This work relies on this PR -> https://github.com/superfly/nomad-firecracker/pull/198

The idea is to highlight recent most machine events to the user so they can debug issues if a machine were to be stopped unexpectedly
![Screen Shot 2022-05-02 at 2 59 06 PM](https://user-images.githubusercontent.com/3229484/166334270-6e51d125-aa3d-44fb-a025-fefde634f2b6.png)
