### PR TITLE
fix: "launch" inconsistent description formatting

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -38,19 +38,19 @@ func newLaunchCommand(client *client.Client) *Command {
 	)
 	launchCmd.AddStringFlag(StringFlagOpts{
 		Name:        "org",
-		Description: `The organization that will own the app`,
+		Description: `Organization that will own the app`,
 	})
 	launchCmd.AddStringFlag(StringFlagOpts{
 		Name:        "name",
-		Description: "The name of the new app",
+		Description: "Name of the new app",
 	})
 	launchCmd.AddStringFlag(StringFlagOpts{
 		Name:        "region",
-		Description: "The region to launch the new app in",
+		Description: "Region to launch the new app in",
 	})
 	launchCmd.AddStringFlag(StringFlagOpts{
 		Name:        "image",
-		Description: "The image to launch",
+		Description: "Image to launch",
 	})
 	launchCmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "now",

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -32,29 +32,29 @@ func newLaunchCommand(client *client.Client) *Command {
 	launchCmd.Args = cobra.NoArgs
 	launchCmd.AddStringFlag(StringFlagOpts{
 		Name:        "path",
-		Description: `path to app code and where a fly.toml file will be saved.`,
+		Description: `Path to app code and where a fly.toml file will be saved`,
 		Default:     ".",
 	},
 	)
 	launchCmd.AddStringFlag(StringFlagOpts{
 		Name:        "org",
-		Description: `the organization that will own the app`,
+		Description: `The organization that will own the app`,
 	})
 	launchCmd.AddStringFlag(StringFlagOpts{
 		Name:        "name",
-		Description: "the name of the new app",
+		Description: "The name of the new app",
 	})
 	launchCmd.AddStringFlag(StringFlagOpts{
 		Name:        "region",
-		Description: "the region to launch the new app in",
+		Description: "The region to launch the new app in",
 	})
 	launchCmd.AddStringFlag(StringFlagOpts{
 		Name:        "image",
-		Description: "the image to launch",
+		Description: "The image to launch",
 	})
 	launchCmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "now",
-		Description: "deploy now without confirmation",
+		Description: "Deploy now without confirmation",
 		Default:     false,
 	})
 	launchCmd.AddBoolFlag(BoolFlagOpts{
@@ -69,11 +69,11 @@ func newLaunchCommand(client *client.Client) *Command {
 	})
 	launchCmd.AddStringFlag(StringFlagOpts{
 		Name:        "dockerfile",
-		Description: "Path to a Dockerfile. Defaults to the Dockerfile in the working directory.",
+		Description: "Path to a Dockerfile. Defaults to the Dockerfile in the working directory",
 	})
 	launchCmd.AddBoolFlag(BoolFlagOpts{
 		Name:        "copy-config",
-		Description: "Use the configuration file if present without prompting.",
+		Description: "Use the configuration file if present without prompting",
 		Default:     false,
 	})
 	launchCmd.AddBoolFlag(BoolFlagOpts{


### PR DESCRIPTION
# Summary

This PR fixes some copy related issues regarding command descriptions.

I was reading through the _launch_ command code out of curiosity to see how the auto-code scanner works and I noticed the commands were formatted inconsistently. I couldn't help but open up a PR (oops!).  

It seems like there is _sort-of a convention_ for formatting command descriptions at Fly:

* Descriptions start with a capital letter
* Descriptions do not end with a period
* Avoid using "the" or throw-away words as the first word

---

Consistent Example:

```
> ~ fly regions --help
Configure the region placement rules for an application.

Usage:
  flyctl regions [command]

Available Commands:
  add         Allow the app to run in the provided regions
  backup      Sets the backup region pool with provided regions
  list        Shows the list of regions the app is allowed to run in
  remove      Prevent the app from running in the provided regions
  set         Sets the region pool with provided regions

Flags:
  -a, --app string      App name to operate on
  -c, --config string   Path to an app config file or directory containing one (default "./fly.toml")
  -h, --help            help for regions

Global Flags:
  -t, --access-token string   Fly API Access Token
  -j, --json                  json output
      --verbose               verbose output

Use "flyctl regions [command] --help" for more information about a command.
```

---

Inconsistent Example: 
```
 fly launch --help
Create and configure a new app from source code or an image reference.

Usage:
  flyctl launch [flags]

Flags:
      --copy-config         Use the configuration file if present without prompting.
      --dockerfile string   Path to a Dockerfile. Defaults to the Dockerfile in the working directory.
      --generate-name       Always generate a name for the app
  -h, --help                help for launch
      --image string        the image to launch
      --name string         the name of the new app
      --no-deploy           Do not prompt for deployment
      --now                 deploy now without confirmation
      --org string          the organization that will own the app
      --path string         path to app code and where a fly.toml file will be saved. (default ".")
      --region string       the region to launch the new app in
      --remote-only         Perform builds remotely without using the local docker daemon

Global Flags:
  -t, --access-token string   Fly API Access Token
  -j, --json                  json output
      --verbose               verbose output
```

This PR fixes ☝️ .
