### PR TITLE
Re-organizing the machines list output and introducing volume

### DIFF
--- a/internal/command/machine/list.go
+++ b/internal/command/machine/list.go
@@ -85,20 +85,27 @@ func runMachineList(ctx context.Context) (err error) {
 		}
 		_ = render.Table(io.Out, appName, rows, "ID")
 	} else {
+
 		for _, machine := range machines {
+			var volName string
+			if machine.Config != nil && len(machine.Config.Mounts) > 0 {
+				volName = machine.Config.Mounts[0].Volume
+			}
+
 			rows = append(rows, []string{
 				machine.ID,
-				fmt.Sprintf("%s:%s", machine.ImageRef.Repository, machine.ImageRef.Tag),
-				machine.CreatedAt,
-				machine.UpdatedAt,
+				machine.Name,
 				machine.State,
 				machine.Region,
-				machine.Name,
+				fmt.Sprintf("%s:%s", machine.ImageRef.Repository, machine.ImageRef.Tag),
 				machine.PrivateIP,
+				volName,
+				machine.CreatedAt,
+				machine.UpdatedAt,
 			})
 		}
 
-		_ = render.Table(io.Out, appName, rows, "ID", "Image", "Created", "Last Updated", "State", "Region", "Name", "IP Address")
+		_ = render.Table(io.Out, appName, rows, "ID", "Name", "State", "Region", "Image", "IP Address", "Volume", "Created", "Last Updated")
 	}
 	return nil
 }

--- a/internal/command/machine/list.go
+++ b/internal/command/machine/list.go
@@ -85,7 +85,6 @@ func runMachineList(ctx context.Context) (err error) {
 		}
 		_ = render.Table(io.Out, appName, rows, "ID")
 	} else {
-
 		for _, machine := range machines {
 			var volName string
 			if machine.Config != nil && len(machine.Config.Mounts) > 0 {


### PR DESCRIPTION
Reorganizes the `machine list` output and adds a `volume` column.

<img width="1282" alt="Screen Shot 2022-08-30 at 11 44 57 AM" src="https://user-images.githubusercontent.com/423038/187493521-d66eb689-1c88-4b29-bd69-e1f746ff0276.png">
