### PR TITLE
Make PKGBUILD diffs easier to review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,10 +219,10 @@ jobs:
       - name: Generate PKGBUILD
         run: |
           mkdir -p aur/flyctl-bin
-          export version=${GITHUB_REF#refs/*/}
-          export pkgver=${version:1}
+          export tag=${GITHUB_REF#refs/*/}
+          export version=${tag:1}
           export sha256sum=$(grep "Linux_x86_64.tar.gz" checksums.txt | cut -d ' ' -f 1)
-          envsubst '${pkgver},${sha256sum}' < aur/PKGBUILD > aur/flyctl-bin/PKGBUILD
+          envsubst '${version},${sha256sum}' < aur/PKGBUILD > aur/flyctl-bin/PKGBUILD
           cat aur/flyctl-bin/PKGBUILD
       - name: Publish flyctl-bin to the AUR
         uses: superfly/aur-releaser@ba29a0a809d7221713a104f9c9a23c34ee5b0742

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Jerome Gravel-Niquet <jeromegn@gmail.com>
 
 pkgname="flyctl-bin"
-pkgver="${pkgver}"
+pkgver="${version}"
 pkgrel="1"
 pkgdesc="Command line tools for fly.io services"
 arch=("x86_64")


### PR DESCRIPTION
## In short

Leaving the `pkgver` variable alone and allowing `mkpkg` to expand it at runtime makes the diffs for each release easier to review for AUR users. Instead of checking the whole source URL by hand, they instead only need to look at the version and hash.

I'm not sure if outside contributions are welcome. Even if they are not, I wanted to make this as easy to follow for Jerome, the maintainer of the `flyctl-bin` package in the AUR. 

## Extra context

There is a conversation here already https://aur.archlinux.org/packages/flyctl-bin

To reproduce some of it here, each time any package in the AUR gets updated, it is good practice for users to review the change in the PKGBUILD file. Right now the diff looks like this: 

```diff
diff --git a/PKGBUILD b/PKGBUILD
index 2561980..bcc34c5 100644
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Jerome Gravel-Niquet <jeromegn@gmail.com>

 pkgname="flyctl-bin"
-pkgver="0.0.463"
+pkgver="0.0.464"
 pkgrel="1"
 pkgdesc="Command line tools for fly.io services"
 arch=("x86_64")
@@ -10,8 +10,8 @@ license=("Apache")
 depends=()
 provides=("flyctl")
 conflicts=("flyctl")
-source=("$pkgname-0.0.463.tgz::https://github.com/superfly/flyctl/releases/download/v0.0.463/flyctl_0.0.463_Linux_x86_64.tar.gz")
-sha256sums=('d7247539b588cbdf0ca0a62b5244a1aba052887a4d603e19a4ce9a4f6b95b398')
+source=("$pkgname-0.0.464.tgz::https://github.com/superfly/flyctl/releases/download/v0.0.464/flyctl_0.0.464_Linux_x86_64.tar.gz")
+sha256sums=('8254ad2c9cdb908713b4ea8294cb4035e87afcb2672da632e4fedde92bff3a40')

 package() {
     mkdir -p "$pkgdir/usr/bin"
```


And after this change, leaving `pkgver` alone, the diff would look like this: 

```diff
diff --git a/PKGBUILD b/PKGBUILD
index 2561980..bcc34c5 100644
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Jerome Gravel-Niquet <jeromegn@gmail.com>

 pkgname="flyctl-bin"
-pkgver="0.0.463"
+pkgver="0.0.464"
 pkgrel="1"
 pkgdesc="Command line tools for fly.io services"
 arch=("x86_64")
@@ -10,8 +10,8 @@ license=("Apache")
 depends=()
 provides=("flyctl")
 conflicts=("flyctl")
 source=("$pkgname-$pkgver.tgz::https://github.com/superfly/flyctl/releases/download/v${pkgver}/flyctl_${pkgver}_Linux_x86_64.tar.gz")
-sha256sums=('d7247539b588cbdf0ca0a62b5244a1aba052887a4d603e19a4ce9a4f6b95b398')
+sha256sums=('8254ad2c9cdb908713b4ea8294cb4035e87afcb2672da632e4fedde92bff3a40')

 package() {
     mkdir -p "$pkgdir/usr/bin"
```