### PR TITLE
fix: Deploy an app if it has already been launched

### DIFF
--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -120,7 +120,7 @@ func run(ctx context.Context) (err error) {
 
 		if deployExisting {
 			fmt.Fprintln(io.Out, "App is not running, deploy...")
-			return deploy.DeployWithConfig(ctx, appConfig)
+			return deploy.DeployWithConfig(ctx, cfg)
 		}
 
 		copyConfig := false


### PR DESCRIPTION
When someone tries to launch an app that has already launched, we theoretically deploy it for them. However, we weren't passing in the loaded app config properly which resulted in errors.

Related to #1447 

<img width="952" alt="Screen Shot 2022-11-25 at 1 22 56 PM" src="https://user-images.githubusercontent.com/3229484/204044474-0fd87d5e-2537-4bb2-9ff5-978af76aecae.png">
