### PR TITLE
Require app name when necessary for certain `machines` and `secrets` commands

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -31,7 +31,7 @@ func newClone() *cobra.Command {
 
 	cmd := command.New(usage, short, long, runMachineClone,
 		command.RequireSession,
-		command.LoadAppNameIfPresent,
+		command.RequireAppName,
 		command.LoadAppConfigIfPresent,
 	)
 

--- a/internal/command/machine/leases.go
+++ b/internal/command/machine/leases.go
@@ -49,7 +49,7 @@ func newLeaseView() *cobra.Command {
 
 	cmd := command.New(usage, short, long, runLeaseView,
 		command.RequireSession,
-		command.LoadAppNameIfPresent,
+		command.RequireAppName,
 	)
 
 	// at least one arg is required but we can accept a list of machine ids
@@ -73,7 +73,7 @@ func newLeaseClear() *cobra.Command {
 
 	cmd := command.New(usage, short, long, runLeaseClear,
 		command.RequireSession,
-		command.LoadAppNameIfPresent,
+		command.RequireAppName,
 	)
 
 	// at least one arg is required but we can accept a list of machine ids

--- a/internal/command/machine/list.go
+++ b/internal/command/machine/list.go
@@ -26,7 +26,7 @@ func newList() *cobra.Command {
 
 	cmd := command.New(usage, short, long, runMachineList,
 		command.RequireSession,
-		command.LoadAppNameIfPresent,
+		command.RequireAppName,
 	)
 
 	cmd.Aliases = []string{"ls"}

--- a/internal/command/secrets/import.go
+++ b/internal/command/secrets/import.go
@@ -20,7 +20,7 @@ func newImport() (cmd *cobra.Command) {
 		usage = "import [flags]"
 	)
 
-	cmd = command.New(usage, short, long, runImport, command.RequireSession, command.LoadAppNameIfPresent)
+	cmd = command.New(usage, short, long, runImport, command.RequireSession, command.RequireAppName)
 
 	flag.Add(cmd,
 		sharedFlags,

--- a/internal/command/secrets/list.go
+++ b/internal/command/secrets/list.go
@@ -23,7 +23,7 @@ actual value of the secret is only available to the application.`
 		usage = "list [flags]"
 	)
 
-	cmd = command.New(usage, short, long, runList, command.RequireSession, command.LoadAppNameIfPresent)
+	cmd = command.New(usage, short, long, runList, command.RequireSession, command.RequireAppName)
 
 	flag.Add(cmd,
 		flag.App(),

--- a/internal/command/secrets/set.go
+++ b/internal/command/secrets/set.go
@@ -21,7 +21,7 @@ func newSet() (cmd *cobra.Command) {
 		usage = "set [flags] NAME=VALUE NAME=VALUE ..."
 	)
 
-	cmd = command.New(usage, short, long, runSet, command.RequireSession, command.LoadAppNameIfPresent)
+	cmd = command.New(usage, short, long, runSet, command.RequireSession, command.RequireAppName)
 
 	flag.Add(cmd,
 		sharedFlags,

--- a/internal/command/secrets/unset.go
+++ b/internal/command/secrets/unset.go
@@ -17,7 +17,7 @@ func newUnset() (cmd *cobra.Command) {
 		usage = "unset [flags] NAME NAME ..."
 	)
 
-	cmd = command.New(usage, short, long, runUnset, command.RequireSession, command.LoadAppNameIfPresent)
+	cmd = command.New(usage, short, long, runUnset, command.RequireSession, command.RequireAppName)
 
 	flag.Add(cmd,
 		sharedFlags,


### PR DESCRIPTION
A user on the [forum](https://community.fly.io/t/flyctl-secrets-list-error-could-not-find-app/11220) was running into an "Error Could not find App" message. I quickly looked into it, and it turns out that several `flyctl machines` and `flyctl secrets` subcommands need an app name to work, but use the `LoadAppNameIfNotPresent` preparer instead of `RequireAppName`. As a result, if they're invoked without an app name being present, they'll make an API call looking for an app with an empty name. This inevitably fails ("Could not find App").

I'm not sure if this is what was going wrong for the user, but in any case we avoid the API call and get a correct/actionable error message ("we couldn't find a fly.toml nor an app specified by the -a flag") consistent with the rest of `flyctl` by using `RequireAppName`.