### PR TITLE
Fix release strategy bug on deploy

### DIFF
--- a/api/resource_releases.go
+++ b/api/resource_releases.go
@@ -49,6 +49,7 @@ func (c *Client) GetAppRelease(ctx context.Context, appName string, id string) (
 					status
 					evaluationId
 					createdAt
+					deploymentStrategy
 				}
 			}
 		}


### PR DESCRIPTION
In `internal/deploy/deploy.go`, if `release.DeploymentStrategy == 'IMMEDIATE'`, the [deploy ends](https://github.com/superfly/flyctl/blob/d58c53243dc6446016cce9d1d457807cbcacf074/internal/command/deploy/deploy.go#L140) without monitoring. However, if a release command is run, `release` is overridden [here](https://github.com/superfly/flyctl/blob/d58c53243dc6446016cce9d1d457807cbcacf074/internal/command/deploy/deploy.go#L134), and the `DeploymentStrategy` property isn't copied over. As a result, the deploy continues to persist, and will eventually fail once the deployment ends, causing CI builds to be marked red.

This diff adds `DeploymentStrategy` to the query that generates `release` in `api/resource_releases.go`. I used the same syntax as the [query used to generate the first `release`](https://github.com/superfly/flyctl/blob/d58c53243dc6446016cce9d1d457807cbcacf074/api/resource_deploy.go#L5). I tested it as follows:
1. Verify that the issue on the main branch exists by logging `release.DeploymentStrategy` before and after line 134, noting that it is set before line 134 and erased after.
2. Apply the commit.
3. Verify that the issue no longer exists by logging `release.DeploymentStrategy` before and after line 134, and observing that it is set in both places.
4. Verify that the job does indeed terminate when `--strategy immediate` is passed in via CLI.