### PR TITLE
Add tools.go, to declare dependency on genqlient

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,8 @@
+//go:build tools
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/Khan/genqlient"
+)


### PR DESCRIPTION
Without this, `go mod vendor && go generate ./...` fails.

Closes #1323