### PR TITLE
WIP: Better support for dockerignore and symbolically linked Dockerfiles

### DIFF
--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -55,7 +55,7 @@ func (*buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 	msg := fmt.Sprintf("docker host: %s %s %s", serverInfo.ServerVersion, serverInfo.OSType, serverInfo.Architecture)
 	cmdfmt.PrintDone(streams.ErrOut, msg)
 
-	excludes, err := readDockerignore(opts.WorkingDir)
+	excludes, err := readDockerignore(opts.WorkingDir, "Dockerfile")
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading .dockerignore")
 	}

--- a/internal/build/imgsrc/builtin_builder.go
+++ b/internal/build/imgsrc/builtin_builder.go
@@ -51,7 +51,7 @@ func (ds *builtinBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 		compressed: dockerFactory.IsRemote(),
 	}
 
-	excludes, err := readDockerignore(opts.WorkingDir)
+	excludes, err := readDockerignore(opts.WorkingDir, "Dockerfile")
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading .dockerignore")
 	}


### PR DESCRIPTION
A dockerignore file has rules that prevent files from being
sent to the Docker daemon as part of the build context and/or
being included in the built image. However the Docker daemon
itself also requires the Dockerfile to be contained inside the
build context. Therefore tools like flyctl and docker-cli have
to have special handling of the dockerignore file. 

When the dockerignore file contains a rule that matches the
Dockerfile or the dockerignore file itself, the build context
must nonetheless include both files. 

The existing implementation works when the file is named "Dockerfile",
but not when the user manually specifies a different path (such as using
`--dockerfile` or using `build.dockerfile` in `fly.toml`), or when
the Dockerfile is present but is a symbolic link. These result in an 
error on the container engine. 

This is related to https://github.com/superfly/flyctl/issues/456
but in the opposite (i.e. not sending a file when we should have). 

TODO:
- [ ] See whether splitting out symbolic link resolution support for both dockerignore and Dockerfile to a separate PR is cleaner than a single PR
- [ ] Add test cases for symbolic links