### PR TITLE
use AppCompact graphql query when interacting with machines API

### DIFF
--- a/internal/command/machine/kill.go
+++ b/internal/command/machine/kill.go
@@ -51,7 +51,7 @@ func runMachineKill(ctx context.Context) (err error) {
 		return fmt.Errorf("app was not found")
 	}
 
-	app, err := client.GetApp(ctx, appName)
+	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/list.go
+++ b/internal/command/machine/list.go
@@ -56,7 +56,7 @@ func runMachineList(ctx context.Context) (err error) {
 	if appName == "" {
 		return fmt.Errorf("app is not found")
 	}
-	app, err := client.GetApp(ctx, appName)
+	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/remove.go
+++ b/internal/command/machine/remove.go
@@ -64,7 +64,7 @@ func runMachineRemove(ctx context.Context) (err error) {
 		return fmt.Errorf("app was not found")
 	}
 
-	app, err := client.GetApp(ctx, appName)
+	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/start.go
+++ b/internal/command/machine/start.go
@@ -50,7 +50,7 @@ func runMachineStart(ctx context.Context) (err error) {
 	if appName == "" {
 		return errors.New("app is not found")
 	}
-	app, err := client.GetApp(ctx, appName)
+	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -54,7 +54,7 @@ func runMachineStatus(ctx context.Context) error {
 	if appName == "" {
 		return fmt.Errorf("app is not found")
 	}
-	app, err := client.GetApp(ctx, appName)
+	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/stop.go
+++ b/internal/command/machine/stop.go
@@ -79,7 +79,7 @@ func runMachineStop(ctx context.Context) (err error) {
 		if appName == "" {
 			return errors.New("app is not found")
 		}
-		app, err := client.GetApp(ctx, appName)
+		app, err := client.GetAppCompact(ctx, appName)
 		if err != nil {
 			return err
 		}

--- a/internal/command/services/postgres/launch.go
+++ b/internal/command/services/postgres/launch.go
@@ -255,7 +255,7 @@ func (p *Launch) configurePostgres() (*api.MachineConfig, error) {
 	return &machineConfig, nil
 }
 
-func (p *Launch) createApp(ctx context.Context) (*api.App, error) {
+func (p *Launch) createApp(ctx context.Context) (*api.AppCompact, error) {
 	fmt.Println("Creating app...")
 	appInput := api.CreateAppInput{
 		OrganizationID:  p.config.Organization.ID,
@@ -265,7 +265,23 @@ func (p *Launch) createApp(ctx context.Context) (*api.App, error) {
 		AppRoleID:       "postgres_cluster",
 	}
 
-	return p.client.CreateApp(ctx, appInput)
+	app, err := p.client.CreateApp(ctx, appInput)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.AppCompact{
+		ID:           app.ID,
+		Name:         app.Name,
+		Status:       app.Status,
+		Deployed:     app.Deployed,
+		Hostname:     app.Hostname,
+		AppURL:       app.AppURL,
+		Version:      app.Version,
+		Release:      app.Release,
+		Organization: app.Organization,
+		IPAddresses:  app.IPAddresses,
+	}, nil
 }
 
 func (p *Launch) setSecrets(ctx context.Context) (map[string]string, error) {

--- a/internal/command/services/postgres/update.go
+++ b/internal/command/services/postgres/update.go
@@ -45,7 +45,7 @@ func runUpdate(ctx context.Context) error {
 	client := client.FromContext(ctx).API()
 	io := iostreams.FromContext(ctx)
 
-	app, err := client.GetApp(ctx, appName)
+	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("get app: %w", err)
 	}
@@ -133,7 +133,7 @@ func runUpdate(ctx context.Context) error {
 	return nil
 }
 
-func updateMachine(ctx context.Context, app *api.App, machine *api.Machine, image string) error {
+func updateMachine(ctx context.Context, app *api.AppCompact, machine *api.Machine, image string) error {
 	var io = iostreams.FromContext(ctx)
 
 	flaps, err := flaps.New(ctx, app)

--- a/pkg/flaps/flaps.go
+++ b/pkg/flaps/flaps.go
@@ -21,13 +21,13 @@ import (
 )
 
 type Client struct {
-	app        *api.App
+	app        *api.AppCompact
 	peerIP     string
 	authToken  string
 	httpClient *http.Client
 }
 
-func New(ctx context.Context, app *api.App) (*Client, error) {
+func New(ctx context.Context, app *api.AppCompact) (*Client, error) {
 	client := client.FromContext(ctx).API()
 	agentclient, err := agent.Establish(ctx, client)
 	if err != nil {


### PR DESCRIPTION
Currently, the graphql query to get an App contains a lot of unnecessary data for what is needed for the machine commands. The following changes it to use the AppCompact query.