### PR TITLE
Detect process name from app config when scaling

### DIFF
--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -115,7 +115,6 @@ func runScaleCount(cmdCtx *cmdctx.CmdContext) error {
 		count, err := strconv.Atoi(cmdCtx.Args[0])
 		if err == nil {
 			groups[defaultGroupName] = count
-			fmt.Println("Using default process group:", defaultGroupName)
 		}
 	}
 

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/cmdctx"
+	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/command"
 
 	"github.com/superfly/flyctl/api"
@@ -106,13 +107,15 @@ func runScaleCount(cmdCtx *cmdctx.CmdContext) error {
 		return fmt.Errorf("it looks like your app is running on v2 of our platform, and does not support this legacy command: try running fly machine clone instead")
 	}
 
+	defaultGroupName := getDefaultGroupName(cmdCtx.AppConfig)
 	groups := map[string]int{}
 
 	// single numeric arg: fly scale count 3
 	if len(cmdCtx.Args) == 1 {
 		count, err := strconv.Atoi(cmdCtx.Args[0])
 		if err == nil {
-			groups["app"] = count
+			groups[defaultGroupName] = count
+			fmt.Println("Using default process group:", defaultGroupName)
 		}
 	}
 
@@ -319,4 +322,24 @@ func formatMemory(size api.VMSize) string {
 		return fmt.Sprintf("%d MB", size.MemoryMB)
 	}
 	return fmt.Sprintf("%d GB", int(size.MemoryGB))
+}
+
+func getDefaultGroupName(cfg *flyctl.AppConfig) string {
+	name := "app"
+	if cfg == nil {
+		return name
+	}
+
+	procsDef, ok := cfg.Definition["processes"]
+	if !ok {
+		return name
+	}
+
+	if procs, ok := procsDef.(map[string]interface{}); ok && len(procs) == 1 {
+		for k := range procs {
+			return k
+		}
+	}
+
+	return name
 }


### PR DESCRIPTION
When running scaling command (`flyctl scale count 5`) i would get a cryptic error message like `Error Invalid VM group:`. While `flyctl scale web=5` works, it would be nice to automatically detect then process name from the config itself (if available), we would still default to `app`.

My config:

```
app = "..."
kill_signal = "SIGINT"
kill_timeout = 5

[processes]
web = "bundle exec ruby app.rb"

[[services]]
  http_checks = []
  internal_port = 8080
  processes = ["web"]
  protocol = "tcp"
  script_checks = []

# ...
```