### PR TITLE
Only prompt user to pick from adminned organizations for admin-only actions

### DIFF
--- a/internal/command/orgs/delete.go
+++ b/internal/command/orgs/delete.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -34,7 +35,7 @@ func newDelete() *cobra.Command {
 }
 
 func runDelete(ctx context.Context) error {
-	org, err := OrgFromFirstArgOrSelect(ctx)
+	org, err := OrgFromFirstArgOrSelect(ctx, api.AdminOnly)
 	if err != nil {
 		return err
 	}

--- a/internal/command/orgs/invite.go
+++ b/internal/command/orgs/invite.go
@@ -19,7 +19,7 @@ import (
 func newInvite() *cobra.Command {
 	const (
 		long = `Invite a user, by email, to join organization. The invitation will be
-sent, and the user will be pending until they respond. See also orgs revoke.
+sent, and the user will be pending until they respond.
 `
 		short = "Invite user (by email) to organization"
 		usage = "invite [slug] [email]"
@@ -36,7 +36,7 @@ sent, and the user will be pending until they respond. See also orgs revoke.
 func runInvite(ctx context.Context) error {
 	client := client.FromContext(ctx).API()
 
-	org, err := OrgFromFirstArgOrSelect(ctx)
+	org, err := OrgFromFirstArgOrSelect(ctx, api.AdminOnly)
 	if err != nil {
 		return nil
 	}

--- a/internal/command/orgs/orgs.go
+++ b/internal/command/orgs/orgs.go
@@ -63,7 +63,7 @@ func emailFromSecondArgOrPrompt(ctx context.Context) (email string, err error) {
 
 var errSlugArgMustBeSpecified = prompt.NonInteractiveError("slug argument must be specified when not running interactively")
 
-func slugFromFirstArgOrSelect(ctx context.Context) (slug string, err error) {
+func slugFromFirstArgOrSelect(ctx context.Context, filters ...api.OrganizationFilter) (slug string, err error) {
 	if slug = flag.FirstArg(ctx); slug != "" {
 		return
 	}
@@ -78,7 +78,7 @@ func slugFromFirstArgOrSelect(ctx context.Context) (slug string, err error) {
 	client := client.FromContext(ctx).API()
 
 	var orgs []api.Organization
-	if orgs, err = client.GetOrganizations(ctx); err != nil {
+	if orgs, err = client.GetOrganizations(ctx, filters...); err != nil {
 		return
 	}
 	sort.OrganizationsByTypeAndName(orgs)
@@ -86,15 +86,15 @@ func slugFromFirstArgOrSelect(ctx context.Context) (slug string, err error) {
 	var org *api.Organization
 	if org, err = prompt.SelectOrg(ctx, orgs); prompt.IsNonInteractive(err) {
 		err = errSlugArgMustBeSpecified
-	} else {
+	} else if err == nil {
 		slug = org.Slug
 	}
 
 	return
 }
 
-func OrgFromFirstArgOrSelect(ctx context.Context) (*api.Organization, error) {
-	slug, err := slugFromFirstArgOrSelect(ctx)
+func OrgFromFirstArgOrSelect(ctx context.Context, filters ...api.OrganizationFilter) (*api.Organization, error) {
+	slug, err := slugFromFirstArgOrSelect(ctx, filters...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/orgs/remove.go
+++ b/internal/command/orgs/remove.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/client"
@@ -32,7 +33,7 @@ invitation to join (if not, see orgs revoke).
 
 func runRemove(ctx context.Context) error {
 	client := client.FromContext(ctx).API()
-	selectedOrg, err := OrgFromFirstArgOrSelect(ctx)
+	selectedOrg, err := OrgFromFirstArgOrSelect(ctx, api.AdminOnly)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
There are a few commands that can only be run by organization admins. When prompting the user to select an organization for these commands, we should only show organizations that they are admins on.