### PR TITLE
Revert "Don't mount volumes to releaseCommandMachine"

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -581,6 +581,11 @@ func (md *machineDeployment) resolveUpdatedMachineConfig(origMachineRaw *api.Mac
 
 	if origMachineRaw.Config.Mounts != nil {
 		launchInput.Config.Mounts = origMachineRaw.Config.Mounts
+	} else if md.appConfig.Mounts != nil {
+		launchInput.Config.Mounts = []api.MachineMount{{
+			Path:   md.volumeDestination,
+			Volume: md.volumes[0].ID,
+		}}
 	}
 
 	if len(launchInput.Config.Mounts) == 1 && launchInput.Config.Mounts[0].Path != md.volumeDestination {


### PR DESCRIPTION
Reverts superfly/flyctl#1777 because it broke launching machines with volumes

