### PR TITLE
Make welcome message formatting more consistent with the rest of the CLI

### DIFF
--- a/internal/command/help/help.go
+++ b/internal/command/help/help.go
@@ -49,19 +49,18 @@ or "flyctl auth login" to log in to an existing account.`
 
 		fmt.Printf(`This is flyctl, the Fly.io command line interface.%s
 
-flyctl does a lot of stuff! Don't panic, it's easy to get started:
+Here's a few commands to get you started:
+  fly launch      Launch a new application
+  fly apps        Create and manage apps
+  fly postgres    Create and manage Postgres databases
+  fly redis       Create and manage Redis databases
+  fly machines    Create and manage individual Fly.io machines
 
-  * fly launch:   launch a new application ("fly help launch" for more)
+If you need help along the way:
+  fly help            Display a complete list of commands
+  fly help <command>  Display help for a specific command, e.g. 'fly help launch'
 
-  * fly apps:     create and manage apps ("fly help apps")
-
-  * fly machines: create and manage individual Fly.io machines ("fly help machines")
-
-  * fly postgres: create and manage Postgres databases ("fly help postgres")
-
-  * fly redis:    create and manage Redis databases ("fly help redis")
-
-  * fly help:     for more help, and a complete list of commands.
+Visit https://fly.io/docs for additional documentation & guides
 `, auth)
 		return nil
 	})


### PR DESCRIPTION
I was finding the existing `flyctl` command difficult to read and didn't like how it was inconsistent with `fly help`:

```sh
flyctl [welcome-formatting] → fly
Update available 0.0.434 -> 0.0.436.
Run "fly version update" to upgrade.
This is flyctl, the Fly.io command line interface.

flyctl does a lot of stuff! Don't panic, it's easy to get started:

  * fly launch:   launch a new application ("fly help launch" for more)

  * fly apps:     create and manage apps ("fly help apps")

  * fly machines: create and manage individual Fly.io machines ("fly help machines")

  * fly postgres: create and manage Postgres databases ("fly help postgres")

  * fly redis:    create and manage Redis databases ("fly help redis")

  * fly help:     for more help, and a complete list of commands.
flyctl [welcome-formatting] → fly help
Update available 0.0.434 -> 0.0.436.
Run "fly version update" to upgrade.

Deploying apps and machines:
  apps            Manage apps
  machine         Commands that manage machines
  launch          Create and configure a new app from source code or a Docker image.
  deploy          Deploy Fly applications
  restart         Restart an application
  destroy         Permanently destroys an app
  open            Open browser to current deployed application

Scaling and configuring:
  scale           Scale app resources
  regions         Manage regions
  secrets         Manage application secrets with the set and unset commands.
```

So I changed the formatting, removed some of the help commands, and capitalized a few things to make it more consistent with the rest of the CLI. Here' the final result when running `fly`:

```sh
This is flyctl, the Fly.io command line interface.

Here's a few commands to get you started:
  fly launch      Launch a new application
  fly apps        Create and manage apps
  fly postgres    Create and manage Postgres databases
  fly redis       Create and manage Redis databases
  fly machines    Create and manage individual Fly.io machines

If you need help along the way:
  fly help            Display a complete list of commands
  fly help <command>  Display help for a specific command, e.g. 'fly help launch'

Visit https://fly.io/docs for additional documentation & guides
flyctl [welcome-formatting] → fly help
Update available 0.0.434 -> 0.0.436.
Run "fly version update" to upgrade.

Deploying apps and machines:
  apps            Manage apps
  machine         Commands that manage machines
  launch          Create and configure a new app from source code or a Docker image.
  deploy          Deploy Fly applications
  restart         Restart an application
  destroy         Permanently destroys an app
  open            Open browser to current deployed application

Scaling and configuring:
  scale           Scale app resources
  regions         Manage regions
  secrets         Manage application secrets with the set and unset commands.

```