### PR TITLE
Fix crash when running `help` subcommand

### DIFF
--- a/internal/command/help/help.go
+++ b/internal/command/help/help.go
@@ -110,7 +110,7 @@ Networking configuration:
 		fmt.Printf(`
 Monitoring and managing things:
 `)
-		listCommands([]string{"logs", "list", "status", "dashboard", "dig", "ping", "ssh", "sftp"})
+		listCommands([]string{"logs", "status", "dashboard", "dig", "ping", "ssh", "sftp"})
 
 		fmt.Printf(`
 Access control:


### PR DESCRIPTION
When the `list` subcommand was removed in 6b6719ddf106096f023eaba215d332b1f7bb0051, this introduced a crash that would occur whenever the program tried to reference information on `list`, which would occur whenever the user runs the help subcommand. The fix was just to stop trying to generate the help information for it.