### PR TITLE
Error if no package.json

### DIFF
--- a/scanner/templates/laravel/Dockerfile
+++ b/scanner/templates/laravel/Dockerfile
@@ -76,7 +76,7 @@ RUN if [ -f "vite.config.js" ]; then \
     elif [ -f "package-lock.json" ]; then \
         npm ci --no-audit; \
         npm run $ASSET_CMD; \
-    else \
+    elseif [ -f package.json ]; then \
         npm install; \
         npm run $ASSET_CMD; \
     fi;


### PR DESCRIPTION
Resolve an error for api-only Laravel installations with no static assets (no package.json file used)

## TODO:

- [ ] Quotes around package.json file name