### PR TITLE
Manage remote builders from flyctl

### DIFF
--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -307,11 +307,11 @@ func (client *Client) GetAppPostgres(ctx context.Context, appName string) (*AppP
 	return &data.AppPostgres, nil
 }
 
-func (client *Client) CreateApp(ctx context.Context, input CreateAppInput) (*App, error) {
+func (client *Client) CreateApp(ctx context.Context, input CreateAppInput) (*AppCompact, error) {
 	query := `
 		mutation($input: CreateAppInput!) {
 			createApp(input: $input) {
-				app {
+				appcompact:app {
 					id
 					name
 					organization {
@@ -338,7 +338,7 @@ func (client *Client) CreateApp(ctx context.Context, input CreateAppInput) (*App
 		return nil, err
 	}
 
-	return &data.CreateApp.App, nil
+	return &data.CreateApp.AppCompact, nil
 }
 
 func (client *Client) DeleteApp(ctx context.Context, appName string) error {

--- a/api/resource_organizations.go
+++ b/api/resource_organizations.go
@@ -45,6 +45,10 @@ func (client *Client) GetOrganizationBySlug(ctx context.Context, slug string) (*
 				remoteBuilderApp {
 					id
 					name
+					organization {
+						id
+						slug
+					}
 				}
 			}
 		}

--- a/api/resource_organizations.go
+++ b/api/resource_organizations.go
@@ -42,6 +42,10 @@ func (client *Client) GetOrganizationBySlug(ctx context.Context, slug string) (*
 				slug
 				name
 				type
+				remoteBuilderApp {
+					id
+					name
+				}
 			}
 		}
 	`

--- a/api/resource_remote_builders.go
+++ b/api/resource_remote_builders.go
@@ -2,7 +2,7 @@ package api
 
 import "context"
 
-func (client *Client) EnsureRemoteBuilder(ctx context.Context, orgID, appName string) (*GqlMachine, *App, error) {
+func (client *Client) EnsureRemoteBuilder(ctx context.Context, orgID string) (*GqlMachine, *AppCompact, error) {
 	query := `
 		mutation($input: EnsureMachineRemoteBuilderInput!) {
 			ensureMachineRemoteBuilder(input: $input) {
@@ -30,16 +30,9 @@ func (client *Client) EnsureRemoteBuilder(ctx context.Context, orgID, appName st
 
 	req := client.NewRequest(query)
 
-	if orgID != "" {
-		req.Var("input", EnsureRemoteBuilderInput{
-			OrganizationID: StringPointer(orgID),
-		})
-	} else {
-		req.Var("input", EnsureRemoteBuilderInput{
-			AppName: StringPointer(appName),
-		})
-
-	}
+	req.Var("input", EnsureRemoteBuilderInput{
+		OrganizationID: StringPointer(orgID),
+	})
 
 	data, err := client.RunWithContext(ctx, req)
 	if err != nil {

--- a/api/types.go
+++ b/api/types.go
@@ -57,7 +57,7 @@ type Query struct {
 
 	// mutations
 	CreateApp struct {
-		App App
+		AppCompact AppCompact
 	}
 
 	SetSecrets struct {
@@ -475,7 +475,7 @@ type Organization struct {
 	InternalNumericID  string
 	Name               string
 	RemoteBuilderImage string
-	RemoteBuilderApp   *App
+	RemoteBuilderApp   *AppCompact
 	Slug               string
 	Type               string
 	Domains            struct {

--- a/api/types.go
+++ b/api/types.go
@@ -73,14 +73,8 @@ type Query struct {
 		ReleaseCommand *ReleaseCommand
 	}
 
-	EnsureRemoteBuilder *struct {
-		App     *App
-		URL     string
-		Release Release
-	}
-
 	EnsureMachineRemoteBuilder *struct {
-		App     *App
+		App     *AppCompact
 		Machine *GqlMachine
 	}
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/morikuni/aec"
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/cmd/presenters"
 	"github.com/superfly/flyctl/cmdctx"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
@@ -77,8 +78,10 @@ func runDeploy(cmdCtx *cmdctx.CmdContext) error {
 		return err
 	}
 
+	ctx = client.NewContext(ctx, cmdCtx.Client)
+
 	daemonType := imgsrc.NewDockerDaemonType(!cmdCtx.Config.GetBool("remote-only"), !cmdCtx.Config.GetBool("local-only"), env.IsCI(), cmdCtx.Config.GetBool("nixpacks"))
-	resolver := imgsrc.NewResolver(daemonType, cmdCtx.Client.API(), app, cmdCtx.IO)
+	resolver := imgsrc.NewResolver(ctx, daemonType, app, cmdCtx.IO)
 
 	var img *imgsrc.DeploymentImage
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -71,8 +71,14 @@ func runDeploy(cmdCtx *cmdctx.CmdContext) error {
 		cmdfmt.PrintServicesList(cmdCtx.IO, parsedCfg.Services)
 	}
 
+	app, err := cmdCtx.Client.API().GetAppCompact(ctx, cmdCtx.AppName)
+
+	if err != nil {
+		return err
+	}
+
 	daemonType := imgsrc.NewDockerDaemonType(!cmdCtx.Config.GetBool("remote-only"), !cmdCtx.Config.GetBool("local-only"), env.IsCI(), cmdCtx.Config.GetBool("nixpacks"))
-	resolver := imgsrc.NewResolver(daemonType, cmdCtx.Client.API(), cmdCtx.AppName, cmdCtx.IO)
+	resolver := imgsrc.NewResolver(daemonType, cmdCtx.Client.API(), app, cmdCtx.IO)
 
 	var img *imgsrc.DeploymentImage
 

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -101,7 +101,10 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 	if orgSlug == "" {
 		eagerBuilderOrg = "personal"
 	}
-	go builder.LaunchOrWake(ctx, eagerBuilderOrg)
+	go func() {
+		builder, _ := builder.NewBuilder(ctx, eagerBuilderOrg)
+		builder.Start(ctx)
+	}()
 
 	appConfig := flyctl.NewAppConfig()
 
@@ -243,7 +246,10 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 
 	// spawn another builder if the chosen org is different
 	if org.Slug != eagerBuilderOrg {
-		go builder.LaunchOrWake(ctx, eagerBuilderOrg)
+		go func() {
+			builder, _ := builder.NewBuilder(ctx, eagerBuilderOrg)
+			builder.Start(ctx)
+		}()
 	}
 
 	regionCode := cmdCtx.Config.GetString("region")

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -101,6 +101,7 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 	if orgSlug == "" {
 		eagerBuilderOrg = "personal"
 	}
+
 	go func() {
 		builder, _ := builder.NewBuilder(ctx, eagerBuilderOrg)
 		builder.Start(ctx)
@@ -271,7 +272,7 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 	}
 
 	if !importedConfig {
-		appWithConfig, err := cmdCtx.Client.API().GetApp(ctx, cmdCtx.AppName)
+		appWithConfig, err := cmdCtx.Client.API().GetApp(ctx, app.Name)
 		if err != nil {
 			return err
 		}
@@ -324,7 +325,7 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 		}
 	}
 
-	fmt.Printf("Created app %s in organization %s\n", cmdCtx.AppName, org.Slug)
+	fmt.Printf("Created app %s in organization %s\n", app.Name, org.Slug)
 
 	// If secrets are requested by the launch scanner, ask the user to input them
 	if srcInfo != nil && len(srcInfo.Secrets) > 0 {
@@ -362,12 +363,12 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 		}
 
 		if len(secrets) > 0 {
-			_, err := cmdCtx.Client.API().SetSecrets(ctx, cmdCtx.AppName, secrets)
+			_, err := cmdCtx.Client.API().SetSecrets(ctx, app.Name, secrets)
 
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Set secrets on %s: %s\n", cmdCtx.AppName, strings.Join(keys, ", "))
+			fmt.Printf("Set secrets on %s: %s\n", app.Name, strings.Join(keys, ", "))
 		}
 	}
 
@@ -376,7 +377,7 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 
 		for _, vol := range srcInfo.Volumes {
 
-			appID, err := cmdCtx.Client.API().GetAppID(ctx, cmdCtx.AppName)
+			appID, err := cmdCtx.Client.API().GetAppID(ctx, app.Name)
 
 			if err != nil {
 				return err
@@ -431,13 +432,13 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 
 	if !cmdCtx.Config.GetBool("no-deploy") && !cmdCtx.Config.GetBool("now") && !srcInfo.SkipDatabase && confirm("Would you like to setup a Postgresql database now?") {
 
-		appID, err := cmdCtx.Client.API().GetAppID(ctx, cmdCtx.AppName)
+		appID, err := cmdCtx.Client.API().GetAppID(ctx, app.Name)
 
 		if err != nil {
 			return err
 		}
 
-		clusterAppName := cmdCtx.AppName + "-db"
+		clusterAppName := app.Name + "-db"
 
 		cmdCtx.Config.Set("name", clusterAppName)
 		cmdCtx.Config.Set("region", region.Code)

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -86,6 +86,7 @@ func newLaunchCommand(client *client.Client) *Command {
 
 func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 	ctx := cmdCtx.Command.Context()
+	ctx = client.NewContext(ctx, cmdCtx.Client)
 
 	dir := cmdCtx.Config.GetString("path")
 
@@ -102,10 +103,7 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 		eagerBuilderOrg = "personal"
 	}
 
-	go func() {
-		builder, _ := builder.NewBuilder(ctx, eagerBuilderOrg)
-		builder.Start(ctx)
-	}()
+	go eageryStartBuilder(ctx, eagerBuilderOrg)
 
 	appConfig := flyctl.NewAppConfig()
 
@@ -247,10 +245,7 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 
 	// spawn another builder if the chosen org is different
 	if org.Slug != eagerBuilderOrg {
-		go func() {
-			builder, _ := builder.NewBuilder(ctx, eagerBuilderOrg)
-			builder.Start(ctx)
-		}()
+		go eageryStartBuilder(ctx, org.Slug)
 	}
 
 	regionCode := cmdCtx.Config.GetString("region")
@@ -581,4 +576,11 @@ func shouldDeployExistingApp(cmdCtx *cmdctx.CmdContext, appName string) (bool, e
 	}
 
 	return true, nil
+}
+
+func eageryStartBuilder(ctx context.Context, org string) {
+	builder, err := builder.NewBuilder(ctx, org)
+	if err == nil {
+		builder.Start(ctx)
+	}
 }

--- a/cmd/turboku.go
+++ b/cmd/turboku.go
@@ -144,6 +144,7 @@ func runTurboku(cmdCtx *cmdctx.CmdContext) error {
 	}
 
 	app, err := fly.CreateApp(ctx, input)
+	var appWithConfig *api.App
 
 	switch isTakenError(err) {
 
@@ -153,11 +154,12 @@ func runTurboku(cmdCtx *cmdctx.CmdContext) error {
 	case errAppNameTaken:
 		fmt.Printf("App %s already exists\n", appName)
 
-		app, err = fly.GetApp(ctx, appName)
-		if err != nil {
-			return err
-		}
 	default:
+		return err
+	}
+
+	appWithConfig, err = fly.GetApp(ctx, app.Name)
+	if err != nil {
 		return err
 	}
 
@@ -216,7 +218,7 @@ func runTurboku(cmdCtx *cmdctx.CmdContext) error {
 	// Generate an app config to write to fly.toml
 	appConfig := flyctl.NewAppConfig()
 
-	appConfig.Definition = app.Config.Definition
+	appConfig.Definition = appWithConfig.Config.Definition
 	procfile := ""
 
 	// Add each process to a Procfile and fly.toml

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -193,7 +193,7 @@ func (f *Client) Wake(ctx context.Context, machineID string) (err error) {
 	err = f.sendRequest(ctx, http.MethodPost, fmt.Sprintf("/%s/signal", machineID), in, nil, nil)
 
 	if err != nil {
-		return fmt.Errorf("failed to send USR1 signal to VM %s: %w", machineID, err)
+		return fmt.Errorf("failed to send USR1 signal VM %s: %w", machineID, err)
 	}
 	return
 }

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -185,9 +185,23 @@ func (f *Client) Destroy(ctx context.Context, input api.RemoveMachineInput) (err
 	return
 }
 
+func (f *Client) Wake(ctx context.Context, machineID string) (err error) {
+	var in = map[string]interface{}{
+		// SIGUSR1
+		"signal": 10,
+	}
+	err = f.sendRequest(ctx, http.MethodPost, fmt.Sprintf("/%s/signal", machineID), in, nil, nil)
+
+	if err != nil {
+		return fmt.Errorf("failed to send USR1 signal to VM %s: %w", machineID, err)
+	}
+	return
+}
+
 func (f *Client) Kill(ctx context.Context, machineID string) (err error) {
 
 	var in = map[string]interface{}{
+		// SIGKILL
 		"signal": 9,
 	}
 	err = f.sendRequest(ctx, http.MethodPost, fmt.Sprintf("/%s/signal", machineID), in, nil, nil)

--- a/helpers/context.go
+++ b/helpers/context.go
@@ -1,0 +1,34 @@
+package helpers
+
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+)
+
+func PrintContextInternals(ctx interface{}, inner bool) {
+	contextValues := reflect.ValueOf(ctx).Elem()
+	contextKeys := reflect.TypeOf(ctx).Elem()
+
+	if !inner {
+		fmt.Printf("\nFields for %s.%s\n", contextKeys.PkgPath(), contextKeys.Name())
+	}
+
+	if contextKeys.Kind() == reflect.Struct {
+		for i := 0; i < contextValues.NumField(); i++ {
+			reflectValue := contextValues.Field(i)
+			reflectValue = reflect.NewAt(reflectValue.Type(), unsafe.Pointer(reflectValue.UnsafeAddr())).Elem()
+
+			reflectField := contextKeys.Field(i)
+
+			if reflectField.Name == "Context" {
+				PrintContextInternals(reflectValue.Interface(), true)
+			} else {
+				fmt.Printf("field name: %+v\n", reflectField.Name)
+				fmt.Printf("value: %+v\n", reflectValue.Interface())
+			}
+		}
+	} else {
+		fmt.Printf("context is empty (int)\n")
+	}
+}

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -174,7 +174,7 @@ func newRemoteDockerClient(ctx context.Context, apiClient *api.Client, app *api.
 	var host string
 	var err error
 
-	machine, err := remoteBuilderMachine(ctx, app)
+	machine, err := builder.GetMachine(ctx, app.Organization.Slug)
 
 	if err != nil {
 		return nil, err
@@ -441,13 +441,6 @@ func resolveDockerfile(cwd string) string {
 		return dockerfilePath
 	}
 	return ""
-}
-
-func remoteBuilderMachine(ctx context.Context, app *api.AppCompact) (*api.Machine, error) {
-	if v := os.Getenv("FLY_REMOTE_BUILDER_HOST"); v != "" {
-		return nil, nil
-	}
-	return builder.GetMachine(ctx, app)
 }
 
 func (d *dockerClientFactory) IsRemote() bool {

--- a/internal/build/imgsrc/nixpacks_builder.go
+++ b/internal/build/imgsrc/nixpacks_builder.go
@@ -103,23 +103,18 @@ func (*nixpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFact
 			return nil, err
 		}
 
-		machine, app, err := remoteBuilderMachine(ctx, dockerFactory.apiClient, dockerFactory.appName)
+		machine, err := remoteBuilderMachine(ctx, dockerFactory.app)
 		if err != nil {
 			return nil, err
 		}
 
-		var remoteHost string
-		for _, ip := range machine.IPs.Nodes {
-			terminal.Debugf("checking ip %+v\n", ip)
-			if ip.Kind == "privatenet" {
-				remoteHost = ip.IP
-				break
-			}
-		}
+		remoteHost := machine.PrivateIP
 
 		if remoteHost == "" {
 			return nil, fmt.Errorf("could not find machine IP")
 		}
+
+		app := dockerFactory.app
 
 		dialer, err := agentclient.ConnectToTunnel(ctx, app.Organization.Slug)
 		if err != nil {

--- a/internal/build/imgsrc/nixpacks_builder.go
+++ b/internal/build/imgsrc/nixpacks_builder.go
@@ -47,6 +47,11 @@ func ensureNixpacksBinary(ctx context.Context, streams *iostreams.IOStreams) err
 
 	err = func() error {
 		out, err := os.Create(installPath)
+
+		if err != nil {
+			return err
+		}
+
 		defer out.Close()
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://raw.githubusercontent.com/railwayapp/nixpacks/master/install.sh", nil)
 		if err != nil {
@@ -104,12 +109,13 @@ func (*nixpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFact
 			return nil, err
 		}
 
-		machine, err := builder.GetMachine(ctx, dockerFactory.app.Organization.Slug)
+		builder, err := builder.NewBuilder(ctx, dockerFactory.app.Organization.Slug)
+
 		if err != nil {
 			return nil, err
 		}
 
-		remoteHost := machine.PrivateIP
+		remoteHost := builder.Machine.PrivateIP
 
 		if remoteHost == "" {
 			return nil, fmt.Errorf("could not find machine IP")

--- a/internal/build/imgsrc/nixpacks_builder.go
+++ b/internal/build/imgsrc/nixpacks_builder.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flyctl"
+	"github.com/superfly/flyctl/internal/command/orgs/builder"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/proxy"
 	"github.com/superfly/flyctl/terminal"
@@ -103,7 +104,7 @@ func (*nixpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFact
 			return nil, err
 		}
 
-		machine, err := remoteBuilderMachine(ctx, dockerFactory.app)
+		machine, err := builder.GetMachine(ctx, dockerFactory.app.Organization.Slug)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -109,10 +109,9 @@ func (r *Resolver) BuildImage(ctx context.Context, streams *iostreams.IOStreams,
 	return nil, errors.New("app does not have a Dockerfile or buildpacks configured. See https://fly.io/docs/reference/configuration/#the-build-section")
 }
 
-func NewResolver(daemonType DockerDaemonType, apiClient *api.Client, app *api.AppCompact, iostreams *iostreams.IOStreams) *Resolver {
+func NewResolver(ctx context.Context, daemonType DockerDaemonType, app *api.AppCompact, iostreams *iostreams.IOStreams) *Resolver {
 	return &Resolver{
-		dockerFactory: newDockerClientFactory(daemonType, apiClient, app, iostreams),
-		apiClient:     apiClient,
+		dockerFactory: newDockerClientFactory(ctx, daemonType, app, iostreams),
 	}
 }
 

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -109,9 +109,9 @@ func (r *Resolver) BuildImage(ctx context.Context, streams *iostreams.IOStreams,
 	return nil, errors.New("app does not have a Dockerfile or buildpacks configured. See https://fly.io/docs/reference/configuration/#the-build-section")
 }
 
-func NewResolver(daemonType DockerDaemonType, apiClient *api.Client, appName string, iostreams *iostreams.IOStreams) *Resolver {
+func NewResolver(daemonType DockerDaemonType, apiClient *api.Client, app *api.AppCompact, iostreams *iostreams.IOStreams) *Resolver {
 	return &Resolver{
-		dockerFactory: newDockerClientFactory(daemonType, apiClient, appName, iostreams),
+		dockerFactory: newDockerClientFactory(daemonType, apiClient, app, iostreams),
 		apiClient:     apiClient,
 	}
 }

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -218,7 +218,7 @@ func determineImage(ctx context.Context, appConfig *app.Config) (img *imgsrc.Dep
 		return nil, err
 	}
 
-	resolver := imgsrc.NewResolver(daemonType, client, deployApp, io)
+	resolver := imgsrc.NewResolver(ctx, daemonType, deployApp, io)
 
 	var imageRef string
 	if imageRef, err = fetchImageRef(ctx, appConfig); err != nil {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -212,7 +212,13 @@ func determineImage(ctx context.Context, appConfig *app.Config) (img *imgsrc.Dep
 	client := client.FromContext(ctx).API()
 	io := iostreams.FromContext(ctx)
 
-	resolver := imgsrc.NewResolver(daemonType, client, appName, io)
+	deployApp, err := client.GetAppCompact(ctx, appName)
+
+	if err != nil {
+		return nil, err
+	}
+
+	resolver := imgsrc.NewResolver(daemonType, client, deployApp, io)
 
 	var imageRef string
 	if imageRef, err = fetchImageRef(ctx, appConfig); err != nil {

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/app"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
+	"github.com/superfly/flyctl/internal/command/orgs/builder"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -94,6 +95,8 @@ func DeployMachinesApp(ctx context.Context, app *api.AppCompact, strategy string
 	if strategy == "" {
 		strategy = "rolling"
 	}
+
+	go builder.LaunchOrWake(ctx, app.Organization.Slug)
 
 	fmt.Fprintf(io.Out, "Deploying with %s strategy\n", strategy)
 

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -10,7 +10,6 @@ import (
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/app"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
-	"github.com/superfly/flyctl/internal/command/orgs/builder"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -95,8 +94,6 @@ func DeployMachinesApp(ctx context.Context, app *api.AppCompact, strategy string
 	if strategy == "" {
 		strategy = "rolling"
 	}
-
-	go builder.LaunchOrWake(ctx, app.Organization.Slug)
 
 	fmt.Fprintf(io.Out, "Deploying with %s strategy\n", strategy)
 

--- a/internal/command/machine/launch.go
+++ b/internal/command/machine/launch.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/app"
-	"github.com/superfly/flyctl/internal/build/imgsrc"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/command/deploy"
+	"github.com/superfly/flyctl/internal/command/orgs/builder"
 	"github.com/superfly/flyctl/internal/filemu"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/prompt"
@@ -104,7 +104,7 @@ func run(ctx context.Context) (err error) {
 	// If we potentially are deploying, launch a remote builder to prepare for deployment
 
 	if !flag.GetBool(ctx, "no-deploy") {
-		go imgsrc.EagerlyEnsureRemoteBuilder(ctx, client, org.Slug)
+		go builder.LaunchOrWake(ctx, org.Slug)
 	}
 
 	// Create the app

--- a/internal/command/machine/launch.go
+++ b/internal/command/machine/launch.go
@@ -101,10 +101,13 @@ func run(ctx context.Context) (err error) {
 		return
 	}
 
-	// If we potentially are deploying, launch a remote builder to prepare for deployment
+	// If we potentially are deploying, start the remote builder to prepare for deployment
 
 	if !flag.GetBool(ctx, "no-deploy") {
-		go builder.LaunchOrWake(ctx, org.Slug)
+		go func() {
+			builder, _ := builder.NewBuilder(ctx, org.Slug)
+			builder.Start(ctx)
+		}()
 	}
 
 	// Create the app

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -331,12 +331,11 @@ func parseKVFlag(ctx context.Context, flagName string, initialMap map[string]str
 
 func determineImage(ctx context.Context, app *api.AppCompact, imageOrPath string) (img *imgsrc.DeploymentImage, err error) {
 	var (
-		client = client.FromContext(ctx).API()
-		io     = iostreams.FromContext(ctx)
+		io = iostreams.FromContext(ctx)
 	)
 
 	daemonType := imgsrc.NewDockerDaemonType(!flag.GetBool(ctx, "build-remote-only"), !flag.GetBool(ctx, "build-local-only"), env.IsCI(), flag.GetBool(ctx, "build-nixpacks"))
-	resolver := imgsrc.NewResolver(daemonType, client, app, io)
+	resolver := imgsrc.NewResolver(ctx, daemonType, app, io)
 
 	// build if relative or absolute path
 	if strings.HasPrefix(imageOrPath, ".") || strings.HasPrefix(imageOrPath, "/") {

--- a/internal/command/orgs/builder/manage.go
+++ b/internal/command/orgs/builder/manage.go
@@ -17,8 +17,6 @@ type Builder struct {
 	Client  *flaps.Client
 }
 
-// TODO: Once the launch command is refactored, we can remove the api.Client
-// from the code path leading here, since the api client will come from context
 func NewBuilder(ctx context.Context, orgSlug string) (builder *Builder, err error) {
 
 	api := client.FromContext(ctx).API()

--- a/internal/command/orgs/builder/manage.go
+++ b/internal/command/orgs/builder/manage.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
+
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/logger"
 )
@@ -16,10 +17,13 @@ type Builder struct {
 	Client  *flaps.Client
 }
 
+// TODO: Once the launch command is refactored, we can remove the api.Client
+// from the code path leading here, since the api client will come from context
 func NewBuilder(ctx context.Context, orgSlug string) (builder *Builder, err error) {
-	client := client.FromContext(ctx).API()
 
-	org, err := client.GetOrganizationBySlug(ctx, orgSlug)
+	api := client.FromContext(ctx).API()
+
+	org, err := api.GetOrganizationBySlug(ctx, orgSlug)
 
 	if err != nil {
 		return nil, err
@@ -28,7 +32,7 @@ func NewBuilder(ctx context.Context, orgSlug string) (builder *Builder, err erro
 	builderApp := org.RemoteBuilderApp
 
 	if builderApp == nil {
-		_, builderApp, err = client.EnsureRemoteBuilder(ctx, org.ID)
+		_, builderApp, err = api.EnsureRemoteBuilder(ctx, org.ID)
 
 		if err != nil {
 			return nil, err

--- a/internal/command/orgs/builder/manage.go
+++ b/internal/command/orgs/builder/manage.go
@@ -1,0 +1,118 @@
+package builder
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func GetMachine(ctx context.Context, app *api.AppCompact) (builder *api.Machine, err error) {
+	flapsClient, err := flaps.New(ctx, app)
+
+	if err != nil {
+		return
+	}
+
+	machines, err := flapsClient.List(ctx, "")
+
+	if len(machines) < 1 {
+		return nil, fmt.Errorf("app %s has no machines", app.Name)
+	} else {
+		builder = machines[0]
+	}
+	return
+}
+
+func LaunchOrWake(ctx context.Context, orgSlug string) (builder *api.Machine, builderApp *api.AppCompact, err error) {
+	out := iostreams.FromContext(ctx).Out
+	client := client.FromContext(ctx).API()
+
+	org, err := client.GetOrganizationBySlug(ctx, orgSlug)
+
+	builderApp = org.RemoteBuilderApp
+
+	if err != nil {
+		return
+	}
+
+	var builderVolume api.Volume
+
+	volumes, err := client.GetVolumes(ctx, builderApp.Name)
+
+	if len(volumes) > 0 {
+		builderVolume = volumes[0]
+	} else {
+
+	}
+
+	if err != nil {
+		return
+	}
+
+	if org.RemoteBuilderApp == nil {
+		builderApp, err = client.CreateApp(ctx, api.CreateAppInput{
+			OrganizationID: org.ID,
+			AppRoleID:      "remote-docker-builder",
+			Machines:       true,
+		})
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+	}
+
+	flapsClient, err := flaps.New(ctx, builderApp)
+
+	if err != nil {
+		return
+	}
+
+	machines, err := flapsClient.List(ctx, "")
+
+	// We found a machine, so start or wake it
+	if len(machines) > 0 {
+		builder = machines[0]
+		if builder.State == "started" {
+			flapsClient.Wake(ctx, builder.ID)
+		} else {
+			flapsClient.Start(ctx, builder.ID)
+		}
+
+	} else {
+
+		region, err := client.GetNearestRegion(ctx)
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		builderVolumeConf := api.MachineMount{
+			Path:   "/data",
+			Volume: builderVolume.Name,
+		}
+
+		input := api.LaunchMachineInput{
+			AppID:  org.RemoteBuilderApp.ID,
+			Region: region.Code,
+			Config: &api.MachineConfig{
+				Image:  "flyio/rchab:sha-58e72ae",
+				Mounts: []api.MachineMount{builderVolumeConf},
+			},
+		}
+
+		builder, err = flapsClient.Launch(ctx, input)
+
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	fmt.Fprintf(out, "Builder instance %s is ready\n", builder.ID)
+
+	return
+}

--- a/internal/command/orgs/builder/manage.go
+++ b/internal/command/orgs/builder/manage.go
@@ -68,11 +68,9 @@ func NewBuilder(ctx context.Context, orgSlug string) (builder *Builder, err erro
 	return
 }
 
+// Start will attempt to start and wait for a machine to be ready, regardless of its current state
 func (b *Builder) Start(ctx context.Context) (err error) {
 	logger := logger.FromContext(ctx)
-
-	// The builder may be in a transitional state now, so we ignore its recorded state and run a series
-	// of start/wait/wake requests to ensure the builder is ready
 
 	logger.Debugf("Starting builder instance %s for builder app %s", b.Machine.ID, b.App.Name)
 
@@ -95,6 +93,7 @@ func (b *Builder) Start(ctx context.Context) (err error) {
 	return
 }
 
+// Wake sends a USR1 signal to a machine, which for remote builders means "stay alive"
 func (b *Builder) Wake(ctx context.Context) (err error) {
 	logger := logger.FromContext(ctx)
 


### PR DESCRIPTION
This PR pulls logic to start or wake remote builder machines into `flyctl`, with the goal of reducing dependencies on the backend, and to fix some bugs with/start wake logic that depends on outdated machine states in the database.

This should also simplify debugging and keep code line with flyd/flaps.