### PR TITLE
Remove unsupported --signal and --time flags from machine stop

### DIFF
--- a/internal/command/machine/stop.go
+++ b/internal/command/machine/stop.go
@@ -3,9 +3,6 @@ package machine
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"syscall"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
@@ -35,16 +32,6 @@ func newStop() *cobra.Command {
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
-		flag.String{
-			Name:        "signal",
-			Shorthand:   "s",
-			Description: "Signal to stop the machine with (default: SIGINT)",
-		},
-
-		flag.Int{
-			Name:        "time",
-			Description: "Seconds to wait before killing the machine",
-		},
 	)
 
 	return cmd
@@ -52,16 +39,14 @@ func newStop() *cobra.Command {
 
 func runMachineStop(ctx context.Context) (err error) {
 	var (
-		io      = iostreams.FromContext(ctx)
-		args    = flag.Args(ctx)
-		signal  = flag.GetString(ctx, "signal")
-		timeout = flag.GetInt(ctx, "time")
+		io   = iostreams.FromContext(ctx)
+		args = flag.Args(ctx)
 	)
 
 	for _, machineID := range args {
 		fmt.Fprintf(io.Out, "Sending kill signal to machine %s...", machineID)
 
-		if err = Stop(ctx, machineID, signal, timeout); err != nil {
+		if err = Stop(ctx, machineID); err != nil {
 			return
 		}
 		fmt.Fprintf(io.Out, "%s has been successfully stopped\n", machineID)
@@ -69,23 +54,13 @@ func runMachineStop(ctx context.Context) (err error) {
 	return
 }
 
-func Stop(ctx context.Context, machineID string, sig string, timeOut int) (err error) {
+func Stop(ctx context.Context, machineID string) (err error) {
 	var (
 		appName = app.NameFromContext(ctx)
 	)
 
-	signal := api.Signal{}
-	if sig != "" {
-		s, err := strconv.Atoi(sig)
-		if err != nil {
-			return fmt.Errorf("could not get signal %s", err)
-		}
-		signal.Signal = syscall.Signal(s)
-	}
 	machineStopInput := api.StopMachineInput{
 		ID:      machineID,
-		Signal:  signal,
-		Timeout: time.Duration(timeOut),
 		Filters: &api.Filters{},
 	}
 


### PR DESCRIPTION
`signal` and `time` can be restored - along with actually [passing them](https://github.com/superfly/flyctl/blob/master/flaps/flaps.go#L144-L146) to the API - once they're supported by flyd.