### PR TITLE
Add flapsClient to context in order to fix panic

### DIFF
--- a/internal/command/postgres/update.go
+++ b/internal/command/postgres/update.go
@@ -78,6 +78,7 @@ func runUpdate(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("list of machines could not be retrieved: %w", err)
 	}
+	ctx = flaps.NewContext(ctx, flapsClient)
 
 	machineList, err := flapsClient.ListActive(ctx)
 	if err != nil {


### PR DESCRIPTION
This fixes a panic with the `fly pg update` operation during the check monitoring process. 