### PR TITLE
fix merging -e env variables into config

### DIFF
--- a/flyctl/app_config.go
+++ b/flyctl/app_config.go
@@ -313,22 +313,31 @@ func (ac *AppConfig) GetInternalPort() (int, error) {
 }
 
 func (ac *AppConfig) SetEnvVariables(vals map[string]string) {
-	var env map[string]string
-
-	if rawEnv, ok := ac.Definition["env"]; ok {
-		if castEnv, ok := rawEnv.(map[string]string); ok {
-			env = castEnv
-		}
-	}
-	if env == nil {
-		env = map[string]string{}
-	}
+	env := ac.GetEnvVariables()
 
 	for k, v := range vals {
 		env[k] = v
 	}
 
 	ac.Definition["env"] = env
+}
+
+func (ac *AppConfig) GetEnvVariables() map[string]string {
+	env := map[string]string{}
+
+	if rawEnv, ok := ac.Definition["env"]; ok {
+		if castEnv, ok := rawEnv.(map[string]interface{}); ok {
+			for k, v := range castEnv {
+				if stringVal, ok := v.(string); ok {
+					env[k] = stringVal
+				} else {
+					env[k] = fmt.Sprintf("%v", v)
+				}
+			}
+		}
+	}
+
+	return env
 }
 
 func (ac *AppConfig) SetReleaseCommand(cmd string) {
@@ -390,17 +399,7 @@ func (ac *AppConfig) SetDockerEntrypoint(entrypoint string) {
 }
 
 func (ac *AppConfig) SetEnvVariable(name, value string) {
-	var env map[string]string
-
-	if rawEnv, ok := ac.Definition["env"]; ok {
-		if castEnv, ok := rawEnv.(map[string]string); ok {
-			env = castEnv
-		}
-	}
-
-	if env == nil {
-		env = map[string]string{}
-	}
+	env := ac.GetEnvVariables()
 
 	env[name] = value
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -313,16 +313,7 @@ func (c *Config) InternalPort() (int, error) {
 }
 
 func (c *Config) SetEnvVariables(vals map[string]string) {
-	var env map[string]string
-
-	if rawEnv, ok := c.Definition["env"]; ok {
-		if castEnv, ok := rawEnv.(map[string]string); ok {
-			env = castEnv
-		}
-	}
-	if env == nil {
-		env = map[string]string{}
-	}
+	env := c.GetEnvVariables()
 
 	for k, v := range vals {
 		env[k] = v
@@ -390,21 +381,29 @@ func (c *Config) SetDockerEntrypoint(entrypoint string) {
 }
 
 func (c *Config) SetEnvVariable(name, value string) {
-	var env map[string]string
-
-	if rawEnv, ok := c.Definition["env"]; ok {
-		if castEnv, ok := rawEnv.(map[string]string); ok {
-			env = castEnv
-		}
-	}
-
-	if env == nil {
-		env = map[string]string{}
-	}
+	env := c.GetEnvVariables()
 
 	env[name] = value
 
 	c.Definition["env"] = env
+}
+
+func (c *Config) GetEnvVariables() map[string]string {
+	env := map[string]string{}
+
+	if rawEnv, ok := c.Definition["env"]; ok {
+		if castEnv, ok := rawEnv.(map[string]interface{}); ok {
+			for k, v := range castEnv {
+				if stringVal, ok := v.(string); ok {
+					env[k] = stringVal
+				} else {
+					env[k] = fmt.Sprintf("%v", v)
+				}
+			}
+		}
+	}
+
+	return env
 }
 
 func (c *Config) SetProcess(name, value string) {


### PR DESCRIPTION
Wrong type checks caused existing env to always get overwritten. Anything from the "env" map gets converted from `map[string]interface{}` to `map[string]string` before deploy-time env variables are set.

Fixes #560 