### PR TITLE
Wait improvements for machine:deploy

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -16,6 +16,7 @@ type Machine struct {
 
 	// InstanceID is unique for each version of the machine
 	InstanceID string `json:"instance_id"`
+	Version    string `json:"version"`
 
 	// PrivateIP is the internal 6PN address of the machine.
 	PrivateIP string `json:"private_ip"`

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -128,8 +128,16 @@ func (f *Client) Wait(ctx context.Context, machine *api.Machine) (err error) {
 
 	waitEndpoint := fmt.Sprintf("/%s/wait", machine.ID)
 
-	if machine.InstanceID != "" {
-		waitEndpoint += fmt.Sprintf("?instance_id=%s", machine.InstanceID)
+	version := machine.InstanceID
+
+	if machine.Version != "" {
+		version = machine.Version
+	}
+	if version != "" {
+		fmt.Printf("Waiting on machine version %s...\n", version)
+		waitEndpoint += fmt.Sprintf("?instance_id=%s&timeout=30", version)
+	} else {
+		waitEndpoint += "?timeout=30"
 	}
 
 	if err := f.sendRequest(ctx, http.MethodGet, waitEndpoint, nil, nil, nil); err != nil {


### PR DESCRIPTION
This uses the returned machine version for wait, and increases the wait timeout to 30s.