### PR TITLE
Set PRIMARY_REGION as a secret so it propagates with machine run.

### DIFF
--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -223,11 +223,6 @@ func (l *Launcher) LaunchNomadPostgres(ctx context.Context, config *CreateCluste
 func (l *Launcher) getPostgresConfig(config *CreateClusterInput) *api.MachineConfig {
 	machineConfig := api.MachineConfig{}
 
-	// Set env
-	machineConfig.Env = map[string]string{
-		"PRIMARY_REGION": config.Region,
-	}
-
 	// Set VM resources
 	machineConfig.Guest = &api.MachineGuest{
 		CPUKind:  config.VMSize.CPUClass,
@@ -300,6 +295,7 @@ func (l *Launcher) setSecrets(ctx context.Context, config *CreateClusterInput) (
 		"SU_PASSWORD":       suPassword,
 		"REPL_PASSWORD":     replPassword,
 		"OPERATOR_PASSWORD": opPassword,
+		"PRIMARY_REGION":    config.Region,
 	}
 
 	if config.SnapshotID != nil {


### PR DESCRIPTION
When creating a new machine with `fly machine run`, environment variables will not be added by default.  So to help provide a better experience for PG on Machines, the `PRIMARY_REGION` environment variable will now be set as a secret. 