### PR TITLE
Fix/add update text

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -211,8 +211,8 @@ type MachineConfig struct {
 
 type MachineDiff struct {
 	Key     string
-	Initial interface{}
-	New     interface{}
+	Initial string
+	New     string
 }
 
 type MachineLease struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -209,6 +209,12 @@ type MachineConfig struct {
 	Checks    map[string]MachineCheck `json:"checks,omitempty"`
 }
 
+type MachineDiff struct {
+	Key     string
+	Initial interface{}
+	New     interface{}
+}
+
 type MachineLease struct {
 	Status string `json:"status"`
 	Data   struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -209,12 +209,6 @@ type MachineConfig struct {
 	Checks    map[string]MachineCheck `json:"checks,omitempty"`
 }
 
-type MachineDiff struct {
-	Key     string
-	Initial string
-	New     string
-}
-
 type MachineLease struct {
 	Status string `json:"status"`
 	Data   struct {

--- a/cmd/presenters/formatting.go
+++ b/cmd/presenters/formatting.go
@@ -3,6 +3,7 @@ package presenters
 import (
 	"fmt"
 	"math"
+	"strings"
 	"time"
 )
 
@@ -41,4 +42,18 @@ func FormatRelativeTime(t time.Time) string {
 
 func FormatTime(t time.Time) string {
 	return t.Format(time.RFC3339)
+}
+
+func GetStringInBetweenTwoString(str string, startS string, endS string) (result string, found bool) {
+	s := strings.Index(str, startS)
+	if s == -1 {
+		return result, false
+	}
+	newS := str[s+len(startS):]
+	e := strings.Index(newS, endS)
+	if e == -1 {
+		return result, false
+	}
+	result = newS[:e]
+	return result, true
 }

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/google/btree v1.0.1 // indirect
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/r3labs/diff/v3 v3.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/getsentry/sentry-go v0.12.0
 	github.com/go-playground/validator/v10 v10.11.0
 	github.com/gofrs/flock v0.8.0
+	github.com/google/go-cmp v0.5.9
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.3.0
@@ -70,7 +71,6 @@ require (
 	github.com/go-playground/locales v0.14.0 // indirect
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/google/btree v1.0.1 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/vektah/gqlparser/v2 v2.4.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -72,11 +72,14 @@ require (
 	github.com/google/btree v1.0.1 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/r3labs/diff/v3 v3.0.0 // indirect
 	github.com/vektah/gqlparser/v2 v2.4.5 // indirect
+	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/tools v0.1.10 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20211104114900-415007cec224 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 	gvisor.dev/gvisor v0.0.0-20220817001344-846276b3dbc5 // indirect
 )
 

--- a/go.mod
+++ b/go.mod
@@ -73,14 +73,11 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
-	github.com/r3labs/diff/v3 v3.0.0 // indirect
 	github.com/vektah/gqlparser/v2 v2.4.5 // indirect
-	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/tools v0.1.10 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20211104114900-415007cec224 // indirect
-	google.golang.org/appengine v1.6.7 // indirect
 	gvisor.dev/gvisor v0.0.0-20220817001344-846276b3dbc5 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -720,6 +720,8 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.0.0-20191010200024-a3d713f9b7f8/go.mod h1:KyKXa9ciM8+lgMXwOVsXi7UxGrsf9mM61Mzs+xKUrKE=
 github.com/google/go-containerregistry v0.1.2/go.mod h1:GPivBPgdAyd2SU+vf6EpsgOtWDuPqjW0hJZt4rNdTZ4=
 github.com/google/go-containerregistry v0.4.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=

--- a/go.sum
+++ b/go.sum
@@ -1241,6 +1241,8 @@ github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:
 github.com/quasilyte/go-ruleguard v0.1.2-0.20200318202121-b00d7a75d3d8/go.mod h1:CGFX09Ci3pq9QZdj86B+VGIdNj4VyCo2iPOGS9esB/k=
 github.com/r3labs/diff v1.1.0 h1:V53xhrbTHrWFWq3gI4b94AjgEJOerO1+1l0xyHOBi8M=
 github.com/r3labs/diff v1.1.0/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
+github.com/r3labs/diff/v3 v3.0.0 h1:ZhPwNxn9gW5WLPBV9GCYaVbMdLOSmJ0DeKdCiSbOLUI=
+github.com/r3labs/diff/v3 v3.0.0/go.mod h1:wCkTySAiDnZao1sZrVTDIzuzgLZ+cNPGn3LC8DlIg5g=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rivo/tview v0.0.0-20210624165335-29d673af0ce2 h1:I5N0WNMgPSq5NKUFspB4jMJ6n2P0ipz5FlOlB4BXviQ=
@@ -1434,6 +1436,8 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74 h1:gga7acRE695APm9hlsSMoOoE65U4/TcqNj90mc69Rlg=
+github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
+github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=

--- a/go.sum
+++ b/go.sum
@@ -718,7 +718,6 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/go.sum
+++ b/go.sum
@@ -1243,8 +1243,6 @@ github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:
 github.com/quasilyte/go-ruleguard v0.1.2-0.20200318202121-b00d7a75d3d8/go.mod h1:CGFX09Ci3pq9QZdj86B+VGIdNj4VyCo2iPOGS9esB/k=
 github.com/r3labs/diff v1.1.0 h1:V53xhrbTHrWFWq3gI4b94AjgEJOerO1+1l0xyHOBi8M=
 github.com/r3labs/diff v1.1.0/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
-github.com/r3labs/diff/v3 v3.0.0 h1:ZhPwNxn9gW5WLPBV9GCYaVbMdLOSmJ0DeKdCiSbOLUI=
-github.com/r3labs/diff/v3 v3.0.0/go.mod h1:wCkTySAiDnZao1sZrVTDIzuzgLZ+cNPGn3LC8DlIg5g=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rivo/tview v0.0.0-20210624165335-29d673af0ce2 h1:I5N0WNMgPSq5NKUFspB4jMJ6n2P0ipz5FlOlB4BXviQ=
@@ -1438,8 +1436,6 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74 h1:gga7acRE695APm9hlsSMoOoE65U4/TcqNj90mc69Rlg=
-github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
-github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -522,8 +522,8 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 		if len(changelog) > 0 {
 			machineDiff = append(machineDiff, api.MachineDiff{
 				Key:     "Guest",
-				Initial: initialMachineConf.Guest,
-				New:     machineConf.Guest,
+				Initial: fmt.Sprintf("%s-cpu-%dx", initialMachineConf.Guest.CPUKind, initialMachineConf.Guest.CPUs),
+				New:     guestSize,
 			})
 		}
 	} else {
@@ -534,8 +534,8 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 			if len(changelog) > 0 {
 				machineDiff = append(machineDiff, api.MachineDiff{
 					Key:     "CPUs",
-					Initial: initialMachineConf.Guest.CPUs,
-					New:     machineConf.Guest.CPUs,
+					Initial: fmt.Sprint(initialMachineConf.Guest.CPUs),
+					New:     fmt.Sprint(machineConf.Guest.CPUs),
 				})
 			}
 		}
@@ -545,10 +545,11 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 			changelog, _ := diff.Diff(initialMachineConf.Guest.MemoryMB, machineConf.Guest.MemoryMB)
 
 			if len(changelog) > 0 {
-				// machineDiff["Memory"] = diffy{
-				// 	initial: initialMachineConf.Guest.MemoryMB,
-				// 	new:     machineConf.Guest.MemoryMB,
-				// }
+				machineDiff = append(machineDiff, api.MachineDiff{
+					Key:     "MemoryMB",
+					Initial: fmt.Sprint(initialMachineConf.Guest.MemoryMB),
+					New:     fmt.Sprint(machineConf.Guest.MemoryMB),
+				})
 			}
 		}
 	}
@@ -562,8 +563,8 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 	if len(changelog) > 0 {
 		machineDiff = append(machineDiff, api.MachineDiff{
 			Key:     "Env",
-			Initial: initialMachineConf.Env,
-			New:     machineConf.Env,
+			Initial: fmt.Sprint(initialMachineConf.Env),
+			New:     fmt.Sprint(machineConf.Env),
 		})
 	}
 
@@ -590,8 +591,8 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 	if len(changelog) > 0 {
 		machineDiff = append(machineDiff, api.MachineDiff{
 			Key:     "Metadata",
-			Initial: initialMachineConf.Metadata,
-			New:     machineConf.Metadata,
+			Initial: fmt.Sprint(initialMachineConf.Metadata),
+			New:     fmt.Sprint(machineConf.Metadata),
 		})
 	}
 
@@ -606,8 +607,8 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 		if len(changelog) > 0 {
 			machineDiff = append(machineDiff, api.MachineDiff{
 				Key:     "Services",
-				Initial: initialMachineConf.Services,
-				New:     machineConf.Services,
+				Initial: fmt.Sprint(initialMachineConf.Services),
+				New:     fmt.Sprint(machineConf.Services),
 			})
 		}
 	}
@@ -633,8 +634,8 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 	if len(changelog) > 0 {
 		machineDiff = append(machineDiff, api.MachineDiff{
 			Key:     "Mounts",
-			Initial: initialMachineConf.Mounts,
-			New:     machineConf.Mounts,
+			Initial: fmt.Sprint(initialMachineConf.Mounts),
+			New:     fmt.Sprint(machineConf.Mounts),
 		})
 	}
 
@@ -652,8 +653,6 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 			New:     machineConf.Image,
 		})
 	}
