### PR TITLE
fix: inaccuate create ssh certificate command

### DIFF
--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -226,7 +226,7 @@ func sshConnect(p *SSHParams, addr string) (*ssh.Client, error) {
 
 	cert, pk, err := singleUseSSHCertificate(p.Ctx, p.Org)
 	if err != nil {
-		return nil, fmt.Errorf("create ssh certificate: %w (if you haven't created a key for your org yet, try `flyctl ssh establish`)", err)
+		return nil, fmt.Errorf("create ssh certificate: %w (if you haven't created a key for your org yet, try `flyctl ssh issue`)", err)
 	}
 
 	pemkey := ssh.MarshalED25519PrivateKey(pk, "single-use certificate")


### PR DESCRIPTION
```
Error create ssh certificate: Post "https://api.fly.io/graphql": context canceled
(if you haven't created a key for your org yet, try `flyctl ssh establish`
```
to
```
Error create ssh certificate: Post "https://api.fly.io/graphql": context canceled
(if you haven't created a key for your org yet, try `flyctl ssh issue`
```