### PR TITLE
Make concurrency settings on machine services optional

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -141,10 +141,10 @@ type MachinePort struct {
 }
 
 type MachineService struct {
-	Protocol     string                    `json:"protocol" toml:"protocol"`
-	InternalPort int                       `json:"internal_port" toml:"internal_port"`
-	Ports        []MachinePort             `json:"ports" toml:"ports"`
-	Concurrency  MachineServiceConcurrency `json:"concurrency,omitempty" toml:"concurrency"`
+	Protocol     string                     `json:"protocol" toml:"protocol"`
+	InternalPort int                        `json:"internal_port" toml:"internal_port"`
+	Ports        []MachinePort              `json:"ports" toml:"ports"`
+	Concurrency  *MachineServiceConcurrency `json:"concurrency,omitempty" toml:"concurrency"`
 }
 
 type MachineServiceConcurrency struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -144,7 +144,7 @@ type MachineService struct {
 	Protocol     string                    `json:"protocol" toml:"protocol"`
 	InternalPort int                       `json:"internal_port" toml:"internal_port"`
 	Ports        []MachinePort             `json:"ports" toml:"ports"`
-	Concurrency  MachineServiceConcurrency `json:"concurrency" toml:"concurrency"`
+	Concurrency  MachineServiceConcurrency `json:"concurrency,omitempty" toml:"concurrency"`
 }
 
 type MachineServiceConcurrency struct {

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -44,7 +44,7 @@ func createMachinesRelease(ctx context.Context, config *app.Config, img *imgsrc.
 		httpService := api.MachineService{
 			Protocol:     "tcp",
 			InternalPort: config.HttpService.InternalPort,
-			Concurrency:  concurrency,
+			Concurrency:  &concurrency,
 			Ports: []api.MachinePort{
 				{
 					Port:       80,


### PR DESCRIPTION
This fixes an issue with `fly machine run` with services that have no concurrency settings.