### PR TITLE
django.go: Fix dj-database-url package's name

### DIFF
--- a/scanner/django.go
+++ b/scanner/django.go
@@ -51,7 +51,7 @@ func configureDjango(sourceDir string, config *ScannerConfig) (*SourceInfo, erro
 			s.DeployDocs = `
 Your Django app is almost ready to deploy!
 
-We recommend using the database_url(pip install dj-database-url) to parse the DATABASE_URL from os.environ['DATABASE_URL']
+We recommend using the dj-database-url(pip install dj-database-url) to parse the DATABASE_URL from os.environ['DATABASE_URL']
 
 For detailed documentation, see https://fly.dev/docs/django/
 		`

--- a/scanner/django.go
+++ b/scanner/django.go
@@ -47,7 +47,7 @@ func configureDjango(sourceDir string, config *ScannerConfig) (*SourceInfo, erro
 		}
 		s.ReleaseCmd = "python manage.py migrate"
 
-		if !checksPass(sourceDir, dirContains("requirements.txt", "database_url")) {
+		if !checksPass(sourceDir, dirContains("requirements.txt", "dj-database-url")) {
 			s.DeployDocs = `
 Your Django app is almost ready to deploy!
 


### PR DESCRIPTION
Package in requirements.txt is [`dj-database-url`](https://pypi.org/project/dj-database-url/) instead of `database_url`. `DATABASE_URL` is the environment variable.