### PR TITLE
Fix typos in launch wizard

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -413,7 +413,7 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 		return nil
 	}
 
-	if !cmdCtx.Config.GetBool("no-deploy") && !cmdCtx.Config.GetBool("now") && !srcInfo.SkipDatabase && confirm("Would you like to setup a Postgresql database now?") {
+	if !cmdCtx.Config.GetBool("no-deploy") && !cmdCtx.Config.GetBool("now") && !srcInfo.SkipDatabase && confirm("Would you like to set up a Postgresql database now?") {
 
 		appID, err := cmdCtx.Client.API().GetAppID(ctx, cmdCtx.AppName)
 		if err != nil {

--- a/cmd/postgres.go
+++ b/cmd/postgres.go
@@ -221,7 +221,7 @@ func runApiCreatePostgresCluster(cmdCtx *cmdctx.CmdContext, org string, input *a
 	fmt.Printf("  Proxy Port:  5432\n")
 	fmt.Printf("  PG Port: 5433\n")
 
-	fmt.Println(aurora.Italic("Save your credentials in a secure place, you won't be able to see them again!"))
+	fmt.Println(aurora.Italic("Save your credentials in a secure place -- you won't be able to see them again!"))
 	fmt.Println()
 
 	cancelCtx := cmdCtx.Command.Context()
@@ -239,7 +239,7 @@ func runApiCreatePostgresCluster(cmdCtx *cmdctx.CmdContext, org string, input *a
 		fmt.Printf("For example: postgres://%s:%s@%s.internal:%d\n", payload.Username, payload.Password, payload.App.Name, 5432)
 
 		fmt.Println()
-		fmt.Println("Now you've setup postgres, here's what you need to understand: https://fly.io/docs/reference/postgres-whats-next/")
+		fmt.Println("Now that you've set up postgres, here's what you need to understand: https://fly.io/docs/reference/postgres-whats-next/")
 	}
 
 	return payload, err

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -147,7 +147,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 	fmt.Fprintf(io.Out, "  Hostname:    %s.internal\n", config.AppName)
 	fmt.Fprintf(io.Out, "  Proxy port:  5432\n")
 	fmt.Fprintf(io.Out, "  Postgres port:  5433\n")
-	fmt.Fprintln(io.Out, aurora.Italic("Save your credentials in a secure place, you won't be able to see them again!"))
+	fmt.Fprintln(io.Out, aurora.Italic("Save your credentials in a secure place -- you won't be able to see them again!"))
 
 	fmt.Fprintln(io.Out)
 	fmt.Fprintln(io.Out, aurora.Bold("Connect to postgres"))
@@ -155,7 +155,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 	fmt.Fprintf(io.Out, "For example: %s\n", connStr)
 
 	fmt.Fprintln(io.Out)
-	fmt.Fprintln(io.Out, "Now you've setup postgres, here's what you need to understand: https://fly.io/docs/reference/postgres-whats-next/")
+	fmt.Fprintln(io.Out, "Now that you've set up postgres, here's what you need to understand: https://fly.io/docs/reference/postgres-whats-next/")
 
 	// TODO: wait for the cluster to be ready
 
@@ -201,7 +201,7 @@ func (l *Launcher) LaunchNomadPostgres(ctx context.Context, config *CreateCluste
 	fmt.Fprintf(io.Out, "  Hostname:    %s.internal\n", payload.App.Name)
 	fmt.Fprintf(io.Out, "  Proxy Port:  5432\n")
 	fmt.Fprintf(io.Out, "  Postgres Port: 5433\n")
-	fmt.Fprintln(io.Out, aurora.Italic("Save your credentials in a secure place, you won't be able to see them again!"))
+	fmt.Fprintln(io.Out, aurora.Italic("Save your credentials in a secure place -- you won't be able to see them again!"))
 
 	if !flag.GetDetach(ctx) {
 		if err := watch.Deployment(ctx, payload.App.Name, ""); err != nil {
@@ -215,7 +215,7 @@ func (l *Launcher) LaunchNomadPostgres(ctx context.Context, config *CreateCluste
 	fmt.Fprintf(io.Out, "For example: postgres://%s:%s@%s.internal:%d\n", payload.Username, payload.Password, payload.App.Name, 5432)
 
 	fmt.Fprintln(io.Out)
-	fmt.Fprintln(io.Out, "Now you've setup postgres, here's what you need to understand: https://fly.io/docs/reference/postgres-whats-next/")
+	fmt.Fprintln(io.Out, "Now that you've set up postgres, here's what you need to understand: https://fly.io/docs/reference/postgres-whats-next/")
 
 	return
 }

--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -75,7 +75,7 @@ func configureRails(sourceDir string) (*SourceInfo, error) {
 
 	s.SkipDeploy = true
 	s.DeployDocs = fmt.Sprintf(`
-Your Rails app is prepared for deployment. Production will be setup with these versions of core runtime packages:
+Your Rails app is prepared for deployment. Production will be set up with these versions of core runtime packages:
 
 Ruby %s
 Bundler %s


### PR DESCRIPTION
This fixes a few typos in the launch wizard (and elsewhere):

* "setup" => "set up"
  * "setup" is the noun form, whereas "set up" is the verb form.
* Add "--" to split up a run-on sentence
  * "Save your credentials in a secure place" and "you won't be able to see them again!" are both complete sentences.