### PR TITLE
Add immediate strategy for machine:deploy

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -106,7 +106,7 @@ func DeployWithConfig(ctx context.Context, appConfig *app.Config) (err error) {
 	var releaseCommand *api.ReleaseCommand
 
 	if appConfig.ForMachines() {
-		return createMachinesRelease(ctx, appConfig, img)
+		return createMachinesRelease(ctx, appConfig, img, flag.GetString(ctx, "strategy"))
 	} else {
 		release, releaseCommand, err = createRelease(ctx, appConfig, img)
 	}

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -14,7 +14,7 @@ import (
 
 // Deploy ta machines app directly from flyctl, applying the desired config to running machines,
 // or launching new ones
-func createMachinesRelease(ctx context.Context, config *app.Config, img *imgsrc.DeploymentImage) (err error) {
+func createMachinesRelease(ctx context.Context, config *app.Config, img *imgsrc.DeploymentImage, strategy string) (err error) {
 	io := iostreams.FromContext(ctx)
 
 	client := client.FromContext(ctx).API()
@@ -120,15 +120,19 @@ func createMachinesRelease(ctx context.Context, config *app.Config, img *imgsrc.
 			launchInput.ID = machine.ID
 			updateResult, err := flapsClient.Update(ctx, launchInput, machine.LeaseNonce)
 
-			if err != nil {
+			if err != nil && strategy == "immediate" {
+				fmt.Printf("Continuing after error: %s\n", err)
+			} else if err != nil {
 				return err
 			}
 
-			fmt.Fprintf(io.Out, "Waiting for update to finish on %s\n", machine.ID)
-			err = flapsClient.Wait(ctx, updateResult)
+			if strategy != "immediate" {
+				fmt.Fprintf(io.Out, "Waiting for update to finish on %s\n", machine.ID)
+				err = flapsClient.Wait(ctx, updateResult)
 
-			if err != nil {
-				return err
+				if err != nil {
+					return err
+				}
 			}
 
 		}


### PR DESCRIPTION
This is a quick hack to make immediate deploys work. In theory, this would do them all in parallel but rolling through and ignoring errors is good enough for now.