### PR TITLE
`fly apps restart`: tag a release when restarting AppsV2 apps

### DIFF
--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/flaps"
-	"github.com/superfly/flyctl/internal/appv2"
+	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command/deploy"
 
 	"github.com/superfly/flyctl/api"
@@ -123,7 +123,7 @@ func runMachinesRestart(ctx context.Context, app *api.AppCompact) error {
 		return fmt.Errorf("failed fetching existing app config: %w", err)
 	}
 
-	cfg, err := appv2.FromDefinition(&apiConfig.Definition)
+	cfg, err := appconfig.FromDefinition(&apiConfig.Definition)
 	if err != nil {
 		return err
 	}

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -501,7 +501,7 @@ func (md *machineDeployment) setStrategy(passedInStrategy string) error {
 	return nil
 }
 
-func CreateReleaseInBackend(ctx context.Context, client *api.Client, app *appv2.Config, strategy, image string) (*gql.MachinesCreateReleaseResponse, error) {
+func CreateReleaseInBackend(ctx context.Context, client *api.Client, app *appconfig.Config, strategy, image string) (*gql.MachinesCreateReleaseResponse, error) {
 	_ = `# @genqlient
 	mutation MachinesCreateRelease($input:CreateReleaseInput!) {
 		createRelease(input:$input) {


### PR DESCRIPTION
This makes `fly apps restart` tag a release for V2 apps, like would happen during a deploy, or when a nomad app was restarted.

This would make the move from nomad -> machines more familiar, but it would also act as a debugging tool; sometimes, things just start acting differently after a reboot, and keeping track of this can be helpful. That said, there could be an argument made that maybe piggybacking off of the release system to give users this info isn't the right approach.

Regardless, I already had this branch finished, so it might be helpful to have a proof of concept working :)