### PR TITLE
Fix env from config

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -85,8 +85,10 @@ func run(ctx context.Context) error {
 func DeployWithConfig(ctx context.Context, appConfig *app.Config) (err error) {
 	apiClient := client.FromContext(ctx).API()
 
-	// Assign an empty map so later assignments won't fail
-	appConfig.Env = map[string]string{}
+	// Assign an empty map if nil so later assignments won't fail
+	if appConfig.Env == nil {
+		appConfig.Env = map[string]string{}
+	}
 
 	// Fetch an image ref or build from source to get the final image reference to deploy
 	img, err := determineImage(ctx, appConfig)


### PR DESCRIPTION
[This PR](https://github.com/superfly/flyctl/pull/1185) was causing `[env]` from the config to get overwritten with an empty map. Fixing here. 
