### PR TITLE
Update base Rails image to point to Debian 11 (from Debian 10)

### DIFF
--- a/scanner/templates/rails/standard/Dockerfile
+++ b/scanner/templates/rails/standard/Dockerfile
@@ -18,7 +18,7 @@
 # performance.
 
 ARG RUBY_VERSION={{ .rubyVersion }}
-ARG VARIANT=jemalloc-slim
+ARG VARIANT=jemalloc-bullseye-slim
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-${VARIANT} as base
 
 LABEL fly_launch_runtime="rails"


### PR DESCRIPTION
Based on feedback from https://community.fly.io/t/help-migrating-postgres-from-heroku-rails-app/7863/16