### PR TITLE
Prefer remote docker builds for deployments

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -20,6 +20,7 @@ import (
 	"github.com/superfly/flyctl/internal/cmdfmt"
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/deployment"
+	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/internal/spinner"
 	"github.com/superfly/flyctl/logs"
@@ -70,7 +71,7 @@ func runDeploy(cmdCtx *cmdctx.CmdContext) error {
 		cmdfmt.PrintServicesList(cmdCtx.IO, parsedCfg.Services)
 	}
 
-	daemonType := imgsrc.NewDockerDaemonType(!cmdCtx.Config.GetBool("remote-only"), !cmdCtx.Config.GetBool("local-only"))
+	daemonType := imgsrc.NewDockerDaemonType(!cmdCtx.Config.GetBool("remote-only"), !cmdCtx.Config.GetBool("local-only"), env.IsCI())
 	resolver := imgsrc.NewResolver(daemonType, cmdCtx.Client.API(), cmdCtx.AppName, cmdCtx.IO)
 
 	var img *imgsrc.DeploymentImage

--- a/internal/build/imgsrc/docker_test.go
+++ b/internal/build/imgsrc/docker_test.go
@@ -8,18 +8,23 @@ import (
 
 func TestAllowedDockerDaemonMode(t *testing.T) {
 	tests := []struct {
-		allowLocal  bool
-		allowRemote bool
-		expected    DockerDaemonType
+		allowLocal   bool
+		allowRemote  bool
+		preferslocal bool
+		expected     DockerDaemonType
 	}{
-		{true, true, DockerDaemonTypeNone | DockerDaemonTypeLocal | DockerDaemonTypeRemote},
-		{false, true, DockerDaemonTypeNone | DockerDaemonTypeRemote},
-		{true, false, DockerDaemonTypeNone | DockerDaemonTypeLocal},
-		{false, false, DockerDaemonTypeNone},
+		{false, false, false, DockerDaemonTypeNone},
+		{false, false, true, DockerDaemonTypeNone | DockerDaemonTypePrefersLocal},
+		{false, true, false, DockerDaemonTypeNone | DockerDaemonTypeRemote},
+		{false, true, true, DockerDaemonTypeNone | DockerDaemonTypeRemote | DockerDaemonTypePrefersLocal},
+		{true, false, false, DockerDaemonTypeNone | DockerDaemonTypeLocal},
+		{true, false, true, DockerDaemonTypeNone | DockerDaemonTypeLocal | DockerDaemonTypePrefersLocal},
+		{true, true, false, DockerDaemonTypeNone | DockerDaemonTypeLocal | DockerDaemonTypeRemote},
+		{true, true, true, DockerDaemonTypeNone | DockerDaemonTypeLocal | DockerDaemonTypeRemote | DockerDaemonTypePrefersLocal},
 	}
 
 	for _, test := range tests {
-		m := NewDockerDaemonType(test.allowLocal, test.allowRemote)
+		m := NewDockerDaemonType(test.allowLocal, test.allowRemote, test.preferslocal)
 		assert.Equal(t, test.expected, m)
 	}
 }

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superfly/flyctl/internal/app"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/internal/state"
@@ -201,7 +202,7 @@ func determineAppConfig(ctx context.Context) (cfg *app.Config, err error) {
 func determineImage(ctx context.Context, appConfig *app.Config) (img *imgsrc.DeploymentImage, err error) {
 	tb := render.NewTextBlock(ctx, "Building image")
 
-	daemonType := imgsrc.NewDockerDaemonType(!flag.GetRemoteOnly(ctx), !flag.GetLocalOnly(ctx))
+	daemonType := imgsrc.NewDockerDaemonType(!flag.GetRemoteOnly(ctx), !flag.GetLocalOnly(ctx), env.IsCI())
 
 	var appName string = app.NameFromContext(ctx)
 	if appConfig.AppName != "" && appName == "" {

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -25,6 +25,7 @@ import (
 	"github.com/superfly/flyctl/internal/build/imgsrc"
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/state"
@@ -393,7 +394,7 @@ func determineImage(ctx context.Context, appName string) (img *imgsrc.Deployment
 		io     = iostreams.FromContext(ctx)
 	)
 
-	daemonType := imgsrc.NewDockerDaemonType(!flag.GetBool(ctx, "build-remote-only"), !flag.GetBool(ctx, "build-local-only"))
+	daemonType := imgsrc.NewDockerDaemonType(!flag.GetBool(ctx, "build-remote-only"), !flag.GetBool(ctx, "build-local-only"), env.IsCI())
 	resolver := imgsrc.NewResolver(daemonType, client, appName, io)
 
 	imageOrPath := flag.FirstArg(ctx)


### PR DESCRIPTION
Prefer remote over local docker when available

Docker is running locally but `flyctl` prefers remote builder unless `CI=1` envvar is set.  

```bash
$ docker version
...
Server: Docker Desktop 4.10.1 (82475)
 Engine:
  Version:          20.10.17
  API version:      1.41 (minimum version 1.12)
...
```

```
$ flyctl deploy
==> Verifying app config
--> Verified app config
==> Building image
Remote builder fly-builder-autumn-mountain-8739 ready
==> Creating build context
--> Creating build context done
==> Building image with Docker
--> docker host: 20.10.12 linux x86_64
...
```

```
$ CI=1 flyctl deploy
==> Verifying app config
--> Verified app config
==> Building image
AllowRemote true
AllowLocal true
PrefersLocal true
==> Creating build context
--> Creating build context done
==> Building image with Docker
--> docker host: 20.10.17 linux x86_64
```