### PR TITLE
Set releaseCommandMachine to an empty list by default

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -139,6 +139,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		leaseTimeout:               leaseTimeout,
 		leaseDelayBetween:          leaseDelayBetween,
 		releaseCommand:             releaseCmd,
+		releaseCommandMachine:      machine.NewMachineSet(flapsClient, io, nil),
 	}
 	err = md.setStrategy(args.Strategy)
 	if err != nil {


### PR DESCRIPTION
By default, releaseCommandMachine isn't set at all. If you have a machine with mounts, but the mounts aren't set in fly.toml, for whatever reason, releaseCommandMachine is never populated, and as such, deploys crash. An easy fix is to just set it to an empty list by default.