### PR TITLE
pin to specific alpine version to prevent edge instability issues

### DIFF
--- a/scanner/templates/laravel/common/Dockerfile
+++ b/scanner/templates/laravel/common/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM alpine:edge as base
+FROM alpine:3.16 as base
 
 LABEL fly_launch_runtime="laravel"
 


### PR DESCRIPTION
This caused an issue for a Laravel user: https://community.fly.io/t/segmentation-fault/6234/4

They got a segfault during the `docker build` with `alpine:edge`.