### PR TITLE
Remove Old Code Related to Unused `--postgres-app` Flag

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -443,7 +443,7 @@ func runLaunch(cmdCtx *cmdctx.CmdContext) error {
 		cmdCtx.AppName = appID
 
 		if err != nil {
-			msg := `Failed attaching %s to the Postgres cluster %s: %w.\nTry attaching manually with 'fly postgres attach --app %s --postgres-app %s'`
+			msg := `Failed attaching %s to the Postgres cluster %s: %w.\nTry attaching manually with 'fly postgres attach --app %s %s'`
 			err = fmt.Errorf(msg, clusterAppName, appID, err, appID, clusterAppName)
 			return err
 		}

--- a/internal/command/postgres/attach.go
+++ b/internal/command/postgres/attach.go
@@ -35,10 +35,6 @@ func newAttach() *cobra.Command {
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
-		// flag.String{
-		// 	Name:        "postgres-app",
-		// 	Description: "The name of the postgres app we are looking to attach.",
-		// },
 		flag.String{
 			Name:        "database-name",
 			Description: "The designated database name for this consuming app.",

--- a/internal/command/postgres/detach.go
+++ b/internal/command/postgres/detach.go
@@ -34,11 +34,6 @@ func newDetach() *cobra.Command {
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
-
-		flag.String{
-			Name:        "postgres-app",
-			Description: "Name of the postgres app to detach",
-		},
 	)
 
 	return cmd


### PR DESCRIPTION
# Overview

I recently was setting up a new fly service and while I was attaching a db to my app with `fly attach`, I noticed that a lot of docs still reference a `--postgres-app` flag that is no longer valid. I was able to figure out how to pass the db cluster name after consulting the [dedicated docs section](https://fly.io/docs/reference/postgres/#attaching-an-app-to-a-postgres-app) for `fly attach`. I already updated the fly CLI docs repo (https://github.com/superfly/docs/pull/272), but I noticed that these flags were still in the CLI codebase itself.

This pr just removes several references to those unused flags.