### PR TITLE
Rails Dockerfile template: include `libvips` for Active Storage

### DIFF
--- a/scanner/templates/rails/standard/Dockerfile
+++ b/scanner/templates/rails/standard/Dockerfile
@@ -102,7 +102,7 @@ RUN npm install
 
 FROM base
 
-ARG DEPLOY_PACKAGES="postgresql-client file vim curl gzip libsqlite3-0"
+ARG DEPLOY_PACKAGES="postgresql-client file vim curl gzip libsqlite3-0 libvips"
 ENV DEPLOY_PACKAGES=${DEPLOY_PACKAGES}
 
 RUN --mount=type=cache,id=prod-apt-cache,sharing=locked,target=/var/cache/apt \


### PR DESCRIPTION
Rails [includes this](https://github.com/rails/rails/pull/46991/files#diff-a83245368df35c610a37260d0a51041de89211857d47cfd0b2d1301a11709164R527) if Active Storage is enabled. I don't know if there's a way fly can know that, but it seems better to assume it is and install the package since in most cases it will be (and advanced users can remove it from the Dockerfile).