### PR TITLE
Extend volume

### DIFF
--- a/api/resource_volumes.go
+++ b/api/resource_volumes.go
@@ -85,6 +85,7 @@ func (c *Client) ExtendVolume(ctx context.Context, input ExtendVolumeInput) (*Ap
 			extendVolume(input: $input) {
 				app {
 					name
+					platformVersion
 				}
 				volume {
 					id

--- a/api/resource_volumes.go
+++ b/api/resource_volumes.go
@@ -1,6 +1,8 @@
 package api
 
-import "context"
+import (
+	"context"
+)
 
 func (c *Client) GetVolumes(ctx context.Context, appName string) ([]Volume, error) {
 	query := `
@@ -75,6 +77,43 @@ func (c *Client) CreateVolume(ctx context.Context, input CreateVolumeInput) (*Vo
 	}
 
 	return &data.CreateVolume.Volume, nil
+}
+
+func (c *Client) ExtendVolume(ctx context.Context, input ExtendVolumeInput) (*App, *Volume, error) {
+	query := `
+		mutation($input: ExtendVolumeInput!) {
+			extendVolume(input: $input) {
+				app {
+					name
+				}
+				volume {
+					id
+					name
+					app{
+						name
+					}
+					region
+					sizeGb
+					encrypted
+					createdAt
+					host {
+						id
+					}
+				}
+			}
+		}
+	`
+
+	req := c.NewRequest(query)
+
+	req.Var("input", input)
+
+	data, err := c.RunWithContext(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &data.ExtendVolume.App, &data.ExtendVolume.Volume, nil
 }
 
 func (c *Client) DeleteVolume(ctx context.Context, volID string) (App *App, err error) {

--- a/api/resource_volumes.go
+++ b/api/resource_volumes.go
@@ -79,7 +79,7 @@ func (c *Client) CreateVolume(ctx context.Context, input CreateVolumeInput) (*Vo
 	return &data.CreateVolume.Volume, nil
 }
 
-func (c *Client) ExtendVolume(ctx context.Context, input ExtendVolumeInput) (*App, *Volume, error) {
+func (c *Client) ExtendVolume(ctx context.Context, input ExtendVolumeInput) (*Volume, error) {
 	query := `
 		mutation($input: ExtendVolumeInput!) {
 			extendVolume(input: $input) {
@@ -111,10 +111,10 @@ func (c *Client) ExtendVolume(ctx context.Context, input ExtendVolumeInput) (*Ap
 
 	data, err := c.RunWithContext(ctx, req)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return &data.ExtendVolume.App, &data.ExtendVolume.Volume, nil
+	return &data.ExtendVolume.Volume, nil
 }
 
 func (c *Client) DeleteVolume(ctx context.Context, volID string) (App *App, err error) {

--- a/api/types.go
+++ b/api/types.go
@@ -169,6 +169,7 @@ type Query struct {
 
 	CreateVolume CreateVolumePayload
 	DeleteVolume DeleteVolumePayload
+	ExtendVolume ExtendVolumePayload
 
 	AddWireGuardPeer              CreatedWireGuardPeer
 	EstablishSSHKey               SSHCertificate
@@ -363,7 +364,17 @@ type CreateVolumeInput struct {
 	RequireUniqueZone bool    `json:"requireUniqueZone"`
 }
 
+type ExtendVolumeInput struct {
+	VolumeID string `json:"volumeId"`
+	SizeGb   int    `json:"sizeGb"`
+}
+
 type CreateVolumePayload struct {
+	App    App
+	Volume Volume
+}
+
+type ExtendVolumePayload struct {
 	App    App
 	Volume Volume
 }

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -18,7 +18,9 @@ import (
 
 func newExtend() *cobra.Command {
 	const (
-		long = ``
+		long = `Extends a target volume to the size specified. Volumes with attached nomad allocations 
+		will be restarted automatically. Machines will require a manual restart to increase the size 
+		of the FS.`
 
 		short = "Extend a target volume"
 

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -1,0 +1,80 @@
+package volumes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/iostreams"
+
+	"github.com/superfly/flyctl/internal/client"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/render"
+)
+
+func newExtend() *cobra.Command {
+	const (
+		long = ``
+
+		short = "Extend a target volume"
+
+		usage = "extend <id>"
+	)
+
+	cmd := command.New(usage, short, long, runExtend,
+		command.RequireSession,
+	)
+
+	cmd.Args = cobra.ExactArgs(1)
+
+	flag.Add(cmd,
+		flag.Int{
+			Name:        "size",
+			Shorthand:   "s",
+			Description: "Target volume size in gigabytes",
+		},
+	)
+
+	return cmd
+}
+
+func runExtend(ctx context.Context) error {
+	var (
+		cfg      = config.FromContext(ctx)
+		io       = iostreams.FromContext(ctx)
+		colorize = io.ColorScheme()
+		client   = client.FromContext(ctx).API()
+		volID    = flag.FirstArg(ctx)
+	)
+
+	sizeGB := flag.GetInt(ctx, "size")
+	if sizeGB == 0 {
+		return fmt.Errorf("Volume size must be specified")
+	}
+
+	input := api.ExtendVolumeInput{
+		VolumeID: volID,
+		SizeGb:   flag.GetInt(ctx, "size"),
+	}
+
+	app, volume, err := client.ExtendVolume(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to extend volume: %w", err)
+	}
+
+	out := iostreams.FromContext(ctx).Out
+
+	if app.PlatformVersion == "machines" {
+		fmt.Fprintf(out, colorize.Yellow("You need to stop and start your Machine to increase the size of the FS"))
+	}
+
+	if cfg.JSONOutput {
+		return render.JSON(out, volume)
+	}
+
+	return printVolume(out, volume)
+}

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -69,7 +69,7 @@ func runExtend(ctx context.Context) error {
 	out := iostreams.FromContext(ctx).Out
 
 	if app.PlatformVersion == "machines" {
-		fmt.Fprintf(out, colorize.Yellow("You need to stop and start your Machine to increase the size of the FS"))
+		fmt.Fprintln(out, colorize.Yellow("You need to stop and start your machine to increase the size of the FS"))
 	}
 
 	if cfg.JSONOutput {

--- a/internal/command/volumes/volumes.go
+++ b/internal/command/volumes/volumes.go
@@ -31,6 +31,7 @@ func New() *cobra.Command {
 		newCreate(),
 		newList(),
 		newDelete(),
+		newExtend(),
 		newShow(),
 		snapshots.New(),
 	)


### PR DESCRIPTION
Adds support for extending volumes.

```
Usage:
  flyctl volumes extend <id> [flags]

Flags:
  -a, --app string      Application name
  -c, --config string   Path to application configuration file
  -h, --help            help for extend
  -s, --size int        Target volume size in gigabytes

Global Flags:
  -t, --access-token string   Fly API Access Token
  -j, --json                  json output
      --verbose               verbose output
```