### PR TITLE
ping timeout on waiting for docker

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -322,7 +322,7 @@ func waitForDaemon(parent context.Context, client *dockerclient.Client) (up bool
 	)
 
 	for ctx.Err() == nil {
-		switch _, err := client.Ping(ctx); err {
+		switch _, err := clientPing(parent, client); err {
 		default:
 			consecutiveSuccesses = 0
 
@@ -352,6 +352,14 @@ func waitForDaemon(parent context.Context, client *dockerclient.Client) (up bool
 	default:
 		return false, nil
 	}
+}
+
+func clientPing(parent context.Context, client *dockerclient.Client) (types.Ping, error) {
+	fmt.Println("Trying to ping remote docker")
+	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
+	defer cancel()
+
+	return client.Ping(ctx)
 }
 
 func clearDeploymentTags(ctx context.Context, docker *dockerclient.Client, tag string) error {

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -305,38 +305,53 @@ func buildRemoteClientOpts(ctx context.Context, apiClient *api.Client, appName, 
 	return
 }
 
-func waitForDaemon(parent context.Context, client *dockerclient.Client) (up bool, err error) {
+func waitForDaemon(parent context.Context, client *dockerclient.Client) (bool, error) {
 	ctx, cancel := context.WithTimeout(parent, 2*time.Minute)
 	defer cancel()
 
-	b := &backoff.Backoff{
-		Min:    50 * time.Millisecond,
-		Max:    200 * time.Millisecond,
-		Factor: 1.2,
-		Jitter: true,
+	select {
+	case <-ctx.Done():
+		return false, nil
+	case up := <-stablePing(ctx, client):
+		return up, nil
 	}
+}
 
-	var (
-		consecutiveSuccesses int
-		healthyStart         time.Time
-	)
+// Ping until we have 1s worth of successful pings
+func stablePing(ctx context.Context, client *dockerclient.Client) chan bool {
+	respChan := make(chan bool, 1)
 
-	for ctx.Err() == nil {
-		switch _, err := clientPing(parent, client); err {
-		default:
-			consecutiveSuccesses = 0
+	go func() {
+		var (
+			consecutiveSuccesses int
+			healthyStart         time.Time
+		)
 
-			dur := b.Duration()
-			terminal.Debugf("Remote builder unavailable, retrying in %s (err: %v)\n", dur, err)
-			pause.For(ctx, dur)
-		case nil:
+		b := &backoff.Backoff{
+			Min:    50 * time.Millisecond,
+			Max:    200 * time.Millisecond,
+			Factor: 1.2,
+			Jitter: true,
+		}
+
+		for ctx.Err() == nil {
+			if _, err := clientPing(ctx, client); err != nil {
+				consecutiveSuccesses = 0
+
+				dur := b.Duration()
+				terminal.Debugf("Remote builder unavailable, retrying in %s (err: %v)\n", dur, err)
+				pause.For(ctx, dur)
+				continue
+			}
+
 			if consecutiveSuccesses++; consecutiveSuccesses == 1 {
 				healthyStart = time.Now()
 			}
 
 			if time.Since(healthyStart) > time.Second {
 				terminal.Debug("Remote builder is ready to build!")
-				return true, nil
+				respChan <- true
+				return
 			}
 
 			b.Reset()
@@ -344,14 +359,9 @@ func waitForDaemon(parent context.Context, client *dockerclient.Client) (up bool
 			terminal.Debugf("Remote builder available, but pinging again in %s to be sure\n", dur)
 			pause.For(ctx, dur)
 		}
-	}
+	}()
 
-	switch {
-	case parent.Err() != nil:
-		return false, parent.Err()
-	default:
-		return false, nil
-	}
+	return respChan
 }
 
 func clientPing(parent context.Context, client *dockerclient.Client) (types.Ping, error) {

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -355,7 +355,6 @@ func waitForDaemon(parent context.Context, client *dockerclient.Client) (up bool
 }
 
 func clientPing(parent context.Context, client *dockerclient.Client) (types.Ping, error) {
-	fmt.Println("Trying to ping remote docker")
 	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
on my personal builder with flyctl upstream I see:

```
Waiting for remote builder fly-builder-delicate-sky-3199... 🌍 DEBUG Remote builder unavailable, retrying in 50ms (err: error during connect: Get "http://[fdaa:0:2b6:a7b:1a:bd57:bf3:2]:2375/_ping": connect tcp [fdaa:0:2b6:a7b:1a:bd57:bf3:2]:2375: connection was refused)
DEBUG Remote builder unavailable, retrying in 56.237502ms (err: error during connect: Get "http://[fdaa:0:2b6:a7b:1a:bd57:bf3:2]:2375/_ping": connect tcp [fdaa:0:2b6:a7b:1a:bd57:bf3:2]:2375: connection was refused)
Waiting for remote builder fly-builder-delicate-sky-3199... 🌍 DEBUG Remote builder available, but pinging again in 50ms to be sure
DEBUG Remote builder available, but pinging again in 50ms to be sure
DEBUG Remote builder available, but pinging again in 50ms to be sure
Waiting for remote builder fly-builder-delicate-sky-3199... 🌎 DEBUG Remote builder available, but pinging again in 50ms to be sure
DEBUG Remote builder available, but pinging again in 50ms to be sure
DEBUG Remote builder available, but pinging again in 50ms to be sure
Waiting for remote builder fly-builder-delicate-sky-3199... 🌏 DEBUG Remote builder available, but pinging again in 50ms to be sure
DEBUG Remote builder available, but pinging again in 50ms to be sure
Waiting for remote builder fly-builder-delicate-sky-3199... 🌍 DEBUG Remote builder available, but pinging again in 50ms to be sure
DEBUG Remote builder available, but pinging again in 50ms to be sure
DEBUG Remote builder available, but pinging again in 50ms to be sure
Waiting for remote builder fly-builder-delicate-sky-3199... 🌎 DEBUG Remote builder available, but pinging again in 50ms to be sure
DEBUG Remote builder is ready to build!
```

and similar output for this so I'm not totally convinced this fixes the whole issue but if the builder gets to a bad state somehow, maybe