### PR TITLE
Fix [experimental] toml parsing and some other bugs

### DIFF
--- a/internal/appv2/config.go
+++ b/internal/appv2/config.go
@@ -3,6 +3,7 @@
 package appv2
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/superfly/flyctl/api"
@@ -77,12 +78,37 @@ type Build struct {
 }
 
 type Experimental struct {
-	Cmd          []string `toml:"cmd,omitempty" json:"cmd,omitempty"`
-	Entrypoint   []string `toml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
-	Exec         []string `toml:"exec,omitempty" json:"exec,omitempty"`
-	AutoRollback bool     `toml:"auto_rollback,omitempty" json:"auto_rollback,omitempty"`
-	EnableConsul bool     `toml:"enable_consul,omitempty" json:"enable_consul,omitempty"`
-	EnableEtcd   bool     `toml:"enable_etcd,omitempty" json:"enable_etcd,omitempty"`
+	Cmd          any  `toml:"cmd,omitempty" json:"cmd,omitempty"`
+	Entrypoint   any  `toml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
+	Exec         any  `toml:"exec,omitempty" json:"exec,omitempty"`
+	AutoRollback bool `toml:"auto_rollback,omitempty" json:"auto_rollback,omitempty"`
+	EnableConsul bool `toml:"enable_consul,omitempty" json:"enable_consul,omitempty"`
+	EnableEtcd   bool `toml:"enable_etcd,omitempty" json:"enable_etcd,omitempty"`
+}
+
+func stringOrSliceToSlice(input any, fieldName string) ([]string, error) {
+	if input == nil {
+		return nil, nil
+	}
+	if c, ok := input.([]string); ok {
+		return c, nil
+	} else if c, ok := input.(string); ok {
+		return []string{c}, nil
+	} else {
+		return nil, fmt.Errorf("could not cast %v to type []string on %s", input, fieldName)
+	}
+}
+
+func (e *Experimental) CmdToStringSlice() ([]string, error) {
+	return stringOrSliceToSlice(e.Cmd, "Experimental.Cmd")
+}
+
+func (e *Experimental) EntrypointToStringSlice() ([]string, error) {
+	return stringOrSliceToSlice(e.Entrypoint, "Experimental.Entrypoint")
+}
+
+func (e *Experimental) ExecToStringSlice() ([]string, error) {
+	return stringOrSliceToSlice(e.Exec, "Experimental.Exec")
 }
 
 func (c *Config) HasNonHttpAndHttpsStandardServices() bool {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -456,13 +456,7 @@ func LoadAppConfigIfPresent(ctx context.Context) (context.Context, error) {
 	for _, path := range appConfigFilePaths(ctx) {
 		switch cfg, err := app.LoadConfig(ctx, path, ""); {
 		case err == nil:
-			cfgv2, err := appv2.LoadConfig(path)
-			if err != nil {
-				return nil, fmt.Errorf("failed loading appv2 config from: %s: %w", path, err)
-			}
-			ctx = appv2.WithConfig(ctx, cfgv2)
 			logger.Debugf("app config loaded from %s", path)
-
 			return app.WithConfig(ctx, cfg), nil // we loaded a configuration file
 		case errors.Is(err, fs.ErrNotExist):
 			logger.Debugf("no app config found at %s; skipped.", path)
@@ -470,6 +464,26 @@ func LoadAppConfigIfPresent(ctx context.Context) (context.Context, error) {
 			continue
 		default:
 			return nil, fmt.Errorf("failed loading app config from %s: %w", path, err)
+		}
+	}
+
+	return ctx, nil
+}
+
+func LoadAppV2ConfigIfPresent(ctx context.Context) (context.Context, error) {
+	logger := logger.FromContext(ctx)
+
+	for _, path := range appConfigFilePaths(ctx) {
+		switch cfg, err := appv2.LoadConfig(path); {
+		case err == nil:
+			logger.Debugf("appv2 config loaded from %s", path)
+			return appv2.WithConfig(ctx, cfg), nil // we loaded a configuration file
+		case errors.Is(err, fs.ErrNotExist):
+			logger.Debugf("no appv2 config found at %s; skipped.", path)
+
+			continue
+		default:
+			return nil, fmt.Errorf("failed loading appv2 config from %s: %w", path, err)
 		}
 	}
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -458,7 +458,7 @@ func LoadAppConfigIfPresent(ctx context.Context) (context.Context, error) {
 		case err == nil:
 			cfgv2, err := appv2.LoadConfig(path)
 			if err != nil {
-				return nil, fmt.Errorf("failed loading app config from: %s: %w", path, err)
+				return nil, fmt.Errorf("failed loading appv2 config from: %s: %w", path, err)
 			}
 			ctx = appv2.WithConfig(ctx, cfgv2)
 			logger.Debugf("app config loaded from %s", path)

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -159,7 +159,10 @@ func DeployWithConfig(ctx context.Context, appConfig *app.Config, args DeployWit
 	}
 
 	if deployToMachines {
-		// FIXME: this function can't use flags anymore!!! too many other things are using it, and they have different flags!!!
+		ctx, err = command.LoadAppV2ConfigIfPresent(ctx)
+		if err != nil {
+			return fmt.Errorf("error loading appv2 config: %w", err)
+		}
 		md, err := NewMachineDeployment(ctx, MachineDeploymentArgs{
 			AppCompact:           appCompact,
 			DeploymentImage:      img,

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -476,6 +476,10 @@ func (md *machineDeployment) validateProcessesConfig() error {
 		if machineProcGroup == api.MachineProcessGroupFlyAppReleaseCommand {
 			continue
 		}
+		// we put the api.MachineProcessGroupApp process group on machine by default
+		if !appConfigProcessesExist && machineProcGroup == api.MachineProcessGroupApp {
+			continue
+		}
 		if !machineProcGroupPresent && appConfigProcessesExist {
 			return fmt.Errorf("error machine %s does not have a process group and should have one from app configuration: %s", mid, appConfigProcessesStr)
 		}

--- a/internal/command/info/machines.go
+++ b/internal/command/info/machines.go
@@ -80,6 +80,11 @@ func showMachineServiceInfo(ctx context.Context, app *api.AppCompact) error {
 		return err
 	}
 
+	if len(machines) == 0 {
+		fmt.Fprintf(io.ErrOut, "No machines found")
+		return nil
+	}
+
 	services := [][]string{}
 	for _, service := range machines[0].Config.Services {
 		for i, port := range service.Ports {

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -32,6 +32,7 @@ func newClone() *cobra.Command {
 	cmd := command.New(usage, short, long, runMachineClone,
 		command.RequireSession,
 		command.LoadAppNameIfPresent,
+		command.LoadAppV2ConfigIfPresent,
 	)
 
 	cmd.Args = cobra.ExactArgs(1)

--- a/internal/command/secrets/secrets.go
+++ b/internal/command/secrets/secrets.go
@@ -61,6 +61,10 @@ func deployForSecrets(ctx context.Context, app *api.AppCompact, release *api.Rel
 	}
 
 	if app.PlatformVersion == "machines" {
+		ctx, err = command.LoadAppV2ConfigIfPresent(ctx)
+		if err != nil {
+			return fmt.Errorf("error loading appv2 config: %w", err)
+		}
 		md, err := deploy.NewMachineDeployment(ctx, deploy.MachineDeploymentArgs{
 			AppCompact:       app,
 			RestartOnly:      true,


### PR DESCRIPTION
These are the bugs that are fixed in this change:

BUG1: handle default app process... we were giving this error for machines:
Error error machine e148e470f20089 has process group 'app' and no processes are defined in app config; add [processes] to fly.toml or remove the process group from this machine

BUG2: handle string literal or string array literal for cmd, entrypoint, exec in [experimental] section
https://community.fly.io/t/cant-deploy-with-error-cannot-unmarshal-string-into-go-struct-field/10605/4
https://community.fly.io/t/github-actions-failed-to-deploy/10802/2

BUG3: `fly info` failed when no machines were returned, now it will say there are no machines
https://flyio.sentry.io/issues/3239322312/events/6451b237d5aa45a3a8c6b6967eaf2d7a/?project=4492967

BUG4: same thing for `fly services list`, plus fix a panic due to context not getting initialized and flapsClient being nil

BUG5: nil deref in `fly doctor` due to context not being fully initialized
https://flyio.sentry.io/issues/3246214906/events/420ea4e522204a3eb4f3e35dc66e82d1/?project=4492967
