### PR TITLE
launch: Do not scan sources if config was copied from existing fly.toml

### DIFF
--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -165,7 +165,7 @@ func run(ctx context.Context) (err error) {
 		appConfig.Build = &app.Build{
 			Dockerfile: dockerfile,
 		}
-	} else {
+	} else if !importedConfig {
 		fmt.Fprintln(io.Out, "Scanning source code")
 		if si, err := scanner.Scan(workingDir, config); err != nil {
 			return err


### PR DESCRIPTION
When trying to launch a project with an existing fly.toml, the scanner will kick in even if the configuration was copied from existing toml file.

```
n$ fly launch --force-machines --name test-admin -o personal
An existing fly.toml file was found for app test-admin
? Would you like to copy its configuration to the new app? Yes
Creating app in /Users/daniel/src/flyio/fly-admin
Scanning source code
Detected a Phoenix app
? Choose a region for deployment: Ashburn, Virginia (US) (iad)
Created app test-admin in organization personal
Admin URL: https://fly.io/apps/test-admin
Hostname: test-admin.fly.dev
Set secrets on test-admin: SECRET_KEY_BASE
? Would you like to set up a Postgresql database now? No
? Would you like to set up an Upstash Redis database now? No
Error mix not found in $PATH - make sure app dependencies are installed and try again
```

After this change it simply skips the scanner which is not needed at deploy time
```
n$ fly launch --force-machines --name test-admin -o personal
An existing fly.toml file was found for app test-admin
? Would you like to copy its configuration to the new app? Yes
Creating app in /Users/daniel/src/flyio/fly-admin
? Choose a region for deployment: Ashburn, Virginia (US) (iad)
Created app test-admin in organization personal
Admin URL: https://fly.io/apps/test-admin
Hostname: test-admin.fly.dev
? Would you like to set up a Postgresql database now? No
? Would you like to set up an Upstash Redis database now? No
Wrote config file fly.toml
? Would you like to deploy now? No
Your app is ready! Deploy with `flyctl deploy`
```