### PR TITLE
Add error check for non-existent organization in `fly orgs show`.

### DIFF
--- a/internal/command/orgs/show.go
+++ b/internal/command/orgs/show.go
@@ -37,6 +37,9 @@ associated member. Details full list of members and roles.
 func runShow(ctx context.Context) (err error) {
 	client := client.FromContext(ctx).API()
 	selectedOrg, err := OrgFromFirstArgOrSelect(ctx)
+	if err != nil {
+		return err
+	}
 
 	org, err := client.GetDetailedOrganizationBySlug(ctx, selectedOrg.Slug)
 	if err != nil {


### PR DESCRIPTION
Fixes #1388
