### PR TITLE
[bug] Fix ability to add metadata when running a new machine

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -513,6 +513,10 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 		return machineConf, err
 	}
 
+	if machineConf.Metadata == nil {
+		machineConf.Metadata = make(map[string]string)
+	}
+
 	for k, v := range parsedMetadata {
 		machineConf.Metadata[k] = v
 	}


### PR DESCRIPTION
## What

`flyctl` had an error when attempting to run a machine while adding metadata via the `-m` flag.

## Details

Fly version `fly v0.0.441 darwin/amd64 Commit: 7a9ec7be BuildDate: 2022-12-16T19:24:02Z`

Running this resulted in an error, only when the `-m` flag (to add meta data) was used:

```bash
fly m run -a some-app -m "foo=bar" "ubuntu:20.04" "sleep" "1h"
```

> There was no error when creating a machine via API that had metadata

## Stacktrace

Here's the stack trace when `DEV=1` was used:

```
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/superfly/flyctl/internal/command/machine.determineMachineConfig({_, _}, {0x0, {{0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}, {0x0, ...}, ...}, ...}, ...)
        /Users/fideloper/Code/Fly/flyctl/internal/command/machine/run.go:521 +0x554
github.com/superfly/flyctl/internal/command/machine.runMachineRun({0x287b7e0, 0xc0010c31d0})
        /Users/fideloper/Code/Fly/flyctl/internal/command/machine/run.go:223 +0x5f6
github.com/superfly/flyctl/internal/command.newRunE.func1(0xc001080c80, {0xc0010aaaf0?, 0x7?, 0x7?})
        /Users/fideloper/Code/Fly/flyctl/internal/command/command.go:110 +0x17e
github.com/spf13/cobra.(*Command).execute(0xc001080c80, {0xc0010aaa80, 0x7, 0x7})
        /Users/fideloper/Sites/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0xc0010b2280)
        /Users/fideloper/Sites/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).ExecuteContextC(...)
        /Users/fideloper/Sites/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:911
github.com/superfly/flyctl/internal/cli.Run({0x287c458?, 0xc000fd1480?}, 0xc0006c2000, {0xc000000150, 0x9, 0x9})
        /Users/fideloper/Code/Fly/flyctl/internal/cli/cli.go:36 +0x21e
main.run()
        /Users/fideloper/Code/Fly/flyctl/main.go:45 +0x117
main.main()
        /Users/fideloper/Code/Fly/flyctl/main.go:26 +0x1e
```

## The Fix

We were attempting to add to an uninitialized `map[string]string`.

The simplest fix is to initialize the map if it's not yet initialized. **Does this fix miss more subtle issues?**

The [blame](https://github.com/superfly/flyctl/blame/master/internal/command/machine/run.go#L517) makes it look like perhaps this was part of a refactor ~1mo ago (which would make sense that this bug could remain this long, I'll bet metadata is little used when running machines via CLI)

```diff
+	if machineConf.Metadata == nil {
+		machineConf.Metadata = make(map[string]string)
+	}

	for k, v := range parsedMetadata {
		machineConf.Metadata[k] = v
	}
```

