### PR TITLE
added alias volume to `fly volumes`

### DIFF
--- a/internal/command/volumes/volumes.go
+++ b/internal/command/volumes/volumes.go
@@ -25,7 +25,7 @@ func New() *cobra.Command {
 
 	cmd := command.New(usage, short, long, nil)
 
-	cmd.Aliases = []string{"vol"}
+	cmd.Aliases = []string{"volume","vol"}
 
 	cmd.AddCommand(
 		newCreate(),


### PR DESCRIPTION
this was a request from the forums:
- https://community.fly.io/t/fly-volume-alias-does-not-exist/7122
this change reflects the current docs

since I make this mistake all the time too, I thought it might be nice to add it. 