### PR TITLE
fly machine restart: inherit app from first machine, require all machines to share app

### DIFF
--- a/internal/command/machine/restart.go
+++ b/internal/command/machine/restart.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
-	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/app"
 	"github.com/superfly/flyctl/internal/command"
@@ -67,25 +67,11 @@ func runMachineRestart(ctx context.Context) error {
 		signal  = flag.GetString(ctx, "signal")
 		timeout = flag.GetInt(ctx, "time")
 		appName = app.NameFromContext(ctx)
-		client  = client.FromContext(ctx).API()
 	)
 
 	app, err := appFromMachineOrName(ctx, args[0], appName)
 	if err != nil {
 		return fmt.Errorf("could not get app: %w", err)
-	}
-
-	// Ensure that all machines are on the same app
-	for _, machineID := range args {
-
-		machine, err := client.GetMachine(ctx, machineID)
-		if err != nil {
-			return err
-		}
-
-		if machine.App.Name != app.Name {
-			return fmt.Errorf("all machines must belong to the same app")
-		}
 	}
 
 	ctx, err = apps.BuildContext(ctx, app)
@@ -118,7 +104,11 @@ func runMachineRestart(ctx context.Context) error {
 	for _, machineID := range args {
 		machine, err := flapsClient.Get(ctx, machineID)
 		if err != nil {
-			return fmt.Errorf("could not get machine %s: %w", machineID, err)
+			if strings.Contains(err.Error(), "machine not found") {
+				return fmt.Errorf("could not get machine %s. perhaps this machine doesn't exist, or isn't part of the app '%s'", machineID, app.Name)
+			} else {
+				return fmt.Errorf("could not get machine %s: %w", machineID, err)
+			}
 		}
 		machines = append(machines, machine)
 	}


### PR DESCRIPTION
This brings behavior in line with other machine commands, like `m start`

(would fix #1703)