### PR TITLE
Indicate the machine VM when listing volumes when present

### DIFF
--- a/api/resource_volumes.go
+++ b/api/resource_volumes.go
@@ -20,9 +20,16 @@ func (c *Client) GetVolumes(ctx context.Context, appName string) ([]Volume, erro
 					host{
 						id
 					}
+					app {
+						platformVersion
+					}
 					attachedAllocation {
 						idShort
 						taskName
+					}
+					attachedMachine {
+						id
+						name
 					}
 				}
 			}

--- a/api/types.go
+++ b/api/types.go
@@ -356,7 +356,8 @@ type Snapshot struct {
 type Volume struct {
 	ID  string `json:"id"`
 	App struct {
-		Name string
+		Name            string
+		PlatformVersion string
 	}
 	Name      string
 	SizeGb    int
@@ -368,6 +369,7 @@ type Volume struct {
 	Encrypted          bool
 	CreatedAt          time.Time
 	AttachedAllocation *AllocationStatus
+	AttachedMachine    *GqlMachine
 	Host               struct {
 		ID string
 	}

--- a/internal/command/volumes/list.go
+++ b/internal/command/volumes/list.go
@@ -57,13 +57,17 @@ func runList(ctx context.Context) error {
 
 	rows := make([][]string, 0, len(volumes))
 	for _, volume := range volumes {
-		var attachedAllocID string
+		var attachedVMID string
 
-		if volume.AttachedAllocation != nil {
-			attachedAllocID = volume.AttachedAllocation.IDShort
+		if volume.App.PlatformVersion == "machines" {
+			if volume.AttachedMachine != nil {
+				attachedVMID = volume.AttachedMachine.ID
+			}
+		} else {
+			attachedVMID = volume.AttachedAllocation.IDShort
 
 			if volume.AttachedAllocation.TaskName != "app" {
-				attachedAllocID = fmt.Sprintf("%s (%s)", volume.AttachedAllocation.IDShort, volume.AttachedAllocation.TaskName)
+				attachedVMID = fmt.Sprintf("%s (%s)", volume.AttachedAllocation.IDShort, volume.AttachedAllocation.TaskName)
 			}
 		}
 
@@ -75,10 +79,9 @@ func runList(ctx context.Context) error {
 			volume.Region,
 			volume.Host.ID,
 			fmt.Sprint(volume.Encrypted),
-			attachedAllocID,
+			attachedVMID,
 			humanize.Time(volume.CreatedAt),
 		})
-
 	}
 
 	return render.Table(out, "", rows, "ID", "State", "Name", "Size", "Region", "Zone", "Encrypted", "Attached VM", "Created At")

--- a/internal/command/volumes/list.go
+++ b/internal/command/volumes/list.go
@@ -64,10 +64,12 @@ func runList(ctx context.Context) error {
 				attachedVMID = volume.AttachedMachine.ID
 			}
 		} else {
-			attachedVMID = volume.AttachedAllocation.IDShort
+			if volume.AttachedAllocation != nil {
+				attachedVMID = volume.AttachedAllocation.IDShort
 
-			if volume.AttachedAllocation.TaskName != "app" {
-				attachedVMID = fmt.Sprintf("%s (%s)", volume.AttachedAllocation.IDShort, volume.AttachedAllocation.TaskName)
+				if volume.AttachedAllocation.TaskName != "app" {
+					attachedVMID = fmt.Sprintf("%s (%s)", volume.AttachedAllocation.IDShort, volume.AttachedAllocation.TaskName)
+				}
 			}
 		}
 


### PR DESCRIPTION
`fly volumes list` will now specify the machine id under `ATTACHED VM` for machine apps.