### PR TITLE
Run hook if image has the proper label

### DIFF
--- a/internal/command/machine/lifecycle_hooks.go
+++ b/internal/command/machine/lifecycle_hooks.go
@@ -5,17 +5,18 @@ import (
 	"fmt"
 
 	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/command/postgres"
 	"github.com/superfly/flyctl/iostreams"
 )
 
 func runOnDeletionHook(ctx context.Context, app *api.AppCompact, machine *api.Machine) {
-	io := iostreams.FromContext(ctx)
+	var (
+		io     = iostreams.FromContext(ctx)
+		labels = machine.ImageRef.Labels
+	)
 
-	image := machine.ImageRef.Repository
-
-	switch image {
-	case "flyio/postgres-flex":
+	if labels["fly.pg-manager"] == flypg.ReplicationManager {
 		fmt.Fprintf(io.Out, "unregistering postgres member '%s' from the cluster... ", machine.PrivateIP)
 		if err := postgres.UnregisterMember(ctx, app, machine); err != nil {
 			fmt.Fprintln(io.Out, "(failed)")


### PR DESCRIPTION
As long as the docker image contains the proper label, run the on-deletion hook.  This will make testing easier. 