### PR TITLE
deploy: filter out zombie machines missing config

### DIFF
--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -193,7 +193,7 @@ func (f *Client) ListActive(ctx context.Context) ([]*api.Machine, error) {
 	}
 
 	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
-		return m.Config.Metadata["process_group"] != "release_command" && m.State != "destroyed"
+		return m.Config != nil && m.Config.Metadata["process_group"] != "release_command" && m.State != "destroyed"
 	})
 
 	return machines, nil


### PR DESCRIPTION
My app, `udns` is in a state where there's a zombie machine holding hostage most flyctl commands, including `deploy` ([ref](https://community.fly.io/t/7289/8)).

This is what the graphql response for the zombie machine looks like:

```json
{                                                                             
    "id": "23908066ec6875",                                                     
    "name": "udns-vin",                                                         
    "state": "started",                                                         
    "region": "",                                                               
    "instance_id": "",                                                          
    "private_ip": "",                                                           
    "config": null,                                                             
    "created_at": "1970-01-01T00:00:00Z",                                       
    "updated_at": "0001-01-01T00:00:00Z"                                        
},  
```

[Its missing](https://github.com/superfly/flyctl/blob/edf8f51219b6542180a5e9c054132520287761a6/api/machine_types.go#L8-L24) `Config`, `InstanceID`, `PrivateIP`, and `Region`.

With this commit though, only filtering out on `Config == nil`.