### PR TITLE
Use -jemalloc-slim as ruby stack variant that always point to existen…

### DIFF
--- a/scanner/templates/rails/standard/Dockerfile
+++ b/scanner/templates/rails/standard/Dockerfile
@@ -18,7 +18,7 @@
 # performance.
 
 ARG RUBY_VERSION={{ .rubyVersion }}
-ARG VARIANT=jemalloc-bullseye-slim
+ARG VARIANT=jemalloc-slim
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-${VARIANT} as base
 
 LABEL fly_launch_runtime="rails"


### PR DESCRIPTION
…t image

As seen in
https://community.fly.io/t/error-jemalloc-bullseye-slim-not-found/8925/8