### PR TITLE
fix type checks on GetEnvVariables

### DIFF
--- a/flyctl/app_config_test.go
+++ b/flyctl/app_config_test.go
@@ -1,6 +1,7 @@
 package flyctl
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -53,4 +54,27 @@ func TestLoadTOMLAppConfigWithServices(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, p.Definition, rawData)
+}
+
+func TestGetAndSetEnvVariables(t *testing.T) {
+	cfg := NewAppConfig()
+
+	cfg.SetEnvVariable("A", "B")
+	cfg.SetEnvVariable("C", "D")
+
+	assert.Equal(t, map[string]string{"A": "B", "C": "D"}, cfg.GetEnvVariables())
+
+	buf := &bytes.Buffer{}
+
+	if err := cfg.WriteTo(buf, TOMLFormat); err != nil {
+		assert.NoError(t, err)
+	}
+
+	cfg2 := NewAppConfig()
+
+	if err := cfg2.unmarshalTOML(bytes.NewReader(buf.Bytes())); err != nil {
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, cfg.GetEnvVariables(), cfg2.GetEnvVariables())
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAndSetEnvVariables(t *testing.T) {
+	cfg := NewConfig()
+
+	cfg.SetEnvVariable("A", "B")
+	cfg.SetEnvVariable("C", "D")
+
+	assert.Equal(t, map[string]string{"A": "B", "C": "D"}, cfg.GetEnvVariables())
+
+	buf := &bytes.Buffer{}
+
+	if err := cfg.EncodeTo(buf); err != nil {
+		assert.NoError(t, err)
+	}
+
+	cfg2 := NewConfig()
+
+	if err := cfg2.unmarshalTOML(bytes.NewReader(buf.Bytes())); err != nil {
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, cfg.GetEnvVariables(), cfg2.GetEnvVariables())
+}


### PR DESCRIPTION
handle both `map[string]interface` from TOML unmarshaling and `map[string]string` from `SetEnvVariables`