### PR TITLE
`fly machines run`: avoid nil deref when there's no fly.toml in cwd

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -128,21 +128,21 @@ func (c *Config) HasUdpService() bool {
 }
 
 func (c *Config) Dockerfile() string {
-	if c.Build == nil {
+	if c == nil || c.Build == nil {
 		return ""
 	}
 	return c.Build.Dockerfile
 }
 
 func (c *Config) Ignorefile() string {
-	if c.Build == nil {
+	if c == nil || c.Build == nil {
 		return ""
 	}
 	return c.Build.Ignorefile
 }
 
 func (c *Config) DockerBuildTarget() string {
-	if c.Build == nil {
+	if c == nil || c.Build == nil {
 		return ""
 	}
 	return c.Build.DockerBuildTarget

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -21,3 +21,25 @@ func TestGetAndSetEnvVariables(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, cfg.Env, cfg2.Env)
 }
+
+func TestConfigDockerGetters(t *testing.T) {
+	validCfg := Config{
+		Build: &Build{
+			Dockerfile:        "some_dockerfile",
+			Ignorefile:        "some_ignore_file",
+			DockerBuildTarget: "some_build_target",
+		},
+	}
+
+	assert.Equal(t, validCfg.Dockerfile(), "some_dockerfile")
+	assert.Equal(t, validCfg.Ignorefile(), "some_ignore_file")
+	assert.Equal(t, validCfg.DockerBuildTarget(), "some_build_target")
+}
+
+func TestNilConfigDockerGetters(t *testing.T) {
+	var nilCfg *Config
+
+	assert.Equal(t, nilCfg.Dockerfile(), "")
+	assert.Equal(t, nilCfg.Ignorefile(), "")
+	assert.Equal(t, nilCfg.DockerBuildTarget(), "")
+}

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -34,9 +34,7 @@ func TestConfigDockerGetters(t *testing.T) {
 	assert.Equal(t, validCfg.Dockerfile(), "some_dockerfile")
 	assert.Equal(t, validCfg.Ignorefile(), "some_ignore_file")
 	assert.Equal(t, validCfg.DockerBuildTarget(), "some_build_target")
-}
 
-func TestNilConfigDockerGetters(t *testing.T) {
 	var nilCfg *Config
 
 	assert.Equal(t, nilCfg.Dockerfile(), "")

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -383,7 +383,10 @@ func determineImage(ctx context.Context, appName string, imageOrPath string) (im
 			NoCache:    flag.GetBool(ctx, "no-build-cache"),
 		}
 
-		dockerfilePath := cfg.Dockerfile()
+		dockerfilePath := ""
+		if cfg != nil {
+			dockerfilePath = cfg.Dockerfile()
+		}
 
 		// dockerfile passed through flags takes precedence over the one set in config
 		if flag.GetString(ctx, "dockerfile") != "" {

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -383,10 +383,7 @@ func determineImage(ctx context.Context, appName string, imageOrPath string) (im
 			NoCache:    flag.GetBool(ctx, "no-build-cache"),
 		}
 
-		dockerfilePath := ""
-		if cfg != nil {
-			dockerfilePath = cfg.Dockerfile()
-		}
+		dockerfilePath := cfg.Dockerfile()
 
 		// dockerfile passed through flags takes precedence over the one set in config
 		if flag.GetString(ctx, "dockerfile") != "" {


### PR DESCRIPTION
Would fix #1890 

This codifies behavior that I'm not sure is correct, necessarily.

Most examples of `fly m run` use `.` as the parameter. Sometimes, it's a docker image name instead (e.g. `registry.fly.io/xxx:yyy`).

I'm not exactly sure what's meant to happen if some other path is passed, such as `./some-dir`. In this patch, it silently ignores the path passed, and just checks to see if a path is passed at all - if so, it builds `./Dockerfile` in the cwd.