### PR TITLE
fix: Remove help subcommand

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,11 @@ func NewRootCmd(client *client.Client) *cobra.Command {
 	err = rootCmd.PersistentFlags().MarkHidden("builtinsfile")
 	checkErr(err)
 
+	rootCmd.SetHelpCommand(&cobra.Command{
+		Use:    "no-help",
+		Hidden: true,
+	})
+
 	rootCmd.AddCommand(
 		newCertificatesCommand(client),
 		newConfigCommand(client),


### PR DESCRIPTION
Apparently cobra automagically adds a help subcommand when an application has any subcommands. Found an issue thread about this on the cobra repo and a fix to remove it! 💯 

https://github.com/spf13/cobra/issues/587#issuecomment-419777078

Related to @tqbf's comment here -> https://github.com/superfly/flyctl/pull/1358