### PR TITLE
Revert "Update to a newer elixir/erlang image since the previous one went missing"

### DIFF
--- a/scanner/templates/phoenix/Dockerfile
+++ b/scanner/templates/phoenix/Dockerfile
@@ -12,8 +12,8 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.12.3-erlang-24.1.4-debian-bullseye-20210902-slim
 #
-ARG BUILDER_IMAGE="hexpm/elixir:1.13.4-erlang-24.3.4.4-debian-buster-20220801-slim"
-ARG RUNNER_IMAGE="debian:buster-20220801-slim"
+ARG BUILDER_IMAGE="hexpm/elixir:1.12.3-erlang-24.1.4-debian-bullseye-20210902-slim"
+ARG RUNNER_IMAGE="debian:bullseye-20210902-slim"
 
 FROM ${BUILDER_IMAGE} as builder
 


### PR DESCRIPTION
Reverts superfly/flyctl#1235

This Docker image does indeed exist, so let's not update here unless we have to. Fly internal CI was having trouble with this specific image.