### PR TITLE
Pg machine restores

### DIFF
--- a/api/resource_images.go
+++ b/api/resource_images.go
@@ -36,14 +36,15 @@ func (client *Client) GetImageInfo(ctx context.Context, appName string) (*App, e
 	return &data.App, nil
 }
 
-func (client *Client) GetLatestImageTag(ctx context.Context, repository string) (string, error) {
+func (client *Client) GetLatestImageTag(ctx context.Context, repository string, snapshotId *string) (string, error) {
 	query := `
-		query($repository: String!) {
-			latestImageTag(repository: $repository) 
+		query($repository: String!, $snapshotId: ID) {
+			latestImageTag(repository: $repository, snapshotId: $snapshotId) 
 		}
 	`
 	req := client.NewRequest(query)
 	req.Var("repository", repository)
+	req.Var("snapshotId", snapshotId)
 
 	data, err := client.RunWithContext(ctx, req)
 	if err != nil {

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -48,9 +48,9 @@ func NewLauncher(client *api.Client) *Launcher {
 
 // Launches a postgres cluster using the machines runtime
 func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClusterInput) error {
-	var (
-		client = client.FromContext(ctx).API()
-	)
+	// var (
+	// 	client = client.FromContext(ctx).API()
+	// )
 
 	app, err := l.createApp(ctx, config)
 	if err != nil {
@@ -81,6 +81,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 			SizeGb:            *config.VolumeSize,
 			Encrypted:         false,
 			RequireUniqueZone: false,
+			SnapshotID:        &config.SnapshotID,
 		}
 
 		vol, err := l.client.CreateVolume(ctx, volInput)
@@ -95,12 +96,12 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 			Encrypted: false,
 		})
 
-		imageRef, err := client.GetLatestImageTag(ctx, "flyio/postgres")
-		if err != nil {
-			return err
-		}
+		// imageRef, err := client.GetLatestImageTag(ctx, "flyio/postgres")
+		// if err != nil {
+		// 	return err
+		// }
 
-		machineConf.Image = imageRef
+		machineConf.Image = "flyio/postgres:13"
 
 		launchInput := api.LaunchMachineInput{
 			AppID:   app.ID,
@@ -269,6 +270,10 @@ func (l *Launcher) setSecrets(ctx context.Context, config *CreateClusterInput) (
 		"SU_PASSWORD":       suPassword,
 		"REPL_PASSWORD":     replPassword,
 		"OPERATOR_PASSWORD": opPassword,
+	}
+
+	if config.SnapshotID != "" {
+		secrets["FLY_RESTORED_FROM"] = config.SnapshotID
 	}
 
 	if config.ConsulURL == "" {

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -127,13 +127,14 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 			return err
 		}
 
-		timeout := time.Minute * 5
+		fmt.Printf("Waiting for machine to start...")
+
+		waitTimeout := time.Minute * 5
 		if snapshot != nil {
-			timeout = time.Hour
+			waitTimeout = time.Hour
 		}
 
-		fmt.Printf("Waiting for machine to start...")
-		err = machines.WaitForStart(ctx, flaps, machine, timeout)
+		err = machines.WaitForStart(ctx, flaps, machine, waitTimeout)
 		if err != nil {
 			return err
 		}

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -235,7 +235,7 @@ func runMachineRun(ctx context.Context) error {
 	fmt.Fprintf(io.Out, " State: %s\n", state)
 
 	// wait for machine to be started
-	if err := WaitForStart(ctx, flapsClient, machine); err != nil {
+	if err := WaitForStart(ctx, flapsClient, machine, time.Minute*5); err != nil {
 		return err
 	}
 
@@ -291,8 +291,8 @@ func createApp(ctx context.Context, message, name string, client *api.Client) (*
 	}, nil
 }
 
-func WaitForStart(ctx context.Context, flapsClient *flaps.Client, machine *api.Machine) error {
-	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+func WaitForStart(ctx context.Context, flapsClient *flaps.Client, machine *api.Machine, timeout time.Duration) error {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	b := &backoff.Backoff{

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -88,7 +89,7 @@ func runUpdate(ctx context.Context) (err error) {
 	}
 
 	// wait for machine to be started
-	if err := WaitForStart(ctx, flapsClient, machine); err != nil {
+	if err := WaitForStart(ctx, flapsClient, machine, time.Minute*5); err != nil {
 		return err
 	}
 

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -194,7 +194,7 @@ func runCreate(ctx context.Context) (err error) {
 
 	snapshot := flag.GetString(ctx, "snapshot-id")
 	if snapshot != "" {
-		input.SnapshotID = snapshot
+		input.SnapshotID = &snapshot
 	}
 
 	fmt.Fprintf(io.Out, "Creating postgres cluster %s in organization %s\n", appName, org.Slug)

--- a/internal/command/postgres/update.go
+++ b/internal/command/postgres/update.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/agent"
@@ -207,7 +208,7 @@ func updateMachine(ctx context.Context, app *api.AppCompact, machine *api.Machin
 		return err
 	}
 
-	if err := machines.WaitForStart(ctx, flaps, updated); err != nil {
+	if err := machines.WaitForStart(ctx, flaps, updated, time.Minute*5); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Adds support for machine-based PG restores.

Couple changes of note:

1. `WaitForStart` now takes a timeout.
2.  The existing operations leveraging `WaitForState` have had their timeout bumped from 30 seconds to 5 minutes.
3.  When a `snapshot-id` is passed into the PG provision process a restore will only be issued against the first volume.  