### PR TITLE
Run Wireguard connection over websockets by default

### DIFF
--- a/cmd/wireguard.go
+++ b/cmd/wireguard.go
@@ -40,7 +40,7 @@ func newWireGuardCommand(client *client.Client) *Command {
 	child(cmd, runWireGuardRemove, "wireguard.remove").Args = cobra.MaximumNArgs(2)
 	child(cmd, runWireGuardStat, "wireguard.status").Args = cobra.MaximumNArgs(2)
 	child(cmd, runWireGuardResetPeer, "wireguard.reset").Args = cobra.MaximumNArgs(1)
-	child(cmd, runWireGuardWebSockets, "wireguard.websockets").Args = cobra.ExactArgs(1)
+	child(cmd, runWireGuardWebSockets, "wireguard.websockets").Args = cobra.MaximumNArgs(1)
 
 	tokens := child(cmd, nil, "wireguard.token")
 
@@ -202,12 +202,22 @@ func resolveOutputWriter(ctx *cmdctx.CmdContext, idx int, prompt string) (w io.W
 }
 
 func runWireGuardWebSockets(ctx *cmdctx.CmdContext) error {
+
+	if len(ctx.Args) == 0 {
+		if viper.GetBool(flyctl.ConfigDisableWireGuardWebsockets) {
+			fmt.Println("Wireguard is configured to connect over UDP. Switch to connecting over websockets with 'fly wg websockets enable'.")
+		} else {
+			fmt.Println("Wireguard is configured to connect over websockets. Switch back to UDP-based connections with 'fly wg websockets disable'.")
+		}
+		return nil
+	}
+
 	switch ctx.Args[0] {
 	case "enable":
-		viper.Set(flyctl.ConfigWireGuardWebsockets, true)
+		viper.Set(flyctl.ConfigDisableWireGuardWebsockets, false)
 
 	case "disable":
-		viper.Set(flyctl.ConfigWireGuardWebsockets, false)
+		viper.Set(flyctl.ConfigDisableWireGuardWebsockets, true)
 
 	default:
 		fmt.Printf("bad arg: flyctl wireguard websockets (enable|disable)\n")

--- a/flyctl/config.go
+++ b/flyctl/config.go
@@ -15,8 +15,8 @@ const (
 	ConfigInstaller       = "installer"
 	BuildKitNodeID        = "buildkit_node_id"
 
-	ConfigWireGuardState      = "wire_guard_state"
-	ConfigWireGuardWebsockets = "wire_guard_websockets"
+	ConfigWireGuardState             = "wire_guard_state"
+	ConfigDisableWireGuardWebsockets = "disable_wire_guard_websockets"
 
 	ConfigRegistryHost = "registry_host"
 )

--- a/flyctl/flyctl.go
+++ b/flyctl/flyctl.go
@@ -122,7 +122,7 @@ func GetAPIToken() string {
 
 }
 
-var writeableConfigKeys = []string{ConfigAPIToken, ConfigInstaller, ConfigWireGuardState, ConfigWireGuardWebsockets, BuildKitNodeID}
+var writeableConfigKeys = []string{ConfigAPIToken, ConfigInstaller, ConfigWireGuardState, ConfigDisableWireGuardWebsockets, BuildKitNodeID}
 
 func SaveConfig() error {
 	out := map[string]interface{}{}

--- a/pkg/agent/server/server.go
+++ b/pkg/agent/server/server.go
@@ -217,13 +217,12 @@ func (s *server) buildTunnel(org *api.Organization, recycle bool) (tunnel *wg.Tu
 		return
 	}
 
-	// WIP: can't stay this way, need something more clever than this
-	if os.Getenv("WSWG") != "" || viper.GetBool(flyctl.ConfigWireGuardWebsockets) {
-		if tunnel, err = wg.ConnectWS(context.Background(), state); err != nil {
+	if os.Getenv("WG_WEBSOCKETS") == "disable" || viper.GetBool(flyctl.ConfigDisableWireGuardWebsockets) {
+		if tunnel, err = wg.Connect(context.Background(), state); err != nil {
 			return
 		}
 	} else {
-		if tunnel, err = wg.Connect(context.Background(), state); err != nil {
+		if tunnel, err = wg.ConnectWS(context.Background(), state); err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
Websocket-based Wireguard has helped a lot of `flyctl` users, and has been in the wild for some time, so this PR makes websockets the default. We also can view the current wireguard websocket status and disable websockets.

```
$ flyctl wg websockets
Wireguard is configured to connect over websockets. Switch back to UDP-based connections with 'fly wg websockets disable'.
$ flyctl wg websockets disable
Wireguard is configured to connect over UDP. Switch to connecting over websockets with 'fly wg websockets enable'.
```