### PR TITLE
machines: clone breaks for non-postgres apps

### DIFF
--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -114,6 +114,17 @@ func (f *Client) Start(ctx context.Context, machineID string) (*api.MachineStart
 	return out, nil
 }
 
+func (f *Client) TryWait(ctx context.Context, machine *api.Machine, state string, tries int) (err error) {
+	for i := tries; i > 0; i-- {
+		if err = f.Wait(ctx, machine, state); err != nil {
+			fmt.Printf("Try#%d: %v\n", i, err)
+		} else {
+			break
+		}
+	}
+	return
+}
+
 func (f *Client) Wait(ctx context.Context, machine *api.Machine, state string) (err error) {
 	waitEndpoint := fmt.Sprintf("/%s/wait", machine.ID)
 

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -114,17 +114,6 @@ func (f *Client) Start(ctx context.Context, machineID string) (*api.MachineStart
 	return out, nil
 }
 
-func (f *Client) TryWait(ctx context.Context, machine *api.Machine, state string, tries int) (err error) {
-	for i := tries; i > 0; i-- {
-		if err = f.Wait(ctx, machine, state); err != nil {
-			fmt.Printf("Try#%d: %v\n", i, err)
-		} else {
-			break
-		}
-	}
-	return
-}
-
 func (f *Client) Wait(ctx context.Context, machine *api.Machine, state string) (err error) {
 	waitEndpoint := fmt.Sprintf("/%s/wait", machine.ID)
 

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
@@ -141,7 +142,8 @@ func runMachineClone(ctx context.Context) (err error) {
 
 	fmt.Printf("Cloning machine in region %s for app %s\n", region, app.Name)
 
-	err = flapsClient.TryWait(ctx, launchedMachine, "started", 3 /*num of tries*/)
+	// wait for a machine to be started
+	err = WaitForStartOrStop(ctx, flapsClient, launchedMachine, "start", time.Minute*5)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -96,7 +96,7 @@ func runMachineClone(ctx context.Context) (err error) {
 	// This is a temperary hack to add volume support for PG apps.
 	// Flaps does not currently specify the volume name within the Machine mount spec,
 	// which is required before we can handle this more generally.
-	if app.PostgresAppRole.Name == "postgres_cluster" {
+	if app.PostgresAppRole != nil && app.PostgresAppRole.Name == "postgres_cluster" {
 		if len(source.Config.Mounts) > 0 {
 			mnt := source.Config.Mounts[0]
 
@@ -139,8 +139,9 @@ func runMachineClone(ctx context.Context) (err error) {
 		return err
 	}
 
-	err = flapsClient.Wait(ctx, launchedMachine, "started")
+	fmt.Printf("Cloning machine in region %s for app %s\n", region, app.Name)
 
+	err = flapsClient.TryWait(ctx, launchedMachine, "started", 3 /*num of tries*/)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
More: https://community.fly.io/t/7265

Exec:

```bash
➜  flyctl ✗ go build -o fly2

➜  flyctl ✗ go test
?   	github.com/superfly/flyctl	[no test files]

➜ fly2 m clone d5683061b4158e --config fly.machines.toml --name udns-gru2 --region gru
Cloning machine in region gru for app udns
Machine d5683061b4158e was cloned to 73287111be1385
```