### PR TITLE
Reworking the PG Machine update process a bit

### DIFF
--- a/internal/command/postgres/update.go
+++ b/internal/command/postgres/update.go
@@ -151,12 +151,13 @@ func runUpdate(ctx context.Context) error {
 	// Update replicas
 	fmt.Fprintf(io.Out, "Updating replicas\n")
 	for _, replica := range replicas {
-		if updateList[replica.ID] == nil {
+		ref := updateList[replica.ID]
+
+		if ref == nil {
 			fmt.Fprintf(io.Out, "  Machine %s is already running the latest image\n", replica.ID)
 			continue
 		}
 
-		ref := updateList[replica.ID]
 		image := fmt.Sprintf("%s:%s", ref.Repository, ref.Tag)
 
 		fmt.Fprintf(io.Out, "  Updating machine %s with image %s %s\n", replica.ID, image, ref.Version)
@@ -166,7 +167,9 @@ func runUpdate(ctx context.Context) error {
 	}
 
 	// Update leader
-	if updateList[leader.ID] != nil {
+
+	ref := updateList[leader.ID]
+	if ref != nil {
 		pgclient := flypg.New(app.Name, dialer)
 
 		fmt.Fprintf(io.Out, "Performing a failover\n")
@@ -175,8 +178,6 @@ func runUpdate(ctx context.Context) error {
 		}
 
 		fmt.Fprintf(io.Out, "Updating leader\n")
-
-		ref := updateList[leader.ID]
 		image := fmt.Sprintf("%s:%s", ref.Repository, ref.Tag)
 
 		fmt.Fprintf(io.Out, "  Updating machine %s with image %s %s\n", leader.ID, image, ref.Version)

--- a/internal/command/postgres/update.go
+++ b/internal/command/postgres/update.go
@@ -68,34 +68,44 @@ func runUpdate(ctx context.Context) error {
 		return fmt.Errorf("list of machines could not be retrieved: %w", err)
 	}
 
-	// map of machine lease to machine
-	machines := make(map[string]*api.Machine)
-
-	out, err := flapsClient.List(ctx, "started")
+	machines, err := flapsClient.List(ctx, "started")
 	if err != nil {
 		return fmt.Errorf("machines could not be retrieved %w", err)
 	}
 
-	if len(out) == 0 {
+	if len(machines) == 0 {
 		return fmt.Errorf("no machines found")
 	}
 
-	fmt.Fprintf(io.Out, "Acquiring lease on postgres cluster\n")
+	// Verify that we actually have updates to perform
+	fmt.Fprintf(io.Out, "Checking for available updates\n")
 
-	for _, machine := range out {
-		lease, err := flapsClient.GetLease(ctx, machine.ID, api.IntPointer(40))
+	// Track machines that have available updates so we can avoid doing unnecessary work.
+	updateList := map[string]*api.ImageVersion{}
+	for _, machine := range machines {
+		image := fmt.Sprintf("%s:%s", machine.ImageRef.Repository, machine.ImageRef.Tag)
+
+		latest, err := client.GetLatestImageDetails(ctx, image)
 		if err != nil {
-			return fmt.Errorf("failed to obtain lease: %w", err)
+			return fmt.Errorf("can't get latest image details for %s: %w", image, err)
 		}
-		machines[lease.Data.Nonce] = machine
+
+		if machine.ImageVersion() != latest.Version {
+			updateList[machine.ID] = latest
+		}
 	}
 
+	if len(updateList) == 0 {
+		fmt.Fprintf(io.Out, "No updates available...\n")
+		return nil
+	}
+
+	// Resolve cluster roles
+	fmt.Fprintf(io.Out, "Identifying cluster roles\n")
 	var (
 		leader   *api.Machine
 		replicas []*api.Machine
 	)
-
-	fmt.Fprintf(io.Out, "Resolving cluster roles\n")
 
 	for _, machine := range machines {
 		address := fmt.Sprintf("[%s]", machine.PrivateIP)
@@ -116,80 +126,75 @@ func runUpdate(ctx context.Context) error {
 		case "replica":
 			replicas = append(replicas, machine)
 		}
-		fmt.Fprintf(io.Out, "  %s: %s\n", machine.ID, role)
+		fmt.Fprintf(io.Out, "  Machine %s: %s\n", machine.ID, role)
 	}
 
 	if leader == nil {
 		return fmt.Errorf("this cluster has no leader")
 	}
 
-	image := fmt.Sprintf("%s:%s", leader.ImageRef.Repository, leader.ImageRef.Tag)
+	// Acquire leases
+	fmt.Fprintf(io.Out, "Attempting to acquire lease(s)\n")
+	for _, machine := range machines {
+		lease, err := flapsClient.GetLease(ctx, machine.ID, api.IntPointer(40))
+		if err != nil {
+			return fmt.Errorf("failed to obtain lease: %w", err)
+		}
+		machine.LeaseNonce = lease.Data.Nonce
 
-	latest, err := client.GetLatestImageDetails(ctx, image)
-	if err != nil {
-		return fmt.Errorf("can't get latest image details for %s: %w", image, err)
+		// Ensure lease is released on return
+		defer releaseLease(ctx, flapsClient, machine)
+
+		fmt.Fprintf(io.Out, "  Machine %s: %s\n", machine.ID, lease.Status)
 	}
 
+	// Update replicas
 	fmt.Fprintf(io.Out, "Updating replicas\n")
-
 	for _, replica := range replicas {
-		current := replica
-
-		if current.ImageVersion() == latest.Version {
-			fmt.Fprintf(io.Out, "  %s: already up to date\n", replica.ID)
+		if updateList[replica.ID] == nil {
+			fmt.Fprintf(io.Out, "  Machine %s is already running the latest image", replica.ID)
 			continue
 		}
 
-		ref := fmt.Sprintf("%s:%s", latest.Repository, latest.Tag)
+		ref := updateList[replica.ID]
+		image := fmt.Sprintf("%s:%s", ref.Repository, ref.Tag)
 
-		if err := updateMachine(ctx, app, replica, ref, latest.Version); err != nil {
+		fmt.Fprintf(io.Out, "  Updating machine %s with image %s %s\n", replica.ID, image, ref.Version)
+		if err := updateMachine(ctx, app, replica, image); err != nil {
 			return fmt.Errorf("can't update %s: %w", replica.ID, err)
 		}
 	}
 
-	current := leader
+	// Update leader
+	if updateList[leader.ID] != nil {
+		pgclient := flypg.New(app.Name, dialer)
 
-	if current.ImageVersion() == latest.Version {
-		fmt.Fprintf(io.Out, "%s(leader): already up to date\n", leader.ID)
-		return nil
-	}
+		fmt.Fprintf(io.Out, "Performing a failover\n")
+		if err := pgclient.Failover(ctx); err != nil {
+			return fmt.Errorf("failed to trigger failover %w", err)
+		}
 
-	ref := fmt.Sprintf("%s:%s", latest.Repository, latest.Tag)
+		fmt.Fprintf(io.Out, "Updating leader\n")
 
-	pgclient := flypg.New(app.Name, dialer)
+		ref := updateList[leader.ID]
+		image := fmt.Sprintf("%s:%s", ref.Repository, ref.Tag)
 
-	fmt.Fprintf(io.Out, "Failing over to a new leader\n")
-
-	if err := pgclient.Failover(ctx); err != nil {
-		return fmt.Errorf("failed to trigger failover %w", err)
-	}
-
-	fmt.Fprintf(io.Out, "Updating leader\n")
-
-	if err := updateMachine(ctx, app, leader, ref, latest.Version); err != nil {
-		return err
-	}
-
-	for lease, machine := range machines {
-		if err := flapsClient.ReleaseLease(ctx, machine.ID, lease); err != nil {
-			return fmt.Errorf("failed to release lease: %w", err)
+		fmt.Fprintf(io.Out, "  Updating machine %s with image %s %s\n", leader.ID, image, ref.Version)
+		if err := updateMachine(ctx, app, leader, image); err != nil {
+			return err
 		}
 	}
 
-	fmt.Fprintf(io.Out, "Successfully updated Postgres cluster\n")
+	fmt.Fprintf(io.Out, "Postgres cluster has been successfully updated!\n")
 
 	return nil
 }
 
-func updateMachine(ctx context.Context, app *api.AppCompact, machine *api.Machine, image, version string) error {
-	io := iostreams.FromContext(ctx)
-
+func updateMachine(ctx context.Context, app *api.AppCompact, machine *api.Machine, image string) error {
 	flaps, err := flaps.New(ctx, app)
 	if err != nil {
 		return err
 	}
-
-	fmt.Fprintf(io.Out, "Updating machine %s with image %s %s\n", machine.ID, image, version)
 
 	machineConf := machine.Config
 	machineConf.Image = image
@@ -202,13 +207,21 @@ func updateMachine(ctx context.Context, app *api.AppCompact, machine *api.Machin
 		Config:  machineConf,
 	}
 
-	updated, err := flaps.Update(ctx, input, "")
+	updated, err := flaps.Update(ctx, input, machine.LeaseNonce)
 	if err != nil {
 		return err
 	}
 
 	if err := machines.WaitForStart(ctx, flaps, updated, time.Minute*5); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func releaseLease(ctx context.Context, client *flaps.Client, machine *api.Machine) error {
+	if err := client.ReleaseLease(ctx, machine.ID, machine.LeaseNonce); err != nil {
+		return fmt.Errorf("failed to release lease: %w", err)
 	}
 
 	return nil

--- a/internal/command/postgres/update.go
+++ b/internal/command/postgres/update.go
@@ -172,9 +172,11 @@ func runUpdate(ctx context.Context) error {
 	// Update leader
 	ref := updateList[leader.ID]
 	if ref != nil {
-		pgclient := flypg.New(app.Name, dialer)
-
+		// Don't perform failover if the cluster is only running a
+		// single node.
 		if len(machines) > 1 {
+			pgclient := flypg.New(app.Name, dialer)
+
 			fmt.Fprintf(io.Out, "Performing a failover\n")
 			if err := pgclient.Failover(ctx); err != nil {
 				return fmt.Errorf("failed to trigger failover %w", err)

--- a/internal/command/postgres/update.go
+++ b/internal/command/postgres/update.go
@@ -77,7 +77,6 @@ func runUpdate(ctx context.Context) error {
 		return fmt.Errorf("no machines found")
 	}
 
-	// Verify that we actually have updates to perform
 	fmt.Fprintf(io.Out, "Checking for available updates\n")
 
 	// Track machines that have available updates so we can avoid doing unnecessary work.
@@ -129,6 +128,7 @@ func runUpdate(ctx context.Context) error {
 		fmt.Fprintf(io.Out, "  Machine %s: %s\n", machine.ID, role)
 	}
 
+	// Don't perform an update if the cluster is not healthy.
 	if leader == nil {
 		return fmt.Errorf("this cluster has no leader")
 	}
@@ -152,7 +152,7 @@ func runUpdate(ctx context.Context) error {
 	fmt.Fprintf(io.Out, "Updating replicas\n")
 	for _, replica := range replicas {
 		if updateList[replica.ID] == nil {
-			fmt.Fprintf(io.Out, "  Machine %s is already running the latest image", replica.ID)
+			fmt.Fprintf(io.Out, "  Machine %s is already running the latest image\n", replica.ID)
 			continue
 		}
 


### PR DESCRIPTION
Notable changes:

* Fixed an issue with the lease nonce getting passed in.
* Added a pre-check that verifies that there are updates to perform. 
* Lease releases are now being deferred.  This will help ensure that leases are released properly in the event of an error. 
* Machines that are already running the latest version will not be sent to flaps.  Identifying the individual machine versions ahead of time will help better accommodate partial upgrade situations. For example, there's no need to perform a failover in the event the leader is already running our target version.

```
./bin/flyctl pg update --app shaun-pg-upgrade-10
Checking for available updates
Identifying cluster roles
  Machine 4d89946a461387: replica
  Machine 0e2865c7950867: leader
  Machine 4d89606c424287: replica
  Machine 3287113c6e5085: replica
Attempting to acquire lease(s)
  Machine 4d89946a461387: success
  Machine 0e2865c7950867: success
  Machine 4d89606c424287: success
  Machine 3287113c6e5085: success
Updating replicas
  Updating machine 4d89946a461387 with image flyio/postgres:14.4 v0.0.26
  Updating machine 4d89606c424287 with image flyio/postgres:14.4 v0.0.26
  Updating machine 3287113c6e5085 with image flyio/postgres:14.4 v0.0.26
Performing a failover
Updating leader
  Updating machine 0e2865c7950867 with image flyio/postgres:14.4 v0.0.26
Postgres cluster has been successfully updated!
```