### PR TITLE
ensure pg and redis gems are present even if Dockerfile exists

### DIFF
--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -146,6 +146,20 @@ func RailsCallback(srcInfo *SourceInfo, options map[string]bool) error {
 		if err := cmd.Run(); err != nil {
 			return errors.Wrap(err, "Failed to generate Dockefile")
 		}
+	} else {
+		if options["postgresql"] && !strings.Contains(string(gemfile), "pg") {
+			cmd := exec.Command("bundle", "add", "pg")
+			if err := cmd.Run(); err != nil {
+				return errors.Wrap(err, "Failed to install pg gem")
+			}
+		}
+
+		if options["redis"] && !strings.Contains(string(gemfile), "redis") {
+			cmd := exec.Command("bundle", "add", "redis")
+			if err := cmd.Run(); err != nil {
+				return errors.Wrap(err, "Failed to install redis gem")
+			}
+		}
 	}
 
 	// read dockerfile


### PR DESCRIPTION
This is normally done by dockerfile-rails, but that won't be run if the Dockerfile already exists.