### PR TITLE
Use a ULID in place of a timestamp to prevent race conditions during parallel deployments

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	dockerclient "github.com/docker/docker/client"
 	"github.com/jpillora/backoff"
+	"github.com/oklog/ulid/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/superfly/flyctl/agent"
@@ -420,7 +421,7 @@ func NewDeploymentTag(appName string, label string) string {
 	}
 
 	if label == "" {
-		label = fmt.Sprintf("deployment-%d", time.Now().Unix())
+		label = fmt.Sprintf("deployment-%s", ulid.Make())
 	}
 
 	registry := viper.GetString(flyctl.ConfigRegistryHost)


### PR DESCRIPTION
Fixes an issue mentioned in the [Fly.io community forums](https://community.fly.io/t/digest-has-already-been-taken-on-deploy/6290/6). These new tags should still sort by time, even [within the same millisecond](https://pkg.go.dev/github.com/oklog/ulid/v2@v2.1.0#section-readme).