### PR TITLE
check against all indicators of a machine being 'release' machines'

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -74,7 +74,7 @@ func (m *Machine) IsFlyAppsPlatform() bool {
 }
 
 func (m *Machine) IsFlyAppsReleaseCommand() bool {
-	return m.IsFlyAppsPlatform() && m.HasProcessGroup(MachineProcessGroupFlyAppReleaseCommand)
+	return m.IsFlyAppsPlatform() && m.IsReleaseCommandMachine()
 }
 
 func (m *Machine) IsActive() bool {
@@ -135,6 +135,10 @@ func (m *Machine) GetLatestEventOfTypeAfterType(latestEventType, firstEventType 
 		}
 	}
 	return nil
+}
+
+func (m *Machine) IsReleaseCommandMachine() bool {
+	return m.HasProcessGroup(MachineProcessGroupFlyAppReleaseCommand) || m.Config.Metadata["process_group"] == "release_command"
 }
 
 type MachineImageRef struct {

--- a/api/machine_types_test.go
+++ b/api/machine_types_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsReleaseCommandMachine(t *testing.T) {
+
+	type testcase struct {
+		name     string
+		machine  Machine
+		expected bool
+	}
+
+	cases := []testcase{
+		{
+			name:     "release machine using 'process_group'",
+			expected: true,
+			machine: Machine{
+				Config: &MachineConfig{
+					Metadata: map[string]string{
+						"process_group": "release_command",
+					},
+				},
+			},
+		},
+		{
+			name:     "release machine using 'fly_process_group'",
+			expected: true,
+			machine: Machine{
+				Config: &MachineConfig{
+					Metadata: map[string]string{
+						"fly_process_group": "fly_app_release_command",
+					},
+				},
+			},
+		},
+		{
+			name:     "non-release machine using 'fly_process_group'",
+			expected: false,
+			machine: Machine{
+				Config: &MachineConfig{
+					Metadata: map[string]string{
+						"fly_process_group": "web",
+					},
+				},
+			},
+		},
+		{
+			name:     "non-release machine using 'process_group'",
+			expected: false,
+			machine: Machine{
+				Config: &MachineConfig{
+					Metadata: map[string]string{
+						"process_group": "web",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.expected, tc.machine.IsReleaseCommandMachine(), tc.name)
+	}
+
+}

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -281,7 +281,7 @@ func (f *Client) ListActive(ctx context.Context) ([]*api.Machine, error) {
 	}
 
 	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
-		return !m.HasProcessGroup(api.MachineProcessGroupFlyAppReleaseCommand) && m.IsActive()
+		return !m.IsReleaseCommandMachine() && m.IsActive()
 	})
 
 	return machines, nil

--- a/internal/machine/query.go
+++ b/internal/machine/query.go
@@ -19,7 +19,7 @@ func ListActive(ctx context.Context) ([]*api.Machine, error) {
 	}
 
 	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
-		return m.Config != nil && m.Config.Metadata["process_group"] != "release_command" && m.State != "destroyed"
+		return m.Config != nil && !m.IsReleaseCommandMachine() && m.State != "destroyed"
 	})
 
 	return machines, nil


### PR DESCRIPTION
in the current flyctl codebase there are 2 indicators of a machine being a "release_machine"
- metadata 'fly_process_group' having a value of `fly_app_release_command`
- metadata 'process_group' having a value of `release_command`

this PR adds a method on Machine struct to check for both indicators when trying to confirm if a machine is a release machine.

note: this pull request was inspired by https://github.com/superfly/flyctl/pull/1859 (i separated them because this change touches postgres and I wanted folks from the pg team to have a look too)