### PR TITLE
Add a `--workdir`/`-w` option to set the working directory of `fly ssh console`.

### DIFF
--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -58,6 +58,12 @@ func stdArgsSSH(cmd *cobra.Command) {
 			Shorthand:   "A",
 			Description: "Address of VM to connect to",
 		},
+		flag.String{
+			Name:        "workdir",
+			Shorthand:   "w",
+			Default:     "",
+			Description: "working directory inside the SSH session",
+		},
 	)
 }
 
@@ -176,14 +182,15 @@ func runConsole(ctx context.Context) error {
 
 	// BUG(tqbf): many of these are no longer really params
 	params := &SSHParams{
-		Ctx:    ctx,
-		Org:    app.Organization,
-		Dialer: dialer,
-		App:    appName,
-		Cmd:    flag.GetString(ctx, "command"),
-		Stdin:  os.Stdin,
-		Stdout: ioutils.NewWriteCloserWrapper(colorable.NewColorableStdout(), func() error { return nil }),
-		Stderr: ioutils.NewWriteCloserWrapper(colorable.NewColorableStderr(), func() error { return nil }),
+		Ctx:     ctx,
+		Org:     app.Organization,
+		Dialer:  dialer,
+		App:     appName,
+		Cmd:     flag.GetString(ctx, "command"),
+		Workdir: flag.GetString(ctx, "workdir"),
+		Stdin:   os.Stdin,
+		Stdout:  ioutils.NewWriteCloserWrapper(colorable.NewColorableStdout(), func() error { return nil }),
+		Stderr:  ioutils.NewWriteCloserWrapper(colorable.NewColorableStderr(), func() error { return nil }),
 	}
 
 	if quiet(ctx) {
@@ -203,7 +210,7 @@ func runConsole(ctx context.Context) error {
 		Mode:   "xterm",
 	}
 
-	if err := sshc.Shell(params.Ctx, term, params.Cmd); err != nil {
+	if err := sshc.Shell(params.Ctx, term, params.Cmd, params.Workdir); err != nil {
 		captureError(err, app)
 		return errors.Wrap(err, "ssh shell")
 	}

--- a/internal/command/ssh/ssh_terminal.go
+++ b/internal/command/ssh/ssh_terminal.go
@@ -56,6 +56,7 @@ type SSHParams struct {
 	App            string
 	Dialer         agent.Dialer
 	Cmd            string
+	Workdir        string
 	Stdin          io.Reader
 	Stdout         io.WriteCloser
 	Stderr         io.WriteCloser
@@ -139,7 +140,7 @@ func SSHConnect(p *SSHParams, addr string) error {
 		Mode:   "xterm",
 	}
 
-	if err := sshClient.Shell(context.Background(), term, p.Cmd); err != nil {
+	if err := sshClient.Shell(context.Background(), term, p.Cmd, ""); err != nil {
 		return errors.Wrap(err, "ssh shell")
 	}
 

--- a/ssh/client.go
+++ b/ssh/client.go
@@ -103,7 +103,7 @@ func (c *Client) Connect(ctx context.Context) error {
 	}
 }
 
-func (c *Client) Shell(ctx context.Context, term *Terminal, cmd string) error {
+func (c *Client) Shell(ctx context.Context, term *Terminal, cmd string, workdir string) error {
 	if c.Client == nil {
 		if err := c.Connect(ctx); err != nil {
 			return err
@@ -116,5 +116,5 @@ func (c *Client) Shell(ctx context.Context, term *Terminal, cmd string) error {
 	}
 	defer sess.Close()
 
-	return term.attach(ctx, sess, cmd)
+	return term.attach(ctx, sess, cmd, workdir)
 }


### PR DESCRIPTION
Unfortunately this prints the initial `cd` command and output to stdout/stderr when launching the session. Go's SSH client (or more probably SSH itself) has no way to start a command in a given working directory. Better solutions welcome.

Partially fixes #1220
