### PR TITLE
machines: impl update to a new image

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -355,7 +355,7 @@ func determineImage(ctx context.Context, appName string, imageOrPath string) (im
 	if strings.HasPrefix(imageOrPath, ".") || strings.HasPrefix(imageOrPath, "/") {
 		opts := imgsrc.ImageOptions{
 			AppName:    appName,
-			WorkingDir: path.Join(state.WorkingDirectory(ctx), imageOrPath),
+			WorkingDir: path.Join(state.WorkingDirectory(ctx)),
 			Publish:    !flag.GetBuildOnly(ctx),
 			ImageLabel: flag.GetString(ctx, "image-label"),
 			Target:     flag.GetString(ctx, "build-target"),
@@ -494,7 +494,7 @@ func selectAppName(ctx context.Context) (name string, err error) {
 	return
 }
 
-func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineConfig, app *api.AppCompact, image string) (machineConf api.MachineConfig, err error) {
+func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineConfig, app *api.AppCompact, imageOrPath string) (machineConf api.MachineConfig, err error) {
 	machineConf = initialMachineConf
 
 	if guestSize := flag.GetString(ctx, "size"); guestSize != "" {
@@ -562,7 +562,7 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 		return
 	}
 
-	img, err := determineImage(ctx, app.Name, image)
+	img, err := determineImage(ctx, app.Name, imageOrPath)
 	if err != nil {
 		return
 	}

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -64,9 +64,13 @@ func runUpdate(ctx context.Context) (err error) {
 		return err
 	}
 
+	imageOrPath := machine.Config.Image
 	image := flag.GetString(ctx, flag.ImageName)
-	if len(image) <= 0 {
-		image = machine.Config.Image
+	dockerfile := flag.GetString(ctx, flag.Dockerfile().Name)
+	if len(image) > 0 {
+		imageOrPath = image
+	} else if len(dockerfile) > 0 {
+		imageOrPath = "." // cwd
 	}
 
 	prevInstanceID := machine.InstanceID
@@ -74,7 +78,7 @@ func runUpdate(ctx context.Context) (err error) {
 	fmt.Fprintf(io.Out, "Machine %s was found and is currently in a %s state, attempting to update...\n", machineID, machine.State)
 
 	machineConf := *machine.Config
-	machineConf, err = determineMachineConfig(ctx, machineConf, app, image)
+	machineConf, err = determineMachineConfig(ctx, machineConf, app, imageOrPath)
 	if err != nil {
 		return
 	}
@@ -107,7 +111,7 @@ func runUpdate(ctx context.Context) (err error) {
 		return err
 	}
 
-	fmt.Fprintf(out, "Image: %s\n", image)
+	fmt.Fprintf(out, "Image: %s\n", machineConf.Image)
 
 	if waitForAction == "start" {
 		fmt.Fprintf(out, "State: Started\n\n")


### PR DESCRIPTION
Ref: https://community.fly.io/t/7398/5

Test:
```bash
# build
➜ go build -o fly2

# before update
➜ fly2 image show -a udns 
Image Details
MACHINE ID    	REGISTRY       	REPOSITORY	TAG                                  	VERSION	DIGEST                                                                  
...
d5683061b4158e	registry.fly.io	udns      	deployment-01GDSX57S50NF2817YKDCBX45H	N/A    	sha256:f0ce12bb6cd58ec68e26ef7148403a6bf60de886a862b62c4fb93d30fd1bb944	
...

# attempt updating to new image
➜ fly2 m update d5683061b4158e -c ./fly.machines.toml -a udns --memory 512 --cpus 1 --image registry.fly.io/udns:deployment-01GDXN4PZ712SBF5DXVDBKCNYY

# verify
➜ fly2 m status d5683061b4158e -d -a udns
Machine ID: d5683061b4158e
Instance ID: 01GDXND0G5X3XFBPWMR9XRTKYY
State: started

VM
  ID            = d5683061b4158e                              
  Instance ID   = 01GDXND0G5X3XFBPWMR9XRTKYY                  
  State         = started                                     
  Image         = udns:deployment-01GDXN4PZ712SBF5DXVDBKCNYY  
  Name          = udns-mia                                    
  Private IP    = fdaa:0:35f3:a7b:2cc3:a2b6:8dce:2            
  Region        = mia                                         
  Process Group = app                                         
  Memory        = 512                                         
  CPUs          = 1                                           
  Created       = 2022-09-18T00:49:49Z                        
  Updated       = 2022-09-26T19:46:58Z                        
  Command       =                                             

Event Logs
STATE  	EVENT 	SOURCE	TIMESTAMP                    	INFO 
started	start 	flyd  	2022-09-27T01:16:58.878+05:30	
created	launch	user  	2022-09-27T01:16:50.514+05:30	
```