### PR TITLE
Ensure cloned machines do not inherit volume config

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -94,6 +94,9 @@ func runMachineClone(ctx context.Context) (err error) {
 		region = source.Region
 	}
 
+	// Ensure attached volumes are not copied to the clone
+	source.Config.Mounts = nil
+
 	input := api.LaunchMachineInput{
 		AppID:  app.Name,
 		Name:   flag.GetString(ctx, "name"),


### PR DESCRIPTION
A volume may only be attached to one machine, so this is necessary for cloning something like a Postgresql instance. Adding a volume to a running machine may be work for another PR.