### PR TITLE
Enable govet linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,7 +32,7 @@ linters:
     # - errcheck
     - goimports
     - gosimple
-    # - govet
+    - govet
     # - ineffassign
     # - staticcheck
     - unconvert

--- a/internal/command/ping/ping.go
+++ b/internal/command/ping/ping.go
@@ -140,6 +140,7 @@ func run(ctx context.Context) error {
 	mu.Unlock()
 
 	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	if name != "" && name != "gateway" && !strings.HasPrefix(name, "fdaa:") {
 		// look up names in the background because I was too
@@ -275,7 +276,6 @@ func run(ctx context.Context) error {
 	for i := 0; count == 0 || i <= count; i++ {
 		select {
 		case <-stp:
-			cancel()
 			return nil
 		case <-ticker.C:
 		}
@@ -288,8 +288,6 @@ func run(ctx context.Context) error {
 			}
 		}
 	}
-
-	cancel()
 
 	return nil
 }


### PR DESCRIPTION
Fixes for:

```
$ golangci-lint run
internal/command/ping/ping.go:142:2: lostcancel: the cancel function is not used on all paths (possible context leak) (govet)
        ctx, cancel := context.WithCancel(ctx)
        ^
internal/command/ping/ping.go:176:3: lostcancel: this return statement may be reached without using the cancel var defined on line 142 (govet)
                return err
                ^
```