### PR TITLE
`fly apps releases`: use new GraphQL queries for AppsV2 apps

### DIFF
--- a/api/resource_releases.go
+++ b/api/resource_releases.go
@@ -105,31 +105,3 @@ func (c *Client) GetAppReleaseNomad(ctx context.Context, appName string, id stri
 
 	return data.App.Release, nil
 }
-
-func (c *Client) GetAppReleaseMachines(ctx context.Context, appName string, id string) (*Release, error) {
-	query := `
-		query ($appName: String!, $releaseId: ID!) {
-			app(name: $appName) {
-				release: releaseUnprocessed(id: $releaseId) {
-					id
-					status
-					evaluationId
-					createdAt
-					deploymentStrategy
-				}
-			}
-		}
-	`
-
-	req := c.NewRequest(query)
-
-	req.Var("appName", appName)
-	req.Var("releaseId", id)
-
-	data, err := c.RunWithContext(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	return data.App.Release, nil
-}

--- a/api/resource_releases.go
+++ b/api/resource_releases.go
@@ -2,7 +2,7 @@ package api
 
 import "context"
 
-func (c *Client) GetAppReleases(ctx context.Context, appName string, limit int) ([]Release, error) {
+func (c *Client) GetAppReleasesNomad(ctx context.Context, appName string, limit int) ([]Release, error) {
 	query := `
 		query ($appName: String!, $limit: Int!) {
 			app(name: $appName) {
@@ -40,11 +40,77 @@ func (c *Client) GetAppReleases(ctx context.Context, appName string, limit int) 
 	return data.App.Releases.Nodes, nil
 }
 
-func (c *Client) GetAppRelease(ctx context.Context, appName string, id string) (*Release, error) {
+func (c *Client) GetAppReleasesMachines(ctx context.Context, appName string, limit int) ([]Release, error) {
+	query := `
+		query ($appName: String!, $limit: Int!) {
+			app(name: $appName) {
+				releases: releasesUnprocessed(first: $limit) {
+					nodes {
+						id
+						version
+						description
+						reason
+						status
+						imageRef
+						stable
+						user {
+							id
+							email
+							name
+						}
+						createdAt
+					}
+				}
+			}
+		}
+	`
+
+	req := c.NewRequest(query)
+
+	req.Var("appName", appName)
+	req.Var("limit", limit)
+
+	data, err := c.RunWithContext(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.App.Releases.Nodes, nil
+}
+
+func (c *Client) GetAppReleaseNomad(ctx context.Context, appName string, id string) (*Release, error) {
 	query := `
 		query ($appName: String!, $releaseId: ID!) {
 			app(name: $appName) {
 				release(id: $releaseId) {
+					id
+					status
+					evaluationId
+					createdAt
+					deploymentStrategy
+				}
+			}
+		}
+	`
+
+	req := c.NewRequest(query)
+
+	req.Var("appName", appName)
+	req.Var("releaseId", id)
+
+	data, err := c.RunWithContext(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.App.Release, nil
+}
+
+func (c *Client) GetAppReleaseMachines(ctx context.Context, appName string, id string) (*Release, error) {
+	query := `
+		query ($appName: String!, $releaseId: ID!) {
+			app(name: $appName) {
+				release: releaseUnprocessed(id: $releaseId) {
 					id
 					status
 					evaluationId

--- a/internal/command/apps/releases.go
+++ b/internal/command/apps/releases.go
@@ -54,6 +54,9 @@ func runReleases(ctx context.Context) error {
 	)
 
 	app, err := client.GetAppCompact(ctx, appName)
+	if err != nil {
+		return fmt.Errorf("failed retrieving app %s: %w", appName, err)
+	}
 
 	if app.PlatformVersion == "machines" {
 		releases, err = client.GetAppReleasesMachines(ctx, appName, 25)

--- a/internal/command/apps/releases.go
+++ b/internal/command/apps/releases.go
@@ -47,9 +47,20 @@ including type, when, success/fail and which user triggered the release.
 }
 
 func runReleases(ctx context.Context) error {
-	appName := app.NameFromContext(ctx)
+	var (
+		appName  = app.NameFromContext(ctx)
+		client   = client.FromContext(ctx).API()
+		releases []api.Release
+	)
 
-	releases, err := client.FromContext(ctx).API().GetAppReleases(ctx, appName, 25)
+	app, err := client.GetAppCompact(ctx, appName)
+
+	if app.PlatformVersion == "machines" {
+		releases, err = client.GetAppReleasesMachines(ctx, appName, 25)
+	} else {
+		releases, err = client.GetAppReleasesNomad(ctx, appName, 25)
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed retrieving app releases %s: %w", appName, err)
 	}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -204,7 +204,7 @@ func DeployWithConfig(ctx context.Context, appConfig *app.Config, args DeployWit
 			return err
 		}
 
-		release, err = apiClient.GetAppRelease(ctx, appConfig.AppName, release.ID)
+		release, err = apiClient.GetAppReleaseNomad(ctx, appConfig.AppName, release.ID)
 		if err != nil {
 			return err
 		}

--- a/internal/command/image/update_nomad.go
+++ b/internal/command/image/update_nomad.go
@@ -101,7 +101,7 @@ func updateImageForNomad(ctx context.Context) error {
 			return err
 		}
 
-		release, err = client.GetAppRelease(ctx, appName, release.ID)
+		release, err = client.GetAppReleaseNomad(ctx, appName, release.ID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
use `releasesUnprocessed`/`releaseUnprocessed` queries for AppsV2 apps