### PR TITLE
Fixed crash when saving config

### DIFF
--- a/internal/appv2/from_machine_set.go
+++ b/internal/appv2/from_machine_set.go
@@ -185,6 +185,12 @@ func processGroupsFromMachineSet(ms machine.MachineSet) (*processGroupInfo, stri
 		counter        = newFreqCounter[machine.LeasableMachine]()
 		serviceCounter = newFreqCounter[machine.LeasableMachine]()
 	)
+
+	if ms.IsEmpty() {
+		return nil, "No machines configured for this app"
+
+	}
+
 	for _, m := range ms.GetMachines() {
 		cmdWords := quotePosixWords(m.Machine().Config.Init.Cmd)
 		cmd := strings.Join(cmdWords, " ")


### PR DESCRIPTION
When an AppV2 has no machines, then it won't be able to load the config, since there aren't any machines to load it from.

Ignore the name of the branch, it was originally meant to fix a different error, but I encountered this one in the mean time.
More discussion here:
https://flyio.discourse.team/t/internal-error-setting-secret-for-machines-apps/1932/2