### PR TITLE
Add `--env` flag for passing environment variables to `fly ssh console`.

### DIFF
--- a/internal/command/ssh/ssh_terminal.go
+++ b/internal/command/ssh/ssh_terminal.go
@@ -56,6 +56,7 @@ type SSHParams struct {
 	App            string
 	Dialer         agent.Dialer
 	Cmd            string
+	Env            map[string]string
 	Stdin          io.Reader
 	Stdout         io.WriteCloser
 	Stderr         io.WriteCloser
@@ -139,7 +140,7 @@ func SSHConnect(p *SSHParams, addr string) error {
 		Mode:   "xterm",
 	}
 
-	if err := sshClient.Shell(context.Background(), term, p.Cmd); err != nil {
+	if err := sshClient.Shell(context.Background(), term, p.Cmd, p.Env); err != nil {
 		return errors.Wrap(err, "ssh shell")
 	}
 

--- a/ssh/client.go
+++ b/ssh/client.go
@@ -103,7 +103,7 @@ func (c *Client) Connect(ctx context.Context) error {
 	}
 }
 
-func (c *Client) Shell(ctx context.Context, term *Terminal, cmd string) error {
+func (c *Client) Shell(ctx context.Context, term *Terminal, cmd string, env map[string]string) error {
 	if c.Client == nil {
 		if err := c.Connect(ctx); err != nil {
 			return err
@@ -115,6 +115,13 @@ func (c *Client) Shell(ctx context.Context, term *Terminal, cmd string) error {
 		return err
 	}
 	defer sess.Close()
+
+	for key, val := range env {
+		err := sess.Setenv(key, val)
+		if err != nil {
+			return err
+		}
+	}
 
 	return term.attach(ctx, sess, cmd)
 }


### PR DESCRIPTION
Note that this currently doesn't work due to requiring `AcceptEnv` whitelisting environments on the server connection. I don't feel confident weighing in on whether or not this is the best solution, but since the user already has root on their VM, I don't know whether whitelisting all environment variables and allowing them to be set from the command line is a usability win or a security loss.

This at least addresses the use case in #1442, whether it's the best solution I don't know.