### PR TITLE
Allow loading app names with the -a while disallowing usage of a TOML config

### DIFF
--- a/internal/flag/context.go
+++ b/internal/flag/context.go
@@ -96,5 +96,9 @@ func GetApp(ctx context.Context) string {
 
 // GetAppConfigFilePath is shorthand for GetString(ctx, AppConfigFilePathName).
 func GetAppConfigFilePath(ctx context.Context) string {
-	return GetString(ctx, AppConfigFilePathName)
+	if path, err := FromContext(ctx).GetString(AppConfigFilePathName); err != nil {
+		return ""
+	} else {
+		return path
+	}
 }


### PR DESCRIPTION
This fixes a bug where `fly machine run` would crash because it doesn't support the `-c` flag.