### PR TITLE
Don't mount volumes to releaseCommandMachine

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -624,11 +624,6 @@ func (md *machineDeployment) resolveUpdatedMachineConfig(origMachineRaw *api.Mac
 
 	if origMachineRaw.Config.Mounts != nil {
 		launchInput.Config.Mounts = origMachineRaw.Config.Mounts
-	} else if md.appConfig.Mounts != nil {
-		launchInput.Config.Mounts = []api.MachineMount{{
-			Path:   md.volumeDestination,
-			Volume: md.volumes[0].ID,
-		}}
 	}
 
 	if len(launchInput.Config.Mounts) == 1 && launchInput.Config.Mounts[0].Path != md.volumeDestination {


### PR DESCRIPTION
From my understanding after reading the code, lunchInput is just the machine used for the release command. We aren't supposed to mount volumes to them anyway, so this should be fine. Should fix #1752