### PR TITLE
Update NextJS port to 3000

### DIFF
--- a/scanner/nextjs.go
+++ b/scanner/nextjs.go
@@ -6,12 +6,12 @@ func configureNextJs(sourceDir string) (*SourceInfo, error) {
 	}
 
 	env := map[string]string{
-		"PORT": "8080",
+		"PORT": "3000",
 	}
 
 	s := &SourceInfo{
 		Family:       "NextJS",
-		Port:         8080,
+		Port:         3000,
 		SkipDatabase: true,
 	}
 


### PR DESCRIPTION
Users following the blog article on [Deploy a NextJS Application](https://fly.io/docs/getting-started/nextjs/) will fail to deploy due to a port mismatch during `fly launch`.

There's a discrepancy between the generated `Dockerfile` and `fly.toml` files.
* The port generated in `fly.toml` is 8080 ([results in `services.internal_port = 8080`](https://github.com/superfly/flyctl/blob/b6d7c3cf51614c1a8b881ec752f8e15387fbd7b1/scanner/nextjs.go#L14)).
* The port generated in `Dockerfile` is 3000 ([`ENV PORT 3000`](https://github.com/superfly/flyctl/blob/30917786f10e8e64d03480460e65dbd274a350aa/scanner/templates/nextjs/Dockerfile#L38))
* The default port for [NextJS apps is 3000](https://nextjs.org/docs/deployment#docker-image). 

This updates the generated port (8080) to match the default (3000). 