### PR TITLE
Fix typo in help text for fly postgres db

### DIFF
--- a/internal/command/postgres/db.go
+++ b/internal/command/postgres/db.go
@@ -18,7 +18,7 @@ import (
 
 func newDb() *cobra.Command {
 	const (
-		short = "manage databases in a clutser"
+		short = "Manage databases in a cluster"
 		long  = short + "\n"
 	)
 


### PR DESCRIPTION
A tiny change to fix a typo in the help text of the `flyctl postgres db` command. Also capitalized the first word to match the rest of the help texts.

```diff
diff previous.txt new.txt
14c14
<   db          manage databases in a clutser
---
>   db          Manage databases in a cluster
```