### PR TITLE
Fix secrets import on files with \r\n as newlines

### DIFF
--- a/internal/command/secrets/import.go
+++ b/internal/command/secrets/import.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/client"
@@ -39,57 +37,10 @@ func runImport(ctx context.Context) (err error) {
 		return
 	}
 
-	secrets := make(map[string]string)
-
-	secretsString, err := ioutil.ReadAll(os.Stdin)
+	secrets, err := parseSecrets(os.Stdin)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to parse secrets from stdin: %w", err)
 	}
-
-	secretsArray := strings.Split(string(secretsString), "\n")
-
-	parsestate := 0
-	parsedkey := ""
-	var parsebuffer strings.Builder
-
-	for _, line := range secretsArray {
-		switch parsestate {
-		case 0:
-			if line != "" {
-				parts := strings.SplitN(line, "=", 2)
-				if strings.HasPrefix(parts[1], "\"\"\"") {
-					// Switch to multiline
-					parsestate = 1
-					parsedkey = parts[0]
-					parsebuffer.WriteString(strings.TrimPrefix(parts[1], "\"\"\""))
-					parsebuffer.WriteString("\n")
-				} else {
-					if len(parts) != 2 {
-						return fmt.Errorf("Secrets must be provided as NAME=VALUE pairs (%s is invalid)", line)
-					}
-					key := parts[0]
-					value := parts[1]
-					secrets[key] = value
-				}
-			}
-		case 1:
-			if strings.HasSuffix(line, "\"\"\"") {
-				// End of multiline
-				parsebuffer.WriteString(strings.TrimSuffix(line, "\"\"\""))
-				secrets[parsedkey] = parsebuffer.String()
-				parsebuffer.Reset()
-				parsestate = 0
-				parsedkey = ""
-			} else {
-				if line != "" {
-					parsebuffer.WriteString(line)
-				}
-				parsebuffer.WriteString("\n")
-			}
-
-		}
-	}
-
 	if len(secrets) < 1 {
 		return errors.New("requires at least one SECRET=VALUE pair")
 	}

--- a/internal/command/secrets/parser.go
+++ b/internal/command/secrets/parser.go
@@ -1,0 +1,61 @@
+package secrets
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	parserStateSingleline = iota
+	parserStateMultiline  = iota
+)
+
+func parseSecrets(reader io.Reader) (map[string]string, error) {
+	secrets := map[string]string{}
+	scanner := bufio.NewScanner(reader)
+	parserState := parserStateSingleline
+	parsedKey := ""
+	parsedVal := strings.Builder{}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch parserState {
+		case parserStateSingleline:
+			// Skip comments and empty lines
+			if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
+				continue
+			}
+
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("Secrets must be provided as NAME=VALUE pairs (%s is invalid)", line)
+			}
+
+			if strings.HasPrefix(parts[1], `"""`) {
+				// Switch to multiline
+				parserState = parserStateMultiline
+				parsedKey = parts[0]
+				parsedVal.WriteString(strings.TrimPrefix(parts[1], "\"\"\""))
+				parsedVal.WriteString("\n")
+			} else {
+				secrets[parts[0]] = parts[1]
+			}
+		case parserStateMultiline:
+			if strings.HasSuffix(line, `"""`) {
+				// End of multiline
+				parsedVal.WriteString(strings.TrimSuffix(line, `"""`))
+				secrets[parsedKey] = parsedVal.String()
+				parsedVal.Reset()
+				parserState = parserStateSingleline
+				parsedKey = ""
+			} else {
+				parsedVal.WriteString(line + "\n")
+			}
+
+		}
+	}
+
+	return secrets, nil
+}

--- a/internal/command/secrets/parser_test.go
+++ b/internal/command/secrets/parser_test.go
@@ -1,0 +1,65 @@
+package secrets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parse_basic(t *testing.T) {
+	reader := strings.NewReader(`
+# A comment plus a new line with spaces
+
+FOO=BAR
+# Another comment
+QUX=NAH
+`)
+	secrets, err := parseSecrets(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"FOO": "BAR",
+		"QUX": "NAH",
+	}, secrets)
+}
+
+func Test_parse_unix(t *testing.T) {
+	reader := strings.NewReader("FOO=BAR\nQUX=NAH\n")
+	secrets, err := parseSecrets(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"FOO": "BAR",
+		"QUX": "NAH",
+	}, secrets)
+}
+
+func Test_parse_windows(t *testing.T) {
+	reader := strings.NewReader("FOO=BAR\r\nQUX=NAH\r\n")
+	secrets, err := parseSecrets(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"FOO": "BAR",
+		"QUX": "NAH",
+	}, secrets)
+}
+
+func Test_parse_mulltiline(t *testing.T) {
+	reader := strings.NewReader(`
+FOO=BAR
+MULTILINE="""SOMETHING
+ANOTHER LINE
+
+ENDSHERE"""
+TRAILERENV=what
+FIN="""Here is the end,
+my only friend"""
+`)
+	secrets, err := parseSecrets(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"FOO":        "BAR",
+		"MULTILINE":  "SOMETHING\nANOTHER LINE\n\nENDSHERE",
+		"TRAILERENV": "what",
+		"FIN":        "Here is the end,\nmy only friend",
+	}, secrets)
+}


### PR DESCRIPTION
I faced this issue while trying to port an app to V2 by exporting its secrets using `env` and importing with `fly secrets import <envfile` 