### PR TITLE
Resolve symlinks when building Docker context

### DIFF
--- a/internal/build/imgsrc/archive.go
+++ b/internal/build/imgsrc/archive.go
@@ -27,7 +27,11 @@ func archiveDirectory(options archiveOptions) (io.ReadCloser, error) {
 		opts.Compression = archive.Gzip
 	}
 
-	r, err := archive.TarWithOptions(options.sourcePath, opts)
+	sourcePath, err := fileutils.ReadSymlinkedDirectory(options.sourcePath)
+	if err != nil {
+		return nil, err
+	}
+	r, err := archive.TarWithOptions(sourcePath, opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Call `ReadSymlinkedDirectory` for Docker Archive source path.
Fixes a [reported issue](https://community.fly.io/t/fly-deploy-not-working-from-symlink/7819) when running `fly deploy` with symlinks in the working directory.