### PR TITLE
Link to new postgres doc post cluster creation

### DIFF
--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -315,7 +315,7 @@ func runApiCreatePostgresCluster(cmdCtx *cmdctx.CmdContext, org string, input *a
 		fmt.Printf("For example: postgres://%s:%s@%s.internal:%d\n", payload.Username, payload.Password, payload.App.Name, 5432)
 
 		fmt.Println()
-		fmt.Println("See the postgres docs for more information on next steps, managing postgres, connecting from outside fly:  https://fly.io/docs/reference/postgres/")
+		fmt.Println("Now you've setup postgres, here's what you need to understand: https://fly.io/docs/reference/postgres-whats-next/")
 	}
 
 	return payload, err

--- a/internal/command/services/postgres/launch.go
+++ b/internal/command/services/postgres/launch.go
@@ -226,6 +226,8 @@ func (p *Launch) Launch(ctx context.Context) error {
 	fmt.Fprintf(io.Out, "  Postgres port:  5433\n")
 	fmt.Fprintf(io.Out, "  Connection string:  %s\n", connStr)
 	fmt.Fprintf(io.Out, "Save your credentials in a secure place, you won't be able to see them again!\n")
+	fmt.Fprintf(io.Out, "\n")
+	fmt.Fprintf(io.Out, "Now you've setup postgres, here's what you need to understand: https://fly.io/docs/reference/postgres-whats-next/\n")
 
 	return nil
 }


### PR DESCRIPTION

This is how it looks:

```bash
$ flyctl pg create --name dangra-pg4
? Select organization: Daniel Graña (personal)
? Select region: gru (São Paulo)
For pricing information visit: https://fly.io/docs/about/pricing/#postgresql-clusters
? Select configuration: Production - Highly available, 1x shared CPU, 256MB RAM, 10GB disk
Creating postgres cluster dangra-pg4 in organization personal
Postgres cluster dangra-pg4 created
  Username:    postgres
  Password:    foobar
  Hostname:    dangra-pg4.internal
  Proxy Port:  5432
  PG Port: 5433
Save your credentials in a secure place, you won't be able to see them again!

Monitoring Deployment

2 desired, 2 placed, 2 healthy, 0 unhealthy [health checks: 6 total, 6 passing]
--> v0 deployed successfully

Connect to postgres
Any app within the personal organization can connect to postgres using the above credentials and the hostname "dangra-pg4.internal."
For example: postgres://postgres:foobar@dangra-pg4.internal:5432

Now you've setup postgres, here's what you need to understand: https://fly.io/docs/reference/postgres-whats-next/