### PR TITLE
Ensure that machines deployment without a fly.toml still works

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -120,6 +120,10 @@ func (c *Config) SetNomadPlatform() {
 	c.platformVersion = NomadPlatform
 }
 
+func (c *Config) SetPlatformVersion(platform string) {
+	c.platformVersion = platform
+}
+
 // ForMachines is true when the config is intended for the machines platform
 func (c *Config) ForMachines() bool {
 	return c.platformVersion == MachinesPlatform

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -163,13 +163,21 @@ func determineAppConfig(ctx context.Context) (cfg *app.Config, err error) {
 		var apiConfig *api.AppConfig
 		if apiConfig, err = client.GetConfig(ctx, app.NameFromContext(ctx)); err != nil {
 			err = fmt.Errorf("failed fetching existing app config: %w", err)
-
 			return
+		}
+
+		basicApp, err := client.GetAppBasic(ctx, app.NameFromContext(ctx))
+
+		if err != nil {
+			return nil, err
 		}
 
 		cfg = &app.Config{
 			Definition: apiConfig.Definition,
 		}
+
+		cfg.AppName = basicApp.Name
+		cfg.SetPlatformVersion(basicApp.PlatformVersion)
 	}
 
 	if env := flag.GetStringSlice(ctx, "env"); len(env) > 0 {


### PR DESCRIPTION
Deploying only with `-a` works, for example, with `-i`. But all other config on machines is removed. If we care about this, we can fetch the existing machine config and merge.