### PR TITLE
Fix Invalid MachineConfig field

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -157,7 +157,6 @@ type MachineConfig struct {
 	Env      map[string]string `json:"env"`
 	Init     MachineInit       `json:"init,omitempty"`
 	Image    string            `json:"image"`
-	ImageRef machineImageRef   `json:"image_ref"`
 	Metadata map[string]string `json:"metadata"`
 	Mounts   []MachineMount    `json:"mounts,omitempty"`
 	Restart  MachineRestart    `json:"restart,omitempty"`

--- a/internal/command/image/show.go
+++ b/internal/command/image/show.go
@@ -191,7 +191,7 @@ func showMachineImage(ctx context.Context, app *api.AppCompact) error {
 	rows := [][]string{}
 
 	for _, machine := range machines {
-		var image = machine.Config.ImageRef
+		var image = machine.ImageRef
 
 		var version = "N/A"
 

--- a/internal/command/services/postgres/update.go
+++ b/internal/command/services/postgres/update.go
@@ -120,7 +120,7 @@ func runUpdate(ctx context.Context) error {
 		return fmt.Errorf("this cluster has no leader")
 	}
 
-	image := fmt.Sprintf("%s:%s", leader.Config.ImageRef.Repository, leader.Config.ImageRef.Tag)
+	image := fmt.Sprintf("%s:%s", leader.ImageRef.Repository, leader.ImageRef.Tag)
 
 	latest, err := client.GetLatestImageDetails(ctx, image)
 	if err != nil {
@@ -130,7 +130,7 @@ func runUpdate(ctx context.Context) error {
 	fmt.Fprintf(io.Out, "Updating replicas\n")
 
 	for _, replica := range replicas {
-		current := replica.Config.ImageRef
+		current := replica.ImageRef
 
 		if current.Labels["fly.version"] == latest.Version {
 			fmt.Fprintf(io.Out, "  %s: already up to date\n", replica.ID)
@@ -144,7 +144,7 @@ func runUpdate(ctx context.Context) error {
 		}
 	}
 
-	current := leader.Config.ImageRef
+	current := leader.ImageRef
 
 	if current.Labels["fly.version"] == latest.Version {
 		fmt.Fprintf(io.Out, "%s(leader): already up to date\n", leader.ID)


### PR DESCRIPTION
ImageRef cannot be part of MachineConfig because it cannot be set by the user. We recently updated flaps with the latest API and it's causing some customers to have issues creating machines.