### PR TITLE
Various machine app fixes

### DIFF
--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -181,8 +181,7 @@ func (f *Client) List(ctx context.Context, state string) ([]*api.Machine, error)
 	return out, nil
 }
 
-// ListActive returns stopped and started machines that aren't in a
-// destroyed or in a reserved process group.
+// ListActive returns only non-destroyed that aren't in a reserved process group.
 func (f *Client) ListActive(ctx context.Context) ([]*api.Machine, error) {
 	getEndpoint := ""
 

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -182,8 +182,7 @@ func (f *Client) List(ctx context.Context, state string) ([]*api.Machine, error)
 }
 
 // ListActive returns stopped and started machines that aren't in a
-// reserved process group. Since the state from 'list' is unreliable,
-// this function fetches the updated status of candidate non-destroyed machines.
+// destroyed or in a reserved process group.
 func (f *Client) ListActive(ctx context.Context) ([]*api.Machine, error) {
 	getEndpoint := ""
 
@@ -195,9 +194,6 @@ func (f *Client) ListActive(ctx context.Context) ([]*api.Machine, error) {
 	}
 
 	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
-		if m.State != "destroyed" {
-			m, err = f.Get(ctx, m.ID)
-		}
 		return m.Config.Metadata["process_group"] != "release_command" && m.State != "destroyed"
 	})
 

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -130,7 +130,6 @@ func RunReleaseCommand(ctx context.Context, app *api.AppCompact, appConfig *app.
 	machineConf.Services = nil
 
 	machine, err := flapsClient.Launch(ctx, launchMachineInput)
-
 	if err != nil {
 		return err
 	}

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -243,10 +243,10 @@ func DeployMachinesApp(ctx context.Context, app *api.AppCompact, strategy string
 
 			launchInput.ID = machine.ID
 
-			// We assume an empty config means the deploy should simply recreate machines with the existing config,
-			// for example for applying recently set secrets
+			// We assume a config with no image specificed means the deploy should recreate machines
+			// with the existing config. For example, for applying recently set secrets.
 
-			if launchInput.Config.Guest == nil {
+			if launchInput.Config.Image == "" {
 				freshMachine, err := flapsClient.Get(ctx, machine.ID)
 				if err != nil {
 					return err


### PR DESCRIPTION
* Remove the extra fetch when listing active machines, now machines lists are accurate
* Fix that machine app deployment didn't actually deploy :)
* Ensure release commands run in the primary region, if specified