### PR TITLE
Truly fallback to remote when local is not available

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -31,15 +31,6 @@ type dockerClientFactory struct {
 }
 
 func newDockerClientFactory(daemonType DockerDaemonType, apiClient *api.Client, appName string, streams *iostreams.IOStreams) *dockerClientFactory {
-	noneFactory := func() *dockerClientFactory {
-		return &dockerClientFactory{
-			mode: DockerDaemonTypeNone,
-			buildFn: func(ctx context.Context) (*dockerclient.Client, error) {
-				return nil, errors.New("no docker daemon available")
-			},
-		}
-	}
-
 	remoteFactory := func() *dockerClientFactory {
 		terminal.Debug("trying remote docker daemon")
 		var cachedDocker *dockerclient.Client
@@ -89,7 +80,13 @@ func newDockerClientFactory(daemonType DockerDaemonType, apiClient *api.Client, 
 	if daemonType.AllowRemote() {
 		return remoteFactory()
 	}
-	return noneFactory()
+
+	return &dockerClientFactory{
+		mode: DockerDaemonTypeNone,
+		buildFn: func(ctx context.Context) (*dockerclient.Client, error) {
+			return nil, errors.New("no docker daemon available")
+		},
+	}
 }
 
 func NewDockerDaemonType(allowLocal, allowRemote, prefersLocal bool) DockerDaemonType {


### PR DESCRIPTION
Remote builder first even if docker is running locally:

```
$ flyctl deploy
==> Verifying app config
--> Verified app config
==> Building image
INFO trying remote docker daemon
Remote builder fly-builder-autumn-mountain-8739 ready
==> Creating build context
--> Creating build context done
==> Building image with Docker
--> docker host: 20.10.12 linux x86_64
Sending build context to Docker daemon  33.15kB
...
```

Prefer local docker on CI env
```
$ CI=1 flyctl deploy
==> Verifying app config
--> Verified app config
==> Building image
==> Creating build context
--> Creating build context done
==> Building image with Docker
--> docker host: 20.10.17 linux x86_64
Sending build context to Docker daemon  105.5kB
[+] Building 97.4s (12/16)
...
```

Fallback to remote builder if local Docker is not available in CI env
```
$ CI=1 DOCKER_HOST=nonexistent flyctl deploy
==> Verifying app config
--> Verified app config
==> Building image
WARN Error connecting to local docker daemon: error during connect: Get "http://nonexistent:2375/_ping": dial tcp: lookup nonexistent: no such host
INFO trying remote docker daemon
Remote builder fly-builder-autumn-mountain-8739 ready
==> Creating build context
--> Creating build context done
==> Building image with Docker
--> docker host: 20.10.12 linux x86_64
Sending build context to Docker daemon  33.14kB
[+] Building 3.3s (2/4)
```

Use remote builder even in CI and remote-only flag is passed
```
$ CI=1 flyctl deploy --remote-only
==> Verifying app config
--> Verified app config
==> Building image
INFO trying remote docker daemon
Remote builder fly-builder-autumn-mountain-8739 ready
==> Creating build context
--> Creating build context done
==> Building image with Docker
--> docker host: 20.10.12 linux x86_64
Sending build context to Docker daemon  33.15kB
[+] Building 0.9s (2/4)
```
