### PR TITLE
Fix NextJS Port

### DIFF
--- a/scanner/nextjs.go
+++ b/scanner/nextjs.go
@@ -5,13 +5,15 @@ func configureNextJs(sourceDir string) (*SourceInfo, error) {
 		return nil, nil
 	}
 
+	env := map[string]string{
+		"PORT": "8080",
+	}
+
 	s := &SourceInfo{
 		Family:       "NextJS",
 		Port:         8080,
 		SkipDatabase: true,
-		Env: map[string]string{
-			"PORT": "8080",
-		},
+		Env: env,
 	}
 
 	s.Files = templates("templates/nextjs")
@@ -20,6 +22,5 @@ func configureNextJs(sourceDir string) (*SourceInfo, error) {
 		"NEXT_PUBLIC_EXAMPLE": "Value goes here",
 	}
 
-	s.Env = env
 	return s, nil
 }

--- a/scanner/nextjs.go
+++ b/scanner/nextjs.go
@@ -5,14 +5,13 @@ func configureNextJs(sourceDir string) (*SourceInfo, error) {
 		return nil, nil
 	}
 
-	env := map[string]string{
-		"PORT": "8080",
-	}
-
 	s := &SourceInfo{
 		Family:       "NextJS",
 		Port:         8080,
 		SkipDatabase: true,
+		Env: map[string]string{
+			"PORT": "8080",
+		},
 	}
 
 	s.Files = templates("templates/nextjs")

--- a/scanner/nuxtjs.go
+++ b/scanner/nuxtjs.go
@@ -5,14 +5,13 @@ func configureNuxt(sourceDir string) (*SourceInfo, error) {
 		return nil, nil
 	}
 
-	env := map[string]string{
-		"PORT": "8080",
-	}
-
 	s := &SourceInfo{
 		Family:       "NuxtJS",
 		Port:         8080,
 		SkipDatabase: true,
+		Env: map[string]string{
+			"PORT": "8080",
+		},
 	}
 
 	s.Files = templates("templates/nuxtjs")

--- a/scanner/nuxtjs.go
+++ b/scanner/nuxtjs.go
@@ -5,17 +5,18 @@ func configureNuxt(sourceDir string) (*SourceInfo, error) {
 		return nil, nil
 	}
 
+	env := map[string]string{
+		"PORT": "8080",
+	}
+
 	s := &SourceInfo{
 		Family:       "NuxtJS",
 		Port:         8080,
 		SkipDatabase: true,
-		Env: map[string]string{
-			"PORT": "8080",
-		},
+		Env: env,
 	}
 
 	s.Files = templates("templates/nuxtjs")
 
-	s.Env = env
 	return s, nil
 }

--- a/scanner/remix.go
+++ b/scanner/remix.go
@@ -5,12 +5,13 @@ func configureRemix(sourceDir string) (*SourceInfo, error) {
 		return nil, nil
 	}
 
+	env := map[string]string{
+		"PORT": "8080",
+	}
+
 	s := &SourceInfo{
 		Family: "Remix",
 		Port:   8080,
-		Env: map[string]string{
-			"PORT": "8080",
-		},
 	}
 
 	if checksPass(sourceDir+"/prisma", dirContains("*.prisma", "sqlite")) {

--- a/scanner/remix.go
+++ b/scanner/remix.go
@@ -5,13 +5,12 @@ func configureRemix(sourceDir string) (*SourceInfo, error) {
 		return nil, nil
 	}
 
-	env := map[string]string{
-		"PORT": "8080",
-	}
-
 	s := &SourceInfo{
 		Family: "Remix",
 		Port:   8080,
+		Env: map[string]string{
+			"PORT": "8080",
+		},
 	}
 
 	if checksPass(sourceDir+"/prisma", dirContains("*.prisma", "sqlite")) {

--- a/scanner/templates/nextjs/Dockerfile
+++ b/scanner/templates/nextjs/Dockerfile
@@ -35,8 +35,6 @@ COPY --from=builder /app ./
 
 USER nextjs
 
-ENV PORT 8080
-
 CMD ["yarn", "start"]
 
 # If using npm comment out above and use below instead

--- a/scanner/templates/nextjs/Dockerfile
+++ b/scanner/templates/nextjs/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=builder /app ./
 
 USER nextjs
 
-ENV PORT 3000
+ENV PORT 8080
 
 CMD ["yarn", "start"]
 


### PR DESCRIPTION
running flyctl on a nextjs package fails right now.

this seems to be happening because the port specified in the fly.toml, 8080, doesn't match the port nextjs is listening on, 3000.

diving deeper, it looks like the environment variables required for nextjs listening on port 8080 are missing. they seem to be set differently to other scanners, like this phoneix one: https://github.com/superfly/flyctl/blob/master/scanner/phoenix.go#L30

I've made the following change to the nextjs scanner to align it with the other scanners.

I've also made the change to nuxtjs and remix because they follow the same convention as nextjs and probably don't work either

all scanners follow the same convention for ports and environment variables with this change