### PR TITLE
Seize control over help output.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,9 @@ import (
 	"github.com/superfly/flyctl/internal/flyerr"
 )
 
+// BUG(tqbf): this code is called by root.New() in internal/command/root/root.go; we're apparently
+// halfway through a migration out of flyctl/cmd/ and into internal/command/, which I support, but
+// this is obviously pretty confusing. I lost 8 minutes to figuring this out so you don't have to.
 func NewRootCmd(client *client.Client) *cobra.Command {
 	rootStrings := docstrings.Get("flyctl")
 	rootCmd := &Command{

--- a/internal/command/help/help.go
+++ b/internal/command/help/help.go
@@ -5,17 +5,32 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/flyctl/docstrings"
+	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 
 	"github.com/olekukonko/tablewriter"
 )
 
+var deprecatedCommands = map[string]bool{
+	"completion":  true,
+	"curl":        true,
+	"dns-records": true,
+	"domains":     true,
+}
+
 func New(root *cobra.Command) *cobra.Command {
 	cmd := command.New("help", "Help on flyctl commands", "", Help(root))
 
-	cmd.AddCommand(command.New("commands", "All flyctl commands", "", HelpCommands(root)))
+	list := command.New("commands", "All flyctl commands", "", HelpCommands(root))
+	flag.Add(list, flag.Bool{
+		Name:        "all",
+		Shorthand:   "a",
+		Default:     false,
+		Description: "show all commands, even the ones we secretly hate.",
+	})
+
+	cmd.AddCommand(list)
 
 	return cmd
 }
@@ -23,7 +38,31 @@ func New(root *cobra.Command) *cobra.Command {
 // the output of `flyctl`, run by itself with no args
 func NewRootHelp() *cobra.Command {
 	return command.New("", "", "", func(ctx context.Context) error {
-		fmt.Println(docstrings.Get("flyctl").Long)
+		auth := `
+
+It doesn't look like you're logged in. Try "flyctl auth signup" to create an account,
+or "flyctl auth login" to log in to an existing account.`
+
+		if client.FromContext(ctx).Authenticated() {
+			auth = ""
+		}
+
+		fmt.Printf(`This is flyctl, the Fly.io command line interface.%s
+
+flyctl does a lot of stuff! Don't panic, it's easy to get started:
+
+  * fly launch:   launch a new application ("fly help launch" for more)
+   
+  * fly apps:     create and manage apps ("fly help apps")
+   
+  * fly machines: create and manage individual Fly.io machines ("fly help machines")
+   
+  * fly postgres: create and manage Postgres databases ("fly help postgres")
+   
+  * fly redis:    create and manage Redis databases ("fly help redis")
+   
+  * fly help:     for more help, and a complete list of commands. 
+`, auth)
 		return nil
 	})
 }
@@ -35,7 +74,72 @@ func Help(root *cobra.Command) func(ctx context.Context) error {
 			return cmd.Help()
 		}
 
-		fmt.Printf("this is help\n")
+		commands := map[string]*cobra.Command{}
+
+		for _, cmd := range root.Commands() {
+			cmd := cmd
+			commands[cmd.Name()] = cmd
+		}
+
+		listCommands := func(names []string) {
+			for _, name := range names {
+				fmt.Printf("  %s %s\n", tablewriter.PadRight(name, " ", 15), commands[name].Short)
+			}
+		}
+
+		fmt.Printf(`
+Deploying apps and machines:
+`)
+		listCommands([]string{"apps", "machine", "launch", "deploy", "restart", "destroy", "open"})
+
+		fmt.Printf(`
+Scaling and configuring:
+`)
+		listCommands([]string{"scale", "regions", "secrets"})
+
+		fmt.Printf(`
+Provisioning storage:
+`)
+		listCommands([]string{"volumes", "postgres", "redis"})
+
+		fmt.Printf(`
+Networking configuration:
+`)
+		listCommands([]string{"ips", "wireguard", "proxy", "certs"})
+
+		fmt.Printf(`
+Monitoring and managing things:
+`)
+		listCommands([]string{"logs", "list", "status", "dashboard", "dig", "ping", "ssh", "sftp"})
+
+		fmt.Printf(`
+Access control:
+`)
+		listCommands([]string{"orgs", "auth", "move"})
+
+		fmt.Printf(`
+More help:
+`)
+		listCommands([]string{"docs", "doctor"})
+		fmt.Printf("  help commands   A complete list of commands (there are a bunch more)\n")
+
+		oneliners := []struct {
+			name, desc string
+		}{
+			{"flyctl platform regions", "List all current Fly.io regions"},
+			{"flyctl scale count 4", "Run 4 instances of the current app"},
+			{"flyctl regions set ams syd", "Run in Amsterdam and Sydney"},
+			{"flyctl ssh console", "Log into an instance of the current app"},
+			{"flyctl sftp", "Copy files to and from an instance"},
+		}
+
+		fmt.Printf(`
+Handy one-liners:
+`)
+		for _, o := range oneliners {
+			fmt.Printf("  %s\n        %s\n\n", o.name, o.desc)
+		}
+
 		return nil
 	}
 }
