### PR TITLE
Allow configuring service concurrency at launch time for nomad apps

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -466,6 +466,29 @@ func (c *Config) SetInternalPort(port int) bool {
 	return false
 }
 
+func (c *Config) SetConcurrency(soft int, hard int) bool {
+	services, ok := c.Definition["services"].([]interface{})
+	if !ok {
+		return false
+	}
+
+	if len(services) == 0 {
+		return false
+	}
+
+	if service, ok := services[0].(map[string]interface{}); ok {
+
+		if concurrency, ok := service["concurrency"].(map[string]interface{}); ok {
+			concurrency["hard_limit"] = hard
+			concurrency["soft_limit"] = soft
+			return true
+
+		}
+	}
+
+	return false
+}
+
 func (c *Config) InternalPort() (int, error) {
 	tmpservices, ok := c.Definition["services"]
 	if !ok {

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -297,8 +297,13 @@ func run(ctx context.Context) (err error) {
 	appConfig.AppName = createdApp.Name
 
 	if srcInfo != nil {
+
 		if srcInfo.Port > 0 {
 			appConfig.SetInternalPort(srcInfo.Port)
+		}
+
+		if srcInfo.Concurrency != nil {
+			appConfig.SetConcurrency(srcInfo.Concurrency["soft_limit"], srcInfo.Concurrency["hard_limit"])
 		}
 
 		for envName, envVal := range srcInfo.Env {

--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -16,6 +16,10 @@ func configurePhoenix(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 
 	s := &SourceInfo{
 		Family: "Phoenix",
+		Concurrency: map[string]int{
+			"soft_limit": 1000,
+			"hard_limit": 1000,
+		},
 		Secrets: []Secret{
 			{
 				Key:  "SECRET_KEY_BASE",

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -53,6 +53,7 @@ type SourceInfo struct {
 	InitCommands                 []InitCommand
 	PostgresInitCommands         []InitCommand
 	PostgresInitCommandCondition bool
+	Concurrency                  map[string]int
 }
 
 type SourceFile struct {


### PR DESCRIPTION
This PR also sets the default concurrency for Elixir apps to 1000.