### PR TITLE
WIP: Automate management of a log shipper VM

### DIFF
--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -184,6 +184,20 @@ func (client *Client) GetAppCompact(ctx context.Context, appName string) (*AppCo
 	return &data.AppCompact, nil
 }
 
+func (client *Client) AppToCompact(app *App) *AppCompact {
+	return &AppCompact{
+		ID:       app.ID,
+		Name:     app.Name,
+		Status:   app.Status,
+		Deployed: app.Deployed,
+		Hostname: app.Hostname,
+		AppURL:   app.AppURL,
+		Organization: &OrganizationBasic{
+			ID:   app.Organization.ID,
+			Slug: app.Organization.Slug,
+		},
+	}
+}
 func (client *Client) GetAppInfo(ctx context.Context, appName string) (*AppInfo, error) {
 	query := `
 		query ($appName: String!) {

--- a/internal/command/logs/logs.go
+++ b/internal/command/logs/logs.go
@@ -52,7 +52,7 @@ to all instances running in a specific region using the --region/-r flag.
 			Description: "Filter by instance ID",
 		},
 	)
-
+	cmd.AddCommand(newShip())
 	return
 }
 

--- a/internal/command/logs/ship.go
+++ b/internal/command/logs/ship.go
@@ -1,0 +1,103 @@
+package logs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/command/orgs"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newShip() *cobra.Command {
+
+	const (
+		short = "Ship logs to an external provider"
+		long  = short + "\n"
+		usage = "ship"
+	)
+
+	cmd := command.New(usage, short, long, runShip, command.RequireSession)
+
+	flag.Add(cmd)
+
+	cmd.Args = cobra.MaximumNArgs(1)
+
+	return cmd
+}
+
+func runShip(ctx context.Context) (err error) {
+	client := client.FromContext(ctx).API()
+	io := iostreams.FromContext(ctx)
+	selectedOrg, err := orgs.OrgFromFirstArgOrSelect(ctx)
+
+	if err != nil {
+		return err
+	}
+
+	appName := selectedOrg.Slug + "-auto-log-shipper"
+
+	_, err = client.GetAppCompact(ctx, appName)
+
+	if err == nil {
+		return
+	}
+
+	input := api.CreateAppInput{
+		Name:           appName,
+		OrganizationID: selectedOrg.ID,
+	}
+
+	app, err := client.CreateApp(ctx, input)
+
+	if err != nil {
+		return err
+	}
+
+	if err != nil {
+		return err
+	}
+
+	flapsClient, err := flaps.New(ctx, client.AppToCompact(app))
+
+	if err != nil {
+		return err
+	}
+	machineConf := &api.MachineConfig{
+		Guest: &api.MachineGuest{
+			CPUKind:  "shared",
+			CPUs:     1,
+			MemoryMB: 256,
+		},
+		Image: "flyio/log-shipper",
+	}
+
+	machines, err := flapsClient.List(ctx, "")
+
+	if len(machines) > 0 {
+		return
+	}
+
+	region, err := client.GetNearestRegion(ctx)
+
+	if err != nil {
+		return err
+	}
+
+	launchInput := api.LaunchMachineInput{
+		AppID:  app.Name,
+		Name:   "log-shipper",
+		Region: region.Code,
+		Config: machineConf,
+	}
+
+	machine, err := flapsClient.Launch(ctx, launchInput)
+
+	fmt.Fprintf(io.Out, "Launched machine %s\n", machine.ID)
+	return err
+}

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -176,14 +176,14 @@ func runMachineRun(ctx context.Context) error {
 	)
 
 	if appName == "" {
-		app, err = createApp(ctx, "Running a machine without specifying an app will create one for you, is this what you want?", "", client)
+		app, err = CreateApp(ctx, "Running a machine without specifying an app will create one for you, is this what you want?", "")
 		if err != nil {
 			return err
 		}
 	} else {
 		app, err = client.GetAppCompact(ctx, appName)
 		if err != nil && strings.Contains(err.Error(), "Could not find App") {
-			app, err = createApp(ctx, fmt.Sprintf("App '%s' does not exist, would you like to create it?", appName), appName, client)
+			app, err = CreateApp(ctx, fmt.Sprintf("App '%s' does not exist, would you like to create it?", appName), appName)
 
 			if err != nil {
 				return err
@@ -273,7 +273,9 @@ func runMachineRun(ctx context.Context) error {
 	return nil
 }
 
-func createApp(ctx context.Context, message, name string, client *api.Client) (*api.AppCompact, error) {
+func CreateApp(ctx context.Context, message, name string) (*api.AppCompact, error) {
+	client := client.FromContext(ctx).API()
+
 	confirm, err := prompt.Confirm(ctx, message)
 	if err != nil {
 		return nil, err

--- a/internal/command/secrets/set.go
+++ b/internal/command/secrets/set.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/app"
@@ -63,6 +64,17 @@ func runSet(ctx context.Context) (err error) {
 	}
 
 	release, err := client.SetSecrets(ctx, appName, secrets)
+	if err != nil {
+		return err
+	}
+
+	return deployForSecrets(ctx, app, release)
+}
+
+func SetAndDeploy(ctx context.Context, app *api.AppCompact, secrets map[string]string) (err error) {
+	client := client.FromContext(ctx).API()
+
+	release, err := client.SetSecrets(ctx, app.Name, secrets)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
WIP: This PR adds the `flyctl logs ship` command which sets up a [log shipper](https://github.com/superfly/fly-log-shipper) VM. Initially, this command should offer automatic log shipping via an integrated [Logtail](https://betterstack.com/logtail) account, and instructions for adding other log providers.

This will be accompanied by a backend PR.
