### PR TITLE
Fix/machine run hang

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/avast/retry-go/v4 v4.2.0
 	github.com/azazeal/pause v1.0.6
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/briandowns/spinner v1.19.0
+	github.com/briandowns/spinner v1.23.0
 	github.com/buildpacks/pack v0.21.0
 	github.com/cavaliergopher/grab/v3 v3.0.1
 	github.com/chzyer/readline v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,8 @@ github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=
 github.com/briandowns/spinner v1.19.0/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=
+github.com/briandowns/spinner v1.23.0 h1:alDF2guRWqa/FOZZYWjlMIx2L6H0wyewPxo/CH4Pt2A=
+github.com/briandowns/spinner v1.23.0/go.mod h1:rPG4gmXeN3wQV/TsAY4w8lPdIM6RX3yqeBQJSrbXjuE=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -732,8 +732,12 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 		machineConf.Restart.Policy = api.MachineRestartPolicyNo
 	case "on-fail":
 		machineConf.Restart.Policy = api.MachineRestartPolicyOnFailure
-	default:
+	case "always":
 		machineConf.Restart.Policy = api.MachineRestartPolicyAlways
+	case "":
+		machineConf.Restart.Policy = api.MachineRestartPolicyAlways
+	default:
+		return machineConf, errors.New("invalid restart provided")
 	}
 
 	// `machine update` and `machine run` both use `determineMachineConfig`` to populate

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -170,7 +170,7 @@ func newRun() *cobra.Command {
 		},
 		flag.String{
 			Name:        "restart",
-			Description: "Configure restart policy, for a machine",
+			Description: "Configure restart policy, for a machine. Options include `no`, `always` and `on-fail`. Default is set to always",
 		},
 		sharedFlags,
 	)
@@ -726,15 +726,14 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 		machineConf.Init.Entrypoint = splitted
 	}
 
-	if restart := flag.GetString(ctx, "restart"); restart != "" {
-		switch flag.GetString(ctx, "restart") {
-		case "always":
-			machineConf.Restart.Policy = api.MachineRestartPolicyAlways
-		case "failure":
-			machineConf.Restart.Policy = api.MachineRestartPolicyOnFailure
-		default:
-			machineConf.Restart.Policy = api.MachineRestartPolicyNo
-		}
+	// default restart policy to always unless otherwise specified
+	switch flag.GetString(ctx, "restart") {
+	case "no":
+		machineConf.Restart.Policy = api.MachineRestartPolicyNo
+	case "on-fail":
+		machineConf.Restart.Policy = api.MachineRestartPolicyOnFailure
+	default:
+		machineConf.Restart.Policy = api.MachineRestartPolicyAlways
 	}
 
 	// `machine update` and `machine run` both use `determineMachineConfig`` to populate

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/dustin/go-humanize"
 	"github.com/google/shlex"
 	"github.com/pkg/errors"
@@ -130,6 +131,8 @@ var sharedFlags = flag.Set{
 		Description: "Do not register the machine's 6PN IP with the intenral DNS system",
 	},
 }
