### PR TITLE
Only sync docs when a successful release happens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
           name: checksums
           path: dist/checksums.txt
   sync_docs:
+    needs: release
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' }}
     steps:


### PR DESCRIPTION
This prevents docs from being published prematurely. Also, it may fix the Gihub API rate limiting happening on docs publishing steps.