### PR TITLE
Preserve machine volume mounts across deployments

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -173,3 +173,12 @@ type MachineStartResponse struct {
 	Status        string `json:"status,omitempty"`
 	PreviousState string `json:"previous_state"`
 }
+
+type LaunchMachineInput struct {
+	AppID   string         `json:"appId,omitempty"`
+	ID      string         `json:"id,omitempty"`
+	Name    string         `json:"name,omitempty"`
+	OrgSlug string         `json:"organizationId,omitempty"`
+	Region  string         `json:"region,omitempty"`
+	Config  *MachineConfig `json:"config"`
+}

--- a/api/types.go
+++ b/api/types.go
@@ -1225,15 +1225,6 @@ type CreateOrganizationInvitation struct {
 	Invitation Invitation
 }
 
-type LaunchMachineInput struct {
-	AppID   string         `json:"appId,omitempty"`
-	ID      string         `json:"id,omitempty"`
-	Name    string         `json:"name,omitempty"`
-	OrgSlug string         `json:"organizationId,omitempty"`
-	Region  string         `json:"region,omitempty"`
-	Config  *MachineConfig `json:"config"`
-}
-
 type GqlMachine struct {
 	ID     string
 	Name   string

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -117,7 +117,15 @@ func createMachinesRelease(ctx context.Context, config *app.Config, img *imgsrc.
 		for _, machine := range machines {
 
 			fmt.Fprintf(io.Out, "Updating VM %s\n", machine.ID)
+
 			launchInput.ID = machine.ID
+
+			// Until mounts are supported in fly.toml, ensure deployments
+			// maintain any existing volume attachments
+			if machine.Config.Mounts != nil {
+				launchInput.Config.Mounts = append(launchInput.Config.Mounts, machine.Config.Mounts[0])
+			}
+
 			updateResult, err := flapsClient.Update(ctx, launchInput, machine.LeaseNonce)
 
 			if err != nil {

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -94,8 +94,14 @@ func runMachineStatus(ctx context.Context) (err error) {
 			machine.UpdatedAt,
 		},
 	}
+	var cols []string = []string{"ID", "Instance ID", "State", "Image", "Name", "Private IP", "Region", "Created", "Updated"}
 
-	if err = render.VerticalTable(io.Out, "VM", obj, "ID", "Instance ID", "State", "Image", "Name", "Private IP", "Region", "Created", "Updated"); err != nil {
+	if len(machine.Config.Mounts) > 0 {
+		cols = append(cols, "Volume")
+		obj[0] = append(obj[0], machine.Config.Mounts[0].Volume)
+	}
+
+	if err = render.VerticalTable(io.Out, "VM", obj, cols...); err != nil {
 		return
 	}
 


### PR DESCRIPTION
Previously, machines would get their volume detached due to it being missing from the machine config. This PR ensures the volume config is merged back in.

Also, `fly machines status <id>` will show the attached volume.