### PR TITLE
Use app name from context for deploy monitor

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -85,7 +85,6 @@ func run(ctx context.Context) error {
 }
 
 func DeployWithConfig(ctx context.Context, appConfig *app.Config) (err error) {
-
 	apiClient := client.FromContext(ctx).API()
 
 	// Fetch an image ref or build from source to get the final image reference to deploy
@@ -147,7 +146,7 @@ func DeployWithConfig(ctx context.Context, appConfig *app.Config) (err error) {
 		return nil
 	}
 
-	err = watch.Deployment(ctx, appConfig.AppName, release.EvaluationID)
+	err = watch.Deployment(ctx, app.NameFromContext(ctx), release.EvaluationID)
 
 	return err
 }


### PR DESCRIPTION
Fixes https://community.fly.io/t/all-of-my-deployments-are-reporting-to-have-failed-in-github-actions/6294

The deploy monitor was only using the app name from the config. This will fetch it from the context.