### PR TITLE
"Release command" machine won't get mounts, metrics, services, checks and statics 

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -550,6 +550,7 @@ func (md *machineDeployment) resolveUpdatedMachineConfig(origMachineRaw *api.Mac
 		Config:  machineConf,
 		Region:  origMachineRaw.Region,
 	}
+
 	launchInput.Config.Metadata = md.defaultMachineMetadata()
 	if origMachineRaw.Config.Metadata != nil {
 		for k, v := range origMachineRaw.Config.Metadata {
@@ -581,7 +582,7 @@ func (md *machineDeployment) resolveUpdatedMachineConfig(origMachineRaw *api.Mac
 
 	if origMachineRaw.Config.Mounts != nil {
 		launchInput.Config.Mounts = origMachineRaw.Config.Mounts
-	} else if md.appConfig.Mounts != nil && !forReleaseCommand {
+	} else if md.appConfig.Mounts != nil {
 		launchInput.Config.Mounts = []api.MachineMount{{
 			Path:   md.volumeDestination,
 			Volume: md.volumes[0].ID,

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -1,0 +1,172 @@
+package deploy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/internal/appv2"
+	"github.com/superfly/flyctl/internal/build/imgsrc"
+)
+
+func Test_resultUpdateMachineConfig_Basic(t *testing.T) {
+	md := &machineDeployment{
+		app: &api.AppCompact{
+			ID: "my-cool-app",
+			Organization: &api.OrganizationBasic{
+				ID: "my-dangling-org",
+			},
+		},
+		img: &imgsrc.DeploymentImage{
+			Tag: "super/ballon",
+		},
+		appConfig: &appv2.Config{
+			AppName: "my-cool-app",
+			Env: map[string]string{
+				"PRIMARY_REGION": "scl",
+				"OTHER":          "value",
+			},
+		},
+	}
+	var err error
+	md.processConfigs, err = md.appConfig.GetProcessConfigs()
+	assert.NoError(t, err)
+
+	launchInput := md.resolveUpdatedMachineConfig(nil, false)
+
+	assert.Equal(t, &api.LaunchMachineInput{
+		OrgSlug: "my-dangling-org",
+		Config: &api.MachineConfig{
+			Env: map[string]string{
+				"PRIMARY_REGION": "scl",
+				"OTHER":          "value",
+			},
+			Image: "super/ballon",
+			Metadata: map[string]string{
+				"fly_platform_version": "v2",
+				"fly_process_group":    "app",
+				"fly_release_id":       "",
+				"fly_release_version":  "0",
+			},
+			Services: []api.MachineService{},
+			Checks:   map[string]api.MachineCheck{},
+		},
+	}, launchInput)
+}
+
+func Test_resultUpdateMachineConfig_RelaseCommand(t *testing.T) {
+	md := &machineDeployment{
+		app: &api.AppCompact{
+			ID: "my-cool-app",
+			Organization: &api.OrganizationBasic{
+				ID: "my-dangling-org",
+			},
+		},
+		img: &imgsrc.DeploymentImage{
+			Tag: "super/ballon",
+		},
+		volumes: []api.Volume{
+			{ID: "vol_12345"},
+		},
+		volumeDestination: "/data",
+		appConfig: &appv2.Config{
+			AppName: "my-cool-app",
+			Env: map[string]string{
+				"PRIMARY_REGION": "scl",
+				"OTHER":          "value",
+			},
+			Metrics: &api.MachineMetrics{
+				Port: 9000,
+				Path: "/prometheus",
+			},
+			Deploy: &appv2.Deploy{
+				ReleaseCommand: "echo foo",
+			},
+			Mounts: &appv2.Volume{
+				Source:      "data",
+				Destination: "/data",
+			},
+			Checks: map[string]*appv2.ToplevelCheck{
+				"alive": {
+					Port: api.Pointer(8080),
+					Type: api.Pointer("tcp"),
+				},
+			},
+			Statics: []appv2.Static{{
+				GuestPath: "/app/assets",
+				UrlPrefix: "/statics",
+			}},
+			Services: []appv2.Service{{
+				Protocol:     "tcp",
+				InternalPort: 8080,
+			}},
+		},
+	}
+	var err error
+	md.processConfigs, err = md.appConfig.GetProcessConfigs()
+	assert.NoError(t, err)
+
+	// New app machine
+	assert.Equal(t, &api.LaunchMachineInput{
+		OrgSlug: "my-dangling-org",
+		Config: &api.MachineConfig{
+			Env: map[string]string{
+				"PRIMARY_REGION": "scl",
+				"OTHER":          "value",
+			},
+			Image: "super/ballon",
+			Metadata: map[string]string{
+				"fly_platform_version": "v2",
+				"fly_process_group":    "app",
+				"fly_release_id":       "",
+				"fly_release_version":  "0",
+			},
+			Metrics: &api.MachineMetrics{
+				Port: 9000,
+				Path: "/prometheus",
+			},
+			Mounts: []api.MachineMount{{
+				Volume: "vol_12345",
+				Path:   "/data",
+			}},
+			Statics: []*api.Static{{
+				GuestPath: "/app/assets",
+				UrlPrefix: "/statics",
+			}},
+			Services: []api.MachineService{{
+				Protocol:     "tcp",
+				InternalPort: 8080,
+				Checks:       []api.MachineCheck{},
+			}},
+			Checks: map[string]api.MachineCheck{
+				"alive": {
+					Port:        api.Pointer(8080),
+					Type:        api.Pointer("tcp"),
+					HTTPHeaders: []api.MachineHTTPHeader{},
+				},
+			},
+		},
+	},
+		md.resolveUpdatedMachineConfig(nil, false),
+	)
+
+	// New release command machine
+	assert.Equal(t, &api.LaunchMachineInput{
+		OrgSlug: "my-dangling-org",
+		Config: &api.MachineConfig{
+			Env: map[string]string{
+				"PRIMARY_REGION": "scl",
+				"OTHER":          "value",
+			},
+			Image: "super/ballon",
+			Metadata: map[string]string{
+				"fly_platform_version": "v2",
+				"fly_process_group":    "app",
+				"fly_release_id":       "",
+				"fly_release_version":  "0",
+			},
+		},
+	},
+		md.resolveUpdatedMachineConfig(nil, true),
+	)
+}

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -54,6 +54,8 @@ func Test_resultUpdateMachineConfig_Basic(t *testing.T) {
 	}, launchInput)
 }
 
+// Test any LaunchMachineInput field that must not be set on a machine
+// used to run release command.
 func Test_resultUpdateMachineConfig_RelaseCommand(t *testing.T) {
 	md := &machineDeployment{
 		app: &api.AppCompact{

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -18,7 +18,7 @@ func Test_resultUpdateMachineConfig_Basic(t *testing.T) {
 			},
 		},
 		img: &imgsrc.DeploymentImage{
-			Tag: "super/ballon",
+			Tag: "super/balloon",
 		},
 		appConfig: &appv2.Config{
 			AppName: "my-cool-app",
@@ -41,7 +41,7 @@ func Test_resultUpdateMachineConfig_Basic(t *testing.T) {
 				"PRIMARY_REGION": "scl",
 				"OTHER":          "value",
 			},
-			Image: "super/ballon",
+			Image: "super/balloon",
 			Metadata: map[string]string{
 				"fly_platform_version": "v2",
 				"fly_process_group":    "app",
@@ -65,7 +65,7 @@ func Test_resultUpdateMachineConfig_RelaseCommand(t *testing.T) {
 			},
 		},
 		img: &imgsrc.DeploymentImage{
-			Tag: "super/ballon",
+			Tag: "super/balloon",
 		},
 		volumes: []api.Volume{
 			{ID: "vol_12345"},
@@ -116,7 +116,7 @@ func Test_resultUpdateMachineConfig_RelaseCommand(t *testing.T) {
 				"PRIMARY_REGION": "scl",
 				"OTHER":          "value",
 			},
-			Image: "super/ballon",
+			Image: "super/balloon",
 			Metadata: map[string]string{
 				"fly_platform_version": "v2",
 				"fly_process_group":    "app",
@@ -160,7 +160,7 @@ func Test_resultUpdateMachineConfig_RelaseCommand(t *testing.T) {
 				"PRIMARY_REGION": "scl",
 				"OTHER":          "value",
 			},
-			Image: "super/ballon",
+			Image: "super/balloon",
 			Metadata: map[string]string{
 				"fly_platform_version": "v2",
 				"fly_process_group":    "app",


### PR DESCRIPTION
Fixes #1752 

```toml
app = "nobodyapp"

[mounts]
source = "data"
destination = "/data"

[deploy]
release_command = "echo RELEASED $(date)"
```

```console
$ fly deploy
...
image: registry.fly.io/nobodyapp:deployment-01GTHFF7XZM7DQ9QYA8Z5RW4J0
image size: 7.1 MB
Running nobodyapp release_command: echo RELEASED $(date)
  release_command 9e784e23ce0683 completed successfully
Deploying nobodyapp app with rolling strategy
  Machine 4d891ddeb67487 [app] update finished: success
  Machine 178175df95d789 [app] update finished: success
  Finished deploying
```