-
-	fmt.Println(machineDiff)
 
 	return machineConf, machineDiff, nil
 }

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -163,6 +163,12 @@ func newRun() *cobra.Command {
 	return cmd
 }
 
+type machineDiff struct {
+	key     string
+	initial string
+	new     string
+}
+
 func runMachineRun(ctx context.Context) error {
 	var (
 		appName = app.NameFromContext(ctx)
@@ -498,8 +504,8 @@ func selectAppName(ctx context.Context) (name string, err error) {
 	return
 }
 
-func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineConfig, app *api.AppCompact, imageOrPath string) (machineConf api.MachineConfig, configDiff []api.MachineDiff, err error) {
-	machineDiff := []api.MachineDiff{}
+func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineConfig, app *api.AppCompact, imageOrPath string) (machineConf api.MachineConfig, configDiff []machineDiff, err error) {
+	machineConfigDiff := []machineDiff{}
 
 	machineConf = initialMachineConf
 
@@ -520,10 +526,10 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 
 		changelog, _ := diff.Diff(initialMachineConf.Guest, machineConf.Guest)
 		if len(changelog) > 0 {
-			machineDiff = append(machineDiff, api.MachineDiff{
-				Key:     "Guest",
-				Initial: fmt.Sprintf("%s-cpu-%dx", initialMachineConf.Guest.CPUKind, initialMachineConf.Guest.CPUs),
-				New:     guestSize,
+			machineConfigDiff = append(machineConfigDiff, machineDiff{
+				key:     "Guest",
+				initial: fmt.Sprintf("%s-cpu-%dx", initialMachineConf.Guest.CPUKind, initialMachineConf.Guest.CPUs),
+				new:     guestSize,
 			})
 		}
 	} else {
@@ -532,10 +538,10 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 			changelog, _ := diff.Diff(initialMachineConf.Guest.CPUs, machineConf.Guest.CPUs)
 
 			if len(changelog) > 0 {
-				machineDiff = append(machineDiff, api.MachineDiff{
-					Key:     "CPUs",
-					Initial: fmt.Sprint(initialMachineConf.Guest.CPUs),
-					New:     fmt.Sprint(machineConf.Guest.CPUs),
+				machineConfigDiff = append(machineConfigDiff, machineDiff{
+					key:     "CPUs",
+					initial: fmt.Sprint(initialMachineConf.Guest.CPUs),
+					new:     fmt.Sprint(machineConf.Guest.CPUs),
 				})
 			}
 		}
@@ -545,10 +551,10 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 			changelog, _ := diff.Diff(initialMachineConf.Guest.MemoryMB, machineConf.Guest.MemoryMB)
 
 			if len(changelog) > 0 {
-				machineDiff = append(machineDiff, api.MachineDiff{
-					Key:     "MemoryMB",
-					Initial: fmt.Sprint(initialMachineConf.Guest.MemoryMB),
-					New:     fmt.Sprint(machineConf.Guest.MemoryMB),
+				machineConfigDiff = append(machineConfigDiff, machineDiff{
+					key:     "MemoryMB",
+					initial: fmt.Sprint(initialMachineConf.Guest.MemoryMB),
+					new:     fmt.Sprint(machineConf.Guest.MemoryMB),
 				})
 			}
 		}
@@ -561,10 +567,10 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 	changelog, _ := diff.Diff(initialMachineConf.Env, machineConf.Env)
 
 	if len(changelog) > 0 {
-		machineDiff = append(machineDiff, api.MachineDiff{
-			Key:     "Env",
-			Initial: fmt.Sprint(initialMachineConf.Env),
-			New:     fmt.Sprint(machineConf.Env),
+		machineConfigDiff = append(machineConfigDiff, machineDiff{
+			key:     "Env",
+			initial: fmt.Sprint(initialMachineConf.Env),
+			new:     fmt.Sprint(machineConf.Env),
 		})
 	}
 
@@ -573,10 +579,10 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 		changelog, _ = diff.Diff(initialMachineConf.Schedule, machineConf.Schedule)
 
 		if len(changelog) > 0 {
-			machineDiff = append(machineDiff, api.MachineDiff{
-				Key:     "Schedule",
-				Initial: initialMachineConf.Schedule,
-				New:     machineConf.Schedule,
+			machineConfigDiff = append(machineConfigDiff, machineDiff{
+				key:     "Schedule",
+				initial: initialMachineConf.Schedule,
+				new:     machineConf.Schedule,
 			})
 		}
 	}
@@ -589,10 +595,10 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 
 	changelog, _ = diff.Diff(initialMachineConf.Metadata, machineConf.Metadata)
 	if len(changelog) > 0 {
-		machineDiff = append(machineDiff, api.MachineDiff{
-			Key:     "Metadata",
-			Initial: fmt.Sprint(initialMachineConf.Metadata),
-			New:     fmt.Sprint(machineConf.Metadata),
+		machineConfigDiff = append(machineConfigDiff, machineDiff{
+			key:     "Metadata",
+			initial: fmt.Sprint(initialMachineConf.Metadata),
+			new:     fmt.Sprint(machineConf.Metadata),
 		})
 	}
 
@@ -605,10 +611,10 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 		changelog, _ := diff.Diff(initialMachineConf.Services, machineConf.Services)
 
 		if len(changelog) > 0 {
-			machineDiff = append(machineDiff, api.MachineDiff{
-				Key:     "Services",
-				Initial: fmt.Sprint(initialMachineConf.Services),
-				New:     fmt.Sprint(machineConf.Services),
+			machineConfigDiff = append(machineConfigDiff, machineDiff{
+				key:     "Services",
+				initial: fmt.Sprint(initialMachineConf.Services),
+				new:     fmt.Sprint(machineConf.Services),
 			})
 		}
 	}
@@ -616,7 +622,7 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 	if entrypoint := flag.GetString(ctx, "entrypoint"); entrypoint != "" {
 		splitted, err := shlex.Split(entrypoint)
 		if err != nil {
-			return machineConf, machineDiff, errors.Wrap(err, "invalid entrypoint")
+			return machineConf, machineConfigDiff, errors.Wrap(err, "invalid entrypoint")
 		}
 		machineConf.Init.Entrypoint = splitted
 	}
@@ -632,10 +638,10 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 	changelog, _ = diff.Diff(initialMachineConf.Mounts, machineConf.Mounts)
 
 	if len(changelog) > 0 {
-		machineDiff = append(machineDiff, api.MachineDiff{
-			Key:     "Mounts",
-			Initial: fmt.Sprint(initialMachineConf.Mounts),
-			New:     fmt.Sprint(machineConf.Mounts),
+		machineConfigDiff = append(machineConfigDiff, machineDiff{
+			key:     "Mounts",
+			initial: fmt.Sprint(initialMachineConf.Mounts),
+			new:     fmt.Sprint(machineConf.Mounts),
 		})
 	}
 
@@ -647,12 +653,12 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 	changelog, _ = diff.Diff(initialMachineConf.Image, machineConf.Image)
 
 	if len(changelog) > 0 {
-		machineDiff = append(machineDiff, api.MachineDiff{
-			Key:     "Image",
-			Initial: initialMachineConf.Image,
-			New:     machineConf.Image,
+		machineConfigDiff = append(machineConfigDiff, machineDiff{
+			key:     "Image",
+			initial: initialMachineConf.Image,
+			new:     machineConf.Image,
 		})
 	}
 
-	return machineConf, machineDiff, nil
+	return machineConf, machineConfigDiff, nil
 }

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -107,13 +107,7 @@ func runUpdate(ctx context.Context) (err error) {
 	fmt.Fprintf(out, "Instance ID has been updated:\n")
 	fmt.Fprintf(out, "%s -> %s\n\n", prevInstanceID, machine.InstanceID)
 	fmt.Fprintln(out, "The following config has been updated")
-
-	for _, v := range machineDiff {
-		fmt.Fprintf(out, "%s: ", v.Key)
-		initial := colorize.Red(fmt.Sprintf("%s", string(v.Initial)))
-		new := colorize.Yellow(fmt.Sprintf("%s", string(v.New)))
-		fmt.Fprintf(out, "%s -> %s\n", initial, new)
-	}
+	fmt.Fprintln(out, machineDiff)
 
 	// wait for machine to be started
 	if err := WaitForStartOrStop(ctx, machine, waitForAction, time.Second*60); err != nil {

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -113,11 +113,11 @@ func runUpdate(ctx context.Context) (err error) {
 	s := strings.Split(machineDiff, ",")
 	var str string
 	for _, val := range s {
-		_, found := presenters.GetStringInBetweenTwoString(val, "-", ":")
-		_, found2 := presenters.GetStringInBetweenTwoString(val, "+", ":")
-		if found2 {
+		_, foundDeletion := presenters.GetStringInBetweenTwoString(val, "-", ":")
+		_, foundAddition := presenters.GetStringInBetweenTwoString(val, "+", ":")
+		if foundAddition {
 			str += colorize.Green(val)
-		} else if found {
+		} else if foundDeletion {
 			str += colorize.Red(val)
 		} else {
 			str += val

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -3,11 +3,13 @@ package machine
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/cmd/presenters"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/flaps"
@@ -107,9 +109,23 @@ func runUpdate(ctx context.Context) (err error) {
 	fmt.Fprintf(out, "Instance ID has been updated:\n")
 	fmt.Fprintf(out, "%s -> %s\n\n", prevInstanceID, machine.InstanceID)
 	fmt.Fprintln(out, "The following config has been updated")
-	fmt.Fprintln(out, machineDiff)
 
-	// wait for machine to be started
+	s := strings.Split(machineDiff, ",")
+	var str string
+	for _, val := range s {
+		_, found := presenters.GetStringInBetweenTwoString(val, "-", ":")
+		_, found2 := presenters.GetStringInBetweenTwoString(val, "+", ":")
+		if found2 {
+			str += colorize.Green(val)
+		} else if found {
+			str += colorize.Red(val)
+		} else {
+			str += val
+		}
+	}
+	fmt.Fprintln(out, str)
+
+	//wait for machine to be started
 	if err := WaitForStartOrStop(ctx, machine, waitForAction, time.Second*60); err != nil {
 		return err
 	}


### PR DESCRIPTION
With a machine update, you don't get notified of the changes to config unless you run a machine status right after, this PR highlights the config bits that get changed when an update is made

<img width="928" alt="updateconfig" src="https://user-images.githubusercontent.com/3229484/197859658-9f91fece-d34a-4749-b7ce-d1fa4e8402b9.png">

Edit: Moved to using a different library, now the diff looks like this:
![Screen Shot 2022-10-28 at 2 21 15 AM](https://user-images.githubusercontent.com/3229484/198368468-0274540f-9eac-4807-922a-133a44c2d9d3.png)

I think color coding it would be cool but for now it shows the diff!

Edit OMGeeeee
![Screen Shot 2022-10-28 at 3 24 40 AM](https://user-images.githubusercontent.com/3229484/198380536-c6da0383-317c-4710-8124-98032ad34a8b.png)

