### PR TITLE
avoids infinite loop when using directory as rootname in ssh issue

### DIFF
--- a/internal/command/ssh/issue.go
+++ b/internal/command/ssh/issue.go
@@ -197,6 +197,7 @@ func runSSHIssue(ctx context.Context) (err error) {
 		pf, err = os.OpenFile(rootname, mode, 0o600)
 		if err != nil {
 			fmt.Fprintf(out, "Can't open private key file: %s\n", err)
+			rootname = ""
 			continue
 		}
 


### PR DESCRIPTION
Hi team. 

I run into an issue when running: `flyctl ssh issue`. If you provide a directory as a path you enter in an infinite loop. By setting `rootname` back to the empty string we break the infinite loop and let the user enter another file. 

Probably you have a better approach, let me know and I will update the PR. 