+
+var s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 
 func newRun() *cobra.Command {
 	const (
@@ -273,9 +276,11 @@ func runMachineRun(ctx context.Context) error {
 	fmt.Fprintf(io.Out, " Instance ID: %s\n", instanceID)
 	fmt.Fprintf(io.Out, " State: %s\n", state)
 
-	fmt.Fprintf(io.Out, "\n Attempting to start machine...\n")
+	fmt.Fprintf(io.Out, "\n Attempting to start machine...\n\n")
+	s.Start()
 	// wait for machine to be started
 	if err := mach.WaitForStartOrStop(ctx, machine, "start", time.Minute*5); err != nil {
+		s.Stop()
 		return err
 	}
 

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -165,6 +165,10 @@ func newRun() *cobra.Command {
 			Name:        "rm",
 			Description: "Automatically remove the machine when it exits",
 		},
+		flag.String{
+			Name:        "restart",
+			Description: "Configure restart policy, for a machine",
+		},
 		sharedFlags,
 	)
 
@@ -714,6 +718,17 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 			return machineConf, errors.Wrap(err, "invalid entrypoint")
 		}
 		machineConf.Init.Entrypoint = splitted
+	}
+
+	if restart := flag.GetString(ctx, "restart"); restart != "" {
+		switch flag.GetString(ctx, "restart") {
+		case "always":
+			machineConf.Restart.Policy = api.MachineRestartPolicyAlways
+		case "failure":
+			machineConf.Restart.Policy = api.MachineRestartPolicyOnFailure
+		default:
+			machineConf.Restart.Policy = api.MachineRestartPolicyNo
+		}
 	}
 
 	// `machine update` and `machine run` both use `determineMachineConfig`` to populate

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -273,6 +273,7 @@ func runMachineRun(ctx context.Context) error {
 	fmt.Fprintf(io.Out, " Instance ID: %s\n", instanceID)
 	fmt.Fprintf(io.Out, " State: %s\n", state)
 
+	fmt.Fprintf(io.Out, "\n Attempting to start machine...\n")
 	// wait for machine to be started
 	if err := mach.WaitForStartOrStop(ctx, machine, "start", time.Minute*5); err != nil {
 		return err

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -17,10 +17,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/client"
-	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
 	"github.com/superfly/flyctl/internal/cmdutil"

--- a/internal/machine/wait.go
+++ b/internal/machine/wait.go
@@ -49,7 +49,7 @@ func WaitForStartOrStop(ctx context.Context, machine *api.Machine, action string
 		default:
 			var flapsErr *flaps.FlapsError
 			if strings.Contains(err.Error(), "machine failed to reach desired state") && machine.Config.Restart.Policy == api.MachineRestartPolicyNo {
-				return fmt.Errorf("failed waiting for machine: %w", err)
+				return fmt.Errorf("machine failed to reach desired start state, and restart policy was set to %s restart", machine.Config.Restart.Policy)
 			}
 			if errors.As(err, &flapsErr) && flapsErr.ResponseStatusCode == http.StatusBadRequest {
 				return fmt.Errorf("failed waiting for machine: %w", err)

--- a/internal/machine/wait.go
+++ b/internal/machine/wait.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/jpillora/backoff"
@@ -47,6 +48,9 @@ func WaitForStartOrStop(ctx context.Context, machine *api.Machine, action string
 			return fmt.Errorf("timeout reached waiting for machine to %s %w", waitOnAction, err)
 		default:
 			var flapsErr *flaps.FlapsError
+			if strings.Contains(err.Error(), "machine failed to reach desired state") && machine.Config.Restart.Policy == api.MachineRestartPolicyNo {
+				return fmt.Errorf("failed waiting for machine: %w", err)
+			}
 			if errors.As(err, &flapsErr) && flapsErr.ResponseStatusCode == http.StatusBadRequest {
 				return fmt.Errorf("failed waiting for machine: %w", err)
 			}


### PR DESCRIPTION
This PR addresses some comments about machine run hanging but also adds some features for better observability
- Abort a machine run when it does not reach the desired state AND restart policy is set to no
- Add restart flag so users can properly run a machine with a specific restart policy
- Spinner to show a pending process is running

<img src="https://user-images.githubusercontent.com/3229484/223881481-b106fee8-c379-4cfc-811e-df24ef8e0e6d.gif" height="400"/>

Separately, I noticed that the [-c flag in machine run is a bit confusing](https://community.fly.io/t/fly-machines-run-command-hangs-forever/10269). The config flag expects a path to a file but I've seen folks sending json blobs through it. To my knowledge, the cli doesn't accept a json blob, only the api does. I think it would be useful to have a way for users to send json via the cli similar to how they would with the api. I'll open an issue for this.

