### PR TITLE
Make PG connection string more prominent

### DIFF
--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -170,6 +170,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 	fmt.Fprintf(io.Out, "  Hostname:    %s.internal\n", config.AppName)
 	fmt.Fprintf(io.Out, "  Proxy port:  5432\n")
 	fmt.Fprintf(io.Out, "  Postgres port:  5433\n")
+	fmt.Fprintf(io.Out, "  Connection string: %s\n", connStr)
 	fmt.Fprintln(io.Out, colorize.Italic("Save your credentials in a secure place -- you won't be able to see them again!"))
 
 	fmt.Fprintln(io.Out)


### PR DESCRIPTION
The created output now more prominently displays the connection string:

```
Postgres cluster super-duper-fun-times-222 created
  Username:    postgres
  Password:    #######
  Hostname:    super-duper-fun-times-222.internal
  Proxy port:  5432
  Postgres port:  5433
  Connection string: postgres://postgres:#######@super-duper-fun-times-222.internal:5432
```
