### PR TITLE
Fix shell selection logic for `fly version update` under Windows.

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -151,8 +151,13 @@ func UpgradeInPlace(ctx context.Context, io *iostreams.IOStreams, prelease bool)
 		}
 	}
 
-	shellToUse, ok := os.LookupEnv("SHELL")
+	var shellToUse string
 	switchToUse := "-c"
+	ok := false
+
+	if runtime.GOOS != "windows" {
+		shellToUse, ok = os.LookupEnv("SHELL")
+	}
 
 	if !ok {
 		if runtime.GOOS == "windows" {


### PR DESCRIPTION
Previously, this checked the $SHELL environment variable and used that
if set. Unfortunately, the Windows update logic is powershell-specific,
while all other platforms use bash.

If someone is running git-bash as their shell under Windows, the script
picks up bash from $SHELL, then happily sends it powershell commands
that fail, after renaming the existing executable and DLL first, thus
trashing the existing installation.
