### PR TITLE
Add heartbeat to remote builder

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -226,7 +226,7 @@ func newRemoteDockerClient(ctx context.Context, apiClient *api.Client, appName s
 		return nil, errors.New("machine did not have a private IP")
 	}
 
-	builderHostOverride, ok := os.LookupEnv("FLY_RCHAP_OVERRIDE_HOST")
+	builderHostOverride, ok := os.LookupEnv("FLY_RCHAB_OVERRIDE_HOST")
 	if ok {
 		oldHost := host
 		host = builderHostOverride

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -226,6 +226,13 @@ func newRemoteDockerClient(ctx context.Context, apiClient *api.Client, appName s
 		return nil, errors.New("machine did not have a private IP")
 	}
 
+	builderHostOverride, ok := os.LookupEnv("FLY_RCHAP_OVERRIDE_HOST")
+	if ok {
+		oldHost := host
+		host = builderHostOverride
+		terminal.Infof("Override builder host with: %s (was %s)", host, oldHost)
+	}
+
 	opts, err := buildRemoteClientOpts(ctx, apiClient, appName, host)
 	if err != nil {
 		streams.StopProgressIndicator()

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -149,7 +149,7 @@ func (r *Resolver) StartHeartbeat(ctx context.Context) chan<- interface{} {
 	time.AfterFunc(maxTime, func() { close(done) })
 
 	go func() {
-		pulse := time.Tick(pulseInterval)
+		pulse := time.NewTicker(pulseInterval)
 		defer close(done)
 		for {
 			select {
@@ -157,7 +157,7 @@ func (r *Resolver) StartHeartbeat(ctx context.Context) chan<- interface{} {
 				return
 			case <-ctx.Done():
 				return
-			case <-pulse:
+			case <-pulse.C:
 				terminal.Debugf("Sending remote builder heartbeat pulse to %s...", heartbeatUrl)
 				resp, err := dockerClient.HTTPClient().Do(heartbeatReq)
 				if err != nil {

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -4,7 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
 
+	dockerclient "github.com/docker/docker/client"
+	"github.com/superfly/flyctl/flyctl"
+	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/api"
@@ -107,6 +114,79 @@ func (r *Resolver) BuildImage(ctx context.Context, streams *iostreams.IOStreams,
 	}
 
 	return nil, errors.New("app does not have a Dockerfile or buildpacks configured. See https://fly.io/docs/reference/configuration/#the-build-section")
+}
+
+// For remote builders send a periodic heartbeat during build to ensure machine stays alive
+// This is a noop for local builders
+func (r *Resolver) StartHeartbeat(ctx context.Context) chan<- interface{} {
+	if !r.dockerFactory.remote {
+		return nil
+	}
+
+	errMsg := "Failed to start remote builder heartbeat. For builds longer than 10 minutes, this may cause issues. Please report issues to https://community.fly.io. %v"
+	dockerClient, err := r.dockerFactory.buildFn(ctx)
+	if err != nil {
+		terminal.Warnf(errMsg, err)
+		return nil
+	}
+	heartbeatUrl, err := getHeartbeatUrl(dockerClient)
+	if err != nil {
+		terminal.Warnf(errMsg, err)
+		return nil
+	}
+	heartbeatReq, err := http.NewRequestWithContext(ctx, http.MethodGet, heartbeatUrl, http.NoBody)
+	if err != nil {
+		terminal.Warnf(errMsg, err)
+		return nil
+	}
+	heartbeatReq.SetBasicAuth(r.dockerFactory.appName, flyctl.GetAPIToken())
+	heartbeatReq.Header.Set("User-Agent", fmt.Sprintf("flyctl/%s", buildinfo.Version().String()))
+
+	pulseInterval := 30 * time.Second
+	maxTime := 1 * time.Hour
+
+	done := make(chan interface{})
+	time.AfterFunc(maxTime, func() { close(done) })
+
+	go func() {
+		pulse := time.Tick(pulseInterval)
+		defer close(done)
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case <-pulse:
+				terminal.Debugf("Sending remote builder heartbeat pulse to %s...", heartbeatUrl)
+				resp, err := dockerClient.HTTPClient().Do(heartbeatReq)
+				if err != nil {
+					terminal.Debugf("Remote builder heartbeat pulse failed: %v", err)
+				} else {
+					terminal.Debugf("Remote builder heartbeat response: %s", resp.Status)
+				}
+			}
+		}
+	}()
+	return done
+}
+
+func getHeartbeatUrl(dockerClient *dockerclient.Client) (string, error) {
+	daemonHost := dockerClient.DaemonHost()
+	parsed, err := url.Parse(daemonHost)
+	if err != nil {
+		return "", err
+	}
+	hostPort := parsed.Host
+	host, _, _ := net.SplitHostPort(hostPort)
+	parsed.Host = host + ":8080"
+	parsed.Scheme = "http"
+	parsed.Path = "/flyio/v1/extendDeadline"
+	return parsed.String(), nil
+}
+
+func (r *Resolver) StopHeartbeat(heartbeat chan<- interface{}) {
+	heartbeat <- struct{}{}
 }
 
 func NewResolver(daemonType DockerDaemonType, apiClient *api.Client, appName string, iostreams *iostreams.IOStreams) *Resolver {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -280,9 +280,11 @@ func determineImage(ctx context.Context, appConfig *app.Config) (img *imgsrc.Dep
 	}
 
 	// finally, build the image
+	heartbeat := resolver.StartHeartbeat(ctx)
 	if img, err = resolver.BuildImage(ctx, io, opts); err == nil && img == nil {
 		err = errors.New("no image specified")
 	}
+	resolver.StopHeartbeat(heartbeat)
 
 	if err == nil {
 		tb.Printf("image: %s\n", img.Tag)


### PR DESCRIPTION
This avoids the remote builder timing out after 10 minutes while
builds are still running.

Depends on https://github.com/superfly/rchab/pull/21
