### PR TITLE
Fix flytoml services port type

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -1410,15 +1410,15 @@ var MachinePresets map[string]*MachineGuest = map[string]*MachineGuest{
 }
 
 type MachinePort struct {
-	Port       int      `json:"port,required" toml:"port"`
-	Handlers   []string `json:"handlers,omitempty" toml:"handlers,omitempty"`
-	ForceHttps bool     `json:"force_https,omitempty" toml:"force_https,omitempty"`
+	Port       int      `json:"port"`
+	Handlers   []string `json:"handlers,omitempty"`
+	ForceHttps bool     `json:"force_https,omitempty"`
 }
 
 type MachineService struct {
-	Protocol     string        `json:"protocol,required" toml:"protocol"`
-	InternalPort int           `json:"internal_port,required" toml:"internal_port"`
-	Ports        []MachinePort `json:"ports" toml:"ports"`
+	Protocol     string        `json:"protocol"`
+	InternalPort int           `json:"internal_port"`
+	Ports        []MachinePort `json:"ports"`
 }
 
 type MachineConfig struct {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/go-playground/validator/v10"
-	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/sourcecode"
 )
@@ -62,13 +61,11 @@ type Config struct {
 	AppName         string                 `toml:"app,omitempty"`
 	Build           *Build                 `toml:"build,omitempty"`
 	PlatformVersion int                    `toml:"platform_version,omitempty"`
+	PrimaryRegion   string                 `toml:"primary_region,omitempty"`
 	HttpService     *HttpService           `toml:"http_service,omitempty"`
 	VM              *VM                    `toml:"vm,omitempty"`
 	Definition      map[string]interface{} `toml:"definition,omitempty"`
 	Path            string                 `toml:"path,omitempty"`
-	Services        []api.MachineService   `toml:"services"`
-	// PrimaryRegion is only used for temporarily storing the target region for a new CM
-	PrimaryRegion string
 }
 type HttpService struct {
 	InternalPort int  `json:"internal_port" toml:"internal_port" validate:"required,numeric"`


### PR DESCRIPTION
Reverts https://github.com/superfly/flyctl/commit/6de2559f7f7d7b7073de20fcee5f20b0a9a96ce7 & https://github.com/superfly/flyctl/commit/ed2cf44f5eb44adae2ccbee435f45c9840e94cb5 

seemingly toml annotation on MachinePort caused typing to be more strict