### PR TITLE
Add Poetry detection to the Python scanner

### DIFF
--- a/scanner/python.go
+++ b/scanner/python.go
@@ -1,7 +1,7 @@
 package scanner
 
 func configurePython(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
-	if !checksPass(sourceDir, fileExists("requirements.txt", "environment.yml")) {
+	if !checksPass(sourceDir, fileExists("requirements.txt", "environment.yml", "poetry.lock")) {
 		return nil, nil
 	}
 

--- a/scanner/python.go
+++ b/scanner/python.go
@@ -1,7 +1,8 @@
 package scanner
 
 func configurePython(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
-	if !checksPass(sourceDir, fileExists("requirements.txt", "environment.yml", "poetry.lock")) {
+	// using 'poetry.lock' as an indicator instead of 'pyproject.toml', as Paketo doesn't support PEP-517 implementations
+	if !checksPass(sourceDir, fileExists("requirements.txt", "environment.yml", "poetry.lock", "Pipfile")) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Support detecting a Poetry environment.
Saves users needing to run `poetry export` if they're just looking to spin up a python project quickly

Using `poetry.lock` as an indicator, Paketo doesn't support other dependency managers. This prevents using the builder for cases it won't work with.

note: Paketo detects based on `pyproject.toml` having `tool.poetry.dependencies.python` set
