### PR TITLE
Laravel:  Build arguments + PHP version

### DIFF
--- a/scanner/templates/laravel/Dockerfile
+++ b/scanner/templates/laravel/Dockerfile
@@ -11,8 +11,8 @@ LABEL fly_launch_runtime="laravel"
 
 RUN apt-get update && apt-get install -y \
     git curl zip unzip rsync ca-certificates vim htop cron \
-    php${DOCKER_VERSION}-pgsql php${PHP_VERSION}-bcmath \
-    php${DOCKER_VERSION}-swoole php${PHP_VERSION}-xml php${PHP_VERSION}-mbstring \
+    php${PHP_VERSION}-pgsql php${PHP_VERSION}-bcmath \
+    php${PHP_VERSION}-swoole php${PHP_VERSION}-xml php${PHP_VERSION}-mbstring \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/scanner/templates/laravel/Dockerfile
+++ b/scanner/templates/laravel/Dockerfile
@@ -7,6 +7,10 @@ ARG PHP_VERSION=8.1
 ARG NODE_VERSION=14
 FROM serversideup/php:${PHP_VERSION}-fpm-nginx as base
 
+# PHP_VERSION needs to be repeated here
+# See https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG PHP_VERSION
+
 LABEL fly_launch_runtime="laravel"
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
The `ARG PHP_VERSON` argument was working to grab the correct base container (`FROM foo-${PHP_VERSION}`), but then later was installing `php8.1-*` packages due to a [quirk in `Dockerfile`'s parsing of `ARG`](https://docs.docker.com/engine/reference/builder/) depending on if it's BEFORE or AFTER a `FROM some-base-container` statement.

Before:

```dockerfile
ARG PHP_VERSION=8.1
ARG NODE_VERSION=14
FROM serversideup/php:${PHP_VERSION}-fpm-nginx as base

# and so on
```

After:

```dockerfile
ARG PHP_VERSION=8.1
ARG NODE_VERSION=14
FROM serversideup/php:${PHP_VERSION}-fpm-nginx as base

# PHP_VERSION is required here as well so RUN statements pick it up correctly
ARG PHP_VERSION

# and so on
```


Done:
- [x] Fixed up build argument usage that was mis-named
- [x] Resolved issue of `php8.1` being installed no matter what version of PHP was set in the build argument