### PR TITLE
PG import command

### DIFF
--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -25,7 +25,7 @@ import (
 
 func newImport() *cobra.Command {
 	const (
-		short = "Imports Postgres database from a Postgres URI"
+		short = "Imports database from a specified Postgres URI"
 		long  = short + "\n"
 		usage = "import"
 	)

--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -34,7 +34,7 @@ type importOpts struct {
 
 func newImport() *cobra.Command {
 	const (
-		short = "Imports a database from a target URI"
+		short = "Imports a database from a Postgres URI"
 		long  = short + "\n"
 		usage = "import"
 	)
@@ -49,7 +49,7 @@ func newImport() *cobra.Command {
 		flag.AppConfig(),
 		flag.String{
 			Name:        "source-uri",
-			Description: "The target postgres uri",
+			Description: "The target postgres uri. This should target the individual database you wish to migrate.",
 		},
 		flag.String{
 			Name:        "image",

--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -167,7 +167,7 @@ func runImport(ctx context.Context) error {
 		return err
 	}
 
-	fmt.Fprintf(io.Out, "Waiting for machine to start...\n")
+	fmt.Fprintf(io.Out, "Waiting for machine %s to start...\n", machine.ID)
 	err = mach.WaitForStartOrStop(ctx, machine, "start", time.Minute*1)
 	if err != nil {
 		return err

--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -23,15 +23,6 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 )
 
-type importOpts struct {
-	sourceURI string
-	targetURI string
-	noOwner   bool
-	clean     bool
-	create    bool
-	dataOnly  bool
-}
-
 func newImport() *cobra.Command {
 	const (
 		short = "Imports a database from a Postgres URI"

--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -1,0 +1,237 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/docker/docker/pkg/ioutils"
+	"github.com/mattn/go-colorable"
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/agent"
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/app"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/command/apps"
+	"github.com/superfly/flyctl/internal/command/ssh"
+	"github.com/superfly/flyctl/internal/flag"
+	mach "github.com/superfly/flyctl/internal/machine"
+	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+type importOpts struct {
+	sourceURI string
+	targetURI string
+	noOwner   bool
+	clean     bool
+	create    bool
+	dataOnly  bool
+}
+
+func newImport() *cobra.Command {
+	const (
+		short = "Imports a database from a target URI"
+		long  = short + "\n"
+		usage = "import"
+	)
+
+	cmd := command.New(usage, short, long, runImport,
+		command.RequireSession,
+		command.RequireAppName,
+	)
+
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+		flag.String{
+			Name:        "source-uri",
+			Description: "The target postgres uri",
+		},
+		flag.String{
+			Name:        "image",
+			Description: "Path to public image containing custom migration process",
+		},
+		flag.String{
+			Name:        "vm-size",
+			Description: "the size of the VM",
+		},
+		flag.String{
+			Name:        "region",
+			Description: "Region to provision migration machine",
+		},
+		flag.Bool{
+			Name:        "no-owner",
+			Description: "Do not set ownership of objects to match the original database. Makes dump restorable by any user.",
+			Default:     true,
+		},
+		flag.Bool{
+			Name:        "create",
+			Description: "Begin by creating the database itself and reconnecting to it. If --clean is also specified, the script drops and recreates the target database before reconnecting to it.",
+			Default:     true,
+		},
+		flag.Bool{
+			Name:        "clean",
+			Description: "Drop database objects prior to creating them.",
+			Default:     true,
+		},
+		flag.Bool{
+			Name:        "data-only",
+			Description: "Dump only the data, not the schema (data definitions).",
+		},
+	)
+
+	return cmd
+}
+
+func runImport(ctx context.Context) error {
+	var (
+		io      = iostreams.FromContext(ctx)
+		client  = client.FromContext(ctx).API()
+		appName = app.NameFromContext(ctx)
+
+		sourceURI = flag.GetString(ctx, "source-uri")
+		machSize  = flag.GetString(ctx, "vm-size")
+		imageRef  = flag.GetString(ctx, "image")
+	)
+
+	app, err := client.GetAppCompact(ctx, appName)
+	if err != nil {
+		return fmt.Errorf("failed to resolve app: %w", err)
+	}
+
+	region, err := prompt.Region(ctx, !app.Organization.PaidPlan, prompt.RegionParams{
+		Message: "Choose a region to deploy the migration machine:",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to resolve region: %s", err)
+	}
+
+	vmSize, err := resolveVMSize(ctx, machSize)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.SetSecrets(ctx, app.Name, map[string]string{
+		"SOURCE_DATABASE_URI": sourceURI,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set secrets: %s", err)
+	}
+
+	ctx, err = apps.BuildContext(ctx, app)
+	if err != nil {
+		return fmt.Errorf("failed to build context: %s", err)
+	}
+
+	flapsClient := flaps.FromContext(ctx)
+
+	machineConfig := &api.MachineConfig{
+		Env: map[string]string{
+			"POSTGRES_PASSWORD": "pass",
+		},
+		Guest: &api.MachineGuest{
+			CPUKind:  vmSize.CPUClass,
+			CPUs:     int(vmSize.CPUCores),
+			MemoryMB: vmSize.MemoryMB,
+		},
+		DNS: &api.DNSConfig{
+			SkipRegistration: true,
+		},
+		Restart: api.MachineRestart{
+			Policy: api.MachineRestartPolicyNo,
+		},
+	}
+
+	if imageRef == "" {
+		imageRef, err = client.GetLatestImageTag(ctx, "flyio/postgres-importer", nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	machineConfig.Image = imageRef
+
+	launchInput := api.LaunchMachineInput{
+		AppID:   app.ID,
+		OrgSlug: app.Organization.ID,
+		Region:  region.Code,
+		Config:  machineConfig,
+	}
+
+	machine, err := flapsClient.Launch(ctx, launchInput)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(io.Out, "Waiting for machine to start...\n")
+	err = mach.WaitForStartOrStop(ctx, machine, "start", time.Minute*1)
+	if err != nil {
+		return err
+	}
+
+	err = ssh.SSHConnect(&ssh.SSHParams{
+		Ctx:    ctx,
+		Org:    app.Organization,
+		Dialer: agent.DialerFromContext(ctx),
+		App:    app.Name,
+		Cmd:    resolveImportCommand(ctx),
+		Stdin:  os.Stdin,
+		Stdout: ioutils.NewWriteCloserWrapper(colorable.NewColorableStdout(), func() error { return nil }),
+		Stderr: ioutils.NewWriteCloserWrapper(colorable.NewColorableStderr(), func() error { return nil }),
+	}, machine.PrivateIP)
+
+	if err != nil {
+		return fmt.Errorf("failed to run ssh: %s", err)
+	}
+
+	if err := flapsClient.Stop(ctx, api.StopMachineInput{ID: machine.ID}); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(io.Out, "Waiting for machine %s to stop...\n", machine.ID)
+	err = mach.WaitForStartOrStop(ctx, machine, "stop", time.Minute*1)
+	if err != nil {
+		return fmt.Errorf("failed waiting for machine %s to stop: %s", machine.ID, err)
+	}
+
+	fmt.Fprintf(io.Out, "%s has been destroyed\n", machine.ID)
+	if err := flapsClient.Destroy(ctx, api.RemoveMachineInput{ID: machine.ID, AppID: app.ID}); err != nil {
+		return fmt.Errorf("failed to destroy machine %s: %s", machine.ID, err)
+	}
+
+	_, err = client.UnsetSecrets(ctx, app.Name, []string{"SOURCE_DATABASE_URI"})
+	if err != nil {
+		return fmt.Errorf("failed to set secrets: %s", err)
+	}
+
+	return nil
+}
+
+func resolveImportCommand(ctx context.Context) string {
+	var (
+		noOwner  = flag.GetBool(ctx, "no-owner")
+		create   = flag.GetBool(ctx, "create")
+		clean    = flag.GetBool(ctx, "clean")
+		dataOnly = flag.GetBool(ctx, "data-only")
+	)
+
+	importCmd := "migrate "
+	if noOwner {
+		importCmd = importCmd + " -no-owner"
+	}
+	if clean {
+		importCmd = importCmd + " -clean"
+	}
+	if create {
+		importCmd = importCmd + " -create"
+	}
+	if dataOnly {
+		importCmd = importCmd + " -data-only"
+	}
+
+	return importCmd
+}

--- a/internal/command/postgres/postgres.go
+++ b/internal/command/postgres/postgres.go
@@ -38,6 +38,7 @@ func New() *cobra.Command {
 		newFailover(),
 		newNomadToMachines(),
 		newAddFlycast(),
+		newImport(),
 	)
 
 	return cmd


### PR DESCRIPTION
This introduces the `fly pg import` command.

```
Import a database from a target URI

Usage:
  flyctl postgres import [flags]

Flags:
  -a, --app string          Application name
      --clean               Drop database objects prior to creating them. (default true)
  -c, --config string       Path to application configuration file
      --create              Begin by creating the database itself and reconnecting to it. If --clean is also specified, the script drops and recreates the target database before reconnecting to it. (default true)
      --data-only           Dump only the data, not the schema (data definitions).
  -h, --help                help for import
      --image string        Path to public image containing custom migration process
      --no-owner            Do not set ownership of objects to match the original database. Makes dump restorable by any user. (default true)
      --region string       Region to provision migration machine
      --source-uri string   The target postgres uri
      --vm-size string      the size of the VM
 ```
 
 Example usage:
 
<img width="887" alt="Screenshot 2023-02-27 at 11 32 36 AM" src="https://user-images.githubusercontent.com/423038/221639449-6011efb1-1f6b-4cfc-b138-720f32957ed0.png">

