### PR TITLE
Use check output as-is

### DIFF
--- a/internal/command/checks/list.go
+++ b/internal/command/checks/list.go
@@ -53,8 +53,7 @@ func runMachinesAppCheckList(ctx context.Context, app *api.AppCompact) error {
 			if nameFilter != "" && nameFilter != check.Name {
 				continue
 			}
-			formattedOutput := formatOutput(check.Output)
-			table.Append([]string{check.Name, check.Status, machine.ID, format.RelativeTime(*check.UpdatedAt), formattedOutput})
+			table.Append([]string{check.Name, check.Status, machine.ID, format.RelativeTime(*check.UpdatedAt), check.Output})
 		}
 	}
 	table.Render()

--- a/internal/command/checks/list.go
+++ b/internal/command/checks/list.go
@@ -48,6 +48,7 @@ func runMachinesAppCheckList(ctx context.Context, app *api.AppCompact) error {
 
 	fmt.Fprintf(out, "Health Checks for %s\n", app.Name)
 	table := helpers.MakeSimpleTable(out, []string{"Name", "Status", "Machine", "Last Updated", "Output"})
+	table.SetRowLine(true)
 	for _, machine := range machines {
 		for _, check := range machine.Checks {
 			if nameFilter != "" && nameFilter != check.Name {


### PR DESCRIPTION
Per latest changes on service side, the output is much cleaner and can be used directly:

```
$ fly checks list -a dangra-pg-m
Health Checks for dangra-pg-m
  NAME | STATUS  | MACHINE        | LAST UPDATED         | OUTPUT
-------*---------*----------------*----------------------*-----------------------------------------------------------------------------
  pg   | passing | 0e286362f02867 | 2022-09-22T02:42:18Z | [✓] transactions: read/write (317.35µs)
       |         |                |                      | [✓] replicationLag: fdaa:0:5ea6:a7b:d33c:89a3:710f:2 is lagging 0s (90ns)
       |         |                |                      | [✓] connections: 10 used, 3 reserved, 300 max (3.16ms)
-------*---------*----------------*----------------------*-----------------------------------------------------------------------------
  vm   | passing | 0e286362f02867 | 2022-09-20T17:51:48Z | [✓] checkDisk: 918.45 MB (93.0%) free space on /data/ (61.03µs)
       |         |                |                      | [✓] checkLoad: load averages: 0.00 0.00 0.00 (68.08µs)
       |         |                |                      | [✓] memory: system spent 0s of the last 60s waiting on memory (43.26µs)
       |         |                |                      | [✓] cpu: system spent 210ms of the last 60s waiting on cpu (23.08µs)
       |         |                |                      | [✓] io: system spent 378ms of the last 60s waiting on io (20.94µs)
-------*---------*----------------*----------------------*-----------------------------------------------------------------------------
  role | passing | 0e286362f02867 | 2022-09-20T17:52:12Z | leader
-------*---------*----------------*----------------------*-----------------------------------------------------------------------------
  pg   | passing | 0e286374c0d867 | 2022-09-20T17:54:00Z | [✓] transactions: readonly (397.75µs)
       |         |                |                      | [✓] replication: syncing from fdaa:0:5ea6:a7b:d33b:ab13:a7b1:2 (173.42µs)
       |         |                |                      | [✓] connections: 5 used, 3 reserved, 300 max (8.16ms)
-------*---------*----------------*----------------------*-----------------------------------------------------------------------------
  vm   | passing | 0e286374c0d867 | 2022-09-20T17:52:48Z | [✓] checkDisk: 860.82 MB (87.1%) free space on /data/ (379.3µs)
       |         |                |                      | [✓] checkLoad: load averages: 0.00 0.00 0.00 (155.56µs)
       |         |                |                      | [✓] memory: system spent 12ms of the last 60s waiting on memory (179.71µs)
       |         |                |                      | [✓] cpu: system spent 594ms of the last 60s waiting on cpu (102.97µs)
       |         |                |                      | [✓] io: system spent 354ms of the last 60s waiting on io (86.37µs)
-------*---------*----------------*----------------------*-----------------------------------------------------------------------------
  role | passing | 0e286374c0d867 | 2022-09-20T17:52:32Z | replica
-------*---------*----------------*----------------------*-----------------------------------------------------------------------------
```