### PR TITLE
Update flaps client to use api.machines.dev by default

### DIFF
--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/buildinfo"
+	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/terminal"
 )
@@ -31,13 +33,36 @@ const headerFlyRequestId = "fly-request-id"
 
 type Client struct {
 	app        *api.AppCompact
-	peerIP     string
+	baseUrl    *url.URL
 	authToken  string
 	httpClient *http.Client
 	userAgent  string
 }
 
 func New(ctx context.Context, app *api.AppCompact) (*Client, error) {
+	cfg := config.FromContext(ctx)
+	if strings.TrimSpace(strings.ToLower(cfg.FlapsBaseURL)) == "peer" {
+		return newWithUsermodeWireguard(ctx, app)
+	}
+	flapsUrl, err := url.Parse(cfg.FlapsBaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid FLAPS_BASE_URL '%s' with error: %w", cfg.FlapsBaseURL, err)
+	}
+	logger := logger.MaybeFromContext(ctx)
+	httpClient, err := api.NewHTTPClient(logger, http.DefaultTransport)
+	if err != nil {
+		return nil, fmt.Errorf("flaps: can't setup HTTP client to %s: %w", flapsUrl.String(), err)
+	}
+	return &Client{
+		app:        app,
+		baseUrl:    flapsUrl,
+		authToken:  flyctl.GetAPIToken(),
+		httpClient: httpClient,
+		userAgent:  strings.TrimSpace(fmt.Sprintf("fly-cli/%s", buildinfo.Version())),
+	}, nil
+}
+
+func newWithUsermodeWireguard(ctx context.Context, app *api.AppCompact) (*Client, error) {
 	logger := logger.MaybeFromContext(ctx)
 
 	client := client.FromContext(ctx).API()
@@ -62,9 +87,15 @@ func New(ctx context.Context, app *api.AppCompact) (*Client, error) {
 		return nil, fmt.Errorf("flaps: can't setup HTTP client for %s: %w", app.Organization.Slug, err)
 	}
 
+	flapsBaseUrlString := fmt.Sprintf("http://[%s]:4280", resolvePeerIP(dialer.State().Peer.Peerip))
+	flapsBaseUrl, err := url.Parse(flapsBaseUrlString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse flaps url '%s' with error: %w", flapsBaseUrlString, err)
+	}
+
 	return &Client{
 		app:        app,
-		peerIP:     resolvePeerIP(dialer.State().Peer.Peerip),
+		baseUrl:    flapsBaseUrl,
 		authToken:  flyctl.GetAPIToken(),
 		httpClient: httpClient,
 		userAgent:  strings.TrimSpace(fmt.Sprintf("fly-cli/%s", buildinfo.Version())),
@@ -400,17 +431,26 @@ func (f *Client) sendRequest(ctx context.Context, method, endpoint string, in, o
 	return nil
 }
 
+func (f *Client) urlFromBaseUrl(pathAndQueryString string) (*url.URL, error) {
+	newUrl := *f.baseUrl // this does a copy: https://github.com/golang/go/issues/38351#issue-597797864
+	newPath, err := url.Parse(pathAndQueryString)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing flaps path '%s' with error: %w", pathAndQueryString, err)
+	}
+	return newUrl.ResolveReference(&url.URL{Path: newPath.Path, RawQuery: newPath.RawQuery}), nil
+}
+
 func (f *Client) NewRequest(ctx context.Context, method, path string, in interface{}, headers map[string][]string) (*http.Request, error) {
-	var (
-		body   io.Reader
-		peerIP = f.peerIP
-	)
+	var body io.Reader
 
 	if headers == nil {
 		headers = make(map[string][]string)
 	}
 
-	targetEndpoint := fmt.Sprintf("http://[%s]:4280/v1/apps/%s/machines%s", peerIP, f.app.Name, path)
+	targetEndpoint, err := f.urlFromBaseUrl(fmt.Sprintf("/v1/apps/%s/machines%s", f.app.Name, path))
+	if err != nil {
+		return nil, err
+	}
 
 	if in != nil {
 		b, err := json.Marshal(in)
@@ -421,7 +461,7 @@ func (f *Client) NewRequest(ctx context.Context, method, path string, in interfa
 		body = bytes.NewReader(b)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, targetEndpoint, body)
+	req, err := http.NewRequestWithContext(ctx, method, targetEndpoint.String(), body)
 	if err != nil {
 		return nil, fmt.Errorf("could not create new request, %w", err)
 	}

--- a/flyctl/config.go
+++ b/flyctl/config.go
@@ -7,6 +7,7 @@ import (
 const (
 	ConfigAPIToken        = "access_token"
 	ConfigAPIBaseURL      = "api_base_url"
+	ConfigFlapsBaseUrl    = "flaps_base_url"
 	ConfigAppName         = "app"
 	ConfigVerboseOutput   = "verbose"
 	ConfigJSONOutput      = "json"

--- a/flyctl/flyctl.go
+++ b/flyctl/flyctl.go
@@ -61,6 +61,7 @@ func initViper() {
 	}
 
 	viper.SetDefault(ConfigAPIBaseURL, "https://api.fly.io")
+	viper.SetDefault(ConfigFlapsBaseUrl, "https://api.machines.dev")
 	viper.SetDefault(ConfigRegistryHost, "registry.fly.io")
 
 	viper.BindEnv(ConfigVerboseOutput, "VERBOSE")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ const (
 
 	envKeyPrefix          = "FLY_"
 	apiBaseURLEnvKey      = envKeyPrefix + "API_BASE_URL"
+	flapsBaseURLEnvKey    = envKeyPrefix + "FLAPS_BASE_URL"
 	AccessTokenEnvKey     = envKeyPrefix + "ACCESS_TOKEN"
 	AccessTokenFileKey    = "access_token"
 	WireGuardStateFileKey = "wire_guard_state"
@@ -30,6 +31,7 @@ const (
 	localOnlyEnvKey       = envKeyPrefix + "LOCAL_ONLY"
 
 	defaultAPIBaseURL   = "https://api.fly.io"
+	defaultFlapsBaseURL = "https://api.machines.dev"
 	defaultRegistryHost = "registry.fly.io"
 )
 
@@ -41,6 +43,9 @@ type Config struct {
 
 	// APIBaseURL denotes the base URL of the API.
 	APIBaseURL string
+
+	// FlapsBaseURL denotes base URL for FLAPS (also known as the Machines API).
+	FlapsBaseURL string
 
 	// RegistryHost denotes the docker registry host.
 	RegistryHost string
@@ -71,6 +76,7 @@ type Config struct {
 func New() *Config {
 	return &Config{
 		APIBaseURL:   defaultAPIBaseURL,
+		FlapsBaseURL: defaultFlapsBaseURL,
 		RegistryHost: defaultRegistryHost,
 	}
 }
@@ -99,6 +105,7 @@ func (cfg *Config) ApplyEnv() {
 	cfg.Region = env.FirstOrDefault(cfg.Region, regionEnvKey)
 	cfg.RegistryHost = env.FirstOrDefault(cfg.RegistryHost, registryHostEnvKey)
 	cfg.APIBaseURL = env.FirstOrDefault(cfg.APIBaseURL, apiBaseURLEnvKey)
+	cfg.FlapsBaseURL = env.FirstOrDefault(cfg.FlapsBaseURL, flapsBaseURLEnvKey)
 }
 
 // ApplyFile sets the properties of cfg which may be set via configuration file

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -35,7 +35,7 @@ func TestAppsV2Example(t *testing.T) {
 	require.Contains(f, result.StdOut().String(), fmt.Sprintf("Created app %s in organization %s", appName, f.OrgSlug()))
 	require.Contains(f, result.StdOut().String(), "Wrote config file fly.toml")
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 	f.Fly("status")
 
 	lastStatusCode := -1


### PR DESCRIPTION
The `FLY_FLAPS_BASE_URL` env var may be used to configure alternative urls. Setting `FLY_FLAPS_BASE_URL=peer` will use usermode wireguard like we have done previously.
