### PR TITLE
Secret generation uses closure, allowing for custom logic

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -326,7 +326,6 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 			// If a secret should be a random default, just generate it without displaying
 			// Otherwise, prompt to type it in
 			if secret.Generate != nil {
-				// // helpers.RandString(64)
 				if val, err = secret.Generate(); err != nil {
 					return fmt.Errorf("could not generate random string: %w", err)
 				}

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -325,8 +325,9 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 
 			// If a secret should be a random default, just generate it without displaying
 			// Otherwise, prompt to type it in
-			if secret.Generate {
-				if val, err = helpers.RandString(64); err != nil {
+			if secret.Generate != nil {
+				// // helpers.RandString(64)
+				if val, err = secret.Generate(); err != nil {
 					return fmt.Errorf("could not generate random string: %w", err)
 				}
 

--- a/helpers/rand.go
+++ b/helpers/rand.go
@@ -4,6 +4,8 @@ package helpers
 import (
 	"crypto/rand"
 	"math/big"
+	mrand "math/rand"
+	"time"
 )
 
 const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -25,4 +27,15 @@ func RandString(n int) (string, error) {
 	}
 
 	return string(b), nil
+}
+
+// RandBytes generates random bytes of a given length
+// See: https://stackoverflow.com/questions/35781197/generating-a-random-fixed-length-byte-array-in-go
+func RandBytes(n int) ([]byte, error) {
+	mrand.Seed(time.Now().UnixNano())
+	token := make([]byte, n)
+	// Always returns nil for error
+	mrand.Read(token)
+
+	return token, nil
 }

--- a/internal/command/machine/launch.go
+++ b/internal/command/machine/launch.go
@@ -333,8 +333,9 @@ func setScannerPrefs(ctx context.Context, appConfig *app.Config, srcInfo *source
 
 			// If a secret should be a random default, just generate it without displaying
 			// Otherwise, prompt to type it in
-			if secret.Generate {
-				if val, err = helpers.RandString(64); err != nil {
+			if secret.Generate != nil {
+				// helpers.RandString(64)
+				if val, err = secret.Generate(); err != nil {
 					return fmt.Errorf("could not generate random string: %w", err)
 				}
 

--- a/internal/command/machine/launch.go
+++ b/internal/command/machine/launch.go
@@ -334,7 +334,6 @@ func setScannerPrefs(ctx context.Context, appConfig *app.Config, srcInfo *source
 			// If a secret should be a random default, just generate it without displaying
 			// Otherwise, prompt to type it in
 			if secret.Generate != nil {
-				// helpers.RandString(64)
 				if val, err = secret.Generate(); err != nil {
 					return fmt.Errorf("could not generate random string: %w", err)
 				}


### PR DESCRIPTION
This allows us to add some custom logic for secret generation for both `fly launch` and `fly machine launch`.

Updated Secret struct:

```go
type Secret struct {
	Key      string
	Help     string
	Value    string
	Generate func() (string, error) // No longer bool
}
```

Code change example:

Before:

```go
s := &SourceInfo{
	Secrets: []Secret{
		{
				Key:  "APP_KEY",
				Help: "Laravel needs a unique application key.",
				Generate: true,
			},
		},
}
```

After:

```go
s := &SourceInfo{
	Secrets: []Secret{
		{
				Key:  "APP_KEY",
				Help: "Laravel needs a unique application key.",
				Generate: func() (string, error) {
					// Method used in RandBytes never returns an error
					r, _ := helpers.RandBytes(32)
					return "base64:" + base64.StdEncoding.EncodeToString(r), nil
				},
			},
		},
}
```