### PR TITLE
Improve scan for django projects

### DIFF
--- a/scanner/django.go
+++ b/scanner/django.go
@@ -6,7 +6,7 @@ import (
 
 // setup django with a postgres database
 func configureDjango(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
-	if !checksPass(sourceDir, dirContains("requirements.txt", "Django")) {
+	if !checksPass(sourceDir, dirContains("requirements.txt", "(?i)Django")) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Currently projects that use tools like `pip-tools` that generate a `requirements.txt` with all declared packages in lower case are not reconized as a Django project.