### PR TITLE
Fix that ssh console could select a destroyed machine on machine apps

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flaps"
@@ -221,15 +220,10 @@ func DeployMachinesApp(ctx context.Context, app *api.AppCompact, strategy string
 		Region:  regionCode,
 	}
 
-	machines, err := flapsClient.List(ctx, "")
+	machines, err := flapsClient.ListActive(ctx)
 	if err != nil {
 		return
 	}
-
-	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
-		m, err = flapsClient.Get(ctx, m.ID)
-		return m.Config.Metadata["process_group"] != "release_command" && m.State != "destroyed"
-	})
 
 	if len(machines) > 0 {
 

--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -214,10 +214,13 @@ func addrForMachines(ctx context.Context, app *api.AppCompact) (addr string, err
 		return "", err
 	}
 
-	machines, err := flapsClient.List(ctx, "")
+	machines, err := flapsClient.ListActive(ctx)
+	if err != nil {
+		return "", err
+	}
 
 	if len(machines) < 1 {
-		return "", fmt.Errorf("app %s has no VMs", app.Name)
+		return "", fmt.Errorf("app %s has no started or stopped VMs", app.Name)
 	}
 
 	if err != nil {

--- a/internal/command/status/machines.go
+++ b/internal/command/status/machines.go
@@ -3,7 +3,6 @@ package status
 import (
 	"context"
 
-	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/render"
@@ -18,12 +17,7 @@ func renderMachineStatus(ctx context.Context, app *api.AppCompact) (err error) {
 		return err
 	}
 
-	machines, err := flapsClient.List(ctx, "")
-
-	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
-		return m.Config.Metadata["process_group"] != "release_command"
-	})
-
+	machines, err := flapsClient.ListActive(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We also add `flaps.ListActive` to return all stopped and started machines, with a reasonable guarantee that non-destroyed machines with the correct state are provided.