### PR TITLE
Add Winget Releaser workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,3 +234,14 @@ jobs:
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: ${{ github.event.ref }}
           force_push: "true"
+  winget-publish:
+    name: Publish to Winget
+    needs: release
+    if: ${{ !contains(github.ref, 'pre') }}
+    runs-on: windows-latest # Action can only be run on windows
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: Fly-io.flyctl
+          installers-regex: '_Windows_\w+\.zip$'
+          token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}


### PR DESCRIPTION
- Resolves https://github.com/superfly/flyctl/issues/1625

[This action](https://github.com/vedantmgoyal2009/winget-releaser) automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

**Before merging this:**
1. Ensure `GORELEASER_GITHUB_TOKEN` has the `public_repo` scope.

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @superfly. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

You can test out the action inputs in this [playground](https://bittu.eu.org/docs/wr-playground).

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been automatically created using WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+automatically+created+using+%F0%9F%9B%AB+WinGet+Releaser).