### PR TITLE
Add a suggestion on how to avoid the use of AWS at build time for

### DIFF
--- a/scanner/templates/rails/standard/Dockerfile
+++ b/scanner/templates/rails/standard/Dockerfile
@@ -77,7 +77,12 @@ RUN --mount=type=cache,id=prod-apt-cache,sharing=locked,target=/var/cache/apt \
 COPY --from=gems /app /app
 COPY --from=node_modules /app/node_modules /app/node_modules
 
+# The following enable assets to precompile on the build server.  Adjust
+# as necessary.  If no combination works for you, see:
+# https://fly.io/docs/rails/getting-started/existing/#access-to-environment-variables-at-build-time
 ENV SECRET_KEY_BASE 1
+# ENV AWS_ACCESS_KEY_ID=1
+# ENV AWS_SECRET_ACCESS_KEY=1
 
 COPY . .
 


### PR DESCRIPTION
Rails apps.  See:

https://community.fly.io/t/rfc-have-fly-launch-produce-a-lib-tasks-fly-rake/6744