### PR TITLE
`fly env`: init flaps client before pulling remote config

### DIFF
--- a/internal/command/checks/list.go
+++ b/internal/command/checks/list.go
@@ -24,7 +24,7 @@ func runAppCheckList(ctx context.Context) error {
 
 	app, err := web.GetAppCompact(ctx, appName)
 	if err != nil {
-		return fmt.Errorf("failed to get app: %s", err)
+		return fmt.Errorf("failed to get app: %w", err)
 	}
 
 	if app.PlatformVersion == "machines" {

--- a/internal/command/config/env.go
+++ b/internal/command/config/env.go
@@ -8,9 +8,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
-	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -53,10 +53,11 @@ func runEnv(ctx context.Context) error {
 		return fmt.Errorf("failed to get app: %s", err)
 	}
 
-	ctx, err = apps.BuildContext(ctx, app)
+	flapsClient, err := flaps.New(ctx, app)
 	if err != nil {
 		return err
 	}
+	ctx = flaps.NewContext(ctx, flapsClient)
 
 	cfg, err := appconfig.FromRemoteApp(ctx, appName)
 	if err != nil {

--- a/internal/command/config/env.go
+++ b/internal/command/config/env.go
@@ -50,7 +50,7 @@ func runEnv(ctx context.Context) error {
 
 	app, err := apiClient.GetAppCompact(ctx, appName)
 	if err != nil {
-		return fmt.Errorf("failed to get app: %s", err)
+		return fmt.Errorf("failed to get app: %w", err)
 	}
 
 	flapsClient, err := flaps.New(ctx, app)

--- a/internal/command/config/env.go
+++ b/internal/command/config/env.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -44,6 +45,16 @@ func runEnv(ctx context.Context) error {
 		return []string{s.Name, s.Digest, s.CreatedAt.Format("2006-01-02T15:04:05")}
 	})
 	if err := render.Table(io.Out, "Secrets", secretRows, "Name", "Digest", "Created At"); err != nil {
+		return err
+	}
+
+	app, err := apiClient.GetAppCompact(ctx, appName)
+	if err != nil {
+		return fmt.Errorf("failed to get app: %s", err)
+	}
+
+	ctx, err = apps.BuildContext(ctx, app)
+	if err != nil {
 		return err
 	}
 

--- a/internal/command/status/status.go
+++ b/internal/command/status/status.go
@@ -99,7 +99,7 @@ func once(ctx context.Context, out io.Writer) (err error) {
 
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
-		return fmt.Errorf("failed to get app: %s", err)
+		return fmt.Errorf("failed to get app: %w", err)
 	}
 
 	platformVersion := app.PlatformVersion


### PR DESCRIPTION

pretty self-explanatory, fixes the first bug in this forum thread: https://community.fly.io/t/machine-environment-errors/11421/2

I wanted to tackle the other bug from that thread in the same PR, but fixing secret deployment is going to be a little bit more involved so I want to go ahead and get this simple fix out.