### PR TITLE
chore: Add URL to the app's monitoring page during deployment

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -196,6 +196,10 @@ func runDeploy(cmdCtx *cmdctx.CmdContext) error {
 	}
 
 	fmt.Println()
+	logURL := fmt.Sprintf("https://fly.io/apps/%s/monitoring", cmdCtx.AppName)
+	fmt.Fprintln(cmdCtx.Out, "Logs:", logURL)
+
+	fmt.Println()
 	cmdCtx.Status("deploy", cmdctx.SDETAIL, "You can detach the terminal anytime without stopping the deployment")
 
 	if releaseCommand != nil {


### PR DESCRIPTION
# Problem
During deployment my routine is quite often like this: 
 - `fly deploy`
 - wait for build and deploy
 - check logs on the website in order to comfortably understand what is going on with the deployment

Therefore, I need to keep the right tab open or open it manually one more time. 

# Solution 
In order to speed up this routine I would love to have the URL to the monitoring tab of the app right in front of my eyes. 


WDYT? 
