### PR TITLE
Postgres launcher: change "what you should know" link

### DIFF
--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -183,7 +183,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 	fmt.Fprintf(io.Out, "Any app within the %s organization can connect to this Postgres using the following connection string:\n", config.Organization.Name)
 
 	fmt.Fprintln(io.Out)
-	fmt.Fprintln(io.Out, "Now that you've set up postgres, here's what you need to understand: https://fly.io/docs/reference/postgres-whats-next/")
+	fmt.Fprintln(io.Out, "Now that you've set up Postgres, here's what you need to understand: https://fly.io/docs/postgres/getting-started/what-you-should-know/")
 
 	// TODO: wait for the cluster to be ready
 
@@ -250,7 +250,7 @@ func (l *Launcher) LaunchNomadPostgres(ctx context.Context, config *CreateCluste
 	fmt.Fprintf(io.Out, "For example: postgres://%s:%s@%s.internal:%d\n", payload.Username, payload.Password, payload.App.Name, 5432)
 
 	fmt.Fprintln(io.Out)
-	fmt.Fprintln(io.Out, "Now that you've set up postgres, here's what you need to understand: https://fly.io/docs/reference/postgres-whats-next/")
+	fmt.Fprintln(io.Out, "Now that you've set up Postgres, here's what you need to understand: https://fly.io/docs/postgres/getting-started/what-you-should-know/")
 
 	return
 }


### PR DESCRIPTION
No rush on this; the current message points to an extant document. This PR just changes the message to point to a doc that's findable in the Postgres docs menu.