### PR TITLE
Make Launching Apps With Existing Databases Easier

### DIFF
--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/client"
@@ -40,6 +41,34 @@ func RunDestroy(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
 	appName := flag.FirstArg(ctx)
+	client := client.FromContext(ctx).API()
+
+	db_app_name := fmt.Sprintf("%s-db", appName)
+	app_has_db := false
+	var db_app api.App
+
+	redis_app_name := fmt.Sprintf("%s-redis", appName)
+	app_has_redis := false
+	var redis_app api.App
+
+	if apps, err := client.GetApps(ctx, nil); err == nil {
+		for _, app := range apps {
+			if app.Name == db_app_name {
+				app_has_db = true
+				db_app = app
+
+			}
+
+			if app.Name == redis_app_name {
+				app_has_redis = true
+				redis_app = app
+
+			}
+
+		}
+	} else {
+		return err
+	}
 
 	if !flag.GetYes(ctx) {
 		const msg = "Destroying an app is not reversible."
@@ -57,12 +86,70 @@ func RunDestroy(ctx context.Context) error {
 		}
 	}
 
-	client := client.FromContext(ctx).API()
 	if err := client.DeleteApp(ctx, appName); err != nil {
 		return err
 	}
 
 	fmt.Fprintf(io.Out, "Destroyed app %s\n", appName)
+
+	destroy_db := flag.GetYes(ctx)
+
+	if app_has_db {
+		if !flag.GetYes(ctx) {
+			const msg = "This app also has a database. Should it be destroyed? This is not reversible."
+			fmt.Fprintln(io.ErrOut, colorize.Red(msg))
+
+			switch confirmed, err := prompt.Confirmf(ctx, "Destroy app %s?", db_app.Name); {
+			case err == nil:
+				destroy_db = confirmed
+			case prompt.IsNonInteractive(err):
+				return prompt.NonInteractiveError("yes flag must be specified when not running interactively")
+			default:
+				return err
+			}
+
+		}
+
+	}
+
+	destroy_redis := flag.GetYes(ctx)
+
+	if app_has_redis {
+		if !flag.GetYes(ctx) {
+			const msg = "This app also has a Redis database. Should it be destroyed? This is not reversible."
+			fmt.Fprintln(io.ErrOut, colorize.Red(msg))
+
+			switch confirmed, err := prompt.Confirmf(ctx, "Destroy app %s?", redis_app.Name); {
+			case err == nil:
+				destroy_redis = confirmed
+			case prompt.IsNonInteractive(err):
+				return prompt.NonInteractiveError("yes flag must be specified when not running interactively")
+			default:
+				return err
+			}
+
+		}
+
+		if err := client.DeleteApp(ctx, redis_app.Name); err != nil {
+			return err
+		}
+	}
+
+	if destroy_db && app_has_db {
+		if err := client.DeleteApp(ctx, db_app.Name); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(io.Out, "Destroyed app %s\n", db_app.Name)
+	}
+
+	if destroy_redis && app_has_redis {
+		if err := client.DeleteApp(ctx, redis_app.Name); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(io.Out, "Destroyed app %s\n", redis_app.Name)
+	}
 
 	return nil
 }

--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -92,7 +92,7 @@ func RunDestroy(ctx context.Context) error {
 
 	fmt.Fprintf(io.Out, "Destroyed app %s\n", appName)
 
-	destroy_db := flag.GetYes(ctx)
+	destroy_db := false
 
 	if app_has_db {
 		if !flag.GetYes(ctx) {
@@ -112,7 +112,7 @@ func RunDestroy(ctx context.Context) error {
 
 	}
 
-	destroy_redis := flag.GetYes(ctx)
+	destroy_redis := false
 
 	if app_has_redis {
 		if !flag.GetYes(ctx) {

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -374,9 +374,13 @@ func run(ctx context.Context) (err error) {
 			options["postgresql"] = true
 
 			if should_attach_db {
+				// If we try to attach to a PG cluster with the usual username
+				// format, we'll get an error (since that username already exists)
+				// by generating a new username with a sufficiently random number
+				// (in this case, the nanon second that the database is being attached)
 				current_time := time.Now().Nanosecond()
 				db_user := fmt.Sprintf("%s-%d", db_app_name, current_time)
-				fmt.Println(db_user)
+
 				err = postgres.AttachCluster(ctx, postgres.AttachParams{
 					PgAppName: db_app_name,
 					AppName:   appConfig.AppName,


### PR DESCRIPTION
Should fix #1719 

This PR does two things. Firstly, it gives users the option of destroying an app's database at the same time as the app itself, which should make the scenario that an app's database already exists a little harder to hit. It also warns the user when it fails to launch the PG or Redis database, so that users no launching an app with an existing database could pose problems for the launch.

Related discussion:
https://flyio.discourse.team/t/destroying-an-apps-database-in-fly-apps-destroy/1902

Edit:
After some discussion, the PR currently allows users to attach an existing database, if a database exists that matches "{app_name}-db". It also warns users when failing to launch a database (redis or PG) that this could cause issues during deployment.