### PR TITLE
Add -c flag back to `fly ssh console`

### DIFF
--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -37,6 +37,7 @@ func newConsole() *cobra.Command {
 	flag.Add(cmd,
 		flag.Org(),
 		flag.App(),
+		flag.AppConfig(),
 		flag.String{
 			Name:        "command",
 			Shorthand:   "C",


### PR DESCRIPTION
Fixes #1117
