### PR TITLE
Machines: secrets set bug fix

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -267,7 +267,7 @@ func DeployMachinesApp(ctx context.Context, app *api.AppCompact, strategy string
 			// Until mounts are supported in fly.toml, ensure deployments
 			// maintain any existing volume attachments
 			if machine.Config.Mounts != nil {
-				launchInput.Config.Mounts = append(launchInput.Config.Mounts, machine.Config.Mounts[0])
+				launchInput.Config.Mounts = machine.Config.Mounts
 			}
 
 			updateResult, err := flapsClient.Update(ctx, launchInput, machine.LeaseNonce)


### PR DESCRIPTION
Fixes bug that breaks deploys when there's multiple machines with volumes.

```
$ fly secrets set TESSST=cha --app shaun-secret-test
Deploying with rolling strategy ✓
Error failed to update VM 9080275c114687: invalid config.mounts, only 1 volume supported
```