### PR TITLE
Revert "Allow deployments to display plain Docker build output"

### DIFF
--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/cmdfmt"
-	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/pkg/iostreams"
 	"github.com/superfly/flyctl/terminal"
@@ -318,7 +317,7 @@ func runBuildKitBuild(ctx context.Context, streams *iostreams.IOStreams, docker 
 			termFd, isTerm := term.GetFdInfo(os.Stderr)
 			tracer := newTracer()
 			var c2 console.Console
-			if io.ColorEnabled() && !flag.GetBool(ctx, "plain") {
+			if io.ColorEnabled() {
 				if cons, err := console.ConsoleFromFile(os.Stderr); err == nil {
 					c2 = cons
 				}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -88,10 +88,6 @@ func New() (cmd *cobra.Command) {
 			Name:        "nix",
 			Description: "Build with Nix",
 		},
-		flag.Bool{
-			Name:        "plain",
-			Description: "Display full Docker build output",
-		},
 	)
 
 	return


### PR DESCRIPTION
Reverts superfly/flyctl#992. `flyctl launch` uses the old CLI format and panics with this new flag in place. Fixes #993 