### PR TITLE
Show cluster size with PG options

### DIFF
--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -316,14 +316,14 @@ func flexConfigurations() []PostgresConfiguration {
 			VMSize:             "shared-cpu-1x",
 		},
 		{
-			Description:        "Production - Highly available, 2x shared CPUs, 4GB RAM, 40GB disk",
+			Description:        "Production (High Availability) - 3 nodes, 2x shared CPUs, 4GB RAM, 40GB disk",
 			DiskGb:             40,
 			InitialClusterSize: 3,
 			MemoryMb:           4096,
 			VMSize:             "shared-cpu-2x",
 		},
 		{
-			Description:        "Production - Highly available, 4x shared CPUs, 8GB RAM, 80GB disk",
+			Description:        "Production (High Availability) - 3 nodes, 4x shared CPUs, 8GB RAM, 80GB disk",
 			DiskGb:             80,
 			InitialClusterSize: 3,
 			MemoryMb:           8192,


### PR DESCRIPTION
So fewer people will be surprised that they're paying for 3 nodes if they choose HA.