### PR TITLE
add hidden kernel-arg flag to machine run

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -1301,6 +1301,8 @@ type MachineGuest struct {
 	CPUKind  string `json:"cpu_kind"`
 	CPUs     int    `json:"cpus"`
 	MemoryMB int    `json:"memory_mb"`
+
+	KernelArgs []string `json:"kernel_args,omitempty"`
 }
 
 const (

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -144,7 +144,7 @@ func newRun() *cobra.Command {
 			Hidden:      true,
 		},
 		flag.StringSlice{
-			Name:        "kernel-args",
+			Name:        "kernel-arg",
 			Description: "List of kernel arguments to be provided to the init. Can be specified multiple times.",
 			Hidden:      true,
 		},

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -143,6 +143,11 @@ func newRun() *cobra.Command {
 			Description: "Do not use the cache when building the image",
 			Hidden:      true,
 		},
+		flag.StringSlice{
+			Name:        "kernel-args",
+			Description: "List of kernel arguments to be provided to the init. Can be specified multiple times.",
+			Hidden:      true,
+		},
 	)
 
 	cmd.Args = cobra.MinimumNArgs(1)
@@ -179,9 +184,10 @@ func runMachineRun(ctx context.Context) error {
 
 	machineConf := api.MachineConfig{
 		Guest: &api.MachineGuest{
-			CPUKind:  "shared",
-			CPUs:     1,
-			MemoryMB: 256,
+			CPUKind:    "shared",
+			CPUs:       1,
+			MemoryMB:   256,
+			KernelArgs: flag.GetStringSlice(ctx, "kernel-args"),
 		},
 	}
 


### PR DESCRIPTION
The following hidden flag can be useful to adjust certain parameters to the init to provide more debugging info.