### PR TITLE
Fixed `services list` for machine apps

### DIFF
--- a/internal/command/services/machines.go
+++ b/internal/command/services/machines.go
@@ -61,7 +61,7 @@ func showMachineServiceInfo(ctx context.Context, app *api.AppInfo) error {
 
 			fields := []string{
 				strings.ToUpper(protocol),
-				fmt.Sprintf("%d => %d [%s]", port.Port, service.InternalPort, strings.Join(handlers, ",")),
+				fmt.Sprintf("%d => %d [%s]", *port.Port, service.InternalPort, strings.Join(handlers, ",")),
 				strings.Title(fmt.Sprint(port.ForceHttps)),
 			}
 			services = append(services, fields)


### PR DESCRIPTION
I was printing the pointer's memory address, and not the port number itself Should fix #1716