### PR TITLE
Remove confusing app config CLI flag for machines

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -47,7 +47,6 @@ func newRun() *cobra.Command {
 	flag.Add(
 		cmd,
 		flag.App(),
-		flag.AppConfig(),
 		flag.Region(),
 		flag.String{
 			Name:        "id",


### PR DESCRIPTION
Machines don't support TOML config at all, and this option has been confusing people into thinking they do. So, remove for now.