### PR TITLE
Defer lease release

### DIFF
--- a/internal/command/postgres/config.go
+++ b/internal/command/postgres/config.go
@@ -432,18 +432,14 @@ func updateMachinesConfig(ctx context.Context, app *api.AppCompact, changes map[
 	if err != nil {
 		return fmt.Errorf("failed to obtain lease: %w", err)
 	}
+	defer flaps.ReleaseLease(ctx, leader.ID, lease.Data.Nonce)
 
 	fmt.Fprintf(io.Out, "Acquired lease %s on machine: %s\n", lease.Data.Nonce, leader.ID)
-
 	fmt.Fprintln(io.Out, "Performing update...")
+
 	err = cmd.UpdateSettings(ctx, changes)
 	if err != nil {
 		return err
-	}
-
-	err = flaps.ReleaseLease(ctx, leader.ID, lease.Data.Nonce)
-	if err != nil {
-		return fmt.Errorf("failed to release lease: %w", err)
 	}
 
 	return


### PR DESCRIPTION
Defer lease release just in case updating settings fails. 