### PR TITLE
Allow specifying Buildkit build secrets on the command line

### DIFF
--- a/flyctl/app_config.go
+++ b/flyctl/app_config.go
@@ -331,6 +331,25 @@ func (ac *AppConfig) SetEnvVariables(vals map[string]string) {
 	ac.Definition["env"] = env
 }
 
+func (ac *AppConfig) SetBuildSecrets(vals map[string]string) {
+	var env map[string]string
+
+	if rawEnv, ok := ac.Definition["env"]; ok {
+		if castEnv, ok := rawEnv.(map[string]string); ok {
+			env = castEnv
+		}
+	}
+	if env == nil {
+		env = map[string]string{}
+	}
+
+	for k, v := range vals {
+		env[k] = v
+	}
+
+	ac.Definition["env"] = env
+}
+
 func (ac *AppConfig) SetReleaseCommand(cmd string) {
 	var deploy map[string]string
 

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/moby/buildkit/client"
+	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/moby/term"
 	"github.com/pkg/errors"
@@ -252,6 +253,14 @@ func runBuildKitBuild(ctx context.Context, streams *iostreams.IOStreams, docker 
 	if s == nil {
 		panic("buildkit not supported")
 	}
+
+	finalSecrets := make(map[string][]byte)
+
+	for k, v := range opts.BuildSecrets {
+		finalSecrets[k] = []byte(v)
+	}
+
+	s.Allow(secretsprovider.FromMap(finalSecrets))
 
 	eg, errCtx := errgroup.WithContext(ctx)
 

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -18,6 +18,7 @@ type ImageOptions struct {
 	ImageRef        string
 	BuildArgs       map[string]string
 	ExtraBuildArgs  map[string]string
+	BuildSecrets    map[string]string
 	ImageLabel      string
 	Publish         bool
 	Tag             string

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -77,6 +77,10 @@ func New() (cmd *cobra.Command) {
 			Name:        "build-target",
 			Description: "Set the target build stage to build if the Dockerfile has more than one stage",
 		},
+		flag.StringSlice{
+			Name:        "build-secret",
+			Description: "Set of build secrets of NAME=VALUE pairs. Can be specified multiple times. See https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information",
+		},
 		flag.Bool{
 			Name:        "no-cache",
 			Description: "Do not use the build cache when building the image",
@@ -230,6 +234,16 @@ func determineImage(ctx context.Context, appConfig *app.Config) (img *imgsrc.Dep
 		BuiltInSettings: build.Settings,
 		Builder:         build.Builder,
 		Buildpacks:      build.Buildpacks,
+	}
+
+	cliBuildSecrets, err := cmdutil.ParseKVStringsToMap(flag.GetStringSlice(ctx, "build-secret"))
+
+	if err != nil {
+		return
+	}
+
+	if cliBuildSecrets != nil {
+		opts.BuildSecrets = cliBuildSecrets
 	}
 
 	var buildArgs map[string]string


### PR DESCRIPTION
See: https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information

This implements the same behavior as `docker build --secret mysecret=test`. Note that changing build secrets requires rebuilding with `--no-cache` or busting cache with a build argument.