### PR TITLE
django.go: Add django-environ as an option to parse DATABASE_URL

### DIFF
--- a/scanner/django.go
+++ b/scanner/django.go
@@ -47,11 +47,11 @@ func configureDjango(sourceDir string, config *ScannerConfig) (*SourceInfo, erro
 		}
 		s.ReleaseCmd = "python manage.py migrate"
 
-		if !checksPass(sourceDir, dirContains("requirements.txt", "dj-database-url")) {
+		if !checksPass(sourceDir, dirContains("requirements.txt", "django-environ", "dj-database-url")) {
 			s.DeployDocs = `
 Your Django app is almost ready to deploy!
 
-We recommend using the dj-database-url(pip install dj-database-url) to parse the DATABASE_URL from os.environ['DATABASE_URL']
+We recommend using the django-environ(pip install django-environ) or dj-database-url(pip install dj-database-url) to parse the DATABASE_URL from os.environ['DATABASE_URL']
 
 For detailed documentation, see https://fly.dev/docs/django/
 		`


### PR DESCRIPTION
Popular packages used:
- https://github.com/sloria/environs (django)
- https://github.com/HBNetwork/python-decouple
- https://github.com/joke2k/django-environ

- `environs[django]` package adds `dj-database-url` as a dependency in the requirements.txt
- `python-decouple` package requires `dj-database-url` to be installed separately.
- `django-environ` doesn't requires `dj-database-url`; it reads `os.environ['DATABASE_URL']`
```
DATABASES = {
    # read os.environ['DATABASE_URL'] and raises
    # ImproperlyConfigured exception if not found
    #
    # The db() method is an alias for db_url().
    'default': env.db(),
}
```

If `django-environ` package is in `requirements.txt`, we don't need to recommend the usage of `dj-database-url`.