### PR TITLE
WIP: Blue-green deploys for machine apps

### DIFF
--- a/pkg/machines/machines.go
+++ b/pkg/machines/machines.go
@@ -1,0 +1,27 @@
+package machines
+
+import (
+	"context"
+
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/pkg/flaps"
+)
+
+type MachineApp struct {
+	FlapsClient *flaps.Client
+	VMs         []*api.V1Machine
+}
+
+func NewMachineApp(ctx context.Context, app *api.AppCompact) (ma *MachineApp, err error) {
+	flapsClient, err := flaps.New(ctx, app)
+
+	ma = &MachineApp{
+		FlapsClient: flapsClient,
+	}
+
+	return ma, err
+}
+
+// func (ma *MachineApp) Lease(strategy string)
+// func (ma *MachineApp) Deploy(strategy string)
+// func (ma *MachineApp) Release(strategy string)


### PR DESCRIPTION
This PR aims to implement blue-green deploys, and along the way, better encapsulate operations intended to be performed on groups of machines (leasing, deployment, etc).