### PR TITLE
`fly ssh console`: Only consider started machines as connection candidates.

### DIFF
--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -271,7 +271,7 @@ func addrForMachines(ctx context.Context, app *api.AppCompact, console bool) (ad
 	})
 
 	if len(machines) < 1 {
-		return "", fmt.Errorf("app %s has no started or stopped VMs", app.Name)
+		return "", fmt.Errorf("app %s has no started VMs", app.Name)
 	}
 
 	if err != nil {

--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/mattn/go-colorable"
 	"github.com/pkg/errors"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/agent"
@@ -264,6 +265,10 @@ func addrForMachines(ctx context.Context, app *api.AppCompact, console bool) (ad
 	if err != nil {
 		return "", err
 	}
+
+	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
+		return m.State == "started"
+	})
 
 	if len(machines) < 1 {
 		return "", fmt.Errorf("app %s has no started or stopped VMs", app.Name)


### PR DESCRIPTION
Maybe fixes #1221