### PR TITLE
fly image show supports machines

### DIFF
--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -157,6 +157,7 @@ func (client *Client) GetAppCompact(ctx context.Context, appName string) (*AppCo
 				status
 				version
 				appUrl
+				platformVersion
 				organization {
 					slug
 				}

--- a/api/types.go
+++ b/api/types.go
@@ -1213,10 +1213,11 @@ type Filters struct {
 }
 
 type machineImageRef struct {
-	Registry   string
-	Repository string
-	Tag        string
-	Digest     string
+	Registry   string            `json:"registry"`
+	Repository string            `json:"repository"`
+	Tag        string            `json:"tag"`
+	Digest     string            `json:"digest"`
+	Labels     map[string]string `json:"labels"`
 }
 type V1Machine struct {
 	ID   string `json:"id"`
@@ -1323,6 +1324,7 @@ type MachineConfig struct {
 	Env      map[string]string `json:"env"`
 	Init     MachineInit       `json:"init,omitempty"`
 	Image    string            `json:"image"`
+	ImageRef machineImageRef   `json:"image_ref"`
 	Metadata map[string]string `json:"metadata"`
 	Mounts   []MachineMount    `json:"mounts,omitempty"`
 	Restart  MachineRestart    `json:"restart,omitempty"`

--- a/api/types.go
+++ b/api/types.go
@@ -421,7 +421,8 @@ type AppCompact struct {
 	IPAddresses  struct {
 		Nodes []IPAddress
 	}
-	Services []Service
+	PlatformVersion string
+	Services        []Service
 }
 
 type AppStatus struct {

--- a/internal/command/image/show.go
+++ b/internal/command/image/show.go
@@ -171,8 +171,8 @@ func showMachineImage(ctx context.Context, app *api.App) error {
 
 		var version = "N/A"
 
-		if machine.ImageRef.Labels != nil && machine.ImageRef.Labels["version"] != "" {
-			version = machine.ImageRef.Labels["version"]
+		if machine.ImageRef.Labels != nil && machine.ImageRef.Labels["fly.version"] != "" {
+			version = machine.ImageRef.Labels["fly.version"]
 		}
 
 		obj := [][]string{

--- a/internal/command/image/show.go
+++ b/internal/command/image/show.go
@@ -53,7 +53,7 @@ func runShow(ctx context.Context) (err error) {
 		appName = app.NameFromContext(ctx)
 	)
 
-	app, err := client.GetApp(ctx, appName)
+	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("get app: %w", err)
 	}
@@ -82,16 +82,16 @@ func runShow(ctx context.Context) (err error) {
 	return nil
 }
 
-func showNomadImage(ctx context.Context, machine *api.App) error {
+func showNomadImage(ctx context.Context, app *api.AppCompact) error {
 	var (
 		client   = client.FromContext(ctx).API()
 		cfg      = config.FromContext(ctx)
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
-		appName  = app.NameFromContext(ctx)
+		// appName  = app.NameFromContext(ctx)
 	)
 
-	info, err := client.GetImageInfo(ctx, appName)
+	info, err := client.GetImageInfo(ctx, app.Name)
 	if err != nil {
 		return fmt.Errorf("failed to get image info: %w", err)
 	}
@@ -143,7 +143,7 @@ func showNomadImage(ctx context.Context, machine *api.App) error {
 	)
 }
 
-func showMachineImage(ctx context.Context, app *api.App) error {
+func showMachineImage(ctx context.Context, app *api.AppCompact) error {
 	var (
 		client = client.FromContext(ctx).API()
 		io     = iostreams.FromContext(ctx)


### PR DESCRIPTION
- [x] Display each machine's image details.
- [x] Display specific machine's image details? e.g: `fly image show image <machine-id> --app <app-name>`

<img width="1042" alt="Screen Shot 2022-05-03 at 15 50 46" src="https://user-images.githubusercontent.com/17580572/166465768-c8fe0307-79a4-49ec-8439-b5658abc4268.png">

<img width="917" alt="Screen Shot 2022-05-14 at 19 19 25" src="https://user-images.githubusercontent.com/17580572/168442107-0631b11a-ef51-41e4-9bd8-8983fb46ffa9.png">
