### PR TITLE
More fixing of services in apps v2.

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -634,6 +634,9 @@ func (md *machineDeployment) resolveUpdatedMachineConfig(origMachineRaw *api.Mac
 	}
 	launchInput.Config.Init = origMachineRaw.Config.Init
 	processGroup := origMachineRaw.Config.Metadata[api.MachineConfigMetadataKeyFlyProcessGroup]
+	if processGroup == "" {
+		processGroup = api.MachineProcessGroupApp
+	}
 	if processConfig, ok := md.processConfigs[processGroup]; ok {
 		launchInput.Config.Services = processConfig.Services
 		launchInput.Config.Init.Cmd = processConfig.Cmd


### PR DESCRIPTION
Now fix the case where a machine does not already have the default
process group... this case happens on fly launch where the developer
chooses to deploy, or in the migration scenario when machines
previously did not have the apps v2 metadata
