### PR TITLE
Laravel Launcher improvements

### DIFF
--- a/internal/sourcecode/scan.go
+++ b/internal/sourcecode/scan.go
@@ -625,9 +625,10 @@ func configureLaravel(sourceDir string) (*SourceInfo, error) {
 
 	s := &SourceInfo{
 		Env: map[string]string{
-			"APP_ENV":     "production",
-			"LOG_CHANNEL": "stderr",
-			"LOG_LEVEL":   "info",
+			"APP_ENV":              "production",
+			"LOG_CHANNEL":          "stderr",
+			"LOG_LEVEL":            "info",
+			"LOG_STDERR_FORMATTER": "Monolog\\Formatter\\JsonFormatter",
 		},
 		Family: "Laravel",
 		Files:  files,

--- a/internal/sourcecode/templates/laravel/common/.dockerignore
+++ b/internal/sourcecode/templates/laravel/common/.dockerignore
@@ -1,32 +1,23 @@
 # excludes from the docker image/build
 
-# 1. Ignore everything (ensures don't upload .git, .env etc)
-**
+# 1. Ignore Laravel-specific files we don't need
+bootstrap/cache/*
+storage/framework/cache/*
+storage/framework/sessions/*
+storage/framework/views/*
+storage/logs/*
+*.env*
 .rr.yml
 rr
 
-# 2. Allow files and directories
-!app/**
-!bootstrap/**
-!config/**
-!database/**
-!docker/**
-!lang/**
-!public/**
-!resources/**
-!routes/**
-!storage/app/**
-!storage/framework/cache/**
-!storage/framework/sessions/**
-!storage/framework/views/**
-!artisan
-!composer.json
-!composer.lock
-!package.json
-!package-lock.json
-!webpack.mix.js
-
-# 3. Ignore unnecessary files that may be inside those allowed directories
+# 2. Ignore common files/directories we don't need
+.vscode
+.idea
+**/*node_modules
+**.git
+**.gitignore
+**.gitattributes
+**.sass-cache
 **/*~
 **/*.log
 **/.DS_Store

--- a/internal/sourcecode/templates/laravel/common/Dockerfile
+++ b/internal/sourcecode/templates/laravel/common/Dockerfile
@@ -42,7 +42,8 @@ RUN composer update \
     && mv docker/supervisor.conf /etc/supervisord.conf \
     && mv docker/nginx.conf /etc/nginx/nginx.conf \
     && mv docker/server.conf /etc/nginx/server.conf \
-    && mv docker/php.ini /etc/php8/conf.d/php.ini
+    && mv docker/php.ini /etc/php8/conf.d/php.ini \
+    && sed -i 's/protected \$proxies/protected \$proxies = "*"/g' app/Http/Middleware/TrustProxies.php
 
 # If we're not using Octane, configure php-fpm
 RUN if ! grep -Fq "laravel/octane" /var/www/html/composer.json; then \

--- a/internal/sourcecode/templates/laravel/common/Dockerfile
+++ b/internal/sourcecode/templates/laravel/common/Dockerfile
@@ -33,7 +33,9 @@ WORKDIR /var/www/html
 COPY . /var/www/html
 
 # Install dependencies, configure server
-RUN composer install --optimize-autoloader --no-dev \
+# For the time being, we run "composer update" as best effort to get php 8.0 working
+RUN composer update \
+    && composer install --optimize-autoloader --no-dev \
     && mkdir -p storage/logs \
     && chown -R app:app /var/www/html \
     && /usr/bin/crontab docker/crontab \

--- a/internal/sourcecode/templates/laravel/common/Dockerfile
+++ b/internal/sourcecode/templates/laravel/common/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:edge as base
 LABEL fly_launch_runtime="laravel"
 
 RUN apk update \
-    && apk add curl zip unzip tzdata supervisor nginx htop vim ca-certificates \
+    && apk add curl zip unzip tzdata supervisor nginx htop vim ca-certificates rsync \
            php8           php8-cli        php8-pecl-mcrypt \
            php8-soap      php8-openssl    php8-gmp \
            php8-pdo_odbc  php8-json       php8-dom \
@@ -33,7 +33,7 @@ WORKDIR /var/www/html
 COPY . /var/www/html
 
 # Install dependencies, configure server
-RUN composer update && composer install --optimize-autoloader --no-dev \
+RUN composer install --optimize-autoloader --no-dev \
     && mkdir -p storage/logs \
     && chown -R app:app /var/www/html \
     && /usr/bin/crontab docker/crontab \
@@ -78,7 +78,9 @@ RUN if [ -f "yarn.lock" ]; then \
 # Create final container, adding in static assets
 FROM base
 
-COPY --from=node_modules_go_brrr /app/public /var/www/html/public
+COPY --from=node_modules_go_brrr /app/public /var/www/html/public-npm
+RUN rsync -ar /var/www/html/public-npm/ /var/www/html/public/ \
+    && rm -rf /var/www/html/public-npm
 
 # The same port nginx.conf is set to listen on and fly.toml references (standard is 8080)
 EXPOSE 8080


### PR DESCRIPTION
1. We previously stomped on the `public` directory, which may have contained assets from 3rd party packages. Now we sync the directories resulting from static asset generation (`npm run production`) and PHP packages `composer install`)
2. `.dockerignore` (despite the mis-typed commit msg)  now blacklists directories/files instead of whitelists them, which will cause less issues when people have custom files/directories they needed but were not whitelisted
3. We use `composer update` as a best-effort attempt to install Composer packages for php8.0, the php version we default to. If/when we detect PHP versions in the future, we should call `composer install` only
4. We need to set Laravel's "trusted proxy" middleware to trust Fly Proxy, and thus generate URL's correctly with `https://` 
5. Logs are formatted as JSON instead of single lines that pollute the log output due to how PHP-FPM captures logs one line at a time