### PR TITLE
Add support for Rails multi-environment configurations

### DIFF
--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -59,9 +59,14 @@ func configureRails(sourceDir string) (*SourceInfo, error) {
 		"NODE_VERSION":    nodeVersion,
 	}
 
-	// master.key comes with Rails apps from v6 onwards, but may not be present
-	// if the app does not use Rails encrypted credentials
-	masterKey, err := ioutil.ReadFile("config/master.key")
+	// master.key comes with Rails apps from v5.2 onwards, but may not be present
+	// if the app does not use Rails encrypted credentials.  Rails v6 added
+	// support for multi-environment credentials.  Use the Rails searching
+	// sequence for production credentials to determine the RAILS_MASTER_KEY.
+	masterKey, err := ioutil.ReadFile("config/credentials/production.key")
+	if err != nil {
+		masterKey, err = ioutil.ReadFile("config/master.key")
+	}
 
 	if err == nil {
 		s.Secrets = []Secret{


### PR DESCRIPTION
See: https://blog.saeloun.com/2019/10/10/rails-6-adds-support-for-multi-environment-credentials.html
And: https://community.fly.io/t/rails-master-key-environment-variable-not-getting-fetched/6657/5

This worked on my machine, but I'm new to flyctl and go so I am requesting a review.