@@ -43,9 +147,26 @@ func Help(root *cobra.Command) func(ctx context.Context) error {
 // the output of `flyctl help commands`; the master list of commands
 func HelpCommands(root *cobra.Command) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
+		all := flag.GetBool(ctx, "all")
+
+		fmt.Printf("flyctl commands:\n")
 		for _, cmd := range root.Commands() {
-			fmt.Printf("%s %s\n", tablewriter.PadRight(cmd.Name(), " ", 15), cmd.Short)
+			if cmd.Hidden {
+				continue
+			}
+
+			name := cmd.Name()
+			if deprecatedCommands[name] && !all {
+				continue
+			}
+
+			fmt.Printf("  %s %s\n", tablewriter.PadRight(name, " ", 15), cmd.Short)
 		}
+
+		fmt.Printf(`
+Flags:
+  -a, --all           List all flyctl commands, even the ones we secretly hate.
+`)
 
 		return nil
 	}

--- a/internal/command/help/help.go
+++ b/internal/command/help/help.go
@@ -123,23 +123,6 @@ More help:
 		listCommands([]string{"docs", "doctor"})
 		fmt.Printf("  help commands   A complete list of commands (there are a bunch more)\n")
 
-		oneliners := []struct {
-			name, desc string
-		}{
-			{"flyctl platform regions", "List all current Fly.io regions"},
-			{"flyctl scale count 4", "Run 4 instances of the current app"},
-			{"flyctl regions set ams syd", "Run in Amsterdam and Sydney"},
-			{"flyctl ssh console", "Log into an instance of the current app"},
-			{"flyctl sftp", "Copy files to and from an instance"},
-		}
-
-		fmt.Printf(`
-Handy one-liners:
-`)
-		for _, o := range oneliners {
-			fmt.Printf("  %s\n        %s\n\n", o.name, o.desc)
-		}
-
 		return nil
 	}
 }

--- a/internal/command/help/help.go
+++ b/internal/command/help/help.go
@@ -1,0 +1,28 @@
+package help
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/docstrings"
+	"github.com/superfly/flyctl/internal/command"
+)
+
+func New(root *cobra.Command) *cobra.Command {
+	cmd := command.New("help", "bad help", "", func(ctx context.Context) error {
+		hf := root.HelpFunc()
+		hf(root, nil)
+
+		return nil
+	})
+
+	return cmd
+}
+
+func NewRootHelp() *cobra.Command {
+	return command.New("help", "bad help", "", func(ctx context.Context) error {
+		fmt.Println(docstrings.Get("flyctl").Long)
+		return nil
+	})
+}

--- a/internal/command/help/help.go
+++ b/internal/command/help/help.go
@@ -7,22 +7,46 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/docstrings"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+
+	"github.com/olekukonko/tablewriter"
 )
 
 func New(root *cobra.Command) *cobra.Command {
-	cmd := command.New("help", "bad help", "", func(ctx context.Context) error {
-		hf := root.HelpFunc()
-		hf(root, nil)
+	cmd := command.New("help", "Help on flyctl commands", "", Help(root))
 
-		return nil
-	})
+	cmd.AddCommand(command.New("commands", "All flyctl commands", "", HelpCommands(root)))
 
 	return cmd
 }
 
