### PR TITLE
Fix inconsistency between optional/required arguments to commands, enforce argument requirements

### DIFF
--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -20,7 +20,7 @@ func newDestroy() *cobra.Command {
 from the Fly platform.
 `
 		short = "Permanently destroys an app"
-		usage = "destroy [APPNAME]"
+		usage = "destroy <APPNAME>"
 	)
 
 	destroy := command.New(usage, short, long, RunDestroy,

--- a/internal/command/apps/move.go
+++ b/internal/command/apps/move.go
@@ -22,7 +22,7 @@ func newMove() *cobra.Command {
 organization the current user belongs to.
 `
 		short = "Move an app to another organization"
-		usage = "move [APPNAME]"
+		usage = "move <APPNAME>"
 	)
 
 	move := command.New(usage, short, long, RunMove,

--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -18,7 +18,7 @@ func newRestart() *cobra.Command {
 	const (
 		long  = `The APPS RESTART command will perform a rolling restart against all running VMs`
 		short = "Restart an application"
-		usage = "restart [APPNAME]"
+		usage = "restart <APPNAME>"
 	)
 
 	cmd := command.New(usage, short, long, runRestart,

--- a/internal/command/apps/resume.go
+++ b/internal/command/apps/resume.go
@@ -25,7 +25,7 @@ meaning there will be one running instance once restarted. Use SCALE SET MIN= to
 the number of configured instances.
 `
 		short = "Resume an application"
-		usage = "resume [APPNAME]"
+		usage = "resume <APPNAME>"
 	)
 
 	resume := command.New(usage, short, long, RunResume,

--- a/internal/command/destroy/destroy.go
+++ b/internal/command/destroy/destroy.go
@@ -15,7 +15,7 @@ func New() *cobra.Command {
 from the Fly platform.
 `
 		short = "Permanently destroys an app"
-		usage = "destroy [APPNAME]"
+		usage = "destroy <APPNAME>"
 	)
 
 	destroy := command.New(usage, short, long, apps.RunDestroy,

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -31,7 +31,7 @@ func newClone() *cobra.Command {
 		command.LoadAppNameIfPresent,
 	)
 
-	cmd.Args = cobra.MaximumNArgs(1)
+	cmd.Args = cobra.ExactArgs(1)
 
 	flag.Add(
 		cmd,

--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -41,7 +41,7 @@ func newDestroy() *cobra.Command {
 		},
 	)
 
-	cmd.Args = cobra.MinimumNArgs(1)
+	cmd.Args = cobra.ExactArgs(1)
 
 	return cmd
 }

--- a/internal/command/machine/exec.go
+++ b/internal/command/machine/exec.go
@@ -38,6 +38,8 @@ func newMachineExec() *cobra.Command {
 		},
 	)
 
+	cmd.Args = cobra.ExactArgs(2)
+
 	return cmd
 }
 

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -23,7 +23,7 @@ func newUpdate() *cobra.Command {
 		short = "Update a machine"
 		long  = short + "\n"
 
-		usage = "update [machine_id]"
+		usage = "update <machine_id>"
 	)
 
 	cmd := command.New(usage, short, long, runUpdate,

--- a/internal/command/move/move.go
+++ b/internal/command/move/move.go
@@ -15,7 +15,7 @@ func New() *cobra.Command {
 organization the current user belongs to.
 `
 		short = "Move an app to another organization"
-		usage = "move [APPNAME]"
+		usage = "move <APPNAME>"
 	)
 
 	move := command.New(usage, short, long, apps.RunMove,

--- a/internal/command/postgres/attach.go
+++ b/internal/command/postgres/attach.go
@@ -35,7 +35,7 @@ func newAttach() *cobra.Command {
 	const (
 		short = "Attach a postgres cluster to an app"
 		long  = short + "\n"
-		usage = "attach [POSTGRES APP]"
+		usage = "attach <POSTGRES APP>"
 	)
 
 	cmd := command.New(usage, short, long, runAttach,

--- a/internal/command/postgres/detach.go
+++ b/internal/command/postgres/detach.go
@@ -22,7 +22,7 @@ func newDetach() *cobra.Command {
 	const (
 		short = "Detach a postgres cluster from an app"
 		long  = short + "\n"
-		usage = "detach [POSTGRES APP]"
+		usage = "detach <POSTGRES APP>"
 	)
 
 	cmd := command.New(usage, short, long, runDetach,

--- a/internal/command/resume/resume.go
+++ b/internal/command/resume/resume.go
@@ -16,7 +16,7 @@ meaning there will be one running instance once restarted. Use SCALE SET MIN= to
 the number of configured instances.
 `
 		short = "Resume an application"
-		usage = "resume [APPNAME]"
+		usage = "resume <APPNAME>"
 	)
 
 	resume := command.New(usage, short, long, apps.RunResume,

--- a/internal/command/turboku/turboku.go
+++ b/internal/command/turboku/turboku.go
@@ -48,7 +48,7 @@ func New() (cmd *cobra.Command) {
 			Description: "the name of the new app",
 		},
 	)
-	cmd.Args = cobra.MinimumNArgs(2)
+	cmd.Args = cobra.ExactArgs(2)
 	return cmd
 }
 


### PR DESCRIPTION
This does two things, separated into the two commits:

1. Canonicalize `[FOO]` as optional, and `<FOO>` as required in usage info.
   This would close #1663, and is a cosmetic change.
2. Make better use of `cobra.ExactArgs` where it seems useful.