### PR TITLE
Properly check if machine has already deployed before redeploying

### DIFF
--- a/internal/command/launch/launch_test.go
+++ b/internal/command/launch/launch_test.go
@@ -1,0 +1,49 @@
+package launch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/flyctl/api"
+)
+
+func TestIsReleaseCommandMachine(t *testing.T) {
+
+	type testcase struct {
+		name     string
+		machines []*api.Machine
+		expected bool
+	}
+
+	cases := []testcase{
+		{
+			name:     "machines app, running",
+			expected: true,
+			machines: []*api.Machine{
+				{
+					State: "started",
+					Checks: []*api.MachineCheckStatus{{
+						Status: "passing",
+					}},
+				},
+			},
+		},
+		{
+			name:     "machines app, not running",
+			expected: false,
+			machines: []*api.Machine{
+				{
+					State: "started",
+					Checks: []*api.MachineCheckStatus{{
+						Status: "warning",
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.expected, areMachinesRunning(tc.machines), tc.name)
+	}
+
+}


### PR DESCRIPTION
Context
Machines don't have any concept of `allocations` (web always returns an empty array)
As a result, it's easily to redeploy an existing machines app with `fly launch`
This pull requests properly checks if a machine has already been deployed to prevent unwanted auto-deploys.
 
 
 fixes https://github.com/superfly/flyctl/issues/1623