### PR TITLE
django.go: Do not require makemigrations on fly launch

### DIFF
--- a/scanner/django.go
+++ b/scanner/django.go
@@ -37,14 +37,6 @@ func configureDjango(sourceDir string, config *ScannerConfig) (*SourceInfo, erro
 
 	// check if requirements.txt has a postgres dependency
 	if checksPass(sourceDir, dirContains("requirements.txt", "psycopg2")) {
-		s.InitCommands = []InitCommand{
-			{
-				// python makemigrations
-				Command:     "python",
-				Args:        []string{"manage.py", "makemigrations"},
-				Description: "Creating database migrations",
-			},
-		}
 		s.ReleaseCmd = "python manage.py migrate"
 
 		if !checksPass(sourceDir, dirContains("requirements.txt", "database_url")) {


### PR DESCRIPTION
`makemigrations` command should not be required during `fly launch`.

We usually assume the migrations are ready (created and applied locally by the developer) when we start the deployment process.