### PR TITLE
Fix `fly launch` not saving the chosen region

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -337,10 +337,6 @@ func (c *Config) marshalTOML(w io.Writer) error {
 		"app": c.AppName,
 	}
 
-	if c.PrimaryRegion != "" {
-		rawData["primary_region"] = c.PrimaryRegion
-	}
-
 	if err := encoder.Encode(rawData); err != nil {
 		return err
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -337,6 +337,10 @@ func (c *Config) marshalTOML(w io.Writer) error {
 		"app": c.AppName,
 	}
 
+	if c.PrimaryRegion != "" {
+		rawData["primary_region"] = c.PrimaryRegion
+	}
+
 	if err := encoder.Encode(rawData); err != nil {
 		return err
 	}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -275,6 +275,12 @@ func determineAppConfig(ctx context.Context) (cfg *app.Config, err error) {
 		cfg.AppName = basicApp.Name
 		cfg.SetPlatformVersion(basicApp.PlatformVersion)
 	} else {
+
+		// TODO: this function is called for every `fly deploy` but I'm pretty sure
+		//       this ends up hitting a nomad-specific code path. We'll cheat for now,
+		//       because ripping this out would be a huge change, but this is probably not *right*
+		delete(cfg.Definition, "primary_region")
+
 		parsedCfg, err := client.ParseConfig(ctx, appNameFromContext, cfg.Definition)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The primary_region should be saved in `fly.toml` for v2 apps. I don't believe this is part of the V1 `fly.toml` file, so there's some weird special casing going on here.

todo: 
- does this affect `fly config save`?
  - should it?
- does this break anything else?

(it's possible that other places that read fly.toml won't like that it's now perfectly OK for it to have `primary_region`. Granted, I think it was supposed to be that way already, but you can never be too safe!)

Fixes #1798