### PR TITLE
implment a new flag: --ignorefile string

### DIFF
--- a/flyctl/app_config.go
+++ b/flyctl/app_config.go
@@ -40,6 +40,7 @@ type Build struct {
 	Image string
 	// Or...
 	Dockerfile        string
+	Ignorefile        string
 	DockerBuildTarget string
 }
 
@@ -99,6 +100,13 @@ func (ac *AppConfig) Dockerfile() string {
 		return ""
 	}
 	return ac.Build.Dockerfile
+}
+
+func (ac *AppConfig) Ignorefile() string {
+	if ac.Build == nil {
+		return ""
+	}
+	return ac.Build.Ignorefile
 }
 
 func (ac *AppConfig) DockerBuildTarget() string {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -115,6 +115,7 @@ type Build struct {
 	Settings          map[string]interface{} `toml:"settings,omitempty"`
 	Builtin           string                 `toml:"builtin,omitempty"`
 	Dockerfile        string                 `toml:"dockerfile,omitempty"`
+	Ignorefile        string                 `toml:"ignorefile,omitempty"`
 	DockerBuildTarget string                 `toml:"buildpacks,omitempty"`
 }
 
@@ -161,6 +162,13 @@ func (c *Config) Dockerfile() string {
 		return ""
 	}
 	return c.Build.Dockerfile
+}
+
+func (c *Config) Ignorefile() string {
+	if c.Build == nil {
+		return ""
+	}
+	return c.Build.Ignorefile
 }
 
 func (c *Config) DockerBuildTarget() string {

--- a/internal/build/imgsrc/archive.go
+++ b/internal/build/imgsrc/archive.go
@@ -55,8 +55,12 @@ func archiveDirectory(options archiveOptions) (io.ReadCloser, error) {
 	return r, nil
 }
 
-func readDockerignore(workingDir string) ([]string, error) {
-	file, err := os.Open(filepath.Join(workingDir, ".dockerignore"))
+func readDockerignore(workingDir string, ignoreFile string) ([]string, error) {
+	if ignoreFile == "" {
+		ignoreFile = filepath.Join(workingDir, ".dockerignore")
+	}
+
+	file, err := os.Open(ignoreFile)
 	if os.IsNotExist(err) {
 		return []string{}, nil
 	} else if err != nil {

--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -70,7 +70,7 @@ func (*buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 	cmdfmt.PrintDone(streams.ErrOut, msg)
 
 	build.ContextBuildStart()
-	excludes, err := readDockerignore(opts.WorkingDir)
+	excludes, err := readDockerignore(opts.WorkingDir, opts.IgnorefilePath)
 	if err != nil {
 		build.ContextBuildFinish()
 		build.BuildFinish()

--- a/internal/build/imgsrc/builtin_builder.go
+++ b/internal/build/imgsrc/builtin_builder.go
@@ -63,7 +63,7 @@ func (*builtinBuilder) Run(ctx context.Context, dockerFactory *dockerClientFacto
 		compressed: dockerFactory.IsRemote(),
 	}
 
-	excludes, err := readDockerignore(opts.WorkingDir)
+	excludes, err := readDockerignore(opts.WorkingDir, opts.IgnorefilePath)
 	if err != nil {
 		build.BuildFinish()
 		return nil, "", errors.Wrap(err, "error reading .dockerignore")

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -99,7 +99,7 @@ func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 		compressed: dockerFactory.IsRemote(),
 	}
 
-	excludes, err := readDockerignore(opts.WorkingDir)
+	excludes, err := readDockerignore(opts.WorkingDir, opts.IgnorefilePath)
 	if err != nil {
 		build.BuildFinish()
 		build.ContextBuildFinish()

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -26,6 +26,7 @@ type ImageOptions struct {
 	AppName         string
 	WorkingDir      string
 	DockerfilePath  string
+	IgnorefilePath  string
 	ImageRef        string
 	BuildArgs       map[string]string
 	ExtraBuildArgs  map[string]string

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -312,6 +312,15 @@ func Dockerfile() String {
 	}
 }
 
+const ignorefileName = "ignorefile"
+
+func Ignorefile() String {
+	return String{
+		Name:        ignorefileName,
+		Description: "Path to a Docker ignore file. Defaults to the .dockerignore file in the working directory.",
+	}
+}
+
 func ImageLabel() String {
 	return String{
 		Name:        "image-label",


### PR DESCRIPTION
  Path to a Docker ignore file. Defaults to the .dockerignore file in the working directory.

Rationale: the hope/plan is to support a path where scanning and dockerfile generation is done at every deploy time rather than only once at launch time.  This has two benefits: it adjusts the Dockerfile as needs change (new version of ruby, addition of a gem that requires a debian library to be installed, etc); and may be less scary to the Dockerphobic.

If we are going to make the Dockerfile invisible, it makes sense to make the .dockerignore file invisible too; it will be generated by the same scan process, which will likely be adjusted to use .gitignore as a starting point.