### PR TITLE
Add:fly pg attachments command

### DIFF
--- a/api/resource_postgres.go
+++ b/api/resource_postgres.go
@@ -130,7 +130,7 @@ func (client *Client) ListPostgresDatabases(ctx context.Context, appName string)
 	return *data.AppPostgres.PostgresAppRole.Databases, nil
 }
 
-func (client *Client) ListPostgresClusterAttachments(ctx context.Context, appName, postgresAppName string) ([]*PostgresClusterAttachment, error) {
+func (client *Client) ListPostgresClusterAttachmentsForApp(ctx context.Context, appName, postgresAppName string) ([]*PostgresClusterAttachment, error) {
 	query := `
 		query($appName: String!, $postgresAppName: String!) {
 			postgresAttachments(appName: $appName, postgresAppName: $postgresAppName) {
@@ -146,6 +146,31 @@ func (client *Client) ListPostgresClusterAttachments(ctx context.Context, appNam
 
 	req := client.NewRequest(query)
 	req.Var("appName", appName)
+	req.Var("postgresAppName", postgresAppName)
+
+	data, err := client.RunWithContext(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.PostgresAttachments.Nodes, nil
+}
+
+func (client *Client) ListPostgresClusterAttachments(ctx context.Context, postgresAppName string) ([]*PostgresClusterAttachment, error) {
+	query := `
+		query($postgresAppName: String!) {
+			postgresAttachments(postgresAppName: $postgresAppName) {
+				nodes {
+					id
+					databaseName
+					databaseUser
+					environmentVariableName
+				}
+		  }
+		}
+		`
+
+	req := client.NewRequest(query)
 	req.Var("postgresAppName", postgresAppName)
 
 	data, err := client.RunWithContext(ctx, req)

--- a/internal/command/postgres/attachments.go
+++ b/internal/command/postgres/attachments.go
@@ -1,0 +1,102 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/app"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/render"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newAttachments() *cobra.Command {
+	const (
+		short = "manage database attachments to apps"
+		long  = short + "\n"
+		usage = "attachments [command]"
+	)
+
+	cmd := command.New(usage, short, long, nil)
+
+	cmd.AddCommand(
+		newAttachmentsList(),
+		newAttach(),
+		newDetach(),
+	)
+
+	return cmd
+}
+
+func newAttachmentsList() *cobra.Command {
+	const (
+		short = "list database attachments"
+		long  = short + "\n"
+		usage = "list"
+	)
+
+	cmd := command.New(usage, short, long, runAttachmentsList,
+		command.RequireSession,
+		command.RequireAppName,
+	)
+
+	cmd.Args = cobra.NoArgs
+
+	cmd.Aliases = []string{"ls"}
+
+	flag.Add(
+		cmd,
+		flag.App(),
+		flag.AppConfig(),
+	)
+
+	return cmd
+}
+
+func runAttachmentsList(ctx context.Context) (err error) {
+	var (
+		io      = iostreams.FromContext(ctx)
+		cfg     = config.FromContext(ctx)
+		client  = client.FromContext(ctx).API()
+		appName = app.NameFromContext(ctx)
+	)
+
+	app, err := client.GetAppCompact(ctx, appName)
+	if err != nil {
+		return
+	}
+
+	if !app.IsPostgresApp() {
+		return fmt.Errorf("app %s is not a postgres app", appName)
+	}
+
+	attachments, err := client.ListPostgresClusterAttachments(ctx, app.ID)
+	if err != nil {
+		return fmt.Errorf("list attachments: %w", err)
+	}
+
+	if cfg.JSONOutput {
+		return render.JSON(io.Out, attachments)
+	}
+
+	rows := [][]string{}
+
+	for _, a := range attachments {
+		rows = append(rows, []string{
+			a.ID,
+			a.DatabaseName,
+			a.DatabaseUser,
+			a.EnvironmentVariableName,
+		})
+	}
+
+	var title = fmt.Sprintf("Attachments for %s", appName)
+
+	render.Table(io.Out, title, rows, "ID", "Database Name", "Database User", "Environment Variable")
+
+	return
+}

--- a/internal/command/postgres/detach.go
+++ b/internal/command/postgres/detach.go
@@ -140,7 +140,7 @@ func detachAppFromPostgres(ctx context.Context, leaderIP string, app *api.AppCom
 		io     = iostreams.FromContext(ctx)
 	)
 
-	attachments, err := client.ListPostgresClusterAttachments(ctx, app.ID, pgApp.ID)
+	attachments, err := client.ListPostgresClusterAttachmentsForApp(ctx, pgApp.ID, app.ID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/postgres/postgres.go
+++ b/internal/command/postgres/postgres.go
@@ -34,6 +34,7 @@ func New() *cobra.Command {
 		newRestart(),
 		newUsers(),
 		newFailover(),
+		newAttachments(),
 	)
 
 	return cmd


### PR DESCRIPTION
* Consolidates the likes of attach and detach.
* Adds a new list attachments command.
* There old commands `fly pg attach` and `fly pg detach` are still there for now.
