### PR TITLE
Add interactive prompt for machine update

### DIFF
--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -101,6 +101,7 @@ func runUpdate(ctx context.Context) (err error) {
 			str += val
 		}
 	}
+	fmt.Fprintln(out, "The following config is being updated")
 	fmt.Fprintln(out, str)
 
 	// interactive update //
@@ -135,7 +136,6 @@ func runUpdate(ctx context.Context) (err error) {
 	fmt.Fprintln(out, colorize.Yellow(fmt.Sprintf("Machine %s has been updated\n", machine.ID)))
 	fmt.Fprintf(out, "Instance ID has been updated:\n")
 	fmt.Fprintf(out, "%s -> %s\n\n", prevInstanceID, machine.InstanceID)
-	fmt.Fprintln(out, "The following config has been updated")
 
 	//wait for machine to be started
 	if err := WaitForStartOrStop(ctx, machine, waitForAction, time.Second*60); err != nil {


### PR DESCRIPTION
This builds off of #1414 to add an interactive element to machine update so users can check the changes to their config before confirming an update

![Screen Shot 2022-10-28 at 5 12 56 PM](https://user-images.githubusercontent.com/3229484/198551231-66e0e4f6-e5df-4f57-a9d3-fefcee388577.png)

![Screen Shot 2022-10-28 at 5 12 27 PM](https://user-images.githubusercontent.com/3229484/198551246-cc7c5705-f69f-4089-8ac8-685009dfbe24.png)
