### PR TITLE
Allow deployments to display plain Docker build output

### DIFF
--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/cmdfmt"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/pkg/iostreams"
 	"github.com/superfly/flyctl/terminal"
@@ -317,7 +318,7 @@ func runBuildKitBuild(ctx context.Context, streams *iostreams.IOStreams, docker 
 			termFd, isTerm := term.GetFdInfo(os.Stderr)
 			tracer := newTracer()
 			var c2 console.Console
-			if io.ColorEnabled() {
+			if io.ColorEnabled() && !flag.GetBool(ctx, "plain") {
 				if cons, err := console.ConsoleFromFile(os.Stderr); err == nil {
 					c2 = cons
 				}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -88,6 +88,10 @@ func New() (cmd *cobra.Command) {
 			Name:        "nix",
 			Description: "Build with Nix",
 		},
+		flag.Bool{
+			Name:        "plain",
+			Description: "Display full Docker build output",
+		},
 	)
 
 	return


### PR DESCRIPTION
This expands on #991, allowing plain build output to be specified explicitly. This option sits closer to Docker's `--progress plain` than using `NO_COLOR=1`.