### PR TITLE
laravel entrypoint allows for more commands to be run

### DIFF
--- a/scanner/templates/laravel/common/docker/run.sh
+++ b/scanner/templates/laravel/common/docker/run.sh
@@ -12,4 +12,10 @@ if [ -f /var/www/html/composer.json ]; then
   fi
 fi
 
-exec supervisord -c /etc/supervisord.conf
+if [ $# -gt 0 ];then
+    # If we passed a command, run it as root
+    exec "$@"
+else
+    # Otherwise start supervisord
+    exec supervisord -c /etc/supervisord.conf
+fi


### PR DESCRIPTION
This didn't work because the entrypoint script ignored passing commands to it.

```toml
[deploy]
    release_command = "php artisan migrate --force"
```

It turns out (duh) that to run `release_command`s, Fly passes the command to the defined entrypoint script.