### PR TITLE
docs: add comments to install all modules when devDeps is ignored by default

### DIFF
--- a/scanner/templates/node/Dockerfile
+++ b/scanner/templates/node/Dockerfile
@@ -18,6 +18,15 @@ RUN volta install node@${NODE_VERSION}
 RUN mkdir /app
 WORKDIR /app
 
+{{ if .yarn -}}
+# Yarn will not install any package listed in "devDependencies" when NODE_ENV is set to "production"
+# to install all modules: "yarn install --production=false"
+# Ref: https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-production-true-false
+{{ else -}}
+# NPM will not install any package listed in "devDependencies" when NODE_ENV is set to "production",
+# to install all modules: "npm install --production=false".
+# Ref: https://docs.npmjs.com/cli/v9/commands/npm-install#description
+{{ end }}
 ENV NODE_ENV production
 
 COPY . .


### PR DESCRIPTION
## Why this changes

When we want to reduce the image size of a NodeJS project and set the `NODE_ENV` to `production` before install, the package manager will ignore `devDependencies`. This is in line with expected behavior.

However, in the current JavaScript ecosystem, where most projects require the use of scaffolding from `devDependencies` for the bundle (or compile), ignoring dependencies when building images can cause user deployments to fail. For users who lack experience with package managers, this cause is hard to spot.

## Description of the changes

Reducing the size of the image reduces the deployment time for users and for some users does not require any changes in settings, which is correct, no changes are required.

Add additional comments to get a hint when the user tries to change the Dockerfile to resolve the error.

### Needs to review

I'm not quite sure if the comments in the template will respect the conditional statement, if it doesn't work we can remove the conditional statement.


## Refs

- [[Node.js] Default generated Dockerfile may cause user deployment to fail](https://community.fly.io/t/node-js-default-generated-dockerfile-may-cause-user-deployment-to-fail/8607)
