### PR TITLE
Machine specific vm sizes

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -990,6 +990,7 @@ type AutoscaleRegionConfigInput struct {
 type VMSize struct {
 	Name        string
 	CPUCores    float32
+	CPUClass    string
 	MemoryGB    float32
 	MemoryMB    int
 	PriceMonth  float32

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -37,7 +37,7 @@ type CreateClusterInput struct {
 	Password           string
 	Region             string
 	VolumeSize         *int
-	VMSize             *string
+	VMSize             *api.VMSize
 	SnapshotID         *string
 }
 
@@ -180,7 +180,7 @@ func (l *Launcher) LaunchNomadPostgres(ctx context.Context, config *CreateCluste
 		ImageRef:       &config.ImageRef,
 		Count:          &config.InitialClusterSize,
 		Password:       &config.Password,
-		VMSize:         config.VMSize,
+		VMSize:         &config.VMSize.Name,
 		VolumeSizeGB:   config.VolumeSize,
 	}
 
@@ -228,7 +228,11 @@ func (l *Launcher) getPostgresConfig(config *CreateClusterInput) *api.MachineCon
 		"PRIMARY_REGION": config.Region,
 	}
 
-	machineConfig.VMSize = *config.VMSize
+	machineConfig.Guest = &api.MachineGuest{
+		CPUKind:  config.VMSize.CPUClass,
+		CPUs:     int(config.VMSize.CPUCores),
+		MemoryMB: config.VMSize.MemoryMB,
+	}
 	machineConfig.Restart.Policy = api.MachineRestartPolicyAlways
 
 	return &machineConfig

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -341,7 +341,7 @@ func postgresNomadConfigurations() []PostgresConfiguration {
 
 // machineVMSizes represents the available VM configurations for Machines.
 func MachineVMSizes() []api.VMSize {
-	// TODO - This should eventually be queried from flaps.
+	// TODO - Eventually we will have a flaps endpoint for this.
 	return []api.VMSize{
 		{
 			Name:     "shared-cpu-1x",


### PR DESCRIPTION
Notable changes:

* Fixes an issue where PG Machine provisions were prompting Nomad specific vm-sizes.
* PG Machine provisions now have their own list of pre-configured setups. 
* Machine specific vm-sizes have been hard-coded, but these should eventually come from flaps.
* Started to tease apart the CPU/Memory coupling.  Eventually i'd like memory to be specified independently of CPU when specifying a custom configuration. 


```
? Select configuration:  [Use arrows to move, type to filter]
  Development - Single node, 1x shared CPU, 256MB RAM, 1GB disk
  Production - Highly available, 2x shared CPUs, 4GB RAM, 40GB disk
  Production - Highly available, 4x shared CPUs, 8GB RAM, 80GB disk
> Specify custom configuration
```