### PR TITLE
Always use slash / for dockerfile paths including on Windows

### DIFF
--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -113,7 +113,9 @@ func (ds *dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClien
 		if err != nil {
 			return nil, err
 		}
-		relativedockerfilePath = p
+		// On Windows, convert \ to a slash / as the docker build will
+		// run in a Linux VM at the end.
+		relativedockerfilePath = filepath.ToSlash(p)
 	}
 
 	// Start tracking this build


### PR DESCRIPTION
On Windows, when a relative path is used for the Dockerfile such as api/Dockerfile.prod in the example below, the fly cmdline would resolve the path using Windows path separators \ and then that gets sent over to the local Linux VM (or the fly remote builder) that runs the actual docker build resulting in issues such as:

```
Error failed to fetch an image or build from source: error building: failed to solve with frontend dockerfile.v0: failed to read dockerfile: open /var/lib/docker/tmp/buildkit-mount668486171/api\Dockerfile.prod: no such file or directory
```

To get around this, always convert the resolved relative path to use POSIX slash /.