### PR TITLE
Enable unused linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,7 @@ linters:
     # - ineffassign
     # - staticcheck
     - unconvert
-    # - unused
+    - unused
     # - varcheck
   fast: true
 

--- a/agent/server/session.go
+++ b/agent/server/session.go
@@ -552,16 +552,6 @@ func (s *session) exactArgs(count int, args []string, err error) bool {
 	return true
 }
 
-func (s *session) minMaxArgs(min, max int, args []string, err error) bool {
-	if len(args) < min || len(args) > max {
-		s.error(err)
-
-		return false
-	}
-
-	return true
-}
-
 func (s *session) marshal(v interface{}) (ok bool) {
 	var sb strings.Builder
 


### PR DESCRIPTION
```
l$ golangci-lint run
agent/server/session.go:555:19: func `(*session).minMaxArgs` is unused (unused)
func (s *session) minMaxArgs(min, max int, args []string, err error) bool {
                  ^
```