### PR TITLE
Allow for build files which only contain a build-target line

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -265,7 +265,7 @@ func unmarshalBuild(data map[string]interface{}) *Build {
 		switch k {
 		case "builder":
 			b.Builder = fmt.Sprint(v)
-			configValueSet = b.Builder != ""
+			configValueSet = configValueSet || b.Builder != ""
 		case "buildpacks":
 			if bpSlice, ok := v.([]interface{}); ok {
 				for _, argV := range bpSlice {
@@ -280,7 +280,7 @@ func unmarshalBuild(data map[string]interface{}) *Build {
 			}
 		case "builtin":
 			b.Builtin = fmt.Sprint(v)
-			configValueSet = b.Builtin != ""
+			configValueSet = configValueSet || b.Builtin != ""
 		case "settings":
 			if settingsMap, ok := v.(map[string]interface{}); ok {
 				for settingK, settingV := range settingsMap {
@@ -289,13 +289,13 @@ func unmarshalBuild(data map[string]interface{}) *Build {
 			}
 		case "image":
 			b.Image = fmt.Sprint(v)
-			configValueSet = b.Image != ""
+			configValueSet = configValueSet || b.Image != ""
 		case "dockerfile":
 			b.Dockerfile = fmt.Sprint(v)
-			configValueSet = b.Dockerfile != ""
+			configValueSet = configValueSet || b.Dockerfile != ""
 		case "build_target", "build-target":
 			b.DockerBuildTarget = fmt.Sprint(v)
-			configValueSet = b.DockerBuildTarget != ""
+			configValueSet = configValueSet || b.DockerBuildTarget != ""
 		default:
 			b.Args[k] = fmt.Sprint(v)
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -260,10 +260,12 @@ func unmarshalBuild(data map[string]interface{}) *Build {
 		Buildpacks: []string{},
 	}
 
+	configValueSet := false
 	for k, v := range buildConfig {
 		switch k {
 		case "builder":
 			b.Builder = fmt.Sprint(v)
+			configValueSet = b.Builder != ""
 		case "buildpacks":
 			if bpSlice, ok := v.([]interface{}); ok {
 				for _, argV := range bpSlice {
@@ -278,6 +280,7 @@ func unmarshalBuild(data map[string]interface{}) *Build {
 			}
 		case "builtin":
 			b.Builtin = fmt.Sprint(v)
+			configValueSet = b.Builtin != ""
 		case "settings":
 			if settingsMap, ok := v.(map[string]interface{}); ok {
 				for settingK, settingV := range settingsMap {
@@ -286,16 +289,19 @@ func unmarshalBuild(data map[string]interface{}) *Build {
 			}
 		case "image":
 			b.Image = fmt.Sprint(v)
+			configValueSet = b.Image != ""
 		case "dockerfile":
 			b.Dockerfile = fmt.Sprint(v)
+			configValueSet = b.Dockerfile != ""
 		case "build_target", "build-target":
 			b.DockerBuildTarget = fmt.Sprint(v)
+			configValueSet = b.DockerBuildTarget != ""
 		default:
 			b.Args[k] = fmt.Sprint(v)
 		}
 	}
 
-	if b.Builder == "" && b.Builtin == "" && b.Image == "" && b.Dockerfile == "" && len(b.Args) == 0 {
+	if !configValueSet && len(b.Args) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
To reproduce this, simply create a fly.toml with:

```
[build]
  build-target = "myapp"
```

If your `Dockerfile` contains multiple build targets, it will end up picking one of them (likely the last one). This is unexpected behavior.