### PR TITLE
Pass environment variables to `nixpacks` with --env

### DIFF
--- a/internal/build/imgsrc/nixpacks_builder.go
+++ b/internal/build/imgsrc/nixpacks_builder.go
@@ -197,16 +197,16 @@ func (*nixpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFact
 	nixpacksPath := filepath.Join(confDir, "bin", "nixpacks")
 
 	nixpacksArgs := []string{"build", "--name", opts.Tag, opts.WorkingDir}
+	for _, kv := range os.Environ() {
+		if strings.HasPrefix(kv, "NIXPACKS_") {
+			nixpacksArgs = append(nixpacksArgs, "--env", kv)
+		}
+	}
 
 	terminal.Debugf("calling nixpacks at %s with args: %v and docker host: %s", nixpacksPath, nixpacksArgs, dockerHost)
 
 	cmd := exec.CommandContext(ctx, nixpacksPath, nixpacksArgs...)
 	cmd.Env = append(cmd.Env, fmt.Sprintf("DOCKER_HOST=%s", dockerHost), fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
-	for _, kv := range os.Environ() {
-		if strings.HasPrefix(kv, "NIXPACKS_") {
-			cmd.Env = append(cmd.Env, kv)
-		}
-	}
 	cmd.Stdout = streams.Out
 	cmd.Stderr = streams.ErrOut
 	cmd.Stdin = nil


### PR DESCRIPTION
As far as I can tell, `nixpacks` doesn't actually read environment variables for the build from the system, but rather accepts them through the `--env` option. E.g., `NIXPACKS_NO_MUSL=1 nixpacks build .` does not work, but `nixpacks build . --env NIXPACKS_NO_MUSL=1` does. This can also be observed by checking the "variables" field in the JSON emitted by `nixpacks plan`. (Finally, I took a brief look at the`nixpacks` source and didn't find it reading environment variables anywhere.)

This keeps the existing behavior (forwarding `NIXPACKS_*` environment variables to `nixpacks`), since that's what existing documentation says will work, but uses the `--env` option to do so instead.

Applicable forum thread: https://community.fly.io/t/ring-rust-dependency-build-failure-with-nixpacks/11121