### PR TITLE
Unmarshal user information into viewer field

### DIFF
--- a/api/resource_user.go
+++ b/api/resource_user.go
@@ -1,6 +1,8 @@
 package api
 
-import "context"
+import (
+	"context"
+)
 
 func (c *Client) GetCurrentUser(ctx context.Context) (*User, error) {
 	query := `
@@ -18,5 +20,5 @@ func (c *Client) GetCurrentUser(ctx context.Context) (*User, error) {
 		return nil, err
 	}
 
-	return &data.CurrentUser, nil
+	return &data.Viewer, nil
 }

--- a/api/types.go
+++ b/api/types.go
@@ -21,7 +21,7 @@ type Query struct {
 	AppMonitoring        AppMonitoring
 	AppPostgres          AppPostgres
 	AppCertsCompact      AppCertsCompact
-	CurrentUser          User
+	Viewer               User
 	PersonalOrganization Organization
 	GqlMachine           GqlMachine
 	Organizations        struct {


### PR DESCRIPTION
This fixes https://github.com/superfly/flyctl/issues/1649 and other procedure that relies on information returned by `GetCurrentUser`. 