### PR TITLE
Improve long help message for `secrets list`

### DIFF
--- a/docstrings/gen.go
+++ b/docstrings/gen.go
@@ -681,9 +681,9 @@ are read from stdin as name=value`,
 		}
 	case "secrets.list":
 		return KeyStrings{"list", "Lists the secrets available to the app",
-			`List the secrets available to the application. It shows each
-secret's name, a digest of the its value and the time the secret was last set.
-The actual value of the secret is only available to the application.`,
+			`List the secrets available to the application. It shows each secret's
+name, a digest of its value and the time the secret was last set. The
+actual value of the secret is only available to the application.`,
 		}
 	case "secrets.set":
 		return KeyStrings{"set [flags] NAME=VALUE NAME=VALUE ...", "Set one or more encrypted secrets for an app",

--- a/helpgen/flyctlhelp.toml
+++ b/helpgen/flyctlhelp.toml
@@ -661,9 +661,9 @@ shortHelp = "Manage app secrets"
 usage = "secrets"
 
 [secrets.list]
-longHelp = """List the secrets available to the application. It shows each
-secret's name, a digest of the its value and the time the secret was last set.
-The actual value of the secret is only available to the application.
+longHelp = """List the secrets available to the application. It shows each secret's
+name, a digest of its value and the time the secret was last set. The
+actual value of the secret is only available to the application.
 """
 shortHelp = "Lists the secrets available to the app"
 usage = "list"

--- a/internal/command/secrets/list.go
+++ b/internal/command/secrets/list.go
@@ -16,9 +16,9 @@ import (
 
 func newList() (cmd *cobra.Command) {
 	const (
-		long = `List the secrets available to the application. It shows each
-		secret's name, a digest of the its value and the time the secret was last set.
-		The actual value of the secret is only available to the application.`
+		long = `List the secrets available to the application. It shows each secret's
+name, a digest of its value and the time the secret was last set. The
+actual value of the secret is only available to the application.`
 		short = `List application secret names, digests and creation times`
 		usage = "list [flags]"
 	)


### PR DESCRIPTION
The long message appears broken on the terminal. This CL not only removes the broken indentation but also amends the alignment.

Before:

```
$ flyctl help secrets list
List the secrets available to the application. It shows each
                secret's name, a digest of the its value and the time the secret was last set.
                The actual value of the secret is only available to the application.

[snip]
```

After:

```
$ ./bin/flyctl help secrets list
List the secrets available to the application. It shows each secret's
name, a digest of its value and the time the secret was last set. The
actual value of the secret is only available to the application.

[snip]
```

Update: I'm happy making any changes or any further amendments throughout the code. The initial intent here was only to fix the broken text but then I couldn't leave the extra `the` in there and consequently had to fix all other instances of that message, to keep them identical [😊](# "trying to follow the good boy scout rule")