### PR TITLE
Obey primaryRegion on machine creation

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -107,10 +107,9 @@ func DeployWithConfig(ctx context.Context, appConfig *app.Config) (err error) {
 
 	if appConfig.ForMachines() {
 		return createMachinesRelease(ctx, appConfig, img, flag.GetString(ctx, "strategy"))
-	} else {
-		release, releaseCommand, err = createRelease(ctx, appConfig, img)
 	}
 
+	release, releaseCommand, err = createRelease(ctx, appConfig, img)
 	if err != nil {
 		return err
 	}
@@ -189,6 +188,10 @@ func determineAppConfig(ctx context.Context) (cfg *app.Config, err error) {
 		}
 
 		cfg.SetEnvVariables(parsedEnv)
+	}
+
+	if regionCode := flag.GetString(ctx, flag.RegionName); regionCode != "" {
+		cfg.SetPrimaryRegion(regionCode)
 	}
 
 	tb.Done("Verified app config")

--- a/internal/command/secrets/secrets.go
+++ b/internal/command/secrets/secrets.go
@@ -67,7 +67,7 @@ func deployForSecrets(ctx context.Context, app *api.AppCompact, release *api.Rel
 			fmt.Fprint(out, "The --detach option isn't available for Machine apps")
 		}
 
-		return deploy.DeployMachinesApp(ctx, app, "rolling", api.MachineConfig{})
+		return deploy.DeployMachinesApp(ctx, app, "rolling", api.MachineConfig{}, nil)
 	}
 
 	if !app.Deployed {


### PR DESCRIPTION
Supersedes #1149

Respect region passed at:
```
fly machine launch --region CODE
```
and in case of machine's app:
```
fly deploy --region CODE
```