### PR TITLE
Deprecate the top-level create command

### DIFF
--- a/internal/command/create/create.go
+++ b/internal/command/create/create.go
@@ -2,31 +2,16 @@ package create
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/superfly/flyctl/internal/command"
-	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
 )
 
 // TODO: deprecate & remove
 func New() (cmd *cobra.Command) {
-	const (
-		long = `The CREATE command will both register a new application
-with the Fly platform and create the fly.toml file which controls how
-the application will be deployed. The --builder flag allows a cloud native
-buildpack to be specified which will be used instead of a Dockerfile to
-create the application image when it is deployed.
-`
-		short = `Create a new application`
-		usage = "create [APPNAME]"
-	)
-
-	cmd = command.New(usage, short, long, apps.RunCreate,
-		command.RequireSession)
-
-	cmd.Args = cobra.RangeArgs(0, 1)
-
-	// TODO: the -name & generate-name flags should be deprecated
+	cmd = &cobra.Command{
+		Use:        "create",
+		Hidden:     true,
+		Deprecated: "replaced by 'apps create'",
+	}
 
 	flag.Add(cmd,
 		flag.String{
@@ -35,11 +20,15 @@ create the application image when it is deployed.
 		},
 		flag.Bool{
 			Name:        "generate-name",
-			Description: "Generate a name for the app",
+			Description: "Generate an app name",
 		},
 		flag.String{
 			Name:        "network",
 			Description: "Specify custom network id",
+		},
+		flag.Bool{
+			Name:        "machines",
+			Description: "Use the machines platform",
 		},
 		flag.Org(),
 	)


### PR DESCRIPTION
This command just runs `fly apps create`, but does not keep its supported flags up to date. Some people have tried to use the new `--machines` flag. Rather than adding that flag, let's deprecate.