### PR TITLE
fix: prevent schedule override

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -527,7 +527,9 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 		return
 	}
 
-	machineConf.Schedule = flag.GetString(ctx, "schedule")
+	if flag.GetString(ctx, "schedule") != "" {
+		machineConf.Schedule = flag.GetString(ctx, "schedule")
+	}
 
 	machineConf.Metadata, err = parseKVFlag(ctx, "metadata", machineConf.Metadata)
 


### PR DESCRIPTION
Schedule was being overridden when an update happened via flyctl. This made machine states inconsistent since a machine would end up stopped if it had been scheduled previously. 
<img width="1269" alt="schedule" src="https://user-images.githubusercontent.com/3229484/191367677-a754e9db-78e0-42f9-b985-97b7e704fd5a.png">
