### PR TITLE
Have NextJS template the default NextJS port

### DIFF
--- a/scanner/nextjs.go
+++ b/scanner/nextjs.go
@@ -6,12 +6,12 @@ func configureNextJs(sourceDir string) (*SourceInfo, error) {
 	}
 
 	env := map[string]string{
-		"PORT": "8080",
+		"PORT": "3000",
 	}
 
 	s := &SourceInfo{
 		Family:       "NextJS",
-		Port:         8080,
+		Port:         3000,
 		SkipDatabase: true,
 	}
 


### PR DESCRIPTION
This template fills in port 8080 when nextJS apps default to 3000: https://nextjs.org/docs/api-reference/cli#production