### PR TITLE
Machines: support VM size configuration in fly.toml

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -105,7 +105,7 @@ func DeployWithConfig(ctx context.Context, appConfig *app.Config) (err error) {
 	var release *api.Release
 	var releaseCommand *api.ReleaseCommand
 
-	if appConfig.Version >= app.MachinesVersion {
+	if appConfig.PlatformVersion >= app.MachinesVersion {
 		return createMachinesRelease(ctx, appConfig, img)
 	} else {
 		release, releaseCommand, err = createRelease(ctx, appConfig, img)

--- a/internal/command/machine/launch.go
+++ b/internal/command/machine/launch.go
@@ -127,13 +127,18 @@ func run(ctx context.Context) (err error) {
 
 	// TODO: Handle imported fly.toml config
 
-	// Setup new fly.toml config file
+	// Setup new fly.toml config file with default values
 
 	appConfig := app.NewConfig()
 
 	// Config version 2 is for machine apps
-	appConfig.Version = app.MachinesVersion
+	appConfig.PlatformVersion = app.MachinesVersion
 	appConfig.AppName = createdApp.Name
+
+	appConfig.VM = &app.VM{
+		CpuCount: 1,
+		Memory:   256,
+	}
 
 	// Launch in the specified region, or when not specified, in the nearest region
 	regionCode := flag.GetString(ctx, "region")


### PR DESCRIPTION
* Remove machine leasing for updates on deploy, since leases prevent direct updates
* Add Vm size configuration to fly.toml
* Rename 'version' to 'platform_version' in fly.toml to avoid confusion with release versions