### PR TITLE
Add a machines subcommand for updating machines

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -32,7 +32,7 @@ type Machine struct {
 }
 
 func (m Machine) FullImageRef() string {
-	return fmt.Sprintf("%s:%s", m.ImageRef.Repository, m.ImageRef.Tag)
+	return fmt.Sprintf("%s/%s:%s", m.ImageRef.Registry, m.ImageRef.Repository, m.ImageRef.Tag)
 }
 
 type machineImageRef struct {

--- a/internal/command/machine/machine.go
+++ b/internal/command/machine/machine.go
@@ -33,6 +33,7 @@ func New() *cobra.Command {
 		newProxy(),
 		newLaunch(),
 		newClone(),
+		newUpdate(),
 	)
 
 	return cmd

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -269,7 +269,7 @@ func runMachineRun(ctx context.Context) error {
 		return err
 	}
 
-	img, err := determineImage(ctx, machineApp.Name)
+	img, err := determineImage(ctx, machineApp.Name, flag.FirstArg(ctx))
 	if err != nil {
 		return err
 	}
@@ -388,7 +388,7 @@ func parseEnvVars(ctx context.Context) (map[string]string, error) {
 	return env, nil
 }
 
-func determineImage(ctx context.Context, appName string) (img *imgsrc.DeploymentImage, err error) {
+func determineImage(ctx context.Context, appName string, imageOrPath string) (img *imgsrc.DeploymentImage, err error) {
 	var (
 		client = client.FromContext(ctx).API()
 		io     = iostreams.FromContext(ctx)
@@ -397,7 +397,6 @@ func determineImage(ctx context.Context, appName string) (img *imgsrc.Deployment
 	daemonType := imgsrc.NewDockerDaemonType(!flag.GetBool(ctx, "build-remote-only"), !flag.GetBool(ctx, "build-local-only"), env.IsCI())
 	resolver := imgsrc.NewResolver(daemonType, client, appName, io)
 
-	imageOrPath := flag.FirstArg(ctx)
 	// build if relative or absolute path
 	if strings.HasPrefix(imageOrPath, ".") || strings.HasPrefix(imageOrPath, "/") {
 		opts := imgsrc.ImageOptions{

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -31,6 +31,91 @@ import (
 	"github.com/superfly/flyctl/internal/state"
 )
 
+var sharedFlags = flag.Set{
+	flag.App(),
+	flag.AppConfig(),
+	flag.StringSlice{
+		Name:        "port",
+		Shorthand:   "p",
+		Description: "Exposed port mappings (format: edgePort[:machinePort]/[protocol[:handler]])",
+	},
+	flag.String{
+		Name:        "size",
+		Shorthand:   "s",
+		Description: "Preset guest cpu and memory for a machine, defaults to shared-cpu-1x",
+	},
+	flag.Int{
+		Name:        "cpus",
+		Description: "Number of CPUs",
+	},
+	flag.Int{
+		Name:        "memory",
+		Description: "Memory (in megabytes) to attribute to the machine",
+	},
+	flag.StringSlice{
+		Name:        "env",
+		Shorthand:   "e",
+		Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
+	},
+	flag.StringSlice{
+		Name:        "volume",
+		Shorthand:   "v",
+		Description: "Volumes to mount in the form of <volume_id_or_name>:/path/inside/machine[:<options>]",
+	},
+	flag.String{
+		Name:        "entrypoint",
+		Description: "ENTRYPOINT replacement",
+	},
+	flag.Bool{
+		Name:        "build-only",
+		Description: "Only build the image without running the machine",
+		Hidden:      true,
+	},
+	flag.Bool{
+		Name:        "build-remote-only",
+		Description: "Perform builds remotely without using the local docker daemon",
+		Hidden:      true,
+	},
+	flag.Bool{
+		Name:        "build-local-only",
+		Description: "Only perform builds locally using the local docker daemon",
+		Hidden:      true,
+	},
+	flag.String{
+		Name:        "dockerfile",
+		Description: "Path to a Dockerfile. Defaults to the Dockerfile in the working directory.",
+	},
+	flag.StringSlice{
+		Name:        "build-arg",
+		Description: "Set of build time variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
+		Hidden:      true,
+	},
+	flag.String{
+		Name:        "image-label",
+		Description: "Image label to use when tagging and pushing to the fly registry. Defaults to \"deployment-{timestamp}\".",
+		Hidden:      true,
+	},
+	flag.String{
+		Name:        "build-target",
+		Description: "Set the target build stage to build if the Dockerfile has more than one stage",
+		Hidden:      true,
+	},
+	flag.Bool{
+		Name:        "no-build-cache",
+		Description: "Do not use the cache when building the image",
+		Hidden:      true,
+	},
+	flag.StringSlice{
+		Name:        "kernel-arg",
+		Description: "List of kernel arguments to be provided to the init. Can be specified multiple times.",
+	},
+	flag.StringSlice{
+		Name:        "metadata",
+		Shorthand:   "m",
+		Description: "Metadata in the form of NAME=VALUE pairs. Can be specified multiple times.",
+	},
+}
+
 func newRun() *cobra.Command {
 	const (
 		short = "Run a machine"
@@ -46,9 +131,8 @@ func newRun() *cobra.Command {
 
 	flag.Add(
 		cmd,
-		flag.App(),
 		flag.Region(),
-		flag.AppConfig(),
+		// deprecated in favor of `flyctl machine update`
 		flag.String{
 			Name:        "id",
 			Description: "Machine ID, if previously known",
@@ -62,92 +146,7 @@ func newRun() *cobra.Command {
 			Name:        "org",
 			Description: `The organization that will own the app`,
 		},
-		flag.StringSlice{
-			Name:        "port",
-			Shorthand:   "p",
-			Description: "Exposed port mappings (format: edgePort[:machinePort]/[protocol[:handler]])",
-		},
-		flag.String{
-			Name:        "size",
-			Shorthand:   "s",
-			Description: "Preset guest cpu and memory for a machine, defaults to shared-cpu-1x",
-		},
-		flag.Int{
-			Name:        "cpus",
-			Description: "Number of CPUs",
-			Hidden:      true,
-		},
-		flag.Int{
-			Name:        "memory",
-			Description: "Memory (in megabytes) to attribute to the machine",
-			Hidden:      true,
-		},
-		flag.StringSlice{
-			Name:        "env",
-			Shorthand:   "e",
-			Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
-		},
-		flag.StringSlice{
-			Name:        "volume",
-			Shorthand:   "v",
-			Description: "Volumes to mount in the form of <volume_id_or_name>:/path/inside/machine[:<options>]",
-			Hidden:      true,
-		},
-		flag.String{
-			Name:        "entrypoint",
-			Description: "ENTRYPOINT replacement",
-			Hidden:      true,
-		},
-		flag.Bool{
-			Name:        "detach",
-			Shorthand:   "d",
-			Description: "Detach from the machine's logs",
-			Hidden:      true,
-		},
-		flag.Bool{
-			Name:        "build-only",
-			Description: "Only build the image without running the machine",
-			Hidden:      true,
-		},
-		flag.Bool{
-			Name:        "build-remote-only",
-			Description: "Perform builds remotely without using the local docker daemon",
-			Hidden:      true,
-		},
-		flag.Bool{
-			Name:        "build-local-only",
-			Description: "Only perform builds locally using the local docker daemon",
-			Hidden:      true,
-		},
-		flag.String{
-			Name:        "dockerfile",
-			Description: "Path to a Dockerfile. Defaults to the Dockerfile in the working directory.",
-		},
-		flag.StringSlice{
-			Name:        "build-arg",
-			Description: "Set of build time variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
-			Hidden:      true,
-		},
-		flag.String{
-			Name:        "image-label",
-			Description: "Image label to use when tagging and pushing to the fly registry. Defaults to \"deployment-{timestamp}\".",
-			Hidden:      true,
-		},
-		flag.String{
-			Name:        "build-target",
-			Description: "Set the target build stage to build if the Dockerfile has more than one stage",
-			Hidden:      true,
-		},
-		flag.Bool{
-			Name:        "no-build-cache",
-			Description: "Do not use the cache when building the image",
-			Hidden:      true,
-		},
-		flag.StringSlice{
-			Name:        "kernel-arg",
-			Description: "List of kernel arguments to be provided to the init. Can be specified multiple times.",
-			Hidden:      true,
-		},
+		sharedFlags,
 	)
 
 	cmd.Args = cobra.MinimumNArgs(1)
@@ -157,23 +156,23 @@ func newRun() *cobra.Command {
 
 func runMachineRun(ctx context.Context) error {
 	var (
-		appName    = app.NameFromContext(ctx)
-		client     = client.FromContext(ctx).API()
-		io         = iostreams.FromContext(ctx)
-		err        error
-		machineApp *api.AppCompact
+		appName = app.NameFromContext(ctx)
+		client  = client.FromContext(ctx).API()
+		io      = iostreams.FromContext(ctx)
+		err     error
+		app     *api.AppCompact
 	)
 
 	if appName == "" {
-		machineApp, err = createApp(ctx, "Running a machine without specifying an app will create one for you, is this what you want?", "", client)
+		app, err = createApp(ctx, "Running a machine without specifying an app will create one for you, is this what you want?", "", client)
 		if err != nil {
 			return err
 		}
 	} else {
-		machineApp, err = client.GetAppCompact(ctx, appName)
+		app, err = client.GetAppCompact(ctx, appName)
 		if err != nil && strings.Contains(err.Error(), "Could not find App") {
-			machineApp, err = createApp(ctx, fmt.Sprintf("App '%s' does not exist, would you like to create it?", appName), appName, client)
-			if machineApp == nil {
+			app, err = createApp(ctx, fmt.Sprintf("App '%s' does not exist, would you like to create it?", appName), appName, client)
+			if app == nil {
 				return nil
 			}
 		}
@@ -192,88 +191,26 @@ func runMachineRun(ctx context.Context) error {
 	}
 
 	input := api.LaunchMachineInput{
-		AppID:  machineApp.Name,
+		AppID:  app.Name,
 		Name:   flag.GetString(ctx, "name"),
 		Region: flag.GetString(ctx, "region"),
 	}
 
-	flapsClient, err := flaps.New(ctx, machineApp)
+	flapsClient, err := flaps.New(ctx, app)
 	if err != nil {
 		return fmt.Errorf("could not make API client: %w", err)
 	}
 
 	machineID := flag.GetString(ctx, "id")
 	if machineID != "" {
-
-		machine, err := flapsClient.Get(ctx, machineID)
-		if err != nil {
-			return fmt.Errorf("failed to get machine, %s: %w", machineID, err)
-		}
-		fmt.Fprintf(io.Out, "machine %s was found and is currently in a %s state, attempting to update...\n", machineID, machine.State)
-		input.ID = machineID
-		input.Name = machine.Name
-		input.Region = ""
-		machineConf = *machine.Config
+		return fmt.Errorf("To update an existing machine, use 'flyctl machine update'.")
 	}
 
-	if guestSize := flag.GetString(ctx, "size"); guestSize != "" {
-		guest, ok := api.MachinePresets[guestSize]
-		if !ok {
-			validSizes := []string{}
-			for size := range api.MachinePresets {
-				if strings.HasPrefix(size, "shared") {
-					validSizes = append(validSizes, size)
-				}
-			}
-			sort.Strings(validSizes)
-			return fmt.Errorf("invalid machine size requested, '%s', available:\n%s", guestSize, strings.Join(validSizes, "\n"))
-		}
-		machineConf.Guest = guest
-	} else {
-		if cpus := flag.GetInt(ctx, "cpus"); cpus != 0 {
-			machineConf.Guest.CPUs = cpus
-		}
+	machineConf, err = determineMachineConfig(ctx, machineConf, app, flag.FirstArg(ctx))
 
-		if memory := flag.GetInt(ctx, "memory"); memory != 0 {
-			machineConf.Guest.MemoryMB = memory
-		}
-	}
-
-	machineConf.Env, err = parseEnvVars(ctx)
 	if err != nil {
 		return err
 	}
-
-	services, err := determineServices(ctx)
-	if err != nil {
-		return err
-	}
-	if len(services) > 0 {
-		machineConf.Services = services
-	}
-
-	if entrypoint := flag.GetString(ctx, "entrypoint"); entrypoint != "" {
-		splitted, err := shlex.Split(entrypoint)
-		if err != nil {
-			return errors.Wrap(err, "invalid entrypoint")
-		}
-		machineConf.Init.Entrypoint = splitted
-	}
-
-	if cmd := flag.Args(ctx)[1:]; len(cmd) > 0 {
-		machineConf.Init.Cmd = cmd
-	}
-
-	machineConf.Mounts, err = determineMounts(ctx)
-	if err != nil {
-		return err
-	}
-
-	img, err := determineImage(ctx, machineApp.Name, flag.FirstArg(ctx))
-	if err != nil {
-		return err
-	}
-	machineConf.Image = img.Tag
 
 	if flag.GetBool(ctx, "build-only") {
 		return nil
@@ -375,17 +312,17 @@ func WaitForStart(ctx context.Context, flapsClient *flaps.Client, machine *api.M
 	}
 }
 
-func parseEnvVars(ctx context.Context) (map[string]string, error) {
-	var env = make(map[string]string)
+func parseKVFlag(ctx context.Context, flagName string, initialMap map[string]string) (parsed map[string]string, err error) {
 
-	if extraEnv := flag.GetStringSlice(ctx, "env"); len(extraEnv) > 0 {
-		parsedEnv, err := cmdutil.ParseKVStringsToMap(flag.GetStringSlice(ctx, "env"))
+	parsed = initialMap
+
+	if value := flag.GetStringSlice(ctx, flagName); len(value) > 0 {
+		parsed, err = cmdutil.ParseKVStringsToMap(value)
 		if err != nil {
-			return nil, errors.Wrap(err, "invalid env")
+			return nil, fmt.Errorf("invalid key/value pairs specified for flag %s", flagName)
 		}
-		env = parsedEnv
 	}
-	return env, nil
+	return parsed, nil
 }
 
 func determineImage(ctx context.Context, appName string, imageOrPath string) (img *imgsrc.DeploymentImage, err error) {
@@ -540,4 +477,78 @@ func selectAppName(ctx context.Context) (name string, err error) {
 	}
 
 	return
+}
+
+func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineConfig, app *api.AppCompact, image string) (machineConf api.MachineConfig, err error) {
+
+	machineConf = initialMachineConf
+
+	if guestSize := flag.GetString(ctx, "size"); guestSize != "" {
+		guest, ok := api.MachinePresets[guestSize]
+		if !ok {
+			validSizes := []string{}
+			for size := range api.MachinePresets {
+				if strings.HasPrefix(size, "shared") {
+					validSizes = append(validSizes, size)
+				}
+			}
+			sort.Strings(validSizes)
+			err = fmt.Errorf("invalid machine size requested, '%s', available:\n%s", guestSize, strings.Join(validSizes, "\n"))
+			return
+		}
+		machineConf.Guest = guest
+	} else {
+		if cpus := flag.GetInt(ctx, "cpus"); cpus != 0 {
+			machineConf.Guest.CPUs = cpus
+		}
+
+		if memory := flag.GetInt(ctx, "memory"); memory != 0 {
+			machineConf.Guest.MemoryMB = memory
+		}
+	}
+
+	machineConf.Env, err = parseKVFlag(ctx, "env", machineConf.Env)
+
+	if err != nil {
+		return
+	}
+
+	machineConf.Metadata, err = parseKVFlag(ctx, "metadata", machineConf.Metadata)
+
+	if err != nil {
+		return
+	}
+
+	services, err := determineServices(ctx)
+	if err != nil {
+		return
+	}
+	if len(services) > 0 {
+		machineConf.Services = services
+	}
+
+	if entrypoint := flag.GetString(ctx, "entrypoint"); entrypoint != "" {
+		splitted, err := shlex.Split(entrypoint)
+		if err != nil {
+			return machineConf, errors.Wrap(err, "invalid entrypoint")
+		}
+		machineConf.Init.Entrypoint = splitted
+	}
+
+	if cmd := flag.Args(ctx)[1:]; len(cmd) > 0 {
+		machineConf.Init.Cmd = cmd
+	}
+
+	machineConf.Mounts, err = determineMounts(ctx)
+	if err != nil {
+		return
+	}
+
+	img, err := determineImage(ctx, app.Name, image)
+	if err != nil {
+		return
+	}
+	machineConf.Image = img.Tag
+
+	return machineConf, nil
 }

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -87,7 +87,6 @@ func runMachineStatus(ctx context.Context) (err error) {
 			machine.InstanceID,
 			machine.State,
 			machine.FullImageRef(),
-			strings.Join(machine.Config.Init.Cmd, " "),
 			machine.Name,
 			machine.PrivateIP,
 			machine.Region,
@@ -95,9 +94,11 @@ func runMachineStatus(ctx context.Context) (err error) {
 			fmt.Sprint(machine.Config.Guest.MemoryMB),
 			machine.CreatedAt,
 			machine.UpdatedAt,
+			strings.Join(machine.Config.Init.Cmd, " "),
 		},
 	}
-	var cols []string = []string{"ID", "Instance ID", "State", "Image", "Command", "Name", "Private IP", "Region", "Memory", "CPUs", "Created", "Updated"}
+
+	var cols []string = []string{"ID", "Instance ID", "State", "Image", "Name", "Private IP", "Region", "Memory", "CPUs", "Created", "Updated", "Command"}
 
 	if len(machine.Config.Mounts) > 0 {
 		cols = append(cols, "Volume")

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -87,14 +87,17 @@ func runMachineStatus(ctx context.Context) (err error) {
 			machine.InstanceID,
 			machine.State,
 			machine.FullImageRef(),
+			strings.Join(machine.Config.Init.Cmd, " "),
 			machine.Name,
 			machine.PrivateIP,
 			machine.Region,
+			fmt.Sprint(machine.Config.Guest.CPUs),
+			fmt.Sprint(machine.Config.Guest.MemoryMB),
 			machine.CreatedAt,
 			machine.UpdatedAt,
 		},
 	}
-	var cols []string = []string{"ID", "Instance ID", "State", "Image", "Name", "Private IP", "Region", "Created", "Updated"}
+	var cols []string = []string{"ID", "Instance ID", "State", "Image", "Command", "Name", "Private IP", "Region", "Memory", "CPUs", "Created", "Updated"}
 
 	if len(machine.Config.Mounts) > 0 {
 		cols = append(cols, "Volume")

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -3,43 +3,29 @@ package machine
 import (
 	"context"
 	"fmt"
-	"path"
-	"path/filepath"
-	"sort"
-	"strconv"
-	"strings"
-	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/google/shlex"
-	"github.com/jpillora/backoff"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/app"
-	"github.com/superfly/flyctl/internal/build/imgsrc"
-	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/command"
-	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/flag"
-	"github.com/superfly/flyctl/internal/prompt"
-	"github.com/superfly/flyctl/internal/state"
 )
 
-func newRun() *cobra.Command {
+func newUpdate() *cobra.Command {
 	const (
-		short = "Run a machine"
+		short = "Update a machine"
 		long  = short + "\n"
 
-		usage = "run <image> [command]"
+		usage = "update [machine_id]"
 	)
 
-	cmd := command.New(usage, short, long, runMachineRun,
+	cmd := command.New(usage, short, long, runUpdate,
 		command.RequireSession,
 		command.LoadAppNameIfPresent,
 	)
@@ -50,27 +36,14 @@ func newRun() *cobra.Command {
 		flag.Region(),
 		flag.AppConfig(),
 		flag.String{
-			Name:        "id",
-			Description: "Machine ID, if previously known",
-		},
-		flag.String{
 			Name:        "name",
 			Shorthand:   "n",
 			Description: "Machine name, will be generated if missing",
-		},
-		flag.String{
-			Name:        "org",
-			Description: `The organization that will own the app`,
 		},
 		flag.StringSlice{
 			Name:        "port",
 			Shorthand:   "p",
 			Description: "Exposed port mappings (format: edgePort[:machinePort]/[protocol[:handler]])",
-		},
-		flag.String{
-			Name:        "size",
-			Shorthand:   "s",
-			Description: "Preset guest cpu and memory for a machine, defaults to shared-cpu-1x",
 		},
 		flag.Int{
 			Name:        "cpus",
@@ -98,11 +71,10 @@ func newRun() *cobra.Command {
 			Description: "ENTRYPOINT replacement",
 			Hidden:      true,
 		},
-		flag.Bool{
-			Name:        "detach",
-			Shorthand:   "d",
-			Description: "Detach from the machine's logs",
-			Hidden:      true,
+		flag.String{
+			Name:        "image",
+			Shorthand:   "i",
+			Description: "Docker Image to update the machine with",
 		},
 		flag.Bool{
 			Name:        "build-only",
@@ -148,95 +120,59 @@ func newRun() *cobra.Command {
 			Description: "List of kernel arguments to be provided to the init. Can be specified multiple times.",
 			Hidden:      true,
 		},
+		flag.StringSlice{
+			Name:        "metadata",
+			Shorthand:   "m",
+			Description: "Metadata in the form of NAME=VALUE pairs. Can be specified multiple times.",
+		},
 	)
 
-	cmd.Args = cobra.MinimumNArgs(1)
+	cmd.Args = cobra.ExactArgs(1)
 
 	return cmd
 }
 
-func runMachineRun(ctx context.Context) error {
+func runUpdate(ctx context.Context) (err error) {
 	var (
-		appName    = app.NameFromContext(ctx)
-		client     = client.FromContext(ctx).API()
-		io         = iostreams.FromContext(ctx)
-		err        error
-		machineApp *api.AppCompact
+		appName = app.NameFromContext(ctx)
+		io      = iostreams.FromContext(ctx)
 	)
 
-	if appName == "" {
-		machineApp, err = createApp(ctx, "Running a machine without specifying an app will create one for you, is this what you want?", "", client)
-		if err != nil {
-			return err
-		}
-	} else {
-		machineApp, err = client.GetAppCompact(ctx, appName)
-		if err != nil && strings.Contains(err.Error(), "Could not find App") {
-			machineApp, err = createApp(ctx, fmt.Sprintf("App '%s' does not exist, would you like to create it?", appName), appName, client)
-			if machineApp == nil {
-				return nil
-			}
-		}
-		if err != nil {
-			return err
-		}
+	machineID := flag.FirstArg(ctx)
+
+	app, err := appFromMachineOrName(ctx, machineID, appName)
+
+	if err != nil {
+		return err
 	}
 
-	machineConf := api.MachineConfig{
-		Guest: &api.MachineGuest{
-			CPUKind:    "shared",
-			CPUs:       1,
-			MemoryMB:   256,
-			KernelArgs: flag.GetStringSlice(ctx, "kernel-arg"),
-		},
-	}
-
-	input := api.LaunchMachineInput{
-		AppID:  machineApp.Name,
-		Name:   flag.GetString(ctx, "name"),
-		Region: flag.GetString(ctx, "region"),
-	}
-
-	flapsClient, err := flaps.New(ctx, machineApp)
+	flapsClient, err := flaps.New(ctx, app)
 	if err != nil {
 		return fmt.Errorf("could not make API client: %w", err)
 	}
 
-	machineID := flag.GetString(ctx, "id")
-	if machineID != "" {
-
-		machine, err := flapsClient.Get(ctx, machineID)
-		if err != nil {
-			return fmt.Errorf("failed to get machine, %s: %w", machineID, err)
-		}
-		fmt.Fprintf(io.Out, "machine %s was found and is currently in a %s state, attempting to update...\n", machineID, machine.State)
-		input.ID = machineID
-		input.Name = machine.Name
-		input.Region = ""
-		machineConf = *machine.Config
+	machine, err := flapsClient.Get(ctx, machineID)
+	if err != nil {
+		return err
 	}
 
-	if guestSize := flag.GetString(ctx, "size"); guestSize != "" {
-		guest, ok := api.MachinePresets[guestSize]
-		if !ok {
-			validSizes := []string{}
-			for size := range api.MachinePresets {
-				if strings.HasPrefix(size, "shared") {
-					validSizes = append(validSizes, size)
-				}
-			}
-			sort.Strings(validSizes)
-			return fmt.Errorf("invalid machine size requested, '%s', available:\n%s", guestSize, strings.Join(validSizes, "\n"))
-		}
-		machineConf.Guest = guest
-	} else {
-		if cpus := flag.GetInt(ctx, "cpus"); cpus != 0 {
-			machineConf.Guest.CPUs = cpus
-		}
+	fmt.Fprintf(io.Out, "Machine %s was found and is currently in a %s state, attempting to update...\n", machineID, machine.State)
 
-		if memory := flag.GetInt(ctx, "memory"); memory != 0 {
-			machineConf.Guest.MemoryMB = memory
-		}
+	input := api.LaunchMachineInput{
+		ID:     machine.ID,
+		AppID:  app.Name,
+		Name:   machine.Name,
+		Region: machine.Region,
+	}
+
+	machineConf := *machine.Config
+
+	if cpus := flag.GetInt(ctx, "cpus"); cpus != 0 {
+		machineConf.Guest.CPUs = cpus
+	}
+
+	if memory := flag.GetInt(ctx, "memory"); memory != 0 {
+		machineConf.Guest.MemoryMB = memory
 	}
 
 	machineConf.Env, err = parseEnvVars(ctx)
@@ -269,7 +205,13 @@ func runMachineRun(ctx context.Context) error {
 		return err
 	}
 
-	img, err := determineImage(ctx, machineApp.Name)
+	image := machine.FullImageRef()
+
+	if flag.GetString(ctx, "image") != "" {
+		image = flag.GetString(ctx, "image")
+	}
+
+	img, err := determineImage(ctx, app.Name, image)
 	if err != nil {
 		return err
 	}
@@ -281,264 +223,16 @@ func runMachineRun(ctx context.Context) error {
 
 	input.Config = &machineConf
 
-	machine, err := flapsClient.Launch(ctx, input)
+	machine, err = flapsClient.Update(ctx, input, "")
+
 	if err != nil {
-		return fmt.Errorf("could not launch machine: %w", err)
+		return err
 	}
-
-	id, instanceID, state, privateIP := machine.ID, machine.InstanceID, machine.State, machine.PrivateIP
-
-	fmt.Fprintf(io.Out, "Success! A machine has been successfully launched, waiting for it to be started\n")
-	fmt.Fprintf(io.Out, " Machine ID: %s\n", id)
-	fmt.Fprintf(io.Out, " Instance ID: %s\n", instanceID)
-	fmt.Fprintf(io.Out, " State: %s\n", state)
 
 	// wait for machine to be started
 	if err := WaitForStart(ctx, flapsClient, machine); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(io.Out, "Machine started, you can connect via the following private ip\n")
-	fmt.Fprintf(io.Out, "  %s\n", privateIP)
-
 	return nil
-}
-
-func createApp(ctx context.Context, message, name string, client *api.Client) (*api.AppCompact, error) {
-	confirm, err := prompt.Confirm(ctx, message)
-	if err != nil {
-		return nil, err
-	}
-
-	if !confirm {
-		return nil, nil
-	}
-
-	org, err := prompt.Org(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if name == "" {
-		name, err = selectAppName(ctx)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	input := api.CreateAppInput{
-		Name:           name,
-		OrganizationID: org.ID,
-	}
-
-	app, err := client.CreateApp(ctx, input)
-	if err != nil {
-		return nil, err
-	}
-
-	return &api.AppCompact{
-		ID:       app.ID,
-		Name:     app.Name,
-		Status:   app.Status,
-		Deployed: app.Deployed,
-		Hostname: app.Hostname,
-		AppURL:   app.AppURL,
-		Organization: &api.OrganizationBasic{
-			ID:   app.Organization.ID,
-			Slug: app.Organization.Slug,
-		},
-	}, nil
-}
-
-func WaitForStart(ctx context.Context, flapsClient *flaps.Client, machine *api.Machine) error {
-	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	b := &backoff.Backoff{
-		Min:    500 * time.Millisecond,
-		Max:    2 * time.Second,
-		Factor: 2,
-		Jitter: false,
-	}
-	for {
-		err := flapsClient.Wait(waitCtx, machine)
-		switch {
-		case errors.Is(err, context.Canceled):
-			return err
-		case errors.Is(err, context.DeadlineExceeded):
-			return fmt.Errorf("timeout reached waiting for machine to start %w", err)
-		case err != nil:
-			time.Sleep(b.Duration())
-			continue
-		}
-		return nil
-	}
-}
-
-func parseEnvVars(ctx context.Context) (map[string]string, error) {
-	var env = make(map[string]string)
-
-	if extraEnv := flag.GetStringSlice(ctx, "env"); len(extraEnv) > 0 {
-		parsedEnv, err := cmdutil.ParseKVStringsToMap(flag.GetStringSlice(ctx, "env"))
-		if err != nil {
-			return nil, errors.Wrap(err, "invalid env")
-		}
-		env = parsedEnv
-	}
-	return env, nil
-}
-
-func determineImage(ctx context.Context, appName string) (img *imgsrc.DeploymentImage, err error) {
-	var (
-		client = client.FromContext(ctx).API()
-		io     = iostreams.FromContext(ctx)
-	)
-
-	daemonType := imgsrc.NewDockerDaemonType(!flag.GetBool(ctx, "build-remote-only"), !flag.GetBool(ctx, "build-local-only"), env.IsCI())
-	resolver := imgsrc.NewResolver(daemonType, client, appName, io)
-
-	imageOrPath := flag.FirstArg(ctx)
-	// build if relative or absolute path
-	if strings.HasPrefix(imageOrPath, ".") || strings.HasPrefix(imageOrPath, "/") {
-		opts := imgsrc.ImageOptions{
-			AppName:    appName,
-			WorkingDir: path.Join(state.WorkingDirectory(ctx), imageOrPath),
-			Publish:    !flag.GetBuildOnly(ctx),
-			ImageLabel: flag.GetString(ctx, "image-label"),
-			Target:     flag.GetString(ctx, "build-target"),
-			NoCache:    flag.GetBool(ctx, "no-build-cache"),
-		}
-		if dockerfilePath := flag.GetString(ctx, "dockerfile"); dockerfilePath != "" {
-			dockerfilePath, err := filepath.Abs(dockerfilePath)
-			if err != nil {
-				return nil, err
-			}
-			opts.DockerfilePath = dockerfilePath
-		}
-
-		extraArgs, err := cmdutil.ParseKVStringsToMap(flag.GetStringSlice(ctx, "build-arg"))
-		if err != nil {
-			return nil, errors.Wrap(err, "invalid build-arg")
-		}
-		opts.BuildArgs = extraArgs
-
-		img, err = resolver.BuildImage(ctx, io, opts)
-		if err != nil {
-			return nil, err
-		}
-		if img == nil {
-			return nil, errors.New("could not find an image to deploy")
-		}
-	} else {
-		opts := imgsrc.RefOptions{
-			AppName:    appName,
-			WorkingDir: state.WorkingDirectory(ctx),
-			Publish:    !flag.GetBool(ctx, "build-only"),
-			ImageRef:   imageOrPath,
-			ImageLabel: flag.GetString(ctx, "image-label"),
-		}
-
-		img, err = resolver.ResolveReference(ctx, io, opts)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if img == nil {
-		return nil, errors.New("could not find an image to deploy")
-	}
-
-	fmt.Fprintf(io.Out, "Image: %s\n", img.Tag)
-	fmt.Fprintf(io.Out, "Image size: %s\n", humanize.Bytes(uint64(img.Size)))
-
-	return img, nil
-}
-
-func determineMounts(ctx context.Context) ([]api.MachineMount, error) {
-	var mounts []api.MachineMount
-
-	for _, v := range flag.GetStringSlice(ctx, "volume") {
-		splittedIDDestOpts := strings.Split(v, ":")
-
-		mount := api.MachineMount{
-			Volume: splittedIDDestOpts[0],
-			Path:   splittedIDDestOpts[1],
-		}
-
-		if len(splittedIDDestOpts) > 2 {
-			splittedOpts := strings.Split(splittedIDDestOpts[2], ",")
-			for _, opt := range splittedOpts {
-				splittedKeyValue := strings.Split(opt, "=")
-				if splittedKeyValue[0] == "size" {
-					i, err := strconv.Atoi(splittedKeyValue[1])
-					if err != nil {
-						return nil, errors.Wrapf(err, "could not parse volume '%s' size option value '%s', must be an integer", splittedIDDestOpts[0], splittedKeyValue[1])
-					}
-					mount.SizeGb = i
-				} else if splittedKeyValue[0] == "encrypt" {
-					mount.Encrypted = true
-				}
-			}
-		}
-
-		mounts = append(mounts, mount)
-	}
-	return mounts, nil
-}
-
-func determineServices(ctx context.Context) ([]api.MachineService, error) {
-	ports := flag.GetStringSlice(ctx, "port")
-
-	if len(ports) <= 0 {
-		return []api.MachineService{}, nil
-	}
-
-	machineServices := make([]api.MachineService, len(ports))
-
-	for i, p := range flag.GetStringSlice(ctx, "port") {
-		proto := "tcp"
-		handlers := []string{}
-
-		splittedPortsProto := strings.Split(p, "/")
-		if len(splittedPortsProto) > 1 {
-			splittedProtoHandlers := strings.Split(splittedPortsProto[1], ":")
-			proto = splittedProtoHandlers[0]
-			handlers = append(handlers, splittedProtoHandlers[1:]...)
-		}
-
-		splittedPorts := strings.Split(splittedPortsProto[0], ":")
-		edgePort, err := strconv.Atoi(splittedPorts[0])
-		if err != nil {
-			return nil, errors.Wrap(err, "invalid edge port")
-		}
-		machinePort := edgePort
-		if len(splittedPorts) > 1 {
-			machinePort, err = strconv.Atoi(splittedPorts[1])
-			if err != nil {
-				return nil, errors.Wrap(err, "invalid machine (internal) port")
-			}
-		}
-
-		machineServices[i] = api.MachineService{
-			Protocol:     proto,
-			InternalPort: machinePort,
-			Ports: []api.MachinePort{
-				{
-					Port:     edgePort,
-					Handlers: handlers,
-				},
-			},
-		}
-	}
-	return machineServices, nil
-}
-
-func selectAppName(ctx context.Context) (name string, err error) {
-	const msg = "App Name:"
-
-	if err = prompt.String(ctx, &name, msg, "", false); prompt.IsNonInteractive(err) {
-		err = prompt.NonInteractiveError("name argument or flag must be specified when not running interactively")
-	}
-
-	return
 }

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -1,0 +1,544 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/google/shlex"
+	"github.com/jpillora/backoff"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/iostreams"
+
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/app"
+	"github.com/superfly/flyctl/internal/build/imgsrc"
+	"github.com/superfly/flyctl/internal/cmdutil"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/env"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/internal/state"
+)
+
+func newRun() *cobra.Command {
+	const (
+		short = "Run a machine"
+		long  = short + "\n"
+
+		usage = "run <image> [command]"
+	)
+
+	cmd := command.New(usage, short, long, runMachineRun,
+		command.RequireSession,
+		command.LoadAppNameIfPresent,
+	)
+
+	flag.Add(
+		cmd,
+		flag.App(),
+		flag.Region(),
+		flag.AppConfig(),
+		flag.String{
+			Name:        "id",
+			Description: "Machine ID, if previously known",
+		},
+		flag.String{
+			Name:        "name",
+			Shorthand:   "n",
+			Description: "Machine name, will be generated if missing",
+		},
+		flag.String{
+			Name:        "org",
+			Description: `The organization that will own the app`,
+		},
+		flag.StringSlice{
+			Name:        "port",
+			Shorthand:   "p",
+			Description: "Exposed port mappings (format: edgePort[:machinePort]/[protocol[:handler]])",
+		},
+		flag.String{
+			Name:        "size",
+			Shorthand:   "s",
+			Description: "Preset guest cpu and memory for a machine, defaults to shared-cpu-1x",
+		},
+		flag.Int{
+			Name:        "cpus",
+			Description: "Number of CPUs",
+			Hidden:      true,
+		},
+		flag.Int{
+			Name:        "memory",
+			Description: "Memory (in megabytes) to attribute to the machine",
+			Hidden:      true,
+		},
+		flag.StringSlice{
+			Name:        "env",
+			Shorthand:   "e",
+			Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
+		},
+		flag.StringSlice{
+			Name:        "volume",
+			Shorthand:   "v",
+			Description: "Volumes to mount in the form of <volume_id_or_name>:/path/inside/machine[:<options>]",
+			Hidden:      true,
+		},
+		flag.String{
+			Name:        "entrypoint",
+			Description: "ENTRYPOINT replacement",
+			Hidden:      true,
+		},
+		flag.Bool{
+			Name:        "detach",
+			Shorthand:   "d",
+			Description: "Detach from the machine's logs",
+			Hidden:      true,
+		},
+		flag.Bool{
+			Name:        "build-only",
+			Description: "Only build the image without running the machine",
+			Hidden:      true,
+		},
+		flag.Bool{
+			Name:        "build-remote-only",
+			Description: "Perform builds remotely without using the local docker daemon",
+			Hidden:      true,
+		},
+		flag.Bool{
+			Name:        "build-local-only",
+			Description: "Only perform builds locally using the local docker daemon",
+			Hidden:      true,
+		},
+		flag.String{
+			Name:        "dockerfile",
+			Description: "Path to a Dockerfile. Defaults to the Dockerfile in the working directory.",
+		},
+		flag.StringSlice{
+			Name:        "build-arg",
+			Description: "Set of build time variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
+			Hidden:      true,
+		},
+		flag.String{
+			Name:        "image-label",
+			Description: "Image label to use when tagging and pushing to the fly registry. Defaults to \"deployment-{timestamp}\".",
+			Hidden:      true,
+		},
+		flag.String{
+			Name:        "build-target",
+			Description: "Set the target build stage to build if the Dockerfile has more than one stage",
+			Hidden:      true,
+		},
+		flag.Bool{
+			Name:        "no-build-cache",
+			Description: "Do not use the cache when building the image",
+			Hidden:      true,
+		},
+		flag.StringSlice{
+			Name:        "kernel-arg",
+			Description: "List of kernel arguments to be provided to the init. Can be specified multiple times.",
+			Hidden:      true,
+		},
+	)
+
+	cmd.Args = cobra.MinimumNArgs(1)
+
+	return cmd
+}
+
+func runMachineRun(ctx context.Context) error {
+	var (
+		appName    = app.NameFromContext(ctx)
+		client     = client.FromContext(ctx).API()
+		io         = iostreams.FromContext(ctx)
+		err        error
+		machineApp *api.AppCompact
+	)
+
+	if appName == "" {
+		machineApp, err = createApp(ctx, "Running a machine without specifying an app will create one for you, is this what you want?", "", client)
+		if err != nil {
+			return err
+		}
+	} else {
+		machineApp, err = client.GetAppCompact(ctx, appName)
+		if err != nil && strings.Contains(err.Error(), "Could not find App") {
+			machineApp, err = createApp(ctx, fmt.Sprintf("App '%s' does not exist, would you like to create it?", appName), appName, client)
+			if machineApp == nil {
+				return nil
+			}
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	machineConf := api.MachineConfig{
+		Guest: &api.MachineGuest{
+			CPUKind:    "shared",
+			CPUs:       1,
+			MemoryMB:   256,
+			KernelArgs: flag.GetStringSlice(ctx, "kernel-arg"),
+		},
+	}
+
+	input := api.LaunchMachineInput{
+		AppID:  machineApp.Name,
+		Name:   flag.GetString(ctx, "name"),
+		Region: flag.GetString(ctx, "region"),
+	}
+
+	flapsClient, err := flaps.New(ctx, machineApp)
+	if err != nil {
+		return fmt.Errorf("could not make API client: %w", err)
+	}
+
+	machineID := flag.GetString(ctx, "id")
+	if machineID != "" {
+
+		machine, err := flapsClient.Get(ctx, machineID)
+		if err != nil {
+			return fmt.Errorf("failed to get machine, %s: %w", machineID, err)
+		}
+		fmt.Fprintf(io.Out, "machine %s was found and is currently in a %s state, attempting to update...\n", machineID, machine.State)
+		input.ID = machineID
+		input.Name = machine.Name
+		input.Region = ""
+		machineConf = *machine.Config
+	}
+
+	if guestSize := flag.GetString(ctx, "size"); guestSize != "" {
+		guest, ok := api.MachinePresets[guestSize]
+		if !ok {
+			validSizes := []string{}
+			for size := range api.MachinePresets {
+				if strings.HasPrefix(size, "shared") {
+					validSizes = append(validSizes, size)
+				}
+			}
+			sort.Strings(validSizes)
+			return fmt.Errorf("invalid machine size requested, '%s', available:\n%s", guestSize, strings.Join(validSizes, "\n"))
+		}
+		machineConf.Guest = guest
+	} else {
+		if cpus := flag.GetInt(ctx, "cpus"); cpus != 0 {
+			machineConf.Guest.CPUs = cpus
+		}
+
+		if memory := flag.GetInt(ctx, "memory"); memory != 0 {
+			machineConf.Guest.MemoryMB = memory
+		}
+	}
+
+	machineConf.Env, err = parseEnvVars(ctx)
+	if err != nil {
+		return err
+	}
+
+	services, err := determineServices(ctx)
+	if err != nil {
+		return err
+	}
+	if len(services) > 0 {
+		machineConf.Services = services
+	}
+
+	if entrypoint := flag.GetString(ctx, "entrypoint"); entrypoint != "" {
+		splitted, err := shlex.Split(entrypoint)
+		if err != nil {
+			return errors.Wrap(err, "invalid entrypoint")
+		}
+		machineConf.Init.Entrypoint = splitted
+	}
+
+	if cmd := flag.Args(ctx)[1:]; len(cmd) > 0 {
+		machineConf.Init.Cmd = cmd
+	}
+
+	machineConf.Mounts, err = determineMounts(ctx)
+	if err != nil {
+		return err
+	}
+
+	img, err := determineImage(ctx, machineApp.Name)
+	if err != nil {
+		return err
+	}
+	machineConf.Image = img.Tag
+
+	if flag.GetBool(ctx, "build-only") {
+		return nil
+	}
+
+	input.Config = &machineConf
+
+	machine, err := flapsClient.Launch(ctx, input)
+	if err != nil {
+		return fmt.Errorf("could not launch machine: %w", err)
+	}
+
+	id, instanceID, state, privateIP := machine.ID, machine.InstanceID, machine.State, machine.PrivateIP
+
+	fmt.Fprintf(io.Out, "Success! A machine has been successfully launched, waiting for it to be started\n")
+	fmt.Fprintf(io.Out, " Machine ID: %s\n", id)
+	fmt.Fprintf(io.Out, " Instance ID: %s\n", instanceID)
+	fmt.Fprintf(io.Out, " State: %s\n", state)
+
+	// wait for machine to be started
+	if err := WaitForStart(ctx, flapsClient, machine); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(io.Out, "Machine started, you can connect via the following private ip\n")
+	fmt.Fprintf(io.Out, "  %s\n", privateIP)
+
+	return nil
+}
+
+func createApp(ctx context.Context, message, name string, client *api.Client) (*api.AppCompact, error) {
+	confirm, err := prompt.Confirm(ctx, message)
+	if err != nil {
+		return nil, err
+	}
+
+	if !confirm {
+		return nil, nil
+	}
+
+	org, err := prompt.Org(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if name == "" {
+		name, err = selectAppName(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	input := api.CreateAppInput{
+		Name:           name,
+		OrganizationID: org.ID,
+	}
+
+	app, err := client.CreateApp(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.AppCompact{
+		ID:       app.ID,
+		Name:     app.Name,
+		Status:   app.Status,
+		Deployed: app.Deployed,
+		Hostname: app.Hostname,
+		AppURL:   app.AppURL,
+		Organization: &api.OrganizationBasic{
+			ID:   app.Organization.ID,
+			Slug: app.Organization.Slug,
+		},
+	}, nil
+}
+
+func WaitForStart(ctx context.Context, flapsClient *flaps.Client, machine *api.Machine) error {
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	b := &backoff.Backoff{
+		Min:    500 * time.Millisecond,
+		Max:    2 * time.Second,
+		Factor: 2,
+		Jitter: false,
+	}
+	for {
+		err := flapsClient.Wait(waitCtx, machine)
+		switch {
+		case errors.Is(err, context.Canceled):
+			return err
+		case errors.Is(err, context.DeadlineExceeded):
+			return fmt.Errorf("timeout reached waiting for machine to start %w", err)
+		case err != nil:
+			time.Sleep(b.Duration())
+			continue
+		}
+		return nil
+	}
+}
+
+func parseEnvVars(ctx context.Context) (map[string]string, error) {
+	var env = make(map[string]string)
+
+	if extraEnv := flag.GetStringSlice(ctx, "env"); len(extraEnv) > 0 {
+		parsedEnv, err := cmdutil.ParseKVStringsToMap(flag.GetStringSlice(ctx, "env"))
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid env")
+		}
+		env = parsedEnv
+	}
+	return env, nil
+}
+
+func determineImage(ctx context.Context, appName string) (img *imgsrc.DeploymentImage, err error) {
+	var (
+		client = client.FromContext(ctx).API()
+		io     = iostreams.FromContext(ctx)
+	)
+
+	daemonType := imgsrc.NewDockerDaemonType(!flag.GetBool(ctx, "build-remote-only"), !flag.GetBool(ctx, "build-local-only"), env.IsCI())
+	resolver := imgsrc.NewResolver(daemonType, client, appName, io)
+
+	imageOrPath := flag.FirstArg(ctx)
+	// build if relative or absolute path
+	if strings.HasPrefix(imageOrPath, ".") || strings.HasPrefix(imageOrPath, "/") {
+		opts := imgsrc.ImageOptions{
+			AppName:    appName,
+			WorkingDir: path.Join(state.WorkingDirectory(ctx), imageOrPath),
+			Publish:    !flag.GetBuildOnly(ctx),
+			ImageLabel: flag.GetString(ctx, "image-label"),
+			Target:     flag.GetString(ctx, "build-target"),
+			NoCache:    flag.GetBool(ctx, "no-build-cache"),
+		}
+		if dockerfilePath := flag.GetString(ctx, "dockerfile"); dockerfilePath != "" {
+			dockerfilePath, err := filepath.Abs(dockerfilePath)
+			if err != nil {
+				return nil, err
+			}
+			opts.DockerfilePath = dockerfilePath
+		}
+
+		extraArgs, err := cmdutil.ParseKVStringsToMap(flag.GetStringSlice(ctx, "build-arg"))
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid build-arg")
+		}
+		opts.BuildArgs = extraArgs
+
+		img, err = resolver.BuildImage(ctx, io, opts)
+		if err != nil {
+			return nil, err
+		}
+		if img == nil {
+			return nil, errors.New("could not find an image to deploy")
+		}
+	} else {
+		opts := imgsrc.RefOptions{
+			AppName:    appName,
+			WorkingDir: state.WorkingDirectory(ctx),
+			Publish:    !flag.GetBool(ctx, "build-only"),
+			ImageRef:   imageOrPath,
+			ImageLabel: flag.GetString(ctx, "image-label"),
+		}
+
+		img, err = resolver.ResolveReference(ctx, io, opts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if img == nil {
+		return nil, errors.New("could not find an image to deploy")
+	}
+
+	fmt.Fprintf(io.Out, "Image: %s\n", img.Tag)
+	fmt.Fprintf(io.Out, "Image size: %s\n", humanize.Bytes(uint64(img.Size)))
+
+	return img, nil
+}
+
+func determineMounts(ctx context.Context) ([]api.MachineMount, error) {
+	var mounts []api.MachineMount
+
+	for _, v := range flag.GetStringSlice(ctx, "volume") {
+		splittedIDDestOpts := strings.Split(v, ":")
+
+		mount := api.MachineMount{
+			Volume: splittedIDDestOpts[0],
+			Path:   splittedIDDestOpts[1],
+		}
+
+		if len(splittedIDDestOpts) > 2 {
+			splittedOpts := strings.Split(splittedIDDestOpts[2], ",")
+			for _, opt := range splittedOpts {
+				splittedKeyValue := strings.Split(opt, "=")
+				if splittedKeyValue[0] == "size" {
+					i, err := strconv.Atoi(splittedKeyValue[1])
+					if err != nil {
+						return nil, errors.Wrapf(err, "could not parse volume '%s' size option value '%s', must be an integer", splittedIDDestOpts[0], splittedKeyValue[1])
+					}
+					mount.SizeGb = i
+				} else if splittedKeyValue[0] == "encrypt" {
+					mount.Encrypted = true
+				}
+			}
+		}
+
+		mounts = append(mounts, mount)
+	}
+	return mounts, nil
+}
+
+func determineServices(ctx context.Context) ([]api.MachineService, error) {
+	ports := flag.GetStringSlice(ctx, "port")
+
+	if len(ports) <= 0 {
+		return []api.MachineService{}, nil
+	}
+
+	machineServices := make([]api.MachineService, len(ports))
+
+	for i, p := range flag.GetStringSlice(ctx, "port") {
+		proto := "tcp"
+		handlers := []string{}
+
+		splittedPortsProto := strings.Split(p, "/")
+		if len(splittedPortsProto) > 1 {
+			splittedProtoHandlers := strings.Split(splittedPortsProto[1], ":")
+			proto = splittedProtoHandlers[0]
+			handlers = append(handlers, splittedProtoHandlers[1:]...)
+		}
+
+		splittedPorts := strings.Split(splittedPortsProto[0], ":")
+		edgePort, err := strconv.Atoi(splittedPorts[0])
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid edge port")
+		}
+		machinePort := edgePort
+		if len(splittedPorts) > 1 {
+			machinePort, err = strconv.Atoi(splittedPorts[1])
+			if err != nil {
+				return nil, errors.Wrap(err, "invalid machine (internal) port")
+			}
+		}
+
+		machineServices[i] = api.MachineService{
+			Protocol:     proto,
+			InternalPort: machinePort,
+			Ports: []api.MachinePort{
+				{
+					Port:     edgePort,
+					Handlers: handlers,
+				},
+			},
+		}
+	}
+	return machineServices, nil
+}
+
+func selectAppName(ctx context.Context) (name string, err error) {
+	const msg = "App Name:"
+
+	if err = prompt.String(ctx, &name, msg, "", false); prompt.IsNonInteractive(err) {
+		err = prompt.NonInteractiveError("name argument or flag must be specified when not running interactively")
+	}
+
+	return
+}

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/shlex"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/api"
@@ -32,99 +30,7 @@ func newUpdate() *cobra.Command {
 
 	flag.Add(
 		cmd,
-		flag.App(),
-		flag.Region(),
-		flag.AppConfig(),
-		flag.String{
-			Name:        "name",
-			Shorthand:   "n",
-			Description: "Machine name, will be generated if missing",
-		},
-		flag.StringSlice{
-			Name:        "port",
-			Shorthand:   "p",
-			Description: "Exposed port mappings (format: edgePort[:machinePort]/[protocol[:handler]])",
-		},
-		flag.Int{
-			Name:        "cpus",
-			Description: "Number of CPUs",
-			Hidden:      true,
-		},
-		flag.Int{
-			Name:        "memory",
-			Description: "Memory (in megabytes) to attribute to the machine",
-			Hidden:      true,
-		},
-		flag.StringSlice{
-			Name:        "env",
-			Shorthand:   "e",
-			Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
-		},
-		flag.StringSlice{
-			Name:        "volume",
-			Shorthand:   "v",
-			Description: "Volumes to mount in the form of <volume_id_or_name>:/path/inside/machine[:<options>]",
-			Hidden:      true,
-		},
-		flag.String{
-			Name:        "entrypoint",
-			Description: "ENTRYPOINT replacement",
-			Hidden:      true,
-		},
-		flag.String{
-			Name:        "image",
-			Shorthand:   "i",
-			Description: "Docker Image to update the machine with",
-		},
-		flag.Bool{
-			Name:        "build-only",
-			Description: "Only build the image without running the machine",
-			Hidden:      true,
-		},
-		flag.Bool{
-			Name:        "build-remote-only",
-			Description: "Perform builds remotely without using the local docker daemon",
-			Hidden:      true,
-		},
-		flag.Bool{
-			Name:        "build-local-only",
-			Description: "Only perform builds locally using the local docker daemon",
-			Hidden:      true,
-		},
-		flag.String{
-			Name:        "dockerfile",
-			Description: "Path to a Dockerfile. Defaults to the Dockerfile in the working directory.",
-		},
-		flag.StringSlice{
-			Name:        "build-arg",
-			Description: "Set of build time variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
-			Hidden:      true,
-		},
-		flag.String{
-			Name:        "image-label",
-			Description: "Image label to use when tagging and pushing to the fly registry. Defaults to \"deployment-{timestamp}\".",
-			Hidden:      true,
-		},
-		flag.String{
-			Name:        "build-target",
-			Description: "Set the target build stage to build if the Dockerfile has more than one stage",
-			Hidden:      true,
-		},
-		flag.Bool{
-			Name:        "no-build-cache",
-			Description: "Do not use the cache when building the image",
-			Hidden:      true,
-		},
-		flag.StringSlice{
-			Name:        "kernel-arg",
-			Description: "List of kernel arguments to be provided to the init. Can be specified multiple times.",
-			Hidden:      true,
-		},
-		flag.StringSlice{
-			Name:        "metadata",
-			Shorthand:   "m",
-			Description: "Metadata in the form of NAME=VALUE pairs. Can be specified multiple times.",
-		},
+		sharedFlags,
 	)
 
 	cmd.Args = cobra.ExactArgs(1)
@@ -167,58 +73,10 @@ func runUpdate(ctx context.Context) (err error) {
 
 	machineConf := *machine.Config
 
-	if cpus := flag.GetInt(ctx, "cpus"); cpus != 0 {
-		machineConf.Guest.CPUs = cpus
-	}
+	machineConf, err = determineMachineConfig(ctx, machineConf, app, machine.Config.Image)
 
-	if memory := flag.GetInt(ctx, "memory"); memory != 0 {
-		machineConf.Guest.MemoryMB = memory
-	}
-
-	machineConf.Env, err = parseEnvVars(ctx)
 	if err != nil {
-		return err
-	}
-
-	services, err := determineServices(ctx)
-	if err != nil {
-		return err
-	}
-	if len(services) > 0 {
-		machineConf.Services = services
-	}
-
-	if entrypoint := flag.GetString(ctx, "entrypoint"); entrypoint != "" {
-		splitted, err := shlex.Split(entrypoint)
-		if err != nil {
-			return errors.Wrap(err, "invalid entrypoint")
-		}
-		machineConf.Init.Entrypoint = splitted
-	}
-
-	if cmd := flag.Args(ctx)[1:]; len(cmd) > 0 {
-		machineConf.Init.Cmd = cmd
-	}
-
-	machineConf.Mounts, err = determineMounts(ctx)
-	if err != nil {
-		return err
-	}
-
-	image := machine.FullImageRef()
-
-	if flag.GetString(ctx, "image") != "" {
-		image = flag.GetString(ctx, "image")
-	}
-
-	img, err := determineImage(ctx, app.Name, image)
-	if err != nil {
-		return err
-	}
-	machineConf.Image = img.Tag
-
-	if flag.GetBool(ctx, "build-only") {
-		return nil
+		return
 	}
 
 	input.Config = &machineConf

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -56,6 +56,14 @@ type Flag interface {
 	addTo(*cobra.Command)
 }
 
+type Set []Flag
+
+func (s Set) addTo(cmd *cobra.Command) {
+	for _, flag := range s {
+		flag.addTo(cmd)
+	}
+}
+
 // Add adds flag to cmd, binding them on v should v not be nil.
 func Add(cmd *cobra.Command, flags ...Flag) {
 	for _, flag := range flags {


### PR DESCRIPTION
This replaces the confusing `fly machine run --id` flag, and allows update semantics and allowed flags to differ from `run`.

Also, we introduce the `--metadata` flag to run/update, in preparation for implementing deployments with [process groups](https://fly.io/docs/reference/configuration/#per-process-commands).