### PR TITLE
add autostart machines option

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -354,11 +354,12 @@ func (mp *MachinePort) HasNonHttpPorts() bool {
 }
 
 type MachineService struct {
-	Protocol     string                     `json:"protocol,omitempty" toml:"protocol,omitempty"`
-	InternalPort int                        `json:"internal_port,omitempty" toml:"internal_port,omitempty"`
-	Ports        []MachinePort              `json:"ports,omitempty" toml:"ports,omitempty"`
-	Checks       []MachineCheck             `json:"checks,omitempty" toml:"checks,omitempty"`
-	Concurrency  *MachineServiceConcurrency `json:"concurrency,omitempty" toml:"concurrency"`
+	Protocol          string                     `json:"protocol,omitempty" toml:"protocol,omitempty"`
+	InternalPort      int                        `json:"internal_port,omitempty" toml:"internal_port,omitempty"`
+	Ports             []MachinePort              `json:"ports,omitempty" toml:"ports,omitempty"`
+	Checks            []MachineCheck             `json:"checks,omitempty" toml:"checks,omitempty"`
+	Concurrency       *MachineServiceConcurrency `json:"concurrency,omitempty" toml:"concurrency"`
+	AutostartMachines bool                       `json:"autostart_machines,omitempty" toml:"autostart_machines,omitempty"`
 }
 
 type MachineServiceConcurrency struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -354,12 +354,12 @@ func (mp *MachinePort) HasNonHttpPorts() bool {
 }
 
 type MachineService struct {
-	Protocol          string                     `json:"protocol,omitempty" toml:"protocol,omitempty"`
-	InternalPort      int                        `json:"internal_port,omitempty" toml:"internal_port,omitempty"`
-	Ports             []MachinePort              `json:"ports,omitempty" toml:"ports,omitempty"`
-	Checks            []MachineCheck             `json:"checks,omitempty" toml:"checks,omitempty"`
-	Concurrency       *MachineServiceConcurrency `json:"concurrency,omitempty" toml:"concurrency"`
-	AutostartMachines bool                       `json:"autostart_machines,omitempty" toml:"autostart_machines,omitempty"`
+	Protocol                string                     `json:"protocol,omitempty" toml:"protocol,omitempty"`
+	InternalPort            int                        `json:"internal_port,omitempty" toml:"internal_port,omitempty"`
+	Ports                   []MachinePort              `json:"ports,omitempty" toml:"ports,omitempty"`
+	Checks                  []MachineCheck             `json:"checks,omitempty" toml:"checks,omitempty"`
+	Concurrency             *MachineServiceConcurrency `json:"concurrency,omitempty" toml:"concurrency"`
+	DisableMachineAutostart bool                       `json:"disable_machine_autostart,omitempty" toml:"disable_machine_autostart,omitempty"`
 }
 
 type MachineServiceConcurrency struct {


### PR DESCRIPTION
Adds a configuration option, `autostart_machines` that enables you to toggle on/off automatically starting machines