### PR TITLE
ignore public/hot directory

### DIFF
--- a/scanner/templates/laravel/.dockerignore
+++ b/scanner/templates/laravel/.dockerignore
@@ -24,3 +24,4 @@ fly.toml
 **/*.log
 **/.DS_Store
 **/Thumbs.db
+public/hot


### PR DESCRIPTION
Thanks @KTanAug21 !

This ignores the `public/hot` directory when running docker builds to avoid errors when running in production on Fly. 

See https://community.fly.io/t/vite-websockets-error/10033/5 for details.
