### PR TITLE
Deploy machines apps after setting secrets

### DIFF
--- a/internal/command/secrets/import.go
+++ b/internal/command/secrets/import.go
@@ -13,8 +13,6 @@ import (
 	"github.com/superfly/flyctl/internal/app"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
-	"github.com/superfly/flyctl/internal/watch"
-	"github.com/superfly/flyctl/iostreams"
 )
 
 func newImport() (cmd *cobra.Command) {
@@ -37,7 +35,6 @@ func newImport() (cmd *cobra.Command) {
 func runImport(ctx context.Context) (err error) {
 	client := client.FromContext(ctx).API()
 	appName := app.NameFromContext(ctx)
-	out := iostreams.FromContext(ctx).Out
 	app, err := client.GetAppCompact(ctx, appName)
 
 	if err != nil {
@@ -107,14 +104,5 @@ func runImport(ctx context.Context) (err error) {
 		return err
 	}
 
-	if !app.Deployed {
-		fmt.Fprint(out, "Secrets are staged for the first deployment")
-		return nil
-	}
-
-	fmt.Fprintf(out, "Release v%d created\n", release.Version)
-
-	err = watch.Deployment(ctx, release.EvaluationID)
-
-	return err
+	return deployForSecrets(ctx, app, release)
 }

--- a/internal/command/secrets/set.go
+++ b/internal/command/secrets/set.go
@@ -12,8 +12,6 @@ import (
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
-	"github.com/superfly/flyctl/internal/watch"
-	"github.com/superfly/flyctl/iostreams"
 )
 
 func newSet() (cmd *cobra.Command) {
@@ -38,7 +36,6 @@ func newSet() (cmd *cobra.Command) {
 func runSet(ctx context.Context) (err error) {
 	client := client.FromContext(ctx).API()
 	appName := app.NameFromContext(ctx)
-	out := iostreams.FromContext(ctx).Out
 	app, err := client.GetAppCompact(ctx, appName)
 
 	if err != nil {
@@ -70,18 +67,5 @@ func runSet(ctx context.Context) (err error) {
 
 	release, err := client.SetSecrets(ctx, appName, secrets)
 
-	if err != nil {
-		return err
-	}
-
-	if !app.Deployed {
-		fmt.Fprint(out, "Secrets are staged for the first deployment")
-		return nil
-	}
-
-	fmt.Fprintf(out, "Release v%d created\n", release.Version)
-
-	err = watch.Deployment(ctx, release.EvaluationID)
-
-	return err
+	return deployForSecrets(ctx, app, release)
 }

--- a/internal/command/secrets/unset.go
+++ b/internal/command/secrets/unset.go
@@ -2,15 +2,12 @@ package secrets
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/app"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
-	"github.com/superfly/flyctl/internal/watch"
-	"github.com/superfly/flyctl/iostreams"
 )
 
 func newUnset() (cmd *cobra.Command) {
@@ -35,7 +32,6 @@ func newUnset() (cmd *cobra.Command) {
 func runUnset(ctx context.Context) (err error) {
 	client := client.FromContext(ctx).API()
 	appName := app.NameFromContext(ctx)
-	out := iostreams.FromContext(ctx).Out
 	app, err := client.GetAppCompact(ctx, appName)
 
 	if err != nil {
@@ -48,14 +44,5 @@ func runUnset(ctx context.Context) (err error) {
 		return err
 	}
 
-	if !app.Deployed {
-		fmt.Fprint(out, "Secrets are staged for the first deployment")
-		return nil
-	}
-
-	fmt.Fprintf(out, "Release v%d created\n", release.Version)
-
-	err = watch.Deployment(ctx, release.EvaluationID)
-
-	return err
+	return deployForSecrets(ctx, app, release)
 }


### PR DESCRIPTION
This PR implements deployment of machines apps if secrets are set and have changed. Also, we refactor deployment so other packages can run deployments with specific strategies.