### PR TITLE
Clone machine and its volumes from last snapshot

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -128,7 +128,7 @@ type MachineMount struct {
 	Path      string `json:"path"`
 	SizeGb    int    `json:"size_gb"`
 	Volume    string `json:"volume"`
-	PoolName  string `json:"pool_name"`
+	Name      string `json:"name"`
 }
 
 type MachineGuest struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -128,6 +128,7 @@ type MachineMount struct {
 	Path      string `json:"path"`
 	SizeGb    int    `json:"size_gb"`
 	Volume    string `json:"volume"`
+	PoolName  string `json:"pool_name"`
 }
 
 type MachineGuest struct {

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -146,7 +146,6 @@ func runMachineClone(ctx context.Context) (err error) {
 			SnapshotID:        snapshotID,
 			RequireUniqueZone: false,
 		}
-		fmt.Printf("%#v\n", volInput)
 		vol, err := client.CreateVolume(ctx, volInput)
 		if err != nil {
 			return err


### PR DESCRIPTION
Before, there was a special case to clone machine and its volumes only for _postgres_cluster_ role. This PR generalizes it to create volumes for any cloned machine and optionally to restore volume's content to latest snapshot from the original volumes.

The biggest change there is that we are creating new volumes no matter what app role the machine belongs to as long as the volume is defined in the source machine.

Optionally, if `--from-snapshot=last` is passed, it restore volumes from most recent snapshot. 