### PR TITLE
Fix panic on machine restart

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.47.3
+    rev: v1.50.0
     hooks:
     -   id: golangci-lint
         # pre-commit github action runs as "manual" hook

--- a/internal/command/machine/restart.go
+++ b/internal/command/machine/restart.go
@@ -116,6 +116,7 @@ func Restart(ctx context.Context, machineID, sig string, timeOut int, forceStop 
 		return fmt.Errorf("could not stop machine %s: %w", input.ID, err)
 	}
 
+	ctx = flaps.NewContext(ctx, flapsClient)
 	if err = WaitForStartOrStop(ctx, &api.Machine{ID: input.ID}, "start", time.Minute*5); err != nil {
 		return
 	}


### PR DESCRIPTION
```
~$ fly -a dangra-pg-m3 m restart 0e286570fe1986
Sending kill signal to machine 0e286570fe1986...panic: interface conversion: interface {} is nil, not *flaps.Client

goroutine 1 [running]:
github.com/superfly/flyctl/flaps.FromContext(...)
        /Users/daniel/src/flyio/flyctl/flaps/context.go:15
github.com/superfly/flyctl/internal/command/machine.WaitForStartOrStop({0x2820320, 0xc000efb110}, 0xc000efb110?, {0x2472215, 0x5}, 0x0?)
        /Users/daniel/src/flyio/flyctl/internal/command/machine/run.go:300 +0x3ca
github.com/superfly/flyctl/internal/command/machine.Restart({0x2820320, 0xc000efb110}, {0x7ff7bfefed06, 0xe}, {0x0, 0x0}, 0x0, 0x0)
        /Users/daniel/src/flyio/flyctl/internal/command/machine/restart.go:119 +0x3c9
github.com/superfly/flyctl/internal/command/machine.runMachineRestart({0x2820320, 0xc000efb110})
        /Users/daniel/src/flyio/flyctl/internal/command/machine/restart.go:74 +0x225
github.com/superfly/flyctl/internal/command.newRunE.func1(0xc000eb7400, {0xc000efaae0?, 0x3?, 0x4?})
        /Users/daniel/src/flyio/flyctl/internal/command/command.go:110 +0x17e
github.com/spf13/cobra.(*Command).execute(0xc000eb7400, {0xc000ee44c0, 0x3, 0x4})
        /Users/daniel/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0xc000ee2f00)
        /Users/daniel/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).ExecuteContextC(...)
        /Users/daniel/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:911
github.com/superfly/flyctl/internal/cli.Run({0x2820f98?, 0xc000e13500?}, 0xc000576000, {0xc00012c130, 0x5, 0x5})
        /Users/daniel/src/flyio/flyctl/internal/cli/cli.go:36 +0x21e
main.run()
        /Users/daniel/src/flyio/flyctl/main.go:45 +0x117
main.main()
        /Users/daniel/src/flyio/flyctl/main.go:26 +0x1e
```