### PR TITLE
Enable staticcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,7 +34,7 @@ linters:
     - gosimple
     - govet
     # - ineffassign
-    # - staticcheck
+    - staticcheck
     - unconvert
     - unused
     # - varcheck

--- a/internal/build/imgsrc/nixpacks_builder.go
+++ b/internal/build/imgsrc/nixpacks_builder.go
@@ -46,7 +46,11 @@ func ensureNixpacksBinary(ctx context.Context, streams *iostreams.IOStreams) err
 
 	err = func() error {
 		out, err := os.Create(installPath)
+		if err != nil {
+			return err
+		}
 		defer out.Close()
+
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://raw.githubusercontent.com/railwayapp/nixpacks/master/install.sh", nil)
 		if err != nil {
 			return err
@@ -56,6 +60,7 @@ func ensureNixpacksBinary(ctx context.Context, streams *iostreams.IOStreams) err
 			return err
 		}
 		defer resp.Body.Close()
+
 		n, err := io.Copy(out, resp.Body)
 		if err != nil {
 			return err

--- a/internal/command/dig/dig.go
+++ b/internal/command/dig/dig.go
@@ -245,7 +245,6 @@ func ResolverForOrg(ctx context.Context, c *agent.Client, orgSlug string) (*net.
 				return nil, err
 			}
 
-			network = "tcp"
 			server := net.JoinHostPort(ts.TunnelConfig.DNS.String(), "53")
 
 			// the connections we get from the agent are over a unix domain socket proxy,
@@ -255,7 +254,7 @@ func ResolverForOrg(ctx context.Context, c *agent.Client, orgSlug string) (*net.
 				net.Conn
 			}
 
-			c, err := d.DialContext(ctx, network, server)
+			c, err := d.DialContext(ctx, "tcp", server)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
```
l$ golangci-lint run
internal/command/dig/dig.go:242:35: SA4009: argument network is overwritten before first use (staticcheck)
                Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
                                                ^
internal/command/dig/dig.go:248:4: SA4009(related information): assignment to network (staticcheck)
                        network = "tcp"
                        ^
internal/build/imgsrc/nixpacks_builder.go:49:3: SA5001: should check returned error before deferring out.Close() (staticcheck)
                defer out.Close()
                ^
```