### PR TITLE
Unhide `--image-ref`

### DIFF
--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -62,7 +62,7 @@ func newCreate() *cobra.Command {
 		},
 		flag.String{
 			Name:   "image-ref",
-			Hidden: true,
+			Description: "Specify a non-default base image for the Postgres app",
 		},
 		flag.Bool{
 			Name:        "stolon",


### PR DESCRIPTION
Since it's part of our current instructions for using Timescale, it's better if `fly pg create -h` shows it.