### PR TITLE
Machines: detect machine platform and implement rolling deployments

### DIFF
--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -230,6 +230,7 @@ func (client *Client) GetAppBasic(ctx context.Context, appName string) (*AppBasi
 			appbasic:app(name: $appName) {
 				id
 				name
+				platformVersion
 				organization {
 					id
 					slug

--- a/api/types.go
+++ b/api/types.go
@@ -441,9 +441,10 @@ type AppInfo struct {
 }
 
 type AppBasic struct {
-	ID           string
-	Name         string
-	Organization *OrganizationBasic
+	ID              string
+	Name            string
+	PlatformVersion string
+	Organization    *OrganizationBasic
 }
 
 type AppMonitoring struct {

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -10,7 +11,7 @@ import (
 func TestLoadTOMLAppConfigWithAppName(t *testing.T) {
 	const path = "./testdata/app-name.toml"
 
-	p, err := LoadConfig(path)
+	p, err := LoadConfig(context.Background(), path, NomadPlatform)
 	assert.NoError(t, err)
 	assert.Equal(t, p.AppName, "test-app")
 }
@@ -18,7 +19,7 @@ func TestLoadTOMLAppConfigWithAppName(t *testing.T) {
 func TestLoadTOMLAppConfigWithBuilderName(t *testing.T) {
 	const path = "./testdata/build.toml"
 
-	p, err := LoadConfig(path)
+	p, err := LoadConfig(context.Background(), path, NomadPlatform)
 	assert.NoError(t, err)
 	assert.Equal(t, p.Build.Builder, "builder/name")
 }
@@ -26,7 +27,7 @@ func TestLoadTOMLAppConfigWithBuilderName(t *testing.T) {
 func TestLoadTOMLAppConfigWithImage(t *testing.T) {
 	const path = "./testdata/image.toml"
 
-	p, err := LoadConfig(path)
+	p, err := LoadConfig(context.Background(), path, NomadPlatform)
 	assert.NoError(t, err)
 	assert.Equal(t, p.Build.Image, "image/name")
 }
@@ -34,7 +35,7 @@ func TestLoadTOMLAppConfigWithImage(t *testing.T) {
 func TestLoadTOMLAppConfigWithDockerfile(t *testing.T) {
 	const path = "./testdata/docker.toml"
 
-	p, err := LoadConfig(path)
+	p, err := LoadConfig(context.Background(), path, NomadPlatform)
 	assert.NoError(t, err)
 	assert.Equal(t, p.Build.Dockerfile, "./Dockerfile")
 }
@@ -42,14 +43,14 @@ func TestLoadTOMLAppConfigWithDockerfile(t *testing.T) {
 func TestLoadTOMLAppConfigWithBuilderNameAndArgs(t *testing.T) {
 	const path = "./testdata/build-with-args.toml"
 
-	p, err := LoadConfig(path)
+	p, err := LoadConfig(context.Background(), path, NomadPlatform)
 	assert.NoError(t, err)
 	assert.Equal(t, p.Build.Args, map[string]string{"A": "B", "C": "D"})
 }
 
 func TestLoadTOMLAppConfigWithServices(t *testing.T) {
 	const path = "./testdata/services.toml"
-	p, err := LoadConfig(path)
+	p, err := LoadConfig(context.Background(), path, NomadPlatform)
 
 	rawData := map[string]interface{}{}
 	toml.DecodeFile("./testdata/services.toml", &rawData)

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -444,7 +444,7 @@ func LoadAppConfigIfPresent(ctx context.Context) (context.Context, error) {
 	logger := logger.FromContext(ctx)
 
 	for _, path := range appConfigFilePaths(ctx) {
-		switch cfg, err := app.LoadConfig(path); {
+		switch cfg, err := app.LoadConfig(ctx, path, ""); {
 		case err == nil:
 			logger.Debugf("app config loaded from %s", path)
 

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -105,7 +105,7 @@ func DeployWithConfig(ctx context.Context, appConfig *app.Config) (err error) {
 	var release *api.Release
 	var releaseCommand *api.ReleaseCommand
 
-	if appConfig.PlatformVersion >= app.MachinesVersion {
+	if appConfig.ForMachines() {
 		return createMachinesRelease(ctx, appConfig, img)
 	} else {
 		release, releaseCommand, err = createRelease(ctx, appConfig, img)

--- a/internal/command/machine/launch.go
+++ b/internal/command/machine/launch.go
@@ -132,13 +132,8 @@ func run(ctx context.Context) (err error) {
 	appConfig := app.NewConfig()
 
 	// Config version 2 is for machine apps
-	appConfig.PlatformVersion = app.MachinesVersion
+	appConfig.SetMachinesPlatform()
 	appConfig.AppName = createdApp.Name
-
-	appConfig.VM = &app.VM{
-		CpuCount: 1,
-		Memory:   256,
-	}
 
 	// Launch in the specified region, or when not specified, in the nearest region
 	regionCode := flag.GetString(ctx, "region")
@@ -153,7 +148,7 @@ func run(ctx context.Context) (err error) {
 		regionCode = region.Code
 	}
 
-	appConfig.PrimaryRegion = regionCode
+	appConfig.SetPrimaryRegion(regionCode)
 
 	var srcInfo *sourcecode.SourceInfo
 
@@ -383,10 +378,11 @@ func setScannerPrefs(ctx context.Context, appConfig *app.Config, srcInfo *source
 				return err
 			}
 
+			region := appConfig.GetPrimaryRegion()
 			volume, err := client.CreateVolume(ctx, api.CreateVolumeInput{
 				AppID:     appID,
 				Name:      vol.Source,
-				Region:    appConfig.PrimaryRegion,
+				Region:    region,
 				SizeGb:    1,
 				Encrypted: true,
 			})
@@ -394,7 +390,7 @@ func setScannerPrefs(ctx context.Context, appConfig *app.Config, srcInfo *source
 			if err != nil {
 				return err
 			} else {
-				fmt.Printf("Created a %dGB volume %s in the %s region\n", volume.SizeGb, volume.ID, appConfig.PrimaryRegion)
+				fmt.Printf("Created a %dGB volume %s in the %s region\n", volume.SizeGb, volume.ID, region)
 			}
 
 		}


### PR DESCRIPTION
Machine deploys now wait for the VM to update successfully before continuing, effectively resulting in rolling deployments.

Also, the app platform is detected through the API so the config need not indicate its own version, though we may want that in the future.