### PR TITLE
fix: Add wait for stopped

### DIFF
--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -132,7 +132,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 			waitTimeout = time.Hour
 		}
 
-		err = machines.WaitForStart(ctx, flaps, machine, waitTimeout)
+		err = machines.WaitForStartOrStop(ctx, flaps, machine, "start", waitTimeout)
 		if err != nil {
 			return err
 		}

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -239,7 +239,7 @@ func runMachineRun(ctx context.Context) error {
 	fmt.Fprintf(io.Out, " State: %s\n", state)
 
 	// wait for machine to be started
-	if err := WaitForStart(ctx, flapsClient, machine, time.Minute*5); err != nil {
+	if err := WaitForStartOrStop(ctx, flapsClient, machine, "start", time.Minute*5); err != nil {
 		return err
 	}
 
@@ -295,7 +295,7 @@ func createApp(ctx context.Context, message, name string, client *api.Client) (*
 	}, nil
 }
 
-func WaitForStart(ctx context.Context, flapsClient *flaps.Client, machine *api.Machine, timeout time.Duration) error {
+func WaitForStartOrStop(ctx context.Context, flapsClient *flaps.Client, machine *api.Machine, action string, timeout time.Duration) error {
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -306,7 +306,7 @@ func WaitForStart(ctx context.Context, flapsClient *flaps.Client, machine *api.M
 		Jitter: false,
 	}
 	for {
-		err := flapsClient.Wait(waitCtx, machine, "started")
+		err := flapsClient.Wait(waitCtx, machine, action)
 		switch {
 		case errors.Is(err, context.Canceled):
 			return err

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -299,6 +299,16 @@ func WaitForStartOrStop(ctx context.Context, flapsClient *flaps.Client, machine 
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
+	var waitOnAction string
+	switch action {
+	case "start":
+		waitOnAction = "started"
+	case "stop":
+		waitOnAction = "stopped"
+	default:
+		return fmt.Errorf("action must be either start or stop")
+	}
+
 	b := &backoff.Backoff{
 		Min:    500 * time.Millisecond,
 		Max:    2 * time.Second,
@@ -306,7 +316,7 @@ func WaitForStartOrStop(ctx context.Context, flapsClient *flaps.Client, machine 
 		Jitter: false,
 	}
 	for {
-		err := flapsClient.Wait(waitCtx, machine, action)
+		err := flapsClient.Wait(waitCtx, machine, waitOnAction)
 		switch {
 		case errors.Is(err, context.Canceled):
 			return err

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -87,8 +87,13 @@ func runUpdate(ctx context.Context) (err error) {
 		return err
 	}
 
+	waitForAction := "started"
+	if machine.Config.Schedule != "" {
+		waitForAction = "stopped"
+	}
+
 	// wait for machine to be started
-	if err := WaitForStart(ctx, flapsClient, machine, time.Minute*5); err != nil {
+	if err := WaitForStartOrStop(ctx, flapsClient, machine, waitForAction, time.Minute*5); err != nil {
 		return err
 	}
 

--- a/internal/command/postgres/update.go
+++ b/internal/command/postgres/update.go
@@ -219,7 +219,7 @@ func updateMachine(ctx context.Context, app *api.AppCompact, machine *api.Machin
 		return err
 	}
 
-	if err := machines.WaitForStart(ctx, flaps, updated, time.Minute*5); err != nil {
+	if err := machines.WaitForStartOrStop(ctx, flaps, updated, "start", time.Minute*5); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Currently a machine update assumes a machine has to be started as the end state. For a scheduled machine, the end state is stopped. As a result of this mismatch in expectation and outcome, the command hangs indefinitely and never returns, which is quite jarring from a UX standpoint.

This fix adds a wait for stopped check similar to start. 