### PR TITLE
Fly.rake

### DIFF
--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -120,7 +120,6 @@ func configureRails(sourceDir string) (*SourceInfo, error) {
 	rake := strings.TrimSpace(`
 # commands used to deploy a Rails application
 namespace :fly do
-
   # BUILD step:
   #  - changes to the fs make here DO get deployed
   #  - NO access to secrets, volumes, databases
@@ -129,15 +128,15 @@ namespace :fly do
 
   # RELEASE step:
   #  - changes to the fs make here are DISCARDED
-  #  - access secrets, databases
-  #  - Failures here prevent deployment
+  #  - full access to secrets, databases
+  #  - failures here prevent deployment
   task :release => 'db:migrate'
 
   # SERVER step:
   #  - changes to the fs make here are deployed
-  #  - access secrets, databases
-  #  - Failures here result in VM being stated, shutdown, and rollback
-  #    to last successful VM.
+  #  - full access to secrets, databases
+  #  - failures here result in VM being stated, shutdown, and rolled back
+  #    to last successful deploy (if any).
   task :server do
     sh 'bin/rails server'
   end

--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -146,7 +146,7 @@ end
 
 	_, err = os.Stat("lib/tasks/fly.rake")
 	if errors.Is(err, os.ErrNotExist) {
-		os.WriteFile("lib/tasks/fly.rake", []byte(rake), 0o644)
+		os.WriteFile("lib/tasks/fly.rake", []byte(rake), 0o600)
 	}
 
 	s.SkipDeploy = true

--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -118,27 +118,28 @@ func configureRails(sourceDir string) (*SourceInfo, error) {
 	}
 
 	rake := strings.TrimSpace(`
+# commands used to deploy a Rails application
 namespace :fly do
-  # commands used to deploy a Rails application
+
+  # BUILD step:
+  #  - changes to the fs make here DO get deployed
+  #  - NO access to secrets, volumes, databases
+  #  - Failures here prevent deployment
   task :build => 'assets:precompile'
 
+  # RELEASE step:
+  #  - changes to the fs make here are DISCARDED
+  #  - access secrets, databases
+  #  - Failures here prevent deployment
   task :release => 'db:migrate'
 
+  # SERVER step:
+  #  - changes to the fs make here are deployed
+  #  - access secrets, databases
+  #  - Failures here result in VM being stated, shutdown, and rollback
+  #    to last successful VM.
   task :server do
     sh 'bin/rails server'
-  end
-
-  # commands useful on the development machine
-  task :ssh do
-    sh 'fly ssh console'
-  end
-
-  task :console do
-    sh 'fly ssh console -C "/home/app/showcase/bin/rails console"'
-  end
-
-  task :dbconsole do
-    sh 'fly ssh console -C "/home/app/showcase/bin/rails dbconsole"'
   end
 end
 `)

--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -1,7 +1,6 @@
 package scanner
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -115,37 +114,6 @@ func configureRails(sourceDir string) (*SourceInfo, error) {
 				Value: string(masterKey),
 			},
 		}
-	}
-
-	rake := strings.TrimSpace(`
-# commands used to deploy a Rails application
-namespace :fly do
-  # BUILD step:
-  #  - changes to the fs make here DO get deployed
-  #  - NO access to secrets, volumes, databases
-  #  - Failures here prevent deployment
-  task :build => 'assets:precompile'
-
-  # RELEASE step:
-  #  - changes to the fs make here are DISCARDED
-  #  - full access to secrets, databases
-  #  - failures here prevent deployment
-  task :release => 'db:migrate'
-
-  # SERVER step:
-  #  - changes to the fs make here are deployed
-  #  - full access to secrets, databases
-  #  - failures here result in VM being stated, shutdown, and rolled back
-  #    to last successful deploy (if any).
-  task :server do
-    sh 'bin/rails server'
-  end
-end
-`)
-
-	_, err = os.Stat("lib/tasks/fly.rake")
-	if errors.Is(err, os.ErrNotExist) {
-		os.WriteFile("lib/tasks/fly.rake", []byte(rake), 0o600)
 	}
 
 	s.SkipDeploy = true

--- a/scanner/templates/rails/standard/Dockerfile
+++ b/scanner/templates/rails/standard/Dockerfile
@@ -81,7 +81,7 @@ ENV SECRET_KEY_BASE 1
 
 COPY . .
 
-RUN bundle exec rails assets:precompile
+RUN bin/rails fly:build
 
 ENV PORT 8080
 

--- a/scanner/templates/rails/standard/Dockerfile
+++ b/scanner/templates/rails/standard/Dockerfile
@@ -85,6 +85,6 @@ RUN bin/rails fly:build
 
 ENV PORT 8080
 
-ARG SERVER_COMMAND="bundle exec puma"
+ARG SERVER_COMMAND="bin/rails fly:server"
 ENV SERVER_COMMAND ${SERVER_COMMAND}
 CMD ${SERVER_COMMAND}

--- a/scanner/templates/rails/standard/lib/tasks/fly.rake
+++ b/scanner/templates/rails/standard/lib/tasks/fly.rake
@@ -1,0 +1,23 @@
+# commands used to deploy a Rails application
+namespace :fly do
+  # BUILD step:
+  #  - changes to the fs make here DO get deployed
+  #  - NO access to secrets, volumes, databases
+  #  - Failures here prevent deployment
+  task :build => 'assets:precompile'
+
+  # RELEASE step:
+  #  - changes to the fs make here are DISCARDED
+  #  - full access to secrets, databases
+  #  - failures here prevent deployment
+  task :release => 'db:migrate'
+
+  # SERVER step:
+  #  - changes to the fs make here are deployed
+  #  - full access to secrets, databases
+  #  - failures here result in VM being stated, shutdown, and rolled back
+  #    to last successful deploy (if any).
+  task :server do
+    sh 'bin/rails server'
+  end
+end


### PR DESCRIPTION
This change effectively adds Ruby hooks in the form of rails tasks for key parts of the build process.

The motivation for this is to improve the initial experience people are seeing when attempting to migrate from places like Heroku.  What they often find is that their build process needs access to secrets, and the docs and advice they get on places like community.fly.io leads them into uncomfortable places like modifying a `Dockerfile` or a `toml` file that they don't understand.

This also greatly simplifies thinks like starting sidekiq.

To be clear, we want and need to retain the flexibility that modifying the `Dockerfile` and `toml` file provide for advanced use cases.  The goal if this change merely to make the initial experience less overwhelming for many and ideally to cover the 80% use case for build configuration.