### PR TITLE
`fly m update`: extra cpu and memory validation, fix invalid suggestions

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -633,10 +633,14 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 	// Potential overrides for Guest
 	if cpus := flag.GetInt(ctx, "cpus"); cpus != 0 {
 		machineConf.Guest.CPUs = cpus
+	} else if flag.IsSpecified(ctx, "cpus") {
+		return nil, fmt.Errorf("cannot have zero cpus")
 	}
 
 	if memory := flag.GetInt(ctx, "memory"); memory != 0 {
 		machineConf.Guest.MemoryMB = memory
+	} else if flag.IsSpecified(ctx, "memory") {
+		return nil, fmt.Errorf("memory cannot be zero")
 	}
 
 	if len(flag.GetStringSlice(ctx, "kernel-arg")) != 0 {

--- a/internal/flag/context.go
+++ b/internal/flag/context.go
@@ -71,6 +71,13 @@ func GetBool(ctx context.Context, name string) bool {
 	}
 }
 
+// IsSpecified returns whether a flag has been specified at all or not.
+// This is useful, for example, when differentiating between 0/"" and unspecified.
+func IsSpecified(ctx context.Context, name string) bool {
+	flag := FromContext(ctx).Lookup(name)
+	return flag != nil && flag.Changed
+}
+
 // GetOrg is shorthand for GetString(ctx, OrgName).
 func GetOrg(ctx context.Context) string {
 	return GetString(ctx, OrgName)

--- a/internal/machine/update.go
+++ b/internal/machine/update.go
@@ -48,10 +48,17 @@ func Update(ctx context.Context, m *api.Machine, input *api.LaunchMachineInput) 
 		}
 
 		if input.Config.Guest.CPUKind == "shared" && input.Config.Guest.MemoryMB%256 != 0 {
-			return fmt.Errorf("invalid config: invalid memory size %d; must be in 256 MiB increment (%d would work)\nView more information here: https://fly.io/docs/about/pricing/#machines", input.Config.Guest.MemoryMB, input.Config.Guest.MemoryMB-(input.Config.Guest.MemoryMB%256))
+			suggestion := input.Config.Guest.MemoryMB - (input.Config.Guest.MemoryMB % 256)
+			if suggestion == 0 {
+				suggestion = 256
+			}
+			return fmt.Errorf("invalid config: invalid memory size %d; must be in 256 MiB increment (%d would work)\nView more information here: https://fly.io/docs/about/pricing/#machines", input.Config.Guest.MemoryMB, suggestion)
 		} else if input.Config.Guest.CPUKind == "performance" && input.Config.Guest.MemoryMB%1024 != 0 {
-			return fmt.Errorf("invalid config: invalid memory size %d; must be in 1024 MiB increment (%d would work)\nView more information here: https://fly.io/docs/about/pricing/#machines", input.Config.Guest.MemoryMB, input.Config.Guest.MemoryMB-(input.Config.Guest.MemoryMB%1024))
-
+			suggestion := input.Config.Guest.MemoryMB - (input.Config.Guest.MemoryMB % 1024)
+			if suggestion == 0 {
+				suggestion = 1024
+			}
+			return fmt.Errorf("invalid config: invalid memory size %d; must be in 1024 MiB increment (%d would work)\nView more information here: https://fly.io/docs/about/pricing/#machines", input.Config.Guest.MemoryMB, suggestion)
 		}
 
 		// Check memory sizes


### PR DESCRIPTION
It used to give you a really useless error message if you specified zero CPUs or zero MB of ram, and if you specified ram in the range of 0-255MB it would suggest 0MB as an option.

Closes #1806