### PR TITLE
Fix `fly volume create` docstring to mention actual default size of 3.

### DIFF
--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -777,7 +777,7 @@ command to update the application.`,
 	case "volumes.create":
 		return KeyStrings{"create <volumename>", "Create new volume for app",
 			`Create new volume for app. --region flag must be included to specify
-region the volume exists in. --size flag is optional, defaults to 10,
+region the volume exists in. --size flag is optional, defaults to 3,
 sets the size as the number of gigabytes the volume will consume.`,
 		}
 	case "volumes.delete":

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -805,7 +805,7 @@ usage = "volumes <command>"
 
 [volumes.create]
 longHelp = """Create new volume for app. --region flag must be included to specify
-region the volume exists in. --size flag is optional, defaults to 10,
+region the volume exists in. --size flag is optional, defaults to 3,
 sets the size as the number of gigabytes the volume will consume."""
 shortHelp = "Create new volume for app"
 usage = "create <volumename>"

--- a/internal/command/volumes/create.go
+++ b/internal/command/volumes/create.go
@@ -21,7 +21,7 @@ import (
 func newCreate() *cobra.Command {
 	const (
 		long = `Create new volume for app. --region flag must be included to specify
-region the volume exists in. --size flag is optional, defaults to 10,
+region the volume exists in. --size flag is optional, defaults to 3,
 sets the size as the number of gigabytes the volume will consume.`
 
 		short = "Create new volume for app"


### PR DESCRIPTION
The docstring previously mentioned the default being 10 instead of 3,
which is in conflict with the flag's doc and the actual default.
