### PR TITLE
Make DefaultProcessName() deterministic

### DIFF
--- a/internal/appconfig/processconfig_test.go
+++ b/internal/appconfig/processconfig_test.go
@@ -8,31 +8,57 @@ import (
 
 func TestGetDefaultProcessName_Nil(t *testing.T) {
 	var cfg *Config
-	assert.Equal(t, "app", cfg.GetDefaultProcessName())
+	assert.Equal(t, "app", cfg.DefaultProcessName())
 }
 
 func TestGetDefaultProcessName_Default(t *testing.T) {
 	cfg, err := LoadConfig("./testdata/processes-none.toml")
 	assert.NoError(t, err)
 	// Test unknown platform version
-	assert.Equal(t, "app", cfg.GetDefaultProcessName())
+	assert.Equal(t, "app", cfg.DefaultProcessName())
 	// Test for machines
 	assert.NoError(t, cfg.SetMachinesPlatform())
-	assert.Equal(t, "app", cfg.GetDefaultProcessName())
+	assert.Equal(t, "app", cfg.DefaultProcessName())
 	// Test for nomad
 	assert.NoError(t, cfg.SetMachinesPlatform())
-	assert.Equal(t, "app", cfg.GetDefaultProcessName())
+	assert.Equal(t, "app", cfg.DefaultProcessName())
 }
 
 func TestGetDefaultProcessName_First(t *testing.T) {
 	cfg, err := LoadConfig("./testdata/processes-one.toml")
 	assert.NoError(t, err)
 	// Test unknown platform version
-	assert.Equal(t, "web", cfg.GetDefaultProcessName())
+	assert.Equal(t, "web", cfg.DefaultProcessName())
 	// Test for machines
 	assert.NoError(t, cfg.SetMachinesPlatform())
-	assert.Equal(t, "web", cfg.GetDefaultProcessName())
+	assert.Equal(t, "web", cfg.DefaultProcessName())
 	// Test for nomad
 	assert.NoError(t, cfg.SetMachinesPlatform())
-	assert.Equal(t, "web", cfg.GetDefaultProcessName())
+	assert.Equal(t, "web", cfg.DefaultProcessName())
+}
+
+func TestGetDefaultProcessName_Many(t *testing.T) {
+	cfg, err := LoadConfig("./testdata/processes-multi.toml")
+	assert.NoError(t, err)
+	// Test unknown platform version
+	assert.Equal(t, "bar", cfg.DefaultProcessName())
+	// Test for machines
+	assert.NoError(t, cfg.SetMachinesPlatform())
+	assert.Equal(t, "bar", cfg.DefaultProcessName())
+	// Test for nomad
+	assert.NoError(t, cfg.SetMachinesPlatform())
+	assert.Equal(t, "bar", cfg.DefaultProcessName())
+}
+
+func TestGetDefaultProcessName_ManyWithApp(t *testing.T) {
+	cfg, err := LoadConfig("./testdata/processes-multiwithapp.toml")
+	assert.NoError(t, err)
+	// Test unknown platform version
+	assert.Equal(t, "app", cfg.DefaultProcessName())
+	// Test for machines
+	assert.NoError(t, cfg.SetMachinesPlatform())
+	assert.Equal(t, "app", cfg.DefaultProcessName())
+	// Test for nomad
+	assert.NoError(t, cfg.SetMachinesPlatform())
+	assert.Equal(t, "app", cfg.DefaultProcessName())
 }

--- a/internal/appconfig/testdata/processes-multi.toml
+++ b/internal/appconfig/testdata/processes-multi.toml
@@ -2,3 +2,6 @@
 app = "foo"
 
 [processes]
+zzz = "/zzzz"
+bar = "/app/bar"
+foo = "/app/foo"

--- a/internal/appconfig/testdata/processes-multiwithapp.toml
+++ b/internal/appconfig/testdata/processes-multiwithapp.toml
@@ -1,0 +1,10 @@
+# Use this file to test processconfig.go
+app = "foo"
+
+# "app" is the default process because it is present
+[processes]
+aaa = "/run1"
+ass = "/run2"
+app = "/run2"
+bbb = "/run3"
+abc = "/run1"

--- a/internal/command/scale/count.go
+++ b/internal/command/scale/count.go
@@ -41,7 +41,7 @@ func runScaleCount(ctx context.Context) error {
 	appConfig := appconfig.ConfigFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 
-	defaultGroupName := appConfig.GetDefaultProcessName()
+	defaultGroupName := appConfig.DefaultProcessName()
 	groups := map[string]int{}
 
 	args := flag.Args(ctx)


### PR DESCRIPTION
In the face of 2+ processes, always returns "app" if defined or the first of the lexicographically sorted list of names. 
Go maps are hashmap which iteration order is not guaranteed, in fact, it is randomized every time. https://stackoverflow.com/a/9621526