### PR TITLE
Remove confusing msg from fly deploy

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -168,16 +168,15 @@ func DeployWithConfig(ctx context.Context, appConfig *app.Config, args DeployWit
 			primaryRegion = flag.GetString(ctx, flag.RegionName)
 		}
 		md, err := NewMachineDeployment(ctx, MachineDeploymentArgs{
-			AppCompact:           appCompact,
-			DeploymentImage:      img,
-			Strategy:             flag.GetString(ctx, "strategy"),
-			EnvFromFlags:         flag.GetStringSlice(ctx, "env"),
-			PrimaryRegionFlag:    primaryRegion,
-			AutoConfirmMigration: flag.GetBool(ctx, "auto-confirm"),
-			BuildOnly:            flag.GetBuildOnly(ctx),
-			SkipHealthChecks:     flag.GetDetach(ctx),
-			WaitTimeout:          time.Duration(flag.GetInt(ctx, "wait-timeout")) * time.Second,
-			LeaseTimeout:         time.Duration(flag.GetInt(ctx, "lease-timeout")) * time.Second,
+			AppCompact:        appCompact,
+			DeploymentImage:   img,
+			Strategy:          flag.GetString(ctx, "strategy"),
+			EnvFromFlags:      flag.GetStringSlice(ctx, "env"),
+			PrimaryRegionFlag: primaryRegion,
+			BuildOnly:         flag.GetBuildOnly(ctx),
+			SkipHealthChecks:  flag.GetDetach(ctx),
+			WaitTimeout:       time.Duration(flag.GetInt(ctx, "wait-timeout")) * time.Second,
+			LeaseTimeout:      time.Duration(flag.GetInt(ctx, "lease-timeout")) * time.Second,
 		})
 		if err != nil {
 			return err

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -34,43 +34,41 @@ type MachineDeployment interface {
 }
 
 type MachineDeploymentArgs struct {
-	AppCompact           *api.AppCompact
-	DeploymentImage      *imgsrc.DeploymentImage
-	Strategy             string
-	EnvFromFlags         []string
-	PrimaryRegionFlag    string
-	AutoConfirmMigration bool
-	BuildOnly            bool
-	SkipHealthChecks     bool
-	RestartOnly          bool
-	WaitTimeout          time.Duration
-	LeaseTimeout         time.Duration
+	AppCompact        *api.AppCompact
+	DeploymentImage   *imgsrc.DeploymentImage
+	Strategy          string
+	EnvFromFlags      []string
+	PrimaryRegionFlag string
+	BuildOnly         bool
+	SkipHealthChecks  bool
+	RestartOnly       bool
+	WaitTimeout       time.Duration
+	LeaseTimeout      time.Duration
 }
 
 type machineDeployment struct {
-	apiClient                  *api.Client
-	gqlClient                  graphql.Client
-	flapsClient                *flaps.Client
-	io                         *iostreams.IOStreams
-	colorize                   *iostreams.ColorScheme
-	app                        *api.AppCompact
-	appConfig                  *appv2.Config
-	processConfigs             map[string]*appv2.ProcessConfig
-	img                        *imgsrc.DeploymentImage
-	machineSet                 machine.MachineSet
-	releaseCommandMachine      machine.MachineSet
-	releaseCommand             []string
-	volumeDestination          string
-	volumes                    []api.Volume
-	strategy                   string
-	releaseId                  string
-	releaseVersion             int
-	autoConfirmAppsV2Migration bool
-	skipHealthChecks           bool
-	restartOnly                bool
-	waitTimeout                time.Duration
-	leaseTimeout               time.Duration
-	leaseDelayBetween          time.Duration
+	apiClient             *api.Client
+	gqlClient             graphql.Client
+	flapsClient           *flaps.Client
+	io                    *iostreams.IOStreams
+	colorize              *iostreams.ColorScheme
+	app                   *api.AppCompact
+	appConfig             *appv2.Config
+	processConfigs        map[string]*appv2.ProcessConfig
+	img                   *imgsrc.DeploymentImage
+	machineSet            machine.MachineSet
+	releaseCommandMachine machine.MachineSet
+	releaseCommand        []string
+	volumeDestination     string
+	volumes               []api.Volume
+	strategy              string
+	releaseId             string
+	releaseVersion        int
+	skipHealthChecks      bool
+	restartOnly           bool
+	waitTimeout           time.Duration
+	leaseTimeout          time.Duration
+	leaseDelayBetween     time.Duration
 }
 
 func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (MachineDeployment, error) {
@@ -121,22 +119,21 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	io := iostreams.FromContext(ctx)
 	apiClient := client.FromContext(ctx).API()
 	md := &machineDeployment{
-		apiClient:                  apiClient,
-		gqlClient:                  apiClient.GenqClient,
-		flapsClient:                flapsClient,
-		io:                         io,
-		colorize:                   io.ColorScheme(),
-		app:                        args.AppCompact,
-		appConfig:                  appConfig,
-		processConfigs:             processConfigs,
-		img:                        args.DeploymentImage,
-		autoConfirmAppsV2Migration: args.AutoConfirmMigration,
-		skipHealthChecks:           args.SkipHealthChecks,
-		restartOnly:                args.RestartOnly,
-		waitTimeout:                waitTimeout,
-		leaseTimeout:               leaseTimeout,
-		leaseDelayBetween:          leaseDelayBetween,
-		releaseCommand:             releaseCmd,
+		apiClient:         apiClient,
+		gqlClient:         apiClient.GenqClient,
+		flapsClient:       flapsClient,
+		io:                io,
+		colorize:          io.ColorScheme(),
+		app:               args.AppCompact,
+		appConfig:         appConfig,
+		processConfigs:    processConfigs,
+		img:               args.DeploymentImage,
+		skipHealthChecks:  args.SkipHealthChecks,
+		restartOnly:       args.RestartOnly,
+		waitTimeout:       waitTimeout,
+		leaseTimeout:      leaseTimeout,
+		leaseDelayBetween: leaseDelayBetween,
+		releaseCommand:    releaseCmd,
 	}
 	err = md.setStrategy(args.Strategy)
 	if err != nil {


### PR DESCRIPTION
Remove the "Migrate %d existing machines into Fly Apps Platform?" confirmation from `fly deploy`.

Previously developers got that message if they were deploying to machines that that were missing the apps v2 metadata. This has just been confusing for developers with little upside.

The original idea was it would give folks a warning if they were deploying and had a heterogenous cluster that they didn't want to trample over. The reality is that `fly deploy` has always applied to all machines, so this confirmation was just confusing.

I debated adding in a check for different images/other configs that would be material, but decided it wasn't worth it. Most developers will use `fly deploy` to update all machines in their app, so we should just do that for them without prompting. Developers that need to update a subset of machines will likely be using `fly m update` or the machines api already anyway (and those are the right answer).
