### PR TITLE
Ignore destroyed machines on deploy

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -228,7 +228,7 @@ func DeployMachinesApp(ctx context.Context, app *api.AppCompact, strategy string
 
 	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
 		m, err = flapsClient.Get(ctx, m.ID)
-		return m.Config.Metadata["process_group"] != "release_command"
+		return m.Config.Metadata["process_group"] != "release_command" && m.State != "destroyed"
 	})
 
 	if len(machines) > 0 {


### PR DESCRIPTION
Otherwise, the deploy fails because updating a destroyed machine returns
a Not Found error

```
$ fly m list
1 machines have been retrieved.
View them in the UI here (​https://fly.io/apps/flocast/machines/)

flocast
ID              IMAGE                           CREATED                 LAST UPDATED          STATE    REGION  NAME                    IP ADDRESS
21781502a57489  flocast:deployment-1660670692   2022-08-16T17:25:28Z    2022-08-16T17:25:29Z  started  mia     bitter-glade-5348       fdaa:0:5ea6:a7b:2c00:6855:66c7:2


$ fly m stop 21781502a57489
21781502a57489 has been successfully stopped

$ fly m remove 21781502a57489
machine 21781502a57489 was found and is currently in stopped state, attempting to destroy...
21781502a57489 has been destroyed

$ fly m list
1 machines have been retrieved.
View them in the UI here (​https://fly.io/apps/flocast/machines/)

flocast
ID              IMAGE                           CREATED                 LAST UPDATED          STATE            REGION  NAME                    IP ADDRESS
21781502a57489  flocast:deployment-1660670692   2022-08-16T17:25:28Z    2022-08-16T17:55:15Z  destroyed        mia     bitter-glade-5348

$ fly deploy
==> Verifying app config
--> Verified app config
...
Deploying with rolling strategy ✓
Error failed to update VM 21781502a57489: machine not found

```



