### PR TITLE
Add vendor directory to npm build step

### DIFF
--- a/scanner/templates/laravel/Dockerfile
+++ b/scanner/templates/laravel/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /var/www/html
 # copy application code, skipping files based on .dockerignore
 COPY . /var/www/html
+COPY --from=base /var/www/html/vendor /app/vendor
 
 RUN composer install --optimize-autoloader --no-dev \
     && mkdir -p storage/logs \


### PR DESCRIPTION
This fixes an issue in Laravel Jetstream (and perhaps other packages) where Tailwind is told to search for classes used in vendor'ed files