### PR TITLE
If a machine won't start, don't hang forever when attempting an update.

### DIFF
--- a/internal/machine/wait.go
+++ b/internal/machine/wait.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jpillora/backoff"
@@ -40,6 +41,8 @@ func WaitForStartOrStop(ctx context.Context, machine *api.Machine, action string
 			return err
 		case errors.Is(err, context.DeadlineExceeded):
 			return fmt.Errorf("timeout reached waiting for machine to %s %w", waitOnAction, err)
+		case strings.Contains(err.Error(), "currently stopped"):
+			return err
 		case err != nil:
 			time.Sleep(b.Duration())
 			continue


### PR DESCRIPTION
To reproduce:

1. Check out https://github.com/fly-apps/hello-rust.
2. Launch with `fly m run . -p 443:8080/tcp:tls:http -p 80:8080/tcp:http -a mytestapp`.
3. Note that, I suspect since we haven't specified a command, the machine fails to start.
4. Run something like `fly m update ... -e FOO=BAR` to force an update that doesn't actually fix the problem.

For me, this command hangs indefinitely.

New to Go and I don't know if there's a better way of matching against bespoke errors like this. Maybe matching against HTTP 409 is better, but I don't know enough about the backend API to know if this is returned anywhere else. It also appears that flaps\flaps.go returns a string here anyway. Please let me know if there should be a better/different fix for this.

Thanks.