### PR TITLE
Ensure deployed tmp/pids directory is empty

### DIFF
--- a/scanner/templates/rails/standard/.dockerignore
+++ b/scanner/templates/rails/standard/.dockerignore
@@ -2,7 +2,7 @@ fly.toml
 
 .git
 tmp
-!tmp/pids
+!tmp/pids/.keep
 log
 public/assets
 public/packs


### PR DESCRIPTION
See: https://community.fly.io/t/cannot-deploy-a-rails-app-a-server-is-already-running-check-app-tmp-pids-server-pid/9489