### PR TITLE
Set entrypoint in config if DockerEntrypoint exists

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -304,7 +304,7 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 			appConfig.SetDockerCommand(srcInfo.DockerCommand)
 		}
 
-		if srcInfo.DockerCommand != "" {
+		if srcInfo.DockerEntrypoint != "" {
 			appConfig.SetDockerEntrypoint(srcInfo.DockerEntrypoint)
 		}
 


### PR DESCRIPTION
runLaunch() was setting the entrypoint in config iff srcInfo.DockerCommand wasn't empty; srcInfo.DockerEntrypoint wasn't used. At the moment, only the Remix template is generating a value for this field.