### PR TITLE
Add PG Volume support to `fly machines clone`

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -93,14 +93,45 @@ func runMachineClone(ctx context.Context) (err error) {
 		region = source.Region
 	}
 
-	// Ensure attached volumes are not copied to the clone
-	source.Config.Mounts = nil
+	targetConfig := source.Config
+
+	// Hack to support Volume cloning for Postgres clusters.
+	if app.PostgresAppRole.Name == "postgres_cluster" {
+		if len(source.Config.Mounts) > 0 {
+			mnt := source.Config.Mounts[0]
+
+			volInput := api.CreateVolumeInput{
+				AppID:             app.ID,
+				Name:              "pg_data",
+				Region:            region,
+				SizeGb:            mnt.SizeGb,
+				Encrypted:         mnt.Encrypted,
+				RequireUniqueZone: false,
+			}
+
+			vol, err := client.CreateVolume(ctx, volInput)
+			if err != nil {
+				return err
+			}
+
+			targetConfig.Mounts = []api.MachineMount{
+				{
+					Volume:    vol.ID,
+					Path:      mnt.Path,
+					SizeGb:    mnt.SizeGb,
+					Encrypted: mnt.Encrypted,
+				},
+			}
+		}
+	} else {
+		targetConfig.Mounts = nil
+	}
 
 	input := api.LaunchMachineInput{
 		AppID:  app.Name,
 		Name:   flag.GetString(ctx, "name"),
 		Region: region,
-		Config: source.Config,
+		Config: targetConfig,
 	}
 
 	launchedMachine, err := flapsClient.Launch(ctx, input)

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -79,7 +79,6 @@ func runMachineClone(ctx context.Context) (err error) {
 		}
 
 		source, err = flapsClient.Get(ctx, machines[0].ID)
-
 		if err != nil {
 			return err
 		}
@@ -88,14 +87,15 @@ func runMachineClone(ctx context.Context) (err error) {
 	}
 
 	region := flag.GetString(ctx, "region")
-
 	if region == "" {
 		region = source.Region
 	}
 
 	targetConfig := source.Config
 
-	// Hack to support Volume cloning for Postgres clusters.
+	// This is a temperary hack to add volume support for PG apps.
+	// Flaps does not currently specify the volume name within the Machine mount spec,
+	// which is required before we can handle this more generally.
 	if app.PostgresAppRole.Name == "postgres_cluster" {
 		if len(source.Config.Mounts) > 0 {
 			mnt := source.Config.Mounts[0]


### PR DESCRIPTION
`fly machines clone <machine-id>` will now create a new volume when cloning a machine tied to a Postgres app. 