### PR TITLE
feat: Add role to machine config type declaration

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -1432,6 +1432,7 @@ type MachineConfig struct {
 	Services []MachineService  `json:"services,omitempty"`
 	VMSize   string            `json:"size,omitempty"`
 	Guest    *MachineGuest     `json:"guest,omitempty"`
+	Role     string            `json:"role,omitempty"`
 }
 
 type DeleteOrganizationMembershipPayload struct {


### PR DESCRIPTION
Add role to machine config, currently we aren't using it for anything but eventually we'll use it to keep track of machines that serve different purposes i.e. serving web requests vs running background jobs