### PR TITLE
Pg config fixes

### DIFF
--- a/flypg/pg.go
+++ b/flypg/pg.go
@@ -168,9 +168,9 @@ func (c *Client) Failover(ctx context.Context) error {
 	return nil
 }
 
-func (c *Client) ViewSettings(ctx context.Context, settings []string, flex bool) (*PGSettings, error) {
+func (c *Client) ViewSettings(ctx context.Context, settings []string, manager string) (*PGSettings, error) {
 	endpoint := "/commands/admin/settings/view"
-	if flex {
+	if manager == ReplicationManager {
 		endpoint = "/commands/admin/settings/view/postgres"
 	}
 
@@ -193,7 +193,8 @@ func (c *Client) UpdateSettings(ctx context.Context, settings map[string]string)
 	return nil
 }
 
-func (c *Client) ApplySettings(ctx context.Context) error {
+// SyncSettings is specific to the repmgr/flex implementation.
+func (c *Client) SyncSettings(ctx context.Context) error {
 	endpoint := "/commands/admin/settings/apply"
 
 	if err := c.Do(ctx, http.MethodPost, endpoint, nil, nil); err != nil {

--- a/internal/command/postgres/config_show.go
+++ b/internal/command/postgres/config_show.go
@@ -198,7 +198,7 @@ func showSettings(ctx context.Context, app *api.AppCompact, manager string, lead
 			value = fmt.Sprintf("%s -> %s", value, p)
 		}
 		rows = append(rows, []string{
-			strings.Replace(setting.Name, "_", "-", -1),
+			strings.ReplaceAll(setting.Name, "_", "-"),
 			value,
 			setting.Unit,
 			desc,

--- a/internal/command/postgres/config_show.go
+++ b/internal/command/postgres/config_show.go
@@ -103,7 +103,12 @@ func runMachineConfigShow(ctx context.Context, app *api.AppCompact) (err error) 
 		return err
 	}
 
-	return showSettings(ctx, app, leader.PrivateIP)
+	manager := flypg.StolonManager
+	if leader.ImageRef.Repository == "flyio/postgres-flex" {
+		manager = flypg.ReplicationManager
+	}
+
+	return showSettings(ctx, app, manager, leader.PrivateIP)
 }
 
 func runNomadConfigShow(ctx context.Context, app *api.AppCompact) (err error) {
@@ -135,10 +140,10 @@ func runNomadConfigShow(ctx context.Context, app *api.AppCompact) (err error) {
 		return err
 	}
 
-	return showSettings(ctx, app, leaderIP)
+	return showSettings(ctx, app, flypg.StolonManager, leaderIP)
 }
 
-func showSettings(ctx context.Context, app *api.AppCompact, leaderIP string) error {
+func showSettings(ctx context.Context, app *api.AppCompact, manager string, leaderIP string) error {
 	var (
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
@@ -152,12 +157,7 @@ func showSettings(ctx context.Context, app *api.AppCompact, leaderIP string) err
 		settings = append(settings, k)
 	}
 
-	_, flex := os.LookupEnv("FORCE_FLEX")
-	if app.ImageDetails.Repository == "flyio/postgres-flex" {
-		flex = true
-	}
-
-	res, err := pgclient.ViewSettings(ctx, settings, flex)
+	res, err := pgclient.ViewSettings(ctx, settings, manager)
 	if err != nil {
 		return err
 	}

--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -290,7 +290,7 @@ func resolveConfigChanges(ctx context.Context, app *api.AppCompact, manager stri
 				restartRequired = true
 			}
 
-			name := strings.Replace(change.Path[len(change.Path)-1], "_", "-", -1)
+			name := strings.ReplaceAll(change.Path[len(change.Path)-1], "_", "-")
 			rows = append(rows, []string{
 				name,
 				fmt.Sprint(change.From),

--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -112,7 +112,7 @@ func runMachineConfigUpdate(ctx context.Context, app *api.AppCompact) error {
 
 		MinPostgresHaVersion         = "0.0.33"
 		MinPostgresStandaloneVersion = "0.0.7"
-		MinPostgresFlexVersion       = "0.0.5"
+		MinPostgresFlexVersion       = "0.0.6"
 	)
 
 	machines, releaseLeaseFunc, err := mach.AcquireAllLeases(ctx)

--- a/internal/command/postgres/failover.go
+++ b/internal/command/postgres/failover.go
@@ -90,6 +90,10 @@ func runFailover(ctx context.Context) (err error) {
 		return err
 	}
 
+	if leader.ImageRef.Repository == "flyio/postgres-flex" {
+		return fmt.Errorf("the 'flyio/postgres-flex' image does not currently support manual failovers")
+	}
+
 	flapsClient := flaps.FromContext(ctx)
 	dialer := agent.DialerFromContext(ctx)
 


### PR DESCRIPTION
Notable changes:

* FORCE_FLEX and associated env vars are no longer required.
* Disabled the pg failover process for PG's running the postgres-flex image type.
* Configuration changes will now sync with each node in the cluster. 
* Refactored the pg config logic a bit.