### PR TITLE
Improvements to deploy and run commands for machines

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -20,7 +20,6 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/config"
-	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/update"
 
@@ -497,14 +496,10 @@ func RequireAppName(ctx context.Context) (context.Context, error) {
 		return nil, err
 	}
 
-	name := flag.GetApp(ctx)
+	var name = app.AppNameFromFlagOrEnv(ctx)
 	if name == "" {
-		// if there's no flag present, first consult with the environment
-		if name = env.First("FLY_APP"); name == "" {
-			// and then with the config file (if any)
-			if cfg := app.ConfigFromContext(ctx); cfg != nil {
-				name = cfg.AppName
-			}
+		if cfg := app.ConfigFromContext(ctx); cfg != nil {
+			name = cfg.AppName
 		}
 	}
 

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -20,8 +20,10 @@ import (
 // or launching new ones
 func createMachinesRelease(ctx context.Context, config *app.Config, img *imgsrc.DeploymentImage, strategy string) (err error) {
 	client := client.FromContext(ctx).API()
+	// context has name either fetched from flag, env, or config
+	name := app.NameFromContext(ctx)
 
-	app, err := client.GetAppCompact(ctx, config.AppName)
+	app, err := client.GetAppCompact(ctx, name)
 	if err != nil {
 		return
 	}

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -66,9 +66,14 @@ func createMachinesRelease(ctx context.Context, config *app.Config, img *imgsrc.
 		machineConfig.Services = append(machineConfig.Services, httpService)
 	}
 
-	// Copy standard services to the machine vonfig
-	if config.Services != nil {
-		machineConfig.Services = append(machineConfig.Services, config.Services...)
+	// Copy standard services to the machine config
+	for _, s := range config.Services {
+		// skip appending if Services isn't valid
+		// ex: when the [[services]] section in toml is empty
+		if len(s.Protocol) > 0 {
+			// TODO: validate for presence of tcp and udp?
+			machineConfig.Services = append(machineConfig.Services, s)
+		}
 	}
 
 	if config.Env != nil {
@@ -291,7 +296,7 @@ func DeployMachinesApp(ctx context.Context, app *api.AppCompact, strategy string
 				if strategy != "immediate" {
 					return err
 				} else {
-					fmt.Printf("Skip deploying to Machine[%s] %s; error: %s\n", machine.Name, machine.ID, err)
+					fmt.Printf("\nSkip deploying to Machine[%s] %s; error: %s\n", machine.Name, machine.ID, err)
 				}
 			}
 

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -238,12 +238,20 @@ func runMachineRun(ctx context.Context) error {
 	fmt.Fprintf(io.Out, " Instance ID: %s\n", instanceID)
 	fmt.Fprintf(io.Out, " State: %s\n", state)
 
-	// wait for machine to be started
-	if err := WaitForStartOrStop(ctx, flapsClient, machine, "start", time.Minute*5); err != nil {
+	waitForAction := "start"
+	if machine.Config.Schedule != "" {
+		waitForAction = "stop"
+	}
+
+	if err := WaitForStartOrStop(ctx, flapsClient, machine, waitForAction, time.Minute*5); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(io.Out, "Machine started, you can connect via the following private ip\n")
+	if machine.Config.Schedule == "" {
+		fmt.Fprintf(io.Out, "Machine started, you can connect via the following private ip\n")
+	} else {
+		fmt.Fprintf(io.Out, "Machine scheduled, you can connect via the following private ip\n")
+	}
 	fmt.Fprintf(io.Out, "  %s\n", privateIP)
 
 	return nil


### PR DESCRIPTION
`fly m run` hangs for `schedule` machines because their default state is `stopped` instead of the usual `started`: https://github.com/superfly/flyctl/tree/c9ad3265b58991fece889b4331067808aaaa44c0

```bash
➜ fly m run registry.fly.io/trie:deployment-01GE8958ZZE0EME3DJTFFX4ZD8 --schedule "monthly" --name test-sin3 --region sin -a trie
Update available 0.0.395 -> v0.0.401.
Run "flyctl version update" to upgrade.
Searching for image 'registry.fly.io/trie:deployment-01GE8958ZZE0EME3DJTFFX4ZD8' remotely...
image found: img_e1zd4mr9q1lv02yw
Image: registry.fly.io/trie:deployment-01GE8958ZZE0EME3DJTFFX4ZD8
Image size: 478 MB

Success! A machine has been successfully launched, waiting for it to be started
 Machine ID: 59185ee1f10683
 Instance ID: 01GE8AENYEVKFSF745EX9S4T23
 State: created
^C^C^C^C^C^C

# after change
➜  blocklists git:(main) ✗ lout m run registry.fly.io/trie:deployment-01GE8958ZZE0EME3DJTFFX4ZD8 --schedule "monthly" --name test-sin2 --region sin -a trie     
Searching for image 'registry.fly.io/trie:deployment-01GE8958ZZE0EME3DJTFFX4ZD8' remotely...
image found: img_e1zd4mr9q1lv02yw
Image: registry.fly.io/trie:deployment-01GE8958ZZE0EME3DJTFFX4ZD8
Image size: 478 MB

Success! A machine has been successfully launched, waiting for it to be started
 Machine ID: 24d8915dc15787
 Instance ID: 01GE8ABC2YRM201A75820Y79D0
 State: created
Machine scheduled, you can connect via the following private ip
  fdaa:0:35f3:a7b:ead:96c4:b580:2
```

---

`fly m deploy` with its default `rolling` strategy doesn't hold to a lease long enough when an app has more than 30+ machines. Hold lease in proportion to the number of machines in an app: https://github.com/superfly/flyctl/tree/207116afc21be7a36df38a0e7e5ea5bf810c2531

Ref: https://community.fly.io/t/7230

---

`fly m deploy` wiped off `schedule` from the config (unlike `fly m run` and `fly m update`), this commit preserves it: https://github.com/superfly/flyctl/tree/fad34a01d4cf957172156a3501824855344d4961

---

`fly m deploy` fails when the `[[services]]` section is empty while `fly m run` and `fly m update` work just fine: https://github.com/superfly/flyctl/tree/065749d353888c2b8b362f539b311c04975b5785

```bash
# in these examples, fly.toml contains an empty [[services]] section
➜  fly deploy --config fly.toml --dockerfile ./node.Dockerfile -a trie --remote-only --strategy immediate                         
==> Verifying app config
--> Verified app config
==> Building image
Waiting for remote builder fly-builder-lingering-waterfall-8625... 🌏 WARN The running flyctl agent (v0.0.395) is older than the current flyctl (v0.0.0-1664577872+dev).
WARN The out-of-date agent will be shut down along with existing wireguard connections. The new agent will start automatically as needed.
Remote builder fly-builder-lingering-waterfall-8625 ready
==> Creating build context
--> Creating build context done
==> Building image with Docker
--> docker host: 20.10.12 linux x86_64
[+] Building 0.0s (0/1)                                                                                                                                                            
[+] Building 2.3s (9/9) FINISHED                                                                                                                                                   
deployment-01GE8958ZZE0EME3DJTFFX4ZD8: digest: sha256:3e83061f75d214db165a7d58f77bc8682f331fd939d747031c2014b02675cdb7 size: 3477
--> Pushing image done
image: registry.fly.io/trie:deployment-01GE8958ZZE0EME3DJTFFX4ZD8
image size: 1.3 GB

Deploying with immediate strategy 🌍
Skip deploying to Machine[test-sin] 9e784903c46583; error: failed to update VM 9e784903c46583: Services [0] Protocol cant be blank
Deploying with immediate strategy ✗ 

# after change
➜  fly2 deploy --config fly.toml --image registry.fly.io/trie:deployment-01GE896R5DWJQJFRN76E9T2KVQ -a trie --remote-only --strategy immediate
==> Verifying app config
--> Verified app config
==> Building image
Searching for image 'registry.fly.io/trie:deployment-01GE896R5DWJQJFRN76E9T2KVQ' remotely...
image found: img_nk3yvl392g9vome7
Deploying with immediate strategy 🌏 
Deploying with immediate strategy ✓
```

---

`fly deploy -a <app-name> ...` fails as app name from `FLY_APP` and/or `-a` / `--app` switch is ignored for Machine apps, because:
1. `machines.go` incorrectly attempts to get app name from app-config instead of context (like every where else).
2. `command.go` doesn't determine app name before determining platform version, which is central to how the eventual command function is *run*.

Ref: https://community.fly.io/t/6171/6

Commit: https://github.com/superfly/flyctl/pull/1327/commits/17e1dc11fd4f31c8cfd7fcae28692c2c70951ca3

```bash
# before fix
➜ fly deploy --config fly.toml --image registry.fly.io/trie:deployment-01GE896R5DWJQJFRN76E9T2KVQ --app trie --remote-only --strategy immediate
==> Verifying app config
--> Verified app config
==> Building image
Searching for image 'registry.fly.io/trie:deployment-01GE896R5DWJQJFRN76E9T2KVQ' remotely...
image found: img_nk3yvl392g9vome7
==> Creating release
Error This operation requires the 'nomad' app platform. This app was created for the  'machines' platform.

# before fix (2)
➜ fly deploy --config fly.toml --dockerfile node.Dockerfile --app trie --remote-only --strategy immediate

platform: 
==> Verifying app config
--> Verified app config
==> Building image
Remote builder fly-builder-lingering-waterfall-8625 ready
==> Creating build context
--> Creating build context done
==> Building image with Docker
--> docker host: 20.10.12 linux x86_64
[+] Building 0.3s (0/1)                                                                                                                                                            
[+] Building 11.3s (9/9) FINISHED
... 
...
...                                                                                                                                                  
image size: 1.3 GB
Error Could not find App

# after fix
➜ fly2 deploy --config fly.toml --image registry.fly.io/trie:deployment-01GE93ZDA4W040HKZ3P8XHJT16 --app trie --remote-only --strategy immediate

platform: 
==> Verifying app config
--> Verified app config
==> Building image
Searching for image 'registry.fly.io/trie:deployment-01GE93ZDA4W040HKZ3P8XHJT16' remotely...
image found: img_8rlxp2l9n50v3jqo
Deploying with immediate strategy ✓
```