### PR TITLE
`fly doctor`: get remote app config if it can't be loaded, return errors

### DIFF
--- a/internal/command/doctor/doctor.go
+++ b/internal/command/doctor/doctor.go
@@ -167,7 +167,10 @@ followed by 'flyctl agent restart', and we'll run WireGuard over HTTPS.
 	// App specific checks below here
 	// ------------------------------------------------------------
 
-	appChecker := NewAppChecker(ctx, isJson, color)
+	appChecker, err := NewAppChecker(ctx, isJson, color)
+	if err != nil {
+		return err
+	}
 	if appChecker == nil {
 		return nil
 	}


### PR DESCRIPTION
Would fix #1874 

Note that this may break JSON formatting on errors. Other commands do it a lot, but doctor seemed to try hard to maintain *not* throwing out error messages and this does break that.

I'm open to making it display the output in a different way, maybe a `{"error": "somemsg"}` kind of thing, but swallowing the errors and silently failing seems a little strange.