### PR TITLE
Update Autoscaling commands for Nomad autoscaler

### DIFF
--- a/cmd/autoscaling.go
+++ b/cmd/autoscaling.go
@@ -25,16 +25,8 @@ func newAutoscaleCommand(client *client.Client) *Command {
 	disableCmd := BuildCommand(cmd, runDisableAutoscaling, disableCmdStrings.Usage, disableCmdStrings.Short, disableCmdStrings.Long, client, requireSession, requireAppName)
 	disableCmd.Args = cobra.RangeArgs(0, 2)
 
-	balanceCmdStrings := docstrings.Get("autoscale.balanced")
-	balanceCmd := BuildCommand(cmd, runBalanceScale, balanceCmdStrings.Usage, balanceCmdStrings.Short, balanceCmdStrings.Long, client, requireSession, requireAppName)
-	balanceCmd.Args = cobra.RangeArgs(0, 2)
-
-	standardCmdStrings := docstrings.Get("autoscale.standard")
-	standardCmd := BuildCommand(cmd, runStandardScale, standardCmdStrings.Usage, standardCmdStrings.Short, standardCmdStrings.Long, client, requireSession, requireAppName)
-	standardCmd.Args = cobra.RangeArgs(0, 2)
-
 	setCmdStrings := docstrings.Get("autoscale.set")
-	setCmd := BuildCommand(cmd, runSetParamsOnly, setCmdStrings.Usage, setCmdStrings.Short, setCmdStrings.Long, client, requireSession, requireAppName)
+	setCmd := BuildCommand(cmd, runSetParams, setCmdStrings.Usage, setCmdStrings.Short, setCmdStrings.Long, client, requireSession, requireAppName)
 	setCmd.Args = cobra.RangeArgs(0, 2)
 
 	showCmdStrings := docstrings.Get("autoscale.show")
@@ -43,16 +35,8 @@ func newAutoscaleCommand(client *client.Client) *Command {
 	return cmd
 }
 
-func runBalanceScale(commandContext *cmdctx.CmdContext) error {
-	return actualScale(commandContext, true, false)
-}
-
-func runStandardScale(commandContext *cmdctx.CmdContext) error {
-	return actualScale(commandContext, false, false)
-}
-
-func runSetParamsOnly(commandContext *cmdctx.CmdContext) error {
-	return actualScale(commandContext, false, true)
+func runSetParams(commandContext *cmdctx.CmdContext) error {
+	return actualScale(commandContext, false)
 }
 
 func runDisableAutoscaling(cmdCtx *cmdctx.CmdContext) error {
@@ -70,7 +54,7 @@ func runDisableAutoscaling(cmdCtx *cmdctx.CmdContext) error {
 	return nil
 }
 
-func actualScale(cmdCtx *cmdctx.CmdContext, balanceRegions bool, setParamsOnly bool) error {
+func actualScale(cmdCtx *cmdctx.CmdContext, balanceRegions bool) error {
 	ctx := cmdCtx.Command.Context()
 
 	currentcfg, err := cmdCtx.Client.API().AppAutoscalingConfig(ctx, cmdCtx.AppName)
@@ -165,13 +149,11 @@ func printScaleConfig(cmdCtx *cmdctx.CmdContext, cfg *api.AutoscalingConfig) {
 
 		if !cfg.Enabled {
 			mode = "Disabled"
-		} else if cfg.BalanceRegions {
-			mode = "Balanced"
 		} else {
-			mode = "Standard"
+			mode = "Enabled"
 		}
 
-		fmt.Fprintf(cmdCtx.Out, "%15s: %s\n", "Scale Mode", mode)
+		fmt.Fprintf(cmdCtx.Out, "%15s: %s\n", "Autoscaling", mode)
 		if cfg.Enabled {
 			fmt.Fprintf(cmdCtx.Out, "%15s: %d\n", "Min Count", cfg.MinCount)
 			fmt.Fprintf(cmdCtx.Out, "%15s: %d\n", "Max Count", cfg.MaxCount)

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -600,24 +600,6 @@ longHelp = """Disable autoscaling to manually controlling app resources
 shortHelp = "Disable autoscaling"
 usage = "disable"
 
-[autoscale.balanced]
-longHelp = """Configure the app to balance regions based on traffic with given parameters:
-
-min=int - minimum number of instances to be allocated from region pool.
-max=int - maximum number of instances to be allocated from region pool.
-"""
-shortHelp = "Configure a traffic balanced app with params (min=int max=int)"
-usage = "balanced"
-
-[autoscale.standard]
-longHelp = """Configure the app without traffic balancing with the given parameters:
-
-min=int - minimum number of instances to be allocated from region pool.
-max=int - maximum number of instances to be allocated from region pool.
-"""
-shortHelp = "Configure a standard balanced app with params (min=int max=int)"
-usage = "standard"
-
 [autoscale.show]
 longHelp = """Show current autoscaling configuration
 """
@@ -625,12 +607,12 @@ shortHelp = "Show current autoscaling configuration"
 usage = "show"
 
 [autoscale.set]
-longHelp = """Allows the setting of the current models autoscaling parameters:
+longHelp = """Enable autoscaling and set the application's autoscaling parameters:
 
-min=int - minimum number of instances to be allocated from region pool.
-max=int - maximum number of instances to be allocated from region pool.
+min=int - minimum number of instances to be allocated globally.
+max=int - maximum number of instances to be allocated globally.
 """
-shortHelp = "Set current models autoscaling parameters"
+shortHelp = "Set app autoscaling parameters"
 usage = "set"
 
 [scale]


### PR DESCRIPTION
The `flyctl autoscaling` commands haven't been updated since the switch to Nomad-based autoscaler in Sept 2021. Remove the `standard` and `balanced` mode controls since they no longer have any behavior with the current autoscaler.