### PR TITLE
Add `--select` to `machines` commands

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -34,12 +34,13 @@ func newClone() *cobra.Command {
 		command.LoadAppConfigIfPresent,
 	)
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cobra.RangeArgs(0, 1)
 
 	flag.Add(
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		selectFlag,
 		flag.String{
 			Name:        "region",
 			Description: "Target region for the new machine",
@@ -79,12 +80,11 @@ func newClone() *cobra.Command {
 
 func runMachineClone(ctx context.Context) (err error) {
 	var (
-		machineID = flag.FirstArg(ctx)
-		out       = iostreams.FromContext(ctx).Out
-		appName   = appconfig.NameFromContext(ctx)
-		io        = iostreams.FromContext(ctx)
-		colorize  = io.ColorScheme()
-		client    = client.FromContext(ctx).API()
+		out      = iostreams.FromContext(ctx).Out
+		appName  = appconfig.NameFromContext(ctx)
+		io       = iostreams.FromContext(ctx)
+		colorize = io.ColorScheme()
+		client   = client.FromContext(ctx).API()
 	)
 
 	app, err := client.GetAppCompact(ctx, appName)
@@ -92,7 +92,9 @@ func runMachineClone(ctx context.Context) (err error) {
 		return err
 	}
 
-	source, ctx, err := selectOneMachine(ctx, app, machineID)
+	machineID := flag.FirstArg(ctx)
+	haveMachineID := len(flag.Args(ctx)) > 0
+	source, ctx, err := selectOneMachine(ctx, app, machineID, haveMachineID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -34,6 +34,7 @@ This command requires a machine to be in a stopped state unless the force flag i
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		selectFlag,
 		flag.Bool{
 			Name:        "force",
 			Shorthand:   "f",
@@ -41,19 +42,20 @@ This command requires a machine to be in a stopped state unless the force flag i
 		},
 	)
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cobra.RangeArgs(0, 1)
 
 	return cmd
 }
 
 func runMachineDestroy(ctx context.Context) (err error) {
 	var (
-		out       = iostreams.FromContext(ctx).Out
-		machineID = flag.FirstArg(ctx)
-		force     = flag.GetBool(ctx, "force")
+		out   = iostreams.FromContext(ctx).Out
+		force = flag.GetBool(ctx, "force")
 	)
 
-	current, ctx, err := selectOneMachine(ctx, nil, machineID)
+	machineID := flag.FirstArg(ctx)
+	haveMachineID := len(flag.Args(ctx)) > 0
+	current, ctx, err := selectOneMachine(ctx, nil, machineID, haveMachineID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/kill.go
+++ b/internal/command/machine/kill.go
@@ -24,24 +24,24 @@ func newKill() *cobra.Command {
 		command.LoadAppNameIfPresent,
 	)
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cobra.RangeArgs(0, 1)
 
 	flag.Add(
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		selectFlag,
 	)
 
 	return cmd
 }
 
 func runMachineKill(ctx context.Context) (err error) {
-	var (
-		machineID = flag.FirstArg(ctx)
-		io        = iostreams.FromContext(ctx)
-	)
+	io := iostreams.FromContext(ctx)
 
-	current, ctx, err := selectOneMachine(ctx, nil, machineID)
+	machineID := flag.FirstArg(ctx)
+	haveMachineID := len(flag.Args(ctx)) > 0
+	current, ctx, err := selectOneMachine(ctx, nil, machineID, haveMachineID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/leases.go
+++ b/internal/command/machine/leases.go
@@ -49,13 +49,13 @@ func newLeaseView() *cobra.Command {
 		command.LoadAppNameIfPresent,
 	)
 
-	// at least one arg is required but we can accept a list of machine ids
-	cmd.Args = cobra.MinimumNArgs(1)
+	cmd.Args = cobra.ArbitraryArgs
 
 	flag.Add(
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		selectFlag,
 	)
 
 	return cmd
@@ -73,13 +73,13 @@ func newLeaseClear() *cobra.Command {
 		command.LoadAppNameIfPresent,
 	)
 
-	// at least one arg is required but we can accept a list of machine ids
-	cmd.Args = cobra.MinimumNArgs(1)
+	cmd.Args = cobra.ArbitraryArgs
 
 	flag.Add(
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		selectFlag,
 	)
 
 	return cmd

--- a/internal/command/machine/restart.go
+++ b/internal/command/machine/restart.go
@@ -27,12 +27,13 @@ func newRestart() *cobra.Command {
 		command.LoadAppNameIfPresent,
 	)
 
-	cmd.Args = cobra.MinimumNArgs(1)
+	cmd.Args = cobra.ArbitraryArgs
 
 	flag.Add(
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		selectFlag,
 		flag.String{
 			Name:        "signal",
 			Shorthand:   "s",

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -750,8 +750,8 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 	// checking if `len(machineConf.Init.Cmd) == 0` and is already set, in which case we're being
 	// called from `run`.
 	// Otherwise, pull the command from the first positional argument.
-	if cmd := flag.Args(ctx)[1:]; len(cmd) > 0 && len(machineConf.Init.Cmd) == 0 {
-		machineConf.Init.Cmd = cmd
+	if len(flag.Args(ctx)) > 1 && len(machineConf.Init.Cmd) == 0 {
+		machineConf.Init.Cmd = flag.Args(ctx)[1:]
 	}
 
 	machineConf.Mounts, err = determineMounts(ctx, machineConf.Mounts, region)

--- a/internal/command/machine/select.go
+++ b/internal/command/machine/select.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,9 +10,20 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/prompt"
 )
 
-func selectOneMachine(ctx context.Context, app *api.AppCompact, machineID string) (*api.Machine, context.Context, error) {
+var selectFlag = flag.Bool{
+	Name:        "select",
+	Description: "Select from a list of machines",
+}
+
+func selectOneMachine(ctx context.Context, app *api.AppCompact, machineID string, haveMachineID bool) (*api.Machine, context.Context, error) {
+	if err := checkSelectCmdline(ctx, haveMachineID); err != nil {
+		return nil, nil, err
+	}
+
 	var err error
 	if app != nil {
 		ctx, err = buildContextFromApp(ctx, app)
@@ -22,41 +34,77 @@ func selectOneMachine(ctx context.Context, app *api.AppCompact, machineID string
 		return nil, nil, err
 	}
 
-	machine, err := flaps.FromContext(ctx).Get(ctx, machineID)
-	if err != nil {
-		if err := rewriteMachineNotFoundErrors(ctx, err, machineID); err != nil {
+	var machine *api.Machine
+	if flag.GetBool(ctx, "select") {
+		machine, err = promptForOneMachine(ctx)
+		if err != nil {
 			return nil, nil, err
 		}
-		return nil, nil, fmt.Errorf("could not get machine %s: %w", machineID, err)
-	}
-	return machine, ctx, nil
-}
-
-func selectManyMachines(ctx context.Context, machineIDs []string) ([]*api.Machine, context.Context, error) {
-	ctx, err := buildContextFromAppNameOrMachineID(ctx, machineIDs[0])
-	if err != nil {
-		return nil, nil, err
-	}
-	flapsClient := flaps.FromContext(ctx)
-
-	var machines []*api.Machine
-	for _, machineID := range machineIDs {
-		machine, err := flapsClient.Get(ctx, machineID)
+	} else {
+		machine, err = flaps.FromContext(ctx).Get(ctx, machineID)
 		if err != nil {
 			if err := rewriteMachineNotFoundErrors(ctx, err, machineID); err != nil {
 				return nil, nil, err
 			}
 			return nil, nil, fmt.Errorf("could not get machine %s: %w", machineID, err)
 		}
-		machines = append(machines, machine)
+	}
+	return machine, ctx, nil
+}
+
+func selectManyMachines(ctx context.Context, machineIDs []string) ([]*api.Machine, context.Context, error) {
+	haveMachineIDs := len(machineIDs) > 0
+	if err := checkSelectCmdline(ctx, haveMachineIDs); err != nil {
+		return nil, nil, err
+	}
+
+	ctx, err := buildContextFromAppNameOrMachineID(ctx, machineIDs...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var machines []*api.Machine
+	if flag.GetBool(ctx, "select") {
+		machines, err = promptForManyMachines(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		flapsClient := flaps.FromContext(ctx)
+		for _, machineID := range machineIDs {
+			machine, err := flapsClient.Get(ctx, machineID)
+			if err != nil {
+				if err := rewriteMachineNotFoundErrors(ctx, err, machineID); err != nil {
+					return nil, nil, err
+				}
+				return nil, nil, fmt.Errorf("could not get machine %s: %w", machineID, err)
+			}
+			machines = append(machines, machine)
+		}
 	}
 	return machines, ctx, nil
 }
 
 func selectManyMachineIDs(ctx context.Context, machineIDs []string) ([]string, context.Context, error) {
-	ctx, err := buildContextFromAppNameOrMachineID(ctx, machineIDs[0])
+	haveMachineIDs := len(machineIDs) > 0
+	if err := checkSelectCmdline(ctx, haveMachineIDs); err != nil {
+		return nil, nil, err
+	}
+
+	ctx, err := buildContextFromAppNameOrMachineID(ctx, machineIDs...)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if flag.GetBool(ctx, "select") {
+		// NOTE: machineIDs must be empty in this case.
+		machines, err := promptForManyMachines(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, machine := range machines {
+			machineIDs = append(machineIDs, machine.ID)
+		}
 	}
 	return machineIDs, ctx, nil
 }
@@ -70,7 +118,7 @@ func buildContextFromApp(ctx context.Context, app *api.AppCompact) (context.Cont
 	return ctx, nil
 }
 
-func buildContextFromAppNameOrMachineID(ctx context.Context, machineID string) (context.Context, error) {
+func buildContextFromAppNameOrMachineID(ctx context.Context, machineIDs ...string) (context.Context, error) {
 	var (
 		appName = appconfig.NameFromContext(ctx)
 
@@ -79,9 +127,12 @@ func buildContextFromAppNameOrMachineID(ctx context.Context, machineID string) (
 	)
 
 	if appName == "" {
+		// NOTE: assuming that we validated the command line arguments
+		// correctly, we must have at least one machine ID when no app
+		// is set.
 		client := client.FromContext(ctx).API()
 		var gqlMachine *api.GqlMachine
-		gqlMachine, err = client.GetMachine(ctx, machineID)
+		gqlMachine, err = client.GetMachine(ctx, machineIDs[0])
 		if err != nil {
 			return nil, fmt.Errorf("could not get machine from GraphQL to determine app name: %w", err)
 		}
@@ -98,11 +149,66 @@ func buildContextFromAppNameOrMachineID(ctx context.Context, machineID string) (
 	return ctx, nil
 }
 
+func promptForOneMachine(ctx context.Context) (*api.Machine, error) {
+	machines, err := flaps.FromContext(ctx).List(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("could not get a list of machines: %w", err)
+	}
+
+	options := buildOptions(machines)
+	var selection int
+	if err := prompt.Select(ctx, &selection, "Select a machine:", "", options...); err != nil {
+		return nil, fmt.Errorf("could not prompt for machine: %w", err)
+	}
+	return machines[selection], nil
+}
+
+func promptForManyMachines(ctx context.Context) ([]*api.Machine, error) {
+	machines, err := flaps.FromContext(ctx).List(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("could not get a list of machines: %w", err)
+	}
+
+	options := buildOptions(machines)
+	var selections []int
+	if err := prompt.MultiSelect(ctx, &selections, "Select machines:", nil, options...); err != nil {
+		return nil, fmt.Errorf("could not prompt for machine: %w", err)
+	}
+
+	var selectedMachines []*api.Machine
+	for _, selection := range selections {
+		selectedMachines = append(selectedMachines, machines[selection])
+	}
+	return selectedMachines, nil
+}
+
+func buildOptions(machines []*api.Machine) (options []string) {
+	for _, machine := range machines {
+		options = append(options, fmt.Sprintf("%s %s (%s)", machine.ID, machine.Name, machine.State))
+	}
+	return
+}
+
 func rewriteMachineNotFoundErrors(ctx context.Context, err error, machineID string) error {
 	if strings.Contains(err.Error(), "machine not found") {
 		appName := appconfig.NameFromContext(ctx)
 		return fmt.Errorf("machine %s was not found in app '%s'", machineID, appName)
 	} else {
+		return nil
+	}
+}
+
+func checkSelectCmdline(ctx context.Context, haveMachineIDs bool) error {
+	haveSelectFlag := flag.GetBool(ctx, "select")
+	appName := appconfig.NameFromContext(ctx)
+	switch {
+	case haveSelectFlag && haveMachineIDs:
+		return errors.New("machine IDs can't be used with --select")
+	case !haveSelectFlag && !haveMachineIDs:
+		return errors.New("a machine ID must be provided unless --select is used")
+	case haveSelectFlag && appName == "":
+		return errors.New("an app name must be specified to use --select")
+	default:
 		return nil
 	}
 }

--- a/internal/command/machine/select.go
+++ b/internal/command/machine/select.go
@@ -180,6 +180,9 @@ func promptForManyMachines(ctx context.Context) ([]*api.Machine, error) {
 	for _, selection := range selections {
 		selectedMachines = append(selectedMachines, machines[selection])
 	}
+	if len(selectedMachines) == 0 {
+		return nil, errors.New("no machines selected")
+	}
 	return selectedMachines, nil
 }
 

--- a/internal/command/machine/select.go
+++ b/internal/command/machine/select.go
@@ -173,7 +173,7 @@ func promptForManyMachines(ctx context.Context) ([]*api.Machine, error) {
 	options := sortAndBuildOptions(machines)
 	var selections []int
 	if err := prompt.MultiSelect(ctx, &selections, "Select machines:", nil, options...); err != nil {
-		return nil, fmt.Errorf("could not prompt for machine: %w", err)
+		return nil, fmt.Errorf("could not prompt for machines: %w", err)
 	}
 
 	var selectedMachines []*api.Machine

--- a/internal/command/machine/select.go
+++ b/internal/command/machine/select.go
@@ -190,7 +190,7 @@ func sortAndBuildOptions(machines []*api.Machine) []string {
 
 	options := []string{}
 	for _, machine := range machines {
-		details := machine.State
+		details := fmt.Sprintf("%s, region %s", machine.State, machine.Region)
 		if group := machine.ProcessGroup(); group != "" {
 			details += fmt.Sprintf(", process group '%s'", group)
 		}

--- a/internal/command/machine/select.go
+++ b/internal/command/machine/select.go
@@ -190,7 +190,11 @@ func sortAndBuildOptions(machines []*api.Machine) []string {
 
 	options := []string{}
 	for _, machine := range machines {
-		options = append(options, fmt.Sprintf("%s %s (%s)", machine.ID, machine.Name, machine.State))
+		details := machine.State
+		if group := machine.ProcessGroup(); group != "" {
+			details += fmt.Sprintf(", process group '%s'", group)
+		}
+		options = append(options, fmt.Sprintf("%s %s (%s)", machine.ID, machine.Name, details))
 	}
 	return options
 }

--- a/internal/command/machine/start.go
+++ b/internal/command/machine/start.go
@@ -24,12 +24,13 @@ func newStart() *cobra.Command {
 		command.LoadAppNameIfPresent,
 	)
 
-	cmd.Args = cobra.MinimumNArgs(1)
+	cmd.Args = cobra.ArbitraryArgs
 
 	flag.Add(
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		selectFlag,
 	)
 
 	return cmd

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -28,12 +28,13 @@ func newStatus() *cobra.Command {
 		command.LoadAppNameIfPresent,
 	)
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cobra.RangeArgs(0, 1)
 
 	flag.Add(
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		selectFlag,
 		flag.Bool{
 			Name:        "display-config",
 			Description: "Display the machine config as JSON",
@@ -48,7 +49,8 @@ func runMachineStatus(ctx context.Context) (err error) {
 	io := iostreams.FromContext(ctx)
 
 	machineID := flag.FirstArg(ctx)
-	machine, ctx, err := selectOneMachine(ctx, nil, machineID)
+	haveMachineID := len(flag.Args(ctx)) > 0
+	machine, ctx, err := selectOneMachine(ctx, nil, machineID, haveMachineID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/stop.go
+++ b/internal/command/machine/stop.go
@@ -25,12 +25,13 @@ func newStop() *cobra.Command {
 		command.LoadAppNameIfPresent,
 	)
 
-	cmd.Args = cobra.MinimumNArgs(1)
+	cmd.Args = cobra.ArbitraryArgs
 
 	flag.Add(
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		selectFlag,
 	)
 
 	return cmd

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -34,6 +34,7 @@ func newUpdate() *cobra.Command {
 		flag.Image(),
 		sharedFlags,
 		flag.Yes(),
+		selectFlag,
 		flag.Bool{
 			Name:        "skip-health-checks",
 			Description: "Updates machine without waiting for health checks.",
@@ -46,7 +47,7 @@ func newUpdate() *cobra.Command {
 		},
 	)
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cobra.RangeArgs(0, 1)
 
 	return cmd
 }
@@ -56,14 +57,15 @@ func runUpdate(ctx context.Context) (err error) {
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
 
-		machineID        = flag.FirstArg(ctx)
 		autoConfirm      = flag.GetBool(ctx, "yes")
 		skipHealthChecks = flag.GetBool(ctx, "skip-health-checks")
 		image            = flag.GetString(ctx, "image")
 		dockerfile       = flag.GetString(ctx, flag.Dockerfile().Name)
 	)
 
-	machine, ctx, err := selectOneMachine(ctx, nil, machineID)
+	machineID := flag.FirstArg(ctx)
+	haveMachineID := len(flag.Args(ctx)) > 0
+	machine, ctx, err := selectOneMachine(ctx, nil, machineID, haveMachineID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This addresses #1846 by implementing a `--select` option for `flyctl machines` subcommands that take a machine ID (or several). When `--select` is used, no machine IDs may be specified as arguments, and an app name must be provided (through fly.toml, `FLY_APP`, or `-a`). A prompt is displayed to allow the user to select machines from the specified app. For commands that accept more than one machine ID, the prompt allows multiple selections.

Originally, I was going to include `-s` as a short form, like `flyctl ssh console` does. However, `run` and `update` already use it as a shorthand for `--size`.