### PR TITLE
Add Role column to fly status for Postgres apps

### DIFF
--- a/internal/command/status/machines.go
+++ b/internal/command/status/machines.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
@@ -64,12 +63,11 @@ func renderMachineStatus(ctx context.Context, app *api.AppCompact) (err error) {
 
 func renderPGStatus(ctx context.Context, app *api.AppCompact, machines []*api.Machine) (err error) {
 	io := iostreams.FromContext(ctx)
-
 	client := client.FromContext(ctx).API()
 
 	agentclient, err := agent.Establish(ctx, client)
 	if err != nil {
-		return errors.Wrap(err, "can't establish agent")
+		return fmt.Errorf("unable to establish agent: %s", err)
 	}
 
 	dialer, err := agentclient.Dialer(ctx, app.Organization.Slug)

--- a/internal/command/status/machines.go
+++ b/internal/command/status/machines.go
@@ -80,15 +80,12 @@ func renderPGStatus(ctx context.Context, app *api.AppCompact, machines []*api.Ma
 	rows := [][]string{}
 
 	for _, machine := range machines {
-		var role string
+		pgCli := flypg.NewFromInstance(fmt.Sprintf("[%s]", machine.PrivateIP), dialer)
 
-		if app.PostgresAppRole != nil {
-			pgCli := flypg.NewFromInstance(fmt.Sprintf("[%s]", machine.PrivateIP), dialer)
-
-			role, err = pgCli.NodeRole(ctx)
-			if err != nil {
-				role = "error"
-			}
+		role, err := pgCli.NodeRole(ctx)
+		if err != nil {
+			// TODO - Determine best way to present this error.
+			role = "error"
 		}
 
 		rows = append(rows, []string{


### PR DESCRIPTION
Adds a `role` column to `fly status` for all machine-based PG apps. 
```
$ ./bin/flyctl status --app shaun-m-test
App
  Name     = shaun-m-test
  Owner    = personal
  Hostname = shaun-m-test.fly.dev
  Platform = machines

ID            	STATE  	ROLE   	REGION	IMAGE                                   	CREATED             	UPDATED
6e8294ef226e87	started	leader 	ord   	registry-1.docker.io/flyio/postgres:14.4	2022-08-31T19:31:02Z	2022-08-31T19:31:10Z
4d896d6aed9d87	started	replica	ord   	registry-1.docker.io/flyio/postgres:14.4	2022-08-31T19:31:14Z	2022-08-31T19:31:25Z
```