### PR TITLE
Allow running commands against individual machines without an app name from context

### DIFF
--- a/api/resource_machines.go
+++ b/api/resource_machines.go
@@ -1,0 +1,31 @@
+package api
+
+import "context"
+
+func (client *Client) GetMachine(ctx context.Context, machineId string) (*GqlMachine, error) {
+	query := `
+		query ($machineId: String!) {
+			gqlmachine:machine(machineId: $machineId) {
+				id
+				name
+				app {
+					name
+					organization {
+						id
+						slug
+					}
+				}
+			}
+		}
+	`
+
+	req := client.NewRequest(query)
+	req.Var("machineId", machineId)
+
+	data, err := client.RunWithContext(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data.GqlMachine, nil
+}

--- a/api/types.go
+++ b/api/types.go
@@ -23,6 +23,7 @@ type Query struct {
 	AppCertsCompact      AppCertsCompact
 	CurrentUser          User
 	PersonalOrganization Organization
+	GqlMachine           GqlMachine
 	Organizations        struct {
 		Nodes []Organization
 	}
@@ -1225,7 +1226,7 @@ type GqlMachine struct {
 	Region string
 	Config MachineConfig
 
-	App *App
+	App *AppCompact
 
 	IPs struct {
 		Nodes []*MachineIP

--- a/internal/command/machine/kill.go
+++ b/internal/command/machine/kill.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/app"
-	"github.com/superfly/flyctl/internal/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/iostreams"
@@ -40,16 +39,12 @@ func newKill() *cobra.Command {
 func runMachineKill(ctx context.Context) (err error) {
 	var (
 		appName   = app.NameFromContext(ctx)
-		client    = client.FromContext(ctx).API()
 		machineID = flag.FirstArg(ctx)
 		io        = iostreams.FromContext(ctx)
 	)
 
-	if appName == "" {
-		return fmt.Errorf("app was not found")
-	}
+	app, err := appFromMachineOrName(ctx, machineID, appName)
 
-	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/machine.go
+++ b/internal/command/machine/machine.go
@@ -1,7 +1,11 @@
 package machine
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/internal/client"
 	"github.com/superfly/flyctl/internal/command"
 )
 
@@ -33,4 +37,21 @@ func New() *cobra.Command {
 
 	return cmd
 
+}
+
+func appFromMachineOrName(ctx context.Context, machineId string, appName string) (app *api.AppCompact, err error) {
+
+	client := client.FromContext(ctx).API()
+
+	if appName == "" {
+		machine, err := client.GetMachine(ctx, machineId)
+		if err != nil {
+			return nil, err
+		}
+		app = machine.App
+	} else {
+		app, err = client.GetAppCompact(ctx, appName)
+	}
+
+	return app, err
 }

--- a/internal/command/machine/remove.go
+++ b/internal/command/machine/remove.go
@@ -9,7 +9,6 @@ import (
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/app"
-	"github.com/superfly/flyctl/internal/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/iostreams"
@@ -49,7 +48,6 @@ func newRemove() *cobra.Command {
 func runMachineRemove(ctx context.Context) (err error) {
 	var (
 		appName   = app.NameFromContext(ctx)
-		client    = client.FromContext(ctx).API()
 		out       = iostreams.FromContext(ctx).Out
 		machineID = flag.FirstArg(ctx)
 		input     = api.RemoveMachineInput{
@@ -59,11 +57,8 @@ func runMachineRemove(ctx context.Context) (err error) {
 		}
 	)
 
-	if appName == "" {
-		return fmt.Errorf("app was not found")
-	}
+	app, err := appFromMachineOrName(ctx, machineID, appName)
 
-	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/start.go
+++ b/internal/command/machine/start.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/app"
-	"github.com/superfly/flyctl/internal/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/iostreams"
@@ -43,18 +41,14 @@ func runMachineStart(ctx context.Context) (err error) {
 		out       = iostreams.FromContext(ctx).Out
 		appName   = app.NameFromContext(ctx)
 		machineID = flag.FirstArg(ctx)
-		client    = client.FromContext(ctx).API()
 	)
 
-	if appName == "" {
-		return errors.New("app is not found")
-	}
-	app, err := client.GetAppCompact(ctx, appName)
+	app, err := appFromMachineOrName(ctx, machineID, appName)
+
 	if err != nil {
-		return err
+		return
 	}
 
-	//machine, err := client.StartMachine(ctx, input)
 	flapsClient, err := flaps.New(ctx, app)
 	if err != nil {
 		return fmt.Errorf("could not make flaps client: %w", err)

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/app"
-	"github.com/superfly/flyctl/internal/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
@@ -49,8 +48,7 @@ func newStatus() *cobra.Command {
 
 func runMachineStatus(ctx context.Context) (err error) {
 	var (
-		io     = iostreams.FromContext(ctx)
-		client = client.FromContext(ctx).API()
+		io = iostreams.FromContext(ctx)
 	)
 
 	var (
@@ -58,14 +56,12 @@ func runMachineStatus(ctx context.Context) (err error) {
 		machineID = flag.FirstArg(ctx)
 	)
 
-	// flaps client
-	if appName == "" {
-		return fmt.Errorf("app is not found")
-	}
-	app, err := client.GetAppCompact(ctx, appName)
+	app, err := appFromMachineOrName(ctx, machineID, appName)
+
 	if err != nil {
 		return err
 	}
+
 	flapsClient, err := flaps.New(ctx, app)
 	if err != nil {
 		return fmt.Errorf("could not make flaps client: %w", err)

--- a/internal/command/machine/stop.go
+++ b/internal/command/machine/stop.go
@@ -7,12 +7,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/app"
-	"github.com/superfly/flyctl/internal/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/iostreams"
@@ -57,7 +55,6 @@ func runMachineStop(ctx context.Context) (err error) {
 		args    = flag.Args(ctx)
 		out     = iostreams.FromContext(ctx).Out
 		appName = app.NameFromContext(ctx)
-		client  = client.FromContext(ctx).API()
 	)
 
 	for _, arg := range args {
@@ -76,13 +73,8 @@ func runMachineStop(ctx context.Context) (err error) {
 			Filters: &api.Filters{},
 		}
 
-		if appName == "" {
-			return errors.New("app is not found")
-		}
-		app, err := client.GetAppCompact(ctx, appName)
-		if err != nil {
-			return err
-		}
+		app, err := appFromMachineOrName(ctx, arg, appName)
+
 		flapsClient, err := flaps.New(ctx, app)
 		if err != nil {
 			return fmt.Errorf("could not make flaps client: %w", err)


### PR DESCRIPTION
This simplifies working with lots of different apps and machines, at the expense of an extra round trip to the graphql API.