### PR TITLE
Various machine launcher fixes and improvements

### DIFF
--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -14,7 +14,6 @@ import (
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/logger"
-	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/client"
 )
@@ -63,9 +62,6 @@ func New(ctx context.Context, app *api.AppCompact) (*Client, error) {
 }
 
 func (f *Client) CreateApp(ctx context.Context, name string, org string) (err error) {
-	io := iostreams.FromContext(ctx)
-	fmt.Fprintf(io.Out, "Creating app: %s", name)
-
 	var in = map[string]interface{}{
 		"app_name": name,
 		"org_slug": org,
@@ -76,8 +72,6 @@ func (f *Client) CreateApp(ctx context.Context, name string, org string) (err er
 }
 
 func (f *Client) Launch(ctx context.Context, builder api.LaunchMachineInput) (*api.Machine, error) {
-	fmt.Println("Machine is launching...")
-
 	var endpoint string
 	if builder.ID != "" {
 		endpoint = fmt.Sprintf("/%s", builder.ID)
@@ -93,8 +87,6 @@ func (f *Client) Launch(ctx context.Context, builder api.LaunchMachineInput) (*a
 }
 
 func (f *Client) Update(ctx context.Context, builder api.LaunchMachineInput, nonce string) (*api.Machine, error) {
-	fmt.Println("Machine is updating...")
-
 	var headers = make(map[string][]string)
 
 	if nonce != "" {
@@ -112,7 +104,6 @@ func (f *Client) Update(ctx context.Context, builder api.LaunchMachineInput, non
 }
 
 func (f *Client) Start(ctx context.Context, machineID string) (*api.MachineStartResponse, error) {
-	fmt.Println("Machine is starting...")
 	startEndpoint := fmt.Sprintf("/%s/start", machineID)
 
 	out := new(api.MachineStartResponse)
@@ -124,8 +115,6 @@ func (f *Client) Start(ctx context.Context, machineID string) (*api.MachineStart
 }
 
 func (f *Client) Wait(ctx context.Context, machine *api.Machine) (err error) {
-	fmt.Println("Waiting on firecracker VM...")
-
 	waitEndpoint := fmt.Sprintf("/%s/wait", machine.ID)
 
 	version := machine.InstanceID
@@ -134,7 +123,6 @@ func (f *Client) Wait(ctx context.Context, machine *api.Machine) (err error) {
 		version = machine.Version
 	}
 	if version != "" {
-		fmt.Printf("Waiting on machine version %s...\n", version)
 		waitEndpoint += fmt.Sprintf("?instance_id=%s&timeout=30", version)
 	} else {
 		waitEndpoint += "?timeout=30"

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -29,8 +29,8 @@ import (
 
 func New() (cmd *cobra.Command) {
 	const (
-		long = `Deploy Fly applications from source or an image using a local or remote builder. 
-		
+		long = `Deploy Fly applications from source or an image using a local or remote builder.
+
 		To disable colorized output and show full Docker build output, set the environment variable NO_COLOR=1.
 	`
 		short = "Deploy Fly applications"
@@ -52,14 +52,11 @@ func New() (cmd *cobra.Command) {
 		flag.Now(),
 		flag.RemoteOnly(false),
 		flag.LocalOnly(),
-		flag.Bool{Name: "nixpacks", Default: false},
+		flag.Nixpacks(),
 		flag.BuildOnly(),
 		flag.Push(),
 		flag.Detach(),
-		flag.String{
-			Name:        "strategy",
-			Description: "The strategy for replacing running instances. Options are canary, rolling, bluegreen, or immediate. Default is canary, or rolling when max-per-region is set.",
-		},
+		flag.Strategy(),
 		flag.Dockerfile(),
 		flag.StringSlice{
 			Name:        "env",

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -32,15 +32,19 @@ func createMachinesRelease(ctx context.Context, config *app.Config, img *imgsrc.
 	// Convert the new, slimmer http service config to standard services
 	if config.HttpService != nil {
 		concurrency := config.HttpService.Concurrency
-		if concurrency.Type == "" {
-			concurrency.Type = "requests"
+
+		if concurrency != nil {
+			if concurrency.Type == "" {
+				concurrency.Type = "requests"
+			}
+			if concurrency.HardLimit == 0 {
+				concurrency.HardLimit = 25
+			}
+			if concurrency.SoftLimit == 0 {
+				concurrency.SoftLimit = int(math.Ceil(float64(concurrency.HardLimit) * 0.8))
+			}
 		}
-		if concurrency.HardLimit == 0 {
-			concurrency.HardLimit = 25
-		}
-		if concurrency.SoftLimit == 0 {
-			concurrency.SoftLimit = int(math.Ceil(float64(concurrency.HardLimit) * 0.8))
-		}
+
 		httpService := api.MachineService{
 			Protocol:     "tcp",
 			InternalPort: config.HttpService.InternalPort,

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -90,6 +90,11 @@ func createMachinesRelease(ctx context.Context, config *app.Config, img *imgsrc.
 
 func DeployMachinesApp(ctx context.Context, app *api.AppCompact, strategy string, machineConfig *api.MachineConfig) (err error) {
 	io := iostreams.FromContext(ctx)
+
+	if strategy == "" {
+		strategy = "rolling"
+	}
+
 	fmt.Fprintf(io.Out, "Deploying with %s strategy\n", strategy)
 
 	flapsClient, err := flaps.New(ctx, app)

--- a/internal/command/machine/launch.go
+++ b/internal/command/machine/launch.go
@@ -48,6 +48,8 @@ func newLaunch() (cmd *cobra.Command) {
 		flag.RemoteOnly(true),
 		flag.LocalOnly(),
 		flag.BuildOnly(),
+		flag.Nixpacks(),
+		flag.Strategy(),
 		flag.Push(),
 		flag.Org(),
 		flag.Dockerfile(),
@@ -135,7 +137,14 @@ func run(ctx context.Context) (err error) {
 	regionCode := flag.GetString(ctx, "region")
 
 	if regionCode == "" {
-		region, err := client.GetNearestRegion(ctx)
+
+		regions, requestRegion, err := client.PlatformRegions(ctx)
+
+		if err != nil {
+			return fmt.Errorf("couldn't fetch platform regions: %w", err)
+		}
+
+		region, err := prompt.SelectRegion(ctx, regions, requestRegion.Code)
 
 		if err != nil {
 			return err
@@ -368,7 +377,7 @@ func setScannerPrefs(ctx context.Context, appConfig *app.Config, srcInfo *scanne
 				Name:      vol.Source,
 				Region:    region,
 				SizeGb:    1,
-				Encrypted: true,
+				Encrypted: false,
 			})
 
 			if err != nil {
@@ -461,6 +470,7 @@ func printAppType(ctx context.Context, srcInfo *scanner.SourceInfo) {
 }
 
 func setupHttpService(ctx context.Context, appConfig *app.Config, srcInfo *scanner.SourceInfo) (err error) {
+	client := client.FromContext(ctx).API()
 
 	var choseHttpService bool = false
 	var port, sourcePort int
@@ -489,7 +499,16 @@ func setupHttpService(ctx context.Context, appConfig *app.Config, srcInfo *scann
 			if err != nil {
 				return
 			}
+			_, err = client.AllocateIPAddress(ctx, appConfig.AppName, "v4", "")
 
+			if err != nil {
+				return err
+			}
+
+			_, err = client.AllocateIPAddress(ctx, appConfig.AppName, "v6", "")
+			if err != nil {
+				return err
+			}
 		}
 
 		appConfig.HttpService.InternalPort = port

--- a/internal/command/machine/launch.go
+++ b/internal/command/machine/launch.go
@@ -61,10 +61,6 @@ func newLaunch() (cmd *cobra.Command) {
 			Description: "Do not prompt for deployment",
 		},
 		flag.Bool{
-			Name:        "copy-config",
-			Description: "Use the configuration file if present, without prompting",
-		},
-		flag.Bool{
 			Name:        "generate-name",
 			Description: "Always generate a name for the app, without prompting",
 		},

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -346,3 +346,18 @@ func BuildTarget() String {
 		Description: "Set the target build stage to build if the Dockerfile has more than one stage",
 	}
 }
+
+func Nixpacks() Bool {
+	return Bool{
+		Name:        "nixpacks",
+		Description: "Deploy using nixpacks to generate the image",
+		Default:     false,
+	}
+}
+
+func Strategy() String {
+	return String{
+		Name:        "strategy",
+		Description: "The strategy for replacing running instances. Options are canary, rolling, bluegreen, or immediate. Default is canary, or rolling when max-per-region is set.",
+	}
+}


### PR DESCRIPTION
This PR fixes bugs preventing the new launcher from completing deployments. Also, the launcher asks for a region to deploy in, defaulting to the nearest.

Flaps debugging output is also gone, as `LOG_LEVEL=debug` makes it clear what's going on, and the default output is distracting now machines are being implemented across various commands.