### PR TITLE
Fix launchers by ensuring the app name is always determined correctly

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -156,7 +156,7 @@ func DeployWithConfig(ctx context.Context, appConfig *app.Config) (err error) {
 			return err
 		}
 
-		release, err = apiClient.GetAppRelease(ctx, app.NameFromContext(ctx), release.ID)
+		release, err = apiClient.GetAppRelease(ctx, appConfig.AppName, release.ID)
 		if err != nil {
 			return err
 		}
@@ -169,7 +169,7 @@ func DeployWithConfig(ctx context.Context, appConfig *app.Config) (err error) {
 		return nil
 	}
 
-	err = watch.Deployment(ctx, app.NameFromContext(ctx), release.EvaluationID)
+	err = watch.Deployment(ctx, appConfig.AppName, release.EvaluationID)
 
 	return err
 }
@@ -232,15 +232,10 @@ func determineImage(ctx context.Context, appConfig *app.Config) (img *imgsrc.Dep
 	tb := render.NewTextBlock(ctx, "Building image")
 	daemonType := imgsrc.NewDockerDaemonType(!flag.GetRemoteOnly(ctx), !flag.GetLocalOnly(ctx), env.IsCI(), flag.GetBool(ctx, "nixpacks"))
 
-	var appName string = app.NameFromContext(ctx)
-	if appConfig.AppName != "" && appName == "" {
-		appName = appConfig.AppName
-	}
-
 	client := client.FromContext(ctx).API()
 	io := iostreams.FromContext(ctx)
 
-	resolver := imgsrc.NewResolver(daemonType, client, appName, io)
+	resolver := imgsrc.NewResolver(daemonType, client, appConfig.AppName, io)
 
 	var imageRef string
 	if imageRef, err = fetchImageRef(ctx, appConfig); err != nil {
@@ -250,7 +245,7 @@ func determineImage(ctx context.Context, appConfig *app.Config) (img *imgsrc.Dep
 	// we're using a pre-built Docker image
 	if imageRef != "" {
 		opts := imgsrc.RefOptions{
-			AppName:    appName,
+			AppName:    appConfig.AppName,
 			WorkingDir: state.WorkingDirectory(ctx),
 			Publish:    !flag.GetBuildOnly(ctx),
 			ImageRef:   imageRef,
@@ -269,7 +264,7 @@ func determineImage(ctx context.Context, appConfig *app.Config) (img *imgsrc.Dep
 
 	// We're building from source
 	opts := imgsrc.ImageOptions{
-		AppName:         appName,
+		AppName:         appConfig.AppName,
 		WorkingDir:      state.WorkingDirectory(ctx),
 		Publish:         flag.GetBool(ctx, "push") || !flag.GetBuildOnly(ctx),
 		ImageLabel:      flag.GetString(ctx, "image-label"),
@@ -374,7 +369,7 @@ func createRelease(ctx context.Context, appConfig *app.Config, img *imgsrc.Deplo
 	tb := render.NewTextBlock(ctx, "Creating release")
 
 	input := api.DeployImageInput{
-		AppID: app.NameFromContext(ctx),
+		AppID: appConfig.AppName,
 		Image: img.Tag,
 	}
 

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -497,7 +497,7 @@ func run(ctx context.Context) (err error) {
 			deployNow = true
 		}
 	}
-	fmt.Printf("%#v", appConfig)
+
 	if deployNow {
 		return deploy.DeployWithConfig(ctx, appConfig)
 	}

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -497,7 +497,7 @@ func run(ctx context.Context) (err error) {
 			deployNow = true
 		}
 	}
-
+	fmt.Printf("%#v", appConfig)
 	if deployNow {
 		return deploy.DeployWithConfig(ctx, appConfig)
 	}


### PR DESCRIPTION
App names can come from config, a flag, or from a newly created app during launch. Previously, deployments were relying only on the app value added to context by the deploy command. Since `launch` skips the context step, we moved app name logic into `determineAppConfig`. But, we neglected to ensure that the app name placed in the config is what's used everywhere during deployments. So, deployments initiated during the launch phase would fail.