### PR TITLE
additions to the Django .dockerignore file

### DIFF
--- a/scanner/templates/django/.dockerignore
+++ b/scanner/templates/django/.dockerignore
@@ -1,1 +1,3 @@
 fly.toml
+.git/
+*.sqlite3


### PR DESCRIPTION
Added the following to the Django `.dockerignore` template when running `fly launch`.

```
.git/
*.sqlite3
```

Based on feedback and suggestion from @wsvincent.