### PR TITLE
serversideup containers provided us a tag we could use 

### DIFF
--- a/scanner/templates/laravel/Dockerfile
+++ b/scanner/templates/laravel/Dockerfile
@@ -5,7 +5,7 @@
 # Valid version values are PHP 7.4+
 ARG PHP_VERSION=8.1
 ARG NODE_VERSION=14
-FROM serversideup/php:${PHP_VERSION}-fpm-nginx as base
+FROM serversideup/php:${PHP_VERSION}-fpm-nginx-v1.5.0 as base
 
 # PHP_VERSION needs to be repeated here
 # See https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact


### PR DESCRIPTION
The serverside up base images provided us a tag we could use at their current version, since we cannot use newer versions of these base containers. The newer versions use s6 version 3+,  which require pid 1. We use pid 1 for our own init system.

This is an interim fix until https://github.com/superfly/flyctl/pull/1406 is complete.