### PR TITLE
Consolidate selection and setup in machine commands

### DIFF
--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -32,7 +32,7 @@ var NonceHeader = "fly-machine-lease-nonce"
 const headerFlyRequestId = "fly-request-id"
 
 type Client struct {
-	app        *api.AppCompact
+	appName    string
 	baseUrl    *url.URL
 	authToken  string
 	httpClient *http.Client
@@ -40,10 +40,27 @@ type Client struct {
 }
 
 func New(ctx context.Context, app *api.AppCompact) (*Client, error) {
+	return newFromAppOrAppName(ctx, app, app.Name)
+}
+
+func NewFromAppName(ctx context.Context, appName string) (*Client, error) {
+	return newFromAppOrAppName(ctx, nil, appName)
+}
+
+func newFromAppOrAppName(ctx context.Context, app *api.AppCompact, appName string) (*Client, error) {
+	if app != nil {
+		appName = app.Name
+	}
+
 	// FIXME: do this once we setup config for `fly config ...` commands, and then use cfg.FlapsBaseURL below
 	// cfg := config.FromContext(ctx)
+	var err error
 	flapsBaseURL := os.Getenv("FLY_FLAPS_BASE_URL")
 	if strings.TrimSpace(strings.ToLower(flapsBaseURL)) == "peer" {
+		app, err = resolveApp(ctx, app, appName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get app '%s': %w", appName, err)
+		}
 		return newWithUsermodeWireguard(ctx, app)
 	} else if flapsBaseURL == "" {
 		flapsBaseURL = "https://api.machines.dev"
@@ -58,12 +75,21 @@ func New(ctx context.Context, app *api.AppCompact) (*Client, error) {
 		return nil, fmt.Errorf("flaps: can't setup HTTP client to %s: %w", flapsUrl.String(), err)
 	}
 	return &Client{
-		app:        app,
+		appName:    appName,
 		baseUrl:    flapsUrl,
 		authToken:  flyctl.GetAPIToken(),
 		httpClient: httpClient,
 		userAgent:  strings.TrimSpace(fmt.Sprintf("fly-cli/%s", buildinfo.Version())),
 	}, nil
+}
+
+func resolveApp(ctx context.Context, app *api.AppCompact, appName string) (*api.AppCompact, error) {
+	var err error
+	if app == nil {
+		client := client.FromContext(ctx).API()
+		app, err = client.GetAppCompact(ctx, appName)
+	}
+	return app, err
 }
 
 func newWithUsermodeWireguard(ctx context.Context, app *api.AppCompact) (*Client, error) {
@@ -98,7 +124,7 @@ func newWithUsermodeWireguard(ctx context.Context, app *api.AppCompact) (*Client
 	}
 
 	return &Client{
-		app:        app,
+		appName:    app.Name,
 		baseUrl:    flapsBaseUrl,
 		authToken:  flyctl.GetAPIToken(),
 		httpClient: httpClient,
@@ -456,7 +482,7 @@ func (f *Client) NewRequest(ctx context.Context, method, path string, in interfa
 		headers = make(map[string][]string)
 	}
 
-	targetEndpoint, err := f.urlFromBaseUrl(fmt.Sprintf("/v1/apps/%s/machines%s", f.app.Name, path))
+	targetEndpoint, err := f.urlFromBaseUrl(fmt.Sprintf("/v1/apps/%s/machines%s", f.appName, path))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -89,26 +89,14 @@ func runMachineClone(ctx context.Context) (err error) {
 
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
-		help := newClone().Help()
-
-		if help != nil {
-			fmt.Println(help)
-		}
-
-		fmt.Println()
-
 		return err
 	}
-	flapsClient, err := flaps.New(ctx, app)
-	if err != nil {
-		return fmt.Errorf("could not make flaps client: %w", err)
-	}
-	ctx = flaps.NewContext(ctx, flapsClient)
 
-	source, err := flapsClient.Get(ctx, machineID)
+	source, ctx, err := selectOneMachineFromApp(ctx, machineID, app)
 	if err != nil {
 		return err
 	}
+	flapsClient := flaps.FromContext(ctx)
 
 	region := flag.GetString(ctx, "region")
 	if region == "" {

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -92,7 +92,7 @@ func runMachineClone(ctx context.Context) (err error) {
 		return err
 	}
 
-	source, ctx, err := selectOneMachineFromApp(ctx, machineID, app)
+	source, ctx, err := selectOneMachine(ctx, app, machineID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
-	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -48,72 +48,60 @@ func newDestroy() *cobra.Command {
 
 func runMachineDestroy(ctx context.Context) (err error) {
 	var (
-		appName   = appconfig.NameFromContext(ctx)
 		out       = iostreams.FromContext(ctx).Out
 		machineID = flag.FirstArg(ctx)
-		input     = api.RemoveMachineInput{
-			AppID: appconfig.NameFromContext(ctx),
-			ID:    machineID,
-			Kill:  flag.GetBool(ctx, "force"),
-		}
+		force     = flag.GetBool(ctx, "force")
 	)
 
-	app, err := appFromMachineOrName(ctx, machineID, appName)
-	if err != nil {
-		help := newDestroy().Help()
-
-		if help != nil {
-			fmt.Println(help)
-		}
-
-		fmt.Println()
-
-		return err
-	}
-
-	ctx, err = apps.BuildContext(ctx, app)
+	current, ctx, err := selectOneMachine(ctx, machineID)
 	if err != nil {
 		return err
 	}
-
 	flapsClient := flaps.FromContext(ctx)
+	appName := appconfig.NameFromContext(ctx)
 
-	// check if machine even exists
-	current, err := flapsClient.Get(ctx, machineID)
+	// This is used for the deletion hook below.
+	client := client.FromContext(ctx).API()
+	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
-		return fmt.Errorf("could not retrieve machine %s", machineID)
+		return fmt.Errorf("could not get app '%s': %w", appName, err)
 	}
 
 	switch current.State {
 	case "stopped":
 		break
 	case "destroyed":
-		return fmt.Errorf("machine %s has already been destroyed", machineID)
+		return fmt.Errorf("machine %s has already been destroyed", current.ID)
 	case "started":
-		if !input.Kill {
-			return fmt.Errorf("machine %s currently started, either stop first or use --force flag", machineID)
+		if !force {
+			return fmt.Errorf("machine %s currently started, either stop first or use --force flag", current.ID)
 		}
 	default:
-		if !input.Kill {
-			return fmt.Errorf("machine %s is in a %s state and cannot be destroyed since it is not stopped, either stop first or use --force flag", machineID, current.State)
+		if !force {
+			return fmt.Errorf("machine %s is in a %s state and cannot be destroyed since it is not stopped, either stop first or use --force flag", current.ID, current.State)
 		}
 	}
-	fmt.Fprintf(out, "machine %s was found and is currently in %s state, attempting to destroy...\n", machineID, current.State)
+	fmt.Fprintf(out, "machine %s was found and is currently in %s state, attempting to destroy...\n", current.ID, current.State)
 
+	input := api.RemoveMachineInput{
+		AppID: appName,
+		ID:    current.ID,
+		Kill:  force,
+	}
 	err = flapsClient.Destroy(ctx, input)
 	if err != nil {
 		switch {
-		case strings.Contains(err.Error(), "not found") && appName != "":
-			return fmt.Errorf("could not find machine %s in app %s to destroy", machineID, appName)
+		case strings.Contains(err.Error(), "not found"):
+			return fmt.Errorf("could not find machine %s in app %s to destroy", current.ID, appName)
 		default:
-			return fmt.Errorf("could not destroy machine %s: %w", machineID, err)
+			return fmt.Errorf("could not destroy machine %s: %w", current.ID, err)
 		}
 	}
 
 	// Best effort post-deletion hook.
 	runOnDeletionHook(ctx, app, current)
 
-	fmt.Fprintf(out, "%s has been destroyed\n", machineID)
+	fmt.Fprintf(out, "%s has been destroyed\n", current.ID)
 
 	return
 }

--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -52,7 +52,7 @@ func runMachineDestroy(ctx context.Context) (err error) {
 		force     = flag.GetBool(ctx, "force")
 	)
 
-	current, ctx, err := selectOneMachine(ctx, machineID)
+	current, ctx, err := selectOneMachine(ctx, nil, machineID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -3,7 +3,6 @@ package machine
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
@@ -90,12 +89,10 @@ func runMachineDestroy(ctx context.Context) (err error) {
 	}
 	err = flapsClient.Destroy(ctx, input)
 	if err != nil {
-		switch {
-		case strings.Contains(err.Error(), "not found"):
-			return fmt.Errorf("could not find machine %s in app %s to destroy", current.ID, appName)
-		default:
-			return fmt.Errorf("could not destroy machine %s: %w", current.ID, err)
+		if err := rewriteMachineNotFoundErrors(ctx, err, current.ID); err != nil {
+			return err
 		}
+		return fmt.Errorf("could not destroy machine %s: %w", current.ID, err)
 	}
 
 	// Best effort post-deletion hook.

--- a/internal/command/machine/exec.go
+++ b/internal/command/machine/exec.go
@@ -49,7 +49,7 @@ func runMachineExec(ctx context.Context) (err error) {
 		config    = config.FromContext(ctx)
 	)
 
-	current, ctx, err := selectOneMachine(ctx, machineID)
+	current, ctx, err := selectOneMachine(ctx, nil, machineID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/exec.go
+++ b/internal/command/machine/exec.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/flaps"
-	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -45,34 +44,16 @@ func newMachineExec() *cobra.Command {
 
 func runMachineExec(ctx context.Context) (err error) {
 	var (
-		appName   = appconfig.NameFromContext(ctx)
 		machineID = flag.FirstArg(ctx)
 		io        = iostreams.FromContext(ctx)
 		config    = config.FromContext(ctx)
 	)
 
-	app, err := appFromMachineOrName(ctx, machineID, appName)
+	current, ctx, err := selectOneMachine(ctx, machineID)
 	if err != nil {
-		help := newMachineExec().Help()
-
-		if help != nil {
-			fmt.Println(help)
-
-		}
-
-		fmt.Println()
 		return err
 	}
-
-	flapsClient, err := flaps.New(ctx, app)
-	if err != nil {
-		return fmt.Errorf("could not make flaps client: %w", err)
-	}
-
-	current, err := flapsClient.Get(ctx, machineID)
-	if err != nil {
-		return fmt.Errorf("could not retrieve machine %s", machineID)
-	}
+	flapsClient := flaps.FromContext(ctx)
 
 	var timeout = flag.GetInt(ctx, "timeout")
 
@@ -83,7 +64,7 @@ func runMachineExec(ctx context.Context) (err error) {
 
 	out, err := flapsClient.Exec(ctx, current.ID, in)
 	if err != nil {
-		return fmt.Errorf("could not exec command on machine %s: %w", machineID, err)
+		return fmt.Errorf("could not exec command on machine %s: %w", current.ID, err)
 	}
 
 	if config.JSONOutput {

--- a/internal/command/machine/kill.go
+++ b/internal/command/machine/kill.go
@@ -41,7 +41,7 @@ func runMachineKill(ctx context.Context) (err error) {
 		io        = iostreams.FromContext(ctx)
 	)
 
-	current, ctx, err := selectOneMachine(ctx, machineID)
+	current, ctx, err := selectOneMachine(ctx, nil, machineID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/kill.go
+++ b/internal/command/machine/kill.go
@@ -39,46 +39,29 @@ func newKill() *cobra.Command {
 
 func runMachineKill(ctx context.Context) (err error) {
 	var (
-		appName   = appconfig.NameFromContext(ctx)
 		machineID = flag.FirstArg(ctx)
 		io        = iostreams.FromContext(ctx)
 	)
 
-	app, err := appFromMachineOrName(ctx, machineID, appName)
+	current, ctx, err := selectOneMachine(ctx, machineID)
 	if err != nil {
-		help := newKill().Help()
-
-		if help != nil {
-			fmt.Println(help)
-
-		}
-
-		fmt.Println()
 		return err
 	}
-
-	flapsClient, err := flaps.New(ctx, app)
-	if err != nil {
-		return fmt.Errorf("could not make flaps client: %w", err)
-	}
-
-	current, err := flapsClient.Get(ctx, machineID)
-	if err != nil {
-		return fmt.Errorf("could not retrieve machine %s", machineID)
-	}
+	flapsClient := flaps.FromContext(ctx)
+	appName := appconfig.NameFromContext(ctx)
 
 	if current.State == "destroyed" {
-		return fmt.Errorf("machine %s has already been destroyed", machineID)
+		return fmt.Errorf("machine %s has already been destroyed", current.ID)
 	}
-	fmt.Fprintf(io.Out, "machine %s was found and is currently in a %s state, attempting to kill...\n", machineID, current.State)
+	fmt.Fprintf(io.Out, "machine %s was found and is currently in a %s state, attempting to kill...\n", current.ID, current.State)
 
-	err = flapsClient.Kill(ctx, machineID)
+	err = flapsClient.Kill(ctx, current.ID)
 	if err != nil {
 		switch {
-		case strings.Contains(err.Error(), "not found") && appName != "":
-			return fmt.Errorf("could not find machine %s in app %s to kill", machineID, appName)
+		case strings.Contains(err.Error(), "not found"):
+			return fmt.Errorf("could not find machine %s in app %s to kill", current.ID, appName)
 		default:
-			return fmt.Errorf("could not kill machine %s: %w", machineID, err)
+			return fmt.Errorf("could not kill machine %s: %w", current.ID, err)
 		}
 	}
 

--- a/internal/command/machine/leases.go
+++ b/internal/command/machine/leases.go
@@ -8,11 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
-	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flaps"
-	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
-	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
@@ -49,7 +46,7 @@ func newLeaseView() *cobra.Command {
 
 	cmd := command.New(usage, short, long, runLeaseView,
 		command.RequireSession,
-		command.RequireAppName,
+		command.LoadAppNameIfPresent,
 	)
 
 	// at least one arg is required but we can accept a list of machine ids
@@ -73,7 +70,7 @@ func newLeaseClear() *cobra.Command {
 
 	cmd := command.New(usage, short, long, runLeaseClear,
 		command.RequireSession,
-		command.RequireAppName,
+		command.LoadAppNameIfPresent,
 	)
 
 	// at least one arg is required but we can accept a list of machine ids
@@ -90,34 +87,16 @@ func newLeaseClear() *cobra.Command {
 
 func runLeaseView(ctx context.Context) (err error) {
 	var (
-		io      = iostreams.FromContext(ctx)
-		args    = flag.Args(ctx)
-		cfg     = config.FromContext(ctx)
-		appName = appconfig.NameFromContext(ctx)
-		client  = client.FromContext(ctx).API()
+		io   = iostreams.FromContext(ctx)
+		args = flag.Args(ctx)
+		cfg  = config.FromContext(ctx)
 	)
 
-	app, err := client.GetAppCompact(ctx, appName)
+	machines, ctx, err := selectManyMachines(ctx, args)
 	if err != nil {
-		return fmt.Errorf("could not get app: %w", err)
+		return err
 	}
-
-	ctx, err = apps.BuildContext(ctx, app)
-	if err != nil {
-		return
-	}
-
 	flapsClient := flaps.FromContext(ctx)
-
-	var machines []*api.Machine
-	// Resolve machines
-	for _, machineID := range args {
-		machine, err := flapsClient.Get(ctx, machineID)
-		if err != nil {
-			return fmt.Errorf("could not get machine %s: %w", machineID, err)
-		}
-		machines = append(machines, machine)
-	}
 
 	var leases = make(map[string]*api.MachineLease)
 
@@ -166,25 +145,17 @@ func runLeaseView(ctx context.Context) (err error) {
 
 func runLeaseClear(ctx context.Context) (err error) {
 	var (
-		io      = iostreams.FromContext(ctx)
-		args    = flag.Args(ctx)
-		appName = appconfig.NameFromContext(ctx)
-		client  = client.FromContext(ctx).API()
+		io   = iostreams.FromContext(ctx)
+		args = flag.Args(ctx)
 	)
 
-	app, err := client.GetAppCompact(ctx, appName)
+	machineIDs, ctx, err := selectManyMachineIDs(ctx, args)
 	if err != nil {
-		return fmt.Errorf("could not get app: %w", err)
+		return err
 	}
-
-	ctx, err = apps.BuildContext(ctx, app)
-	if err != nil {
-		return
-	}
-
 	flapsClient := flaps.FromContext(ctx)
 
-	for _, machineID := range args {
+	for _, machineID := range machineIDs {
 		lease, err := flapsClient.FindLease(ctx, machineID)
 		if err != nil {
 			if strings.Contains(err.Error(), " lease not found") {

--- a/internal/command/machine/machine.go
+++ b/internal/command/machine/machine.go
@@ -1,11 +1,7 @@
 package machine
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
-	"github.com/superfly/flyctl/api"
-	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/command"
 )
 
@@ -39,20 +35,4 @@ func New() *cobra.Command {
 	)
 
 	return cmd
-}
-
-func appFromMachineOrName(ctx context.Context, machineId string, appName string) (app *api.AppCompact, err error) {
-	client := client.FromContext(ctx).API()
-
-	if appName == "" {
-		machine, err := client.GetMachine(ctx, machineId)
-		if err != nil {
-			return nil, err
-		}
-		app = machine.App
-	} else {
-		app, err = client.GetAppCompact(ctx, appName)
-	}
-
-	return app, err
 }

--- a/internal/command/machine/restart.go
+++ b/internal/command/machine/restart.go
@@ -4,16 +4,12 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
-	"github.com/superfly/flyctl/flaps"
-	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
-	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
 	mach "github.com/superfly/flyctl/internal/machine"
 )
@@ -66,18 +62,7 @@ func runMachineRestart(ctx context.Context) error {
 		args    = flag.Args(ctx)
 		signal  = flag.GetString(ctx, "signal")
 		timeout = flag.GetInt(ctx, "time")
-		appName = appconfig.NameFromContext(ctx)
 	)
-
-	app, err := appFromMachineOrName(ctx, args[0], appName)
-	if err != nil {
-		return fmt.Errorf("could not get app: %w", err)
-	}
-
-	ctx, err = apps.BuildContext(ctx, app)
-	if err != nil {
-		return err
-	}
 
 	// Resolve flags
 	input := &api.RestartMachineInput{
@@ -97,20 +82,9 @@ func runMachineRestart(ctx context.Context) error {
 		input.Signal = sig
 	}
 
-	flapsClient := flaps.FromContext(ctx)
-
-	var machines []*api.Machine
-	// Resolve machines
-	for _, machineID := range args {
-		machine, err := flapsClient.Get(ctx, machineID)
-		if err != nil {
-			if strings.Contains(err.Error(), "machine not found") {
-				return fmt.Errorf("could not get machine %s. perhaps this machine doesn't exist, or isn't part of the app '%s'", machineID, app.Name)
-			} else {
-				return fmt.Errorf("could not get machine %s: %w", machineID, err)
-			}
-		}
-		machines = append(machines, machine)
+	machines, ctx, err := selectManyMachines(ctx, args)
+	if err != nil {
+		return err
 	}
 
 	// Acquire leases

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -258,7 +258,7 @@ func runMachineRun(ctx context.Context) error {
 		return fmt.Errorf("to update an existing machine, use 'flyctl machine update'")
 	}
 
-	machineConf, err = determineMachineConfig(ctx, *machineConf, app, flag.FirstArg(ctx), input.Region)
+	machineConf, err = determineMachineConfig(ctx, *machineConf, app.Name, flag.FirstArg(ctx), input.Region)
 	if err != nil {
 		return err
 	}
@@ -620,7 +620,7 @@ func selectAppName(ctx context.Context) (name string, err error) {
 	return
 }
 
-func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineConfig, app *api.AppCompact, imageOrPath string, region string) (*api.MachineConfig, error) {
+func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineConfig, appName string, imageOrPath string, region string) (*api.MachineConfig, error) {
 	machineConf, err := mach.CloneConfig(initialMachineConf)
 	if err != nil {
 		return nil, err
@@ -761,7 +761,7 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 		return machineConf, err
 	}
 
-	img, err := determineImage(ctx, app.Name, imageOrPath)
+	img, err := determineImage(ctx, appName, imageOrPath)
 	if err != nil {
 		return machineConf, err
 	}

--- a/internal/command/machine/select.go
+++ b/internal/command/machine/select.go
@@ -2,7 +2,6 @@ package machine
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -12,20 +11,8 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 )
 
-func selectOneMachine(ctx context.Context, machineID string) (*api.Machine, context.Context, error) {
-	return selectOneMachineImpl(ctx, machineID, nil)
-}
-
-func selectOneMachineFromApp(ctx context.Context, machineID string, app *api.AppCompact) (*api.Machine, context.Context, error) {
-	if app == nil {
-		return nil, nil, errors.New("tried to select a machine from a nil app; this is a bug")
-	}
-	return selectOneMachineImpl(ctx, machineID, app)
-}
-
-func selectOneMachineImpl(ctx context.Context, machineID string, app *api.AppCompact) (*api.Machine, context.Context, error) {
+func selectOneMachine(ctx context.Context, app *api.AppCompact, machineID string) (*api.Machine, context.Context, error) {
 	var err error
-
 	if app != nil {
 		ctx, err = buildContextFromApp(ctx, app)
 	} else {

--- a/internal/command/machine/select.go
+++ b/internal/command/machine/select.go
@@ -1,0 +1,121 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/appconfig"
+)
+
+func selectOneMachine(ctx context.Context, machineID string) (*api.Machine, context.Context, error) {
+	return selectOneMachineImpl(ctx, machineID, nil)
+}
+
+func selectOneMachineFromApp(ctx context.Context, machineID string, app *api.AppCompact) (*api.Machine, context.Context, error) {
+	if app == nil {
+		return nil, nil, errors.New("tried to select a machine from a nil app; this is a bug")
+	}
+	return selectOneMachineImpl(ctx, machineID, app)
+}
+
+func selectOneMachineImpl(ctx context.Context, machineID string, app *api.AppCompact) (*api.Machine, context.Context, error) {
+	var err error
+
+	if app != nil {
+		ctx, err = buildContextFromApp(ctx, app)
+	} else {
+		ctx, err = buildContextFromAppNameOrMachineID(ctx, machineID)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	machine, err := flaps.FromContext(ctx).Get(ctx, machineID)
+	if err != nil {
+		if err := rewriteMachineNotFoundErrors(ctx, err, machineID); err != nil {
+			return nil, nil, err
+		}
+		return nil, nil, fmt.Errorf("could not get machine %s: %w", machineID, err)
+	}
+	return machine, ctx, nil
+}
+
+func selectManyMachines(ctx context.Context, machineIDs []string) ([]*api.Machine, context.Context, error) {
+	ctx, err := buildContextFromAppNameOrMachineID(ctx, machineIDs[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	flapsClient := flaps.FromContext(ctx)
+
+	var machines []*api.Machine
+	for _, machineID := range machineIDs {
+		machine, err := flapsClient.Get(ctx, machineID)
+		if err != nil {
+			if err := rewriteMachineNotFoundErrors(ctx, err, machineID); err != nil {
+				return nil, nil, err
+			}
+			return nil, nil, fmt.Errorf("could not get machine %s: %w", machineID, err)
+		}
+		machines = append(machines, machine)
+	}
+	return machines, ctx, nil
+}
+
+func selectManyMachineIDs(ctx context.Context, machineIDs []string) ([]string, context.Context, error) {
+	ctx, err := buildContextFromAppNameOrMachineID(ctx, machineIDs[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	return machineIDs, ctx, nil
+}
+
+func buildContextFromApp(ctx context.Context, app *api.AppCompact) (context.Context, error) {
+	flapsClient, err := flaps.New(ctx, app)
+	if err != nil {
+		return nil, fmt.Errorf("could not create flaps client: %w", err)
+	}
+	ctx = flaps.NewContext(ctx, flapsClient)
+	return ctx, nil
+}
+
+func buildContextFromAppNameOrMachineID(ctx context.Context, machineID string) (context.Context, error) {
+	var (
+		appName = appconfig.NameFromContext(ctx)
+
+		flapsClient *flaps.Client
+		err         error
+	)
+
+	if appName == "" {
+		client := client.FromContext(ctx).API()
+		var gqlMachine *api.GqlMachine
+		gqlMachine, err = client.GetMachine(ctx, machineID)
+		if err != nil {
+			return nil, fmt.Errorf("could not get machine from GraphQL to determine app name: %w", err)
+		}
+		ctx = appconfig.WithName(ctx, gqlMachine.App.Name)
+		flapsClient, err = flaps.New(ctx, gqlMachine.App)
+	} else {
+		flapsClient, err = flaps.NewFromAppName(ctx, appName)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("could not create flaps client: %w", err)
+	}
+
+	ctx = flaps.NewContext(ctx, flapsClient)
+	return ctx, nil
+}
+
+func rewriteMachineNotFoundErrors(ctx context.Context, err error, machineID string) error {
+	if strings.Contains(err.Error(), "machine not found") {
+		appName := appconfig.NameFromContext(ctx)
+		return fmt.Errorf("machine %s was not found in app '%s'", machineID, appName)
+	} else {
+		return nil
+	}
+}

--- a/internal/command/machine/start.go
+++ b/internal/command/machine/start.go
@@ -43,7 +43,12 @@ func runMachineStart(ctx context.Context) (err error) {
 		args = flag.Args(ctx)
 	)
 
-	for _, machineID := range args {
+	machineIDs, ctx, err := selectManyMachineIDs(ctx, args)
+	if err != nil {
+		return err
+	}
+
+	for _, machineID := range machineIDs {
 		if err = Start(ctx, machineID); err != nil {
 			return
 		}
@@ -57,28 +62,18 @@ func Start(ctx context.Context, machineID string) (err error) {
 		appName = appconfig.NameFromContext(ctx)
 	)
 
-	app, err := appFromMachineOrName(ctx, machineID, appName)
-	if err != nil {
-		return fmt.Errorf("could not make flaps client: %w", err)
-	}
-
-	flapsClient, err := flaps.New(ctx, app)
-	if err != nil {
-		return fmt.Errorf("could not make flaps client: %w", err)
-	}
-
-	machine, err := flapsClient.Start(ctx, machineID)
+	machine, err := flaps.FromContext(ctx).Start(ctx, machineID)
 	if err != nil {
 		switch {
-		case strings.Contains(err.Error(), "not found") && appName != "":
-			return fmt.Errorf("machine %s was not found in app %s", machineID, appName)
+		case strings.Contains(err.Error(), "not found"):
+			return fmt.Errorf("machine %s was not found in app '%s'", machineID, appName)
 		default:
 			return fmt.Errorf("could not start machine %s: %w", machineID, err)
 		}
 	}
 
 	if machine.Status == "error" {
-		return fmt.Errorf("machine could not be started %s", machine.Message)
+		return fmt.Errorf("machine could not be started: %s", machine.Message)
 	}
 	return
 }

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -68,7 +68,7 @@ func runMachineStatus(ctx context.Context) (err error) {
 	io := iostreams.FromContext(ctx)
 
 	machineID := flag.FirstArg(ctx)
-	machine, ctx, err := selectOneMachine(ctx, machineID)
+	machine, ctx, err := selectOneMachine(ctx, nil, machineID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -63,7 +63,7 @@ func runUpdate(ctx context.Context) (err error) {
 		dockerfile       = flag.GetString(ctx, flag.Dockerfile().Name)
 	)
 
-	machine, ctx, err := selectOneMachine(ctx, machineID)
+	machine, ctx, err := selectOneMachine(ctx, nil, machineID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -7,12 +7,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/api"
-	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
-	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/watch"
@@ -55,7 +53,6 @@ func newUpdate() *cobra.Command {
 
 func runUpdate(ctx context.Context) (err error) {
 	var (
-		appName  = appconfig.NameFromContext(ctx)
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
 
@@ -66,27 +63,11 @@ func runUpdate(ctx context.Context) (err error) {
 		dockerfile       = flag.GetString(ctx, flag.Dockerfile().Name)
 	)
 
-	app, err := appFromMachineOrName(ctx, machineID, appName)
-	if err != nil {
-		return fmt.Errorf("could not make flaps client: %w", err)
-	}
-
-	ctx, err = apps.BuildContext(ctx, app)
+	machine, ctx, err := selectOneMachine(ctx, machineID)
 	if err != nil {
 		return err
 	}
-
-	flapsClient, err := flaps.New(ctx, app)
-	if err != nil {
-		return fmt.Errorf("could not make flaps client: %w", err)
-	}
-
-	// Get machine
-
-	machine, err := flapsClient.Get(ctx, machineID)
-	if err != nil {
-		return err
-	}
+	appName := appconfig.NameFromContext(ctx)
 
 	// Acquire lease
 	machine, releaseLeaseFunc, err := mach.AcquireLease(ctx, machine)
@@ -110,7 +91,7 @@ func runUpdate(ctx context.Context) (err error) {
 	}
 
 	// Identify configuration changes
-	machineConf, err := determineMachineConfig(ctx, *machine.Config, app, imageOrPath, machine.Region)
+	machineConf, err := determineMachineConfig(ctx, *machine.Config, appName, imageOrPath, machine.Region)
 	if err != nil {
 		return err
 	}
@@ -130,7 +111,7 @@ func runUpdate(ctx context.Context) (err error) {
 	// Perform update
 	input := &api.LaunchMachineInput{
 		ID:               machine.ID,
-		AppID:            app.Name,
+		AppID:            appName,
 		Name:             machine.Name,
 		Region:           machine.Region,
 		Config:           machineConf,
@@ -149,7 +130,7 @@ func runUpdate(ctx context.Context) (err error) {
 		fmt.Fprintln(io.Out)
 	}
 
-	fmt.Fprintf(io.Out, "\nMonitor machine status here:\nhttps://fly.io/apps/%s/machines/%s\n", app.Name, machine.ID)
+	fmt.Fprintf(io.Out, "\nMonitor machine status here:\nhttps://fly.io/apps/%s/machines/%s\n", appName, machine.ID)
 
 	return nil
 }


### PR DESCRIPTION
This PR was born out of a quick discussion in Slack. A number of machine commands use `apps.BuildContext`, which always sets up an agent for Wireguard. After the switch to `api.machines.dev` by default, this is usually not necessary. Furthermore, going to `api.machines.dev` means that we generally don't need to get an `AppCompact` from the API, since `flaps.New` needs it only for Wireguard mode.

Furthermore, the inconsistencies in how `fly machines <command> <mid>` works are behind #1849 and make it more complicated to wrap up `--select` for these commands (#1852).

This consolidates all app/machine selection and setup logic (including the creation of the flaps client for the app selected) into a new file, `select.go`. In doing so, it eliminates calls to `apps.BuildContext` and in most cases removes the API round-trip to get an `AppCompact`, which should speed things up.

Finally, by consolidating this logic in one place, we get consistent behavior for subcommands that take machine IDs. With the exception of clone, which still requires an app to be specified, these subcommands will now use the app of the first machine specified. All subsequent machines are required to be in the same app. Notably, this
    
* loosens the requirements for `leases` and
* **strengthens** the requirements for `start` and `stop`.

**If tightening up `start` and `stop` is probably going to break people's stuff,** I will revise to special-case these two.

(BTW, I've also pushed a full draft of #1852 based on a slightly older version of these changes.)
