### PR TITLE
Fix typo in info command output

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -57,7 +57,7 @@ func runInfo(cmdCtx *cmdctx.CmdContext) error {
 			return err
 		}
 
-		err = cmdCtx.Frender(cmdctx.PresenterOption{Presentable: &presenters.IPAddresses{IPAddresses: app.IPAddresses.Nodes}, Title: "IP Adresses"})
+		err = cmdCtx.Frender(cmdctx.PresenterOption{Presentable: &presenters.IPAddresses{IPAddresses: app.IPAddresses.Nodes}, Title: "IP Addresses"})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This commit fixes a typo in the output of the info command. The output section of IP Address is printed as "IP Adresses".