### PR TITLE
Launch machines on preferred region

### DIFF
--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -169,6 +169,9 @@ func (client *Client) GetAppCompact(ctx context.Context, appName string) (*AppCo
 					repository
 					version
 				}
+				autoscaling {
+					preferredRegion
+				}
 			}
 		}
 	`

--- a/api/types.go
+++ b/api/types.go
@@ -440,6 +440,7 @@ type AppCompact struct {
 	PostgresAppRole *struct {
 		Name string
 	}
+	Autoscaling  *AutoscalingConfig
 	ImageDetails ImageVersion
 }
 
@@ -955,11 +956,12 @@ type Region struct {
 }
 
 type AutoscalingConfig struct {
-	BalanceRegions bool
-	Enabled        bool
-	MaxCount       int
-	MinCount       int
-	Regions        []AutoscalingRegionConfig
+	BalanceRegions  bool
+	Enabled         bool
+	MaxCount        int
+	MinCount        int
+	PreferredRegion string
+	Regions         []AutoscalingRegionConfig
 }
 
 type AutoscalingRegionConfig struct {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -107,10 +107,9 @@ func DeployWithConfig(ctx context.Context, appConfig *app.Config) (err error) {
 
 	if appConfig.ForMachines() {
 		return createMachinesRelease(ctx, appConfig, img, flag.GetString(ctx, "strategy"))
-	} else {
-		release, releaseCommand, err = createRelease(ctx, appConfig, img)
 	}
 
+	release, releaseCommand, err = createRelease(ctx, appConfig, img)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes a bug that ignores the region passed as
:
```
fly machines launch --region CODE
```