### PR TITLE
Remove Puma `-C config/puma.rb` option

### DIFF
--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -32,7 +32,7 @@ func configureRails(sourceDir string) (*SourceInfo, error) {
 		},
 		ReleaseCmd: "bundle exec rails db:migrate",
 		Env: map[string]string{
-			"SERVER_COMMAND": "bundle exec puma -C config/puma.rb",
+			"SERVER_COMMAND": "bundle exec puma",
 			"PORT":           "8080",
 		},
 	}

--- a/scanner/templates/rails/standard/Dockerfile
+++ b/scanner/templates/rails/standard/Dockerfile
@@ -85,6 +85,6 @@ RUN bundle exec rails assets:precompile
 
 ENV PORT 8080
 
-ARG SERVER_COMMAND="bundle exec puma -C config/puma.rb"
+ARG SERVER_COMMAND="bundle exec puma"
 ENV SERVER_COMMAND ${SERVER_COMMAND}
 CMD ${SERVER_COMMAND}


### PR DESCRIPTION
Since Puma v2.8.0 (puma/puma@7d7a1fbebe4dde2edf045ada80730ce4f41c4cd5), Puma will automatically use `config/puma.rb` if it is present, so specifying `-C config/puma.rb` is not necessary.  Also, specifying `-C config/puma.rb` precludes Puma from automatically using `config/puma/<environment>.rb` if the user has put their config there instead.  (See the [Configuration File section][1] of the Puma README for more information.)

[1]: https://github.com/puma/puma/blob/v5.6.4/README.md#configuration-file