### PR TITLE
Fix missing region in IP address list for info command

### DIFF
--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -214,6 +214,7 @@ func (client *Client) GetAppInfo(ctx context.Context, appName string) (*AppInfo,
 						id
 						address
 						type
+						region
 						createdAt
 					}
 				}


### PR DESCRIPTION
When running `flyctl info`, the IP address list does not print the region of each IP address. This change to the GraphQL query corrects the omission.