+// the output of `flyctl`, run by itself with no args
 func NewRootHelp() *cobra.Command {
-	return command.New("help", "bad help", "", func(ctx context.Context) error {
+	return command.New("", "", "", func(ctx context.Context) error {
 		fmt.Println(docstrings.Get("flyctl").Long)
 		return nil
 	})
+}
+
+// the output of `flyctl help`, possibly with more arguments
+func Help(root *cobra.Command) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		if cmd, _, err := root.Find(flag.Args(ctx)); err == nil && cmd != root {
+			return cmd.Help()
+		}
+
+		fmt.Printf("this is help\n")
+		return nil
+	}
+}
+
+// the output of `flyctl help commands`; the master list of commands
+func HelpCommands(root *cobra.Command) func(ctx context.Context) error {
+	return func(ctx context.Context) error {
+		for _, cmd := range root.Commands() {
+			fmt.Printf("%s %s\n", tablewriter.PadRight(cmd.Name(), " ", 15), cmd.Short)
+		}
+
+		return nil
+	}
 }

--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -190,7 +190,7 @@ func New() *cobra.Command {
 	// and finally, add the new commands
 	root.AddCommand(newCommands...)
 
-	root.AddCommand(help.New(root))
+	root.SetHelpCommand(help.New(root))
 
 	root.RunE = help.NewRootHelp().RunE
 

--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/dig"
 	"github.com/superfly/flyctl/internal/command/docs"
 	"github.com/superfly/flyctl/internal/command/doctor"
+	"github.com/superfly/flyctl/internal/command/help"
 	"github.com/superfly/flyctl/internal/command/history"
 	"github.com/superfly/flyctl/internal/command/image"
 	"github.com/superfly/flyctl/internal/command/ips"
@@ -188,6 +189,10 @@ func New() *cobra.Command {
 
 	// and finally, add the new commands
 	root.AddCommand(newCommands...)
+
+	root.AddCommand(help.New(root))
+
+	root.RunE = help.NewRootHelp().RunE
 
 	return root
 }


### PR DESCRIPTION
Our current help output (in particular: what you get if you just run `flyctl` by itself) is **bananas**. Time to clean it up.

Right now, all this does is print the help "front matter" without the command list, unless you run `fly help`. But from here it's easy to control what exactly we're going to print.

Our current help:

```
flyctl is a command line interface to the Fly.io platform.

It allows users to manage authentication, application launch,
deployment, network configuration, logging and more with just the
one command.

* Launch an app with the launch command
* Deploy an app with the deploy command
* View a deployed web application with the open command
* Check the status of an application with the status command

To read more, use the docs command to view Fly's help on the web.

Usage:
  flyctl [flags]
  flyctl [command]

Available Commands:
  agent       Commands that manage the Fly agent, a background process that manages flyctl wireguard connections
  apps        Manage apps
  auth        Manage authentication
  autoscale   Autoscaling app resources
  certs       Manage certificates
  checks      Manage health checks
  completion  generate the autocompletion script for the specified shell
  config      Manage an app's configuration
  curl        Run a performance test against a URL
  dashboard   Open web browser on Fly Web UI for this app
  deploy      Deploy Fly applications
  destroy     Permanently destroys an app
  dig         Make DNS requests against Fly.io's internal DNS server
  dns-records Manage DNS records
  docs        View Fly documentation
  doctor      The DOCTOR command allows you to debug your Fly environment
  domains     Manage domains
  help        bad help
  help        Help about any command
  history     List an app's change history
  image       Manage app image
  info        Show detailed app information
  ips         Manage IP addresses for apps
  launch      Launch a new app
  list        Lists your Fly resources
  logs        View app logs
  machine     Commands that manage machines
  monitor     Monitor currently running application deployments
  move        Move an app to another organization
  open        Open browser to current deployed application
  orgs        Commands for managing Fly organizations
  ping        Test connectivity with ICMP ping messages
  platform    Fly platform information
  postgres    Manage Postgres clusters.
  proxy       Proxies connections to a fly VM
  redis       Launch and manage Redis databases managed by Upstash.com
  regions     Manage regions
  releases    List app releases
  restart     Restart an application
  resume      Resume an application
  scale       Scale app resources
  secrets     Manage application secrets with the set and unset commands.
  sftp        Get or put files from a remote VM.
  ssh         Use SSH to login to or run commands on VMs
  status      Show app status
  suspend     Suspend an application
  turboku     Launches heroku apps
  version     Show version information for the flyctl command
  vm          Commands that manage VM instances
  volumes     Volume management commands
  wireguard   Commands that manage WireGuard peer connections

Flags:
  -t, --access-token string   Fly API Access Token
  -j, --json                  json output
      --verbose               verbose output

Use "flyctl [command] --help" for more information about a command.
```

We can cut this down sharply, and group commands into topics --- this doesn't change anything in the command hierarchy, just what the help text shows.