### PR TITLE
enable building docs on Mac

### DIFF
--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -8,7 +8,8 @@ go run doc/main.go
 
 echo "Cleaning up output"
 
-if sed --help | grep GNU > /dev/null; then
+# test for GNU sed.  Hat tip: https://stackoverflow.com/a/65497543
+if sed --version >/dev/null 2>&1; then
   sed -i 's/```/~~~/g' out/*.md
 else
   sed -i "" -e 's/```/~~~/g' out/*.md


### PR DESCRIPTION
Background: sed's syntax for "in place" differs between GNU and BSD/Darwin.

Unfortunately, grepping for 'GNU' is no longer a useful way to determine
which version of sed you are using, as it now produces the following on Mac:

% man sed | grep GNU
     -r      Same as -E for compatibility with GNU sed.