### PR TITLE
Fix wildcard cert display

### DIFF
--- a/cmd/certificates.go
+++ b/cmd/certificates.go
@@ -229,8 +229,6 @@ func reportNextStepCert(cmdCtx *cmdctx.CmdContext, hostname string, cert *api.Ap
 				cmdCtx.Statusf("certs", cmdctx.SINFO, "%d: Adding an AAAA record to your DNS service which reads:\n\n", stepcnt)
 				cmdCtx.Statusf("certs", cmdctx.SINFO, "    AAAA @ %s\n\n", ipV6.Address)
 				cmdCtx.Statusf("certs", cmdctx.SINFO, " OR \n\n")
-				cmdCtx.Statusf("certs", cmdctx.SINFO, "%d: Adding an CNAME record to your DNS service which reads:\n\n", stepcnt)
-				cmdCtx.Statusf("certs", cmdctx.SINFO, "    %s\n", cert.DNSValidationInstructions)
 				// stepcnt = stepcnt + 1 Uncomment if more steps
 
 			}

--- a/cmd/certificates.go
+++ b/cmd/certificates.go
@@ -228,9 +228,7 @@ func reportNextStepCert(cmdCtx *cmdctx.CmdContext, hostname string, cert *api.Ap
 				cmdCtx.Statusf("certs", cmdctx.SINFO, "You can validate your ownership of %s by:\n\n", hostname)
 				cmdCtx.Statusf("certs", cmdctx.SINFO, "%d: Adding an AAAA record to your DNS service which reads:\n\n", stepcnt)
 				cmdCtx.Statusf("certs", cmdctx.SINFO, "    AAAA @ %s\n\n", ipV6.Address)
-				cmdCtx.Statusf("certs", cmdctx.SINFO, " OR \n\n")
 				// stepcnt = stepcnt + 1 Uncomment if more steps
-
 			}
 		} else {
 			if cert.ClientStatus == "Ready" {

--- a/cmd/certificates.go
+++ b/cmd/certificates.go
@@ -242,9 +242,9 @@ func reportNextStepCert(cmdCtx *cmdctx.CmdContext, hostname string, cert *api.Ap
 			}
 		}
 	} else if cert.IsWildcard {
-		// If this is an wildcard domain we should guide towards creating A and AAAA records
+		// If this is an wildcard domain we should guide towards satisfying a DNS-01 challenge
 		addArecord := !configuredipV4
-		addAAAArecord := !cert.AcmeALPNConfigured
+		addCNAMErecord := !cert.AcmeDNSConfigured
 
 		stepcnt := 1
 		cmdCtx.Statusf("certs", cmdctx.SINFO, "You are creating a wildcard certificate for %s\n", hostname)
@@ -256,11 +256,8 @@ func reportNextStepCert(cmdCtx *cmdctx.CmdContext, hostname string, cert *api.Ap
 			cmdCtx.Statusf("certs", cmdctx.SINFO, "\n    A @ %s\n\n", ipV4.Address)
 		}
 
-		if addAAAArecord {
+		if addCNAMErecord {
 			cmdCtx.Statusf("certs", cmdctx.SINFO, "You can validate your ownership of %s by:\n\n", hostname)
-			cmdCtx.Statusf("certs", cmdctx.SINFO, "%d: Adding an AAAA record to your DNS service which reads:\n\n", stepcnt)
-			cmdCtx.Statusf("certs", cmdctx.SINFO, "    AAAA @ %s\n\n", ipV6.Address)
-			cmdCtx.Statusf("certs", cmdctx.SINFO, " OR \n\n")
 			cmdCtx.Statusf("certs", cmdctx.SINFO, "%d: Adding an CNAME record to your DNS service which reads:\n\n", stepcnt)
 			cmdCtx.Statusf("certs", cmdctx.SINFO, "    %s\n", cert.DNSValidationInstructions)
 			// stepcnt = stepcnt + 1 Uncomment if more steps


### PR DESCRIPTION
before
```
You are creating a wildcard certificate for *.example1.com
We are using lets_encrypt for this certificate.

You can direct traffic to *.example1.com by:

1: Adding an A record to your DNS service which reads

    A @ 37.16.7.222

You can validate your ownership of *.example1.com by:

2: Adding an AAAA record to your DNS service which reads:

    AAAA @ 2a09:8280:1::3:3aef

 OR

2: Adding an CNAME record to your DNS service which reads:

    CNAME _acme-challenge.example1.com => example1.com.8j2ol.flydns.net.

```

after
```
You are creating a wildcard certificate for *.example.com
We are using lets_encrypt for this certificate.

You can direct traffic to *.example.com by:

1: Adding an A record to your DNS service which reads

    A @ 37.16.7.222

You can validate your ownership of *.example.com by:

2: Adding an CNAME record to your DNS service which reads:

    CNAME _acme-challenge.example.com => example.com.8j2ol.flydns.net.
```
```
You are creating a certificate for mic-check.space
We are using lets_encrypt for this certificate.

You can direct traffic to mic-check.space by:

1: Adding an A record to your DNS service which reads

    A @ 37.16.7.222

You can validate your ownership of mic-check.space by:

2: Adding an AAAA record to your DNS service which reads:

    AAAA @ 2a09:8280:1::3:3aef



```