### PR TITLE
Machine API now launches when an existing dev agent is running

### DIFF
--- a/agent/start.go
+++ b/agent/start.go
@@ -41,7 +41,7 @@ func StartDaemon(ctx context.Context) (*Client, error) {
 
 	env := os.Environ()
 
-	env = append(env, fmt.Sprintf("DEV_VERSION_NUM=%d", versionNum))
+	env = append(env, fmt.Sprintf("FLY_DEV_VERSION_NUM=%d", versionNum))
 	env = append(env, "FLY_NO_UPDATE_CHECK=1")
 
 	cmd.Env = env

--- a/agent/start.go
+++ b/agent/start.go
@@ -13,6 +13,7 @@ import (
 	"github.com/azazeal/pause"
 
 	"github.com/superfly/flyctl/flyctl"
+	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/filemu"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/sentry"
@@ -35,7 +36,15 @@ func StartDaemon(ctx context.Context) (*Client, error) {
 	}
 
 	cmd := exec.Command(os.Args[0], "agent", "run", logFile)
-	cmd.Env = append(os.Environ(), "FLY_NO_UPDATE_CHECK=1")
+
+	versionNum := buildinfo.Version().Pre[0].VersionNum
+
+	env := os.Environ()
+
+	env = append(env, fmt.Sprintf("DEV_VERSION_NUM=%d", versionNum))
+	env = append(env, "FLY_NO_UPDATE_CHECK=1")
+
+	cmd.Env = env
 	setSysProcAttributes(cmd)
 
 	if err := cmd.Start(); err != nil {

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -37,7 +37,7 @@ func loadMeta() {
 	}
 
 	if IsDev() {
-		envVersionNum := os.Getenv("DEV_VERSION_NUM")
+		envVersionNum := os.Getenv("FLY_DEV_VERSION_NUM")
 		versionNum := uint64(parsedBuildDate.Unix())
 
 		if envVersionNum != "" {

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -2,6 +2,8 @@ package buildinfo
 
 import (
 	"errors"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/blang/semver"
@@ -35,10 +37,22 @@ func loadMeta() {
 	}
 
 	if IsDev() {
+		envVersionNum := os.Getenv("DEV_VERSION_NUM")
+		versionNum := uint64(parsedBuildDate.Unix())
+
+		if envVersionNum != "" {
+			num, err := strconv.ParseUint(envVersionNum, 10, 64)
+
+			if err == nil {
+				versionNum = num
+			}
+
+		}
+
 		parsedVersion = semver.Version{
 			Pre: []semver.PRVersion{
 				{
-					VersionNum: uint64(parsedBuildDate.Unix()),
+					VersionNum: versionNum,
 					IsNum:      true,
 				},
 			},


### PR DESCRIPTION
This is catalogued a lot more here:
https://flyio.discourse.team/t/launching-proxy-fails-on-dev-version/1802/2

Basically, this fixes a weird version number bug when a daemon fails to launch and tries again. Pretty obscure, but it was preventing me from testing the machines api.