### PR TITLE
Fix services bug for v2 apps.

### DIFF
--- a/internal/appv2/processconfig.go
+++ b/internal/appv2/processconfig.go
@@ -19,7 +19,7 @@ func (c *Config) GetProcessConfigs() (map[string]*ProcessConfig, error) {
 	processCount := len(c.Processes)
 	configProcesses := lo.Assign(c.Processes)
 	if processCount == 0 {
-		configProcesses[""] = ""
+		configProcesses[api.MachineProcessGroupApp] = ""
 	}
 	defaultProcessName := lo.Keys(configProcesses)[0]
 


### PR DESCRIPTION
Services and checks were not added to machines when no processes were
defined. This was due to the "default" process being "", but we
started assigning the default process group of "app" to machines at
some point.
