### PR TITLE
fixing laravel cron + cache commands

### DIFF
--- a/scanner/templates/laravel/common/Dockerfile
+++ b/scanner/templates/laravel/common/Dockerfile
@@ -39,7 +39,7 @@ RUN composer update \
     && composer install --optimize-autoloader --no-dev \
     && mkdir -p storage/logs \
     && chown -R app:app /var/www/html \
-    && /usr/bin/crontab docker/crontab \
+    && echo "* * * * * /usr/bin/php /var/www/html/artisan schedule:run" > /etc/crontabs/app \
     && mv docker/supervisor.conf /etc/supervisord.conf \
     && mv docker/nginx.conf /etc/nginx/nginx.conf \
     && mv docker/server.conf /etc/nginx/server.conf \

--- a/scanner/templates/laravel/common/Dockerfile
+++ b/scanner/templates/laravel/common/Dockerfile
@@ -1,4 +1,6 @@
 # syntax = docker/dockerfile:experimental
+
+# The "base" container installs PHP, etc
 FROM alpine:3.16 as base
 
 LABEL fly_launch_runtime="laravel"
@@ -63,7 +65,9 @@ RUN composer dump-autoload \
     && chmod -R ug+w /var/www/html/storage \
     && chmod -R 755 /var/www/html
 
+
 # Multi-stage build: Build static assets
+# This allows us to not include Node within the final container
 FROM node:14 as node_modules_go_brrr
 
 RUN mkdir /app
@@ -71,6 +75,10 @@ RUN mkdir /app
 RUN mkdir -p  /app
 WORKDIR /app
 COPY . .
+
+# Use yarn or npm depending on what type of
+# lock file we might find. Defaults to
+# NPM if no lock file is found.
 RUN if [ -f "yarn.lock" ]; then \
         yarn install; \
     elif [ -f "package-lock.json" ]; then \
@@ -79,9 +87,14 @@ RUN if [ -f "yarn.lock" ]; then \
         npm install; \
     fi
 
-# Create final container, adding in static assets
+# From our base container created above, we
+# create our image, adding in static assets
+# generated above
 FROM base
 
+# Packages like Laravel Nova may have added assets to the public directory
+# or maybe some custom assets were added manually! Either way, we merge
+# in the assets we generated above rather than overwrite them
 COPY --from=node_modules_go_brrr /app/public /var/www/html/public-npm
 RUN rsync -ar /var/www/html/public-npm/ /var/www/html/public/ \
     && rm -rf /var/www/html/public-npm

--- a/scanner/templates/laravel/common/docker/crontab
+++ b/scanner/templates/laravel/common/docker/crontab
@@ -1,1 +1,0 @@
-* * * * * /bin/su -c "/usr/bin/php /var/www/html/artisan schedule:run" - app > /proc/1/fd/1 2>&1

--- a/scanner/templates/laravel/common/docker/run.sh
+++ b/scanner/templates/laravel/common/docker/run.sh
@@ -18,10 +18,10 @@ if [ $# -gt 0 ];then
 else
     # Otherwise start supervisord
 
-    ## Uncomment these if you'd like to cache Laravel settings
-    # /usr/bin/php /var/www/html/artisan config:cache
-    # /usr/bin/php /var/www/html/artisan route:cache
-    # /usr/bin/php /var/www/html/artisan view:cache
+    ## Do some caching
+    /usr/bin/php /var/www/html/artisan config:cache
+    /usr/bin/php /var/www/html/artisan route:cache
+    /usr/bin/php /var/www/html/artisan view:cache
     # chown -R app:app /var/www/html
     exec supervisord -c /etc/supervisord.conf
 fi

--- a/scanner/templates/laravel/common/docker/run.sh
+++ b/scanner/templates/laravel/common/docker/run.sh
@@ -17,5 +17,11 @@ if [ $# -gt 0 ];then
     exec "$@"
 else
     # Otherwise start supervisord
+
+    ## Uncomment these if you'd like to cache Laravel settings
+    # /usr/bin/php /var/www/html/artisan config:cache
+    # /usr/bin/php /var/www/html/artisan route:cache
+    # /usr/bin/php /var/www/html/artisan view:cache
+    # chown -R app:app /var/www/html
     exec supervisord -c /etc/supervisord.conf
 fi


### PR DESCRIPTION
1. previous setup did not allow PHP to see env vars / secrets set by the user when running Laravel scheduler via cron
2. Users ran into issues attempting to run Laravel's cache commands in the "correct" spot of the deployment process.