### PR TITLE
`launch` and `deploy`: support both `docker` and `podman` when do local image build

### DIFF
--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	pack "github.com/buildpacks/pack/pkg/client"
+	packclient "github.com/buildpacks/pack/pkg/client"
 	projectTypes "github.com/buildpacks/pack/pkg/project/types"
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/internal/cmdfmt"
@@ -55,7 +55,7 @@ func (*buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 	defer docker.Close() // skipcq: GO-S2307
 	defer clearDeploymentTags(ctx, docker, opts.Tag)
 
-	packClient, err := pack.NewClient(pack.WithDockerClient(docker), pack.WithLogger(newPackLogger(streams.Out)))
+	packClient, err := packclient.NewClient(packclient.WithDockerClient(docker), packclient.WithLogger(newPackLogger(streams.Out)))
 	if err != nil {
 		build.BuilderInitFinish()
 		build.BuildFinish()
@@ -84,11 +84,12 @@ func (*buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 	}
 	build.ContextBuildFinish()
 
-	err = packClient.Build(ctx, pack.BuildOptions{
+	err = packClient.Build(ctx, packclient.BuildOptions{
 		AppPath:        opts.WorkingDir,
 		Builder:        builder,
 		ClearCache:     opts.NoCache,
 		Image:          newCacheTag(opts.AppName),
+		DockerHost:     opts.BuildpacksDockerHost,
 		Buildpacks:     buildpacks,
 		Env:            normalizeBuildArgs(opts.BuildArgs),
 		TrustBuilder:   returnTrue,

--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -75,6 +75,10 @@ func (*buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 	msg := fmt.Sprintf("docker host: %s %s %s", serverInfo.ServerVersion, serverInfo.OSType, serverInfo.Architecture)
 	cmdfmt.PrintDone(streams.ErrOut, msg)
 
+	if opts.BuildpacksDockerHost != "" {
+		cmdfmt.PrintDone(streams.ErrOut, fmt.Sprintf("buildpacks docker host: %v", opts.BuildpacksDockerHost))
+	}
+
 	build.ContextBuildStart()
 	excludes, err := readDockerignore(opts.WorkingDir, opts.IgnorefilePath, "")
 	if err != nil {

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -44,6 +44,7 @@ type ImageOptions struct {
 	Builder         string
 	Buildpacks      []string
 	Label           map[string]string
+	BuildpacksDockerHost string
 }
 
 type RefOptions struct {

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -26,24 +26,24 @@ import (
 )
 
 type ImageOptions struct {
-	AppName         string
-	WorkingDir      string
-	DockerfilePath  string
-	IgnorefilePath  string
-	ImageRef        string
-	BuildArgs       map[string]string
-	ExtraBuildArgs  map[string]string
-	BuildSecrets    map[string]string
-	ImageLabel      string
-	Publish         bool
-	Tag             string
-	Target          string
-	NoCache         bool
-	BuiltIn         string
-	BuiltInSettings map[string]interface{}
-	Builder         string
-	Buildpacks      []string
-	Label           map[string]string
+	AppName              string
+	WorkingDir           string
+	DockerfilePath       string
+	IgnorefilePath       string
+	ImageRef             string
+	BuildArgs            map[string]string
+	ExtraBuildArgs       map[string]string
+	BuildSecrets         map[string]string
+	ImageLabel           string
+	Publish              bool
+	Tag                  string
+	Target               string
+	NoCache              bool
+	BuiltIn              string
+	BuiltInSettings      map[string]interface{}
+	Builder              string
+	Buildpacks           []string
+	Label                map[string]string
 	BuildpacksDockerHost string
 }
 

--- a/internal/command/command_run.go
+++ b/internal/command/command_run.go
@@ -42,12 +42,13 @@ func DetermineImage(ctx context.Context, appName string, imageOrPath string) (im
 	// build if relative or absolute path
 	if strings.HasPrefix(imageOrPath, ".") || strings.HasPrefix(imageOrPath, "/") {
 		opts := imgsrc.ImageOptions{
-			AppName:    appName,
-			WorkingDir: path.Join(state.WorkingDirectory(ctx)),
-			Publish:    !flag.GetBuildOnly(ctx),
-			ImageLabel: flag.GetString(ctx, "image-label"),
-			Target:     flag.GetString(ctx, "build-target"),
-			NoCache:    flag.GetBool(ctx, "no-build-cache"),
+			AppName:              appName,
+			WorkingDir:           path.Join(state.WorkingDirectory(ctx)),
+			Publish:              !flag.GetBuildOnly(ctx),
+			ImageLabel:           flag.GetString(ctx, "image-label"),
+			Target:               flag.GetString(ctx, "build-target"),
+			NoCache:              flag.GetBool(ctx, "no-build-cache"),
+			BuildpacksDockerHost: flag.GetString(ctx, "buildpacks-docker-host"),
 		}
 
 		dockerfilePath := cfg.Dockerfile()

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -48,6 +48,7 @@ var CommonFlags = flag.Set{
 	flag.NoCache(),
 	flag.Nixpacks(),
 	flag.BuildOnly(),
+	flag.BpDockerHost(),
 	flag.Bool{
 		Name:        "provision-extensions",
 		Description: "Provision any extensions assigned as a default to first deployments",

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -86,15 +86,16 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgs
 
 	// We're building from source
 	opts := imgsrc.ImageOptions{
-		AppName:         appConfig.AppName,
-		WorkingDir:      state.WorkingDirectory(ctx),
-		Publish:         flag.GetBool(ctx, "push") || !flag.GetBuildOnly(ctx),
-		ImageLabel:      flag.GetString(ctx, "image-label"),
-		NoCache:         flag.GetBool(ctx, "no-cache"),
-		BuiltIn:         build.Builtin,
-		BuiltInSettings: build.Settings,
-		Builder:         build.Builder,
-		Buildpacks:      build.Buildpacks,
+		AppName:              appConfig.AppName,
+		WorkingDir:           state.WorkingDirectory(ctx),
+		Publish:              flag.GetBool(ctx, "push") || !flag.GetBuildOnly(ctx),
+		ImageLabel:           flag.GetString(ctx, "image-label"),
+		NoCache:              flag.GetBool(ctx, "no-cache"),
+		BuiltIn:              build.Builtin,
+		BuiltInSettings:      build.Settings,
+		Builder:              build.Builder,
+		Buildpacks:           build.Buildpacks,
+		BuildpacksDockerHost: flag.GetString(ctx, "buildpacks-docker-host"),
 	}
 
 	// flyctl supports key=value form while Docker supports id=key,src=/path/to/secret form.

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -530,7 +530,6 @@ func JSONOutput() Bool {
 }
 
 func ProcessGroup(desc string) String {
-
 	if desc == "" {
 		desc = "The target process group"
 	}
@@ -540,5 +539,19 @@ func ProcessGroup(desc string) String {
 		Description: desc,
 		Shorthand:   "g",
 		Aliases:     []string{"group"},
+	}
+}
+
+// BuildpacksDockerHost address to docker daemon that will be exposed to the buildpacks build container
+const buildpacksDockerHost = "buildpacks-docker-host"
+
+func BpDockerHost() String {
+	return String{
+		Name: buildpacksDockerHost,
+		Description: `Address to docker daemon that will be exposed to the build container.
+If not set (or set to empty string) the standard socket location will be used.
+Special value 'inherit' may be used in which case DOCKER_HOST environment variable will be used.
+This option may set DOCKER_HOST environment variable for the build container if needed.
+`,
 	}
 }


### PR DESCRIPTION
implement as upstream: https://github.com/buildpacks/pack/pull/988

add `--buildpacks-docker-host` flag

this will allow using local build with tools other than docker, like `podman`, we need to add this flag because https://buildpacks.io/docs/app-developer-guide/building-on-podman/#pack-build  
with this PR, flyctl build image will just works like buildpacks:

```shell
fly deploy --local-only --buildpacks-docker-host=inherit
```

-------------------------------------------------

we need some env setup (only once for a local machine) for this to work (for detailed document, please see https://buildpacks.io/docs/app-developer-guide/building-on-podman/ ):

```shell
# enable podman user socket
systemctl enable --user podman.socket
systemctl start --user podman.socket

# add below to .zshrc or .bashrc
export DOCKER_HOST="unix://$(podman info -f "{{.Host.RemoteSocket.Path}}")"
```
