### PR TITLE
Support specifying Docker build targets with 'build-target' along with 'build_target'

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -168,7 +168,7 @@ func unmarshalBuild(data map[string]interface{}) *Build {
 			b.Image = fmt.Sprint(v)
 		case "dockerfile":
 			b.Dockerfile = fmt.Sprint(v)
-		case "build_target":
+		case "build_target", "build-target":
 			b.DockerBuildTarget = fmt.Sprint(v)
 		default:
 			b.Args[k] = fmt.Sprint(v)


### PR DESCRIPTION
`build-target` is what's documented, so we should support it. Fixes #1006 