### PR TITLE
Avoid sending empty image_ref object when launching machine

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -1346,7 +1346,7 @@ type MachineConfig struct {
 	Env      map[string]string `json:"env"`
 	Init     MachineInit       `json:"init,omitempty"`
 	Image    string            `json:"image"`
-	ImageRef machineImageRef   `json:"image_ref"`
+	ImageRef *machineImageRef  `json:"image_ref,omitempty"`
 	Metadata map[string]string `json:"metadata"`
 	Mounts   []MachineMount    `json:"mounts,omitempty"`
 	Restart  MachineRestart    `json:"restart,omitempty"`


### PR DESCRIPTION
Before this change launching a machine would result in an unknown attr
error due to an empty image_ref object being sent.

```
unknown attribute 'image_ref' for machine config.
```

This change opens up to some potential nil ptr issues in the image show and postgres
server update commands if the apis do not properly respond with the image_ref prop.
I could add some nil checks, but didn't want to rock the boat too much in this change.