### PR TITLE
Clarify --org takes the organization slug

### DIFF
--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -38,7 +38,7 @@ func newLaunchCommand(client *client.Client) *Command {
 	)
 	launchCmd.AddStringFlag(StringFlagOpts{
 		Name:        "org",
-		Description: `Organization that will own the app`,
+		Description: `Organization that will own the app (use org slug here; see "fly orgs list")`,
 	})
 	launchCmd.AddStringFlag(StringFlagOpts{
 		Name:        "name",


### PR DESCRIPTION
If I just copy the capitalized org name from the dashboard, `launch` errors out with "organization CapOrgName not found".

supersedes #1304 due to corrupted GH PR