### PR TITLE
Add `--no-tail` option to `logs`

### DIFF
--- a/logs/logs.go
+++ b/logs/logs.go
@@ -14,6 +14,7 @@ type LogOptions struct {
 	AppName    string
 	VMID       string
 	RegionCode string
+	NoTail     bool
 }
 
 func (opts *LogOptions) toNatsSubject() (subject string) {

--- a/logs/polling.go
+++ b/logs/polling.go
@@ -91,6 +91,10 @@ func Poll(ctx context.Context, out chan<- LogEntry, client *api.Client, opts *Lo
 				Meta:      entry.Meta,
 			}
 		}
+
+		if opts.NoTail {
+			return nil
+		}
 	}
 }
 


### PR DESCRIPTION
Hello,

I was trying to simply pipe some of my logs to some shell programs (`grep`, `cut`, `sort`, etc) and I wasn't interested in streaming live logs. I moved one of my applications over from `heroku` and I am used to having supply an argument to continue streaming the logs (`heroku logs --tail`).

Couldn't find anyone else asking for this which I found strange, so I decided to try to implement it. This seems to work great for me but please let me know if you want me to make any changes.
