### PR TITLE
Fix non-interactive preflight test

### DIFF
--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -205,7 +205,6 @@ func TestAppsV2ConfigChanges(t *testing.T) {
 	}
 
 	require.Contains(f, string(configFileBytes), "internal_port = 9999")
-
 }
 
 func TestAppsV2ConfigSave_ProcessGroups(t *testing.T) {
@@ -299,7 +298,6 @@ func TestAppsV2ConfigSave_PostgresSingleNode(t *testing.T) {
     interval = "15s"
     timeout = "10s"
     path = "/flycheck/vm"`)
-
 }
 
 func TestAppsV2_PostgresNoMachines(t *testing.T) {
@@ -393,9 +391,8 @@ func TestAppsV2Config_ParseExperimental(t *testing.T) {
 		f.Fatalf("Failed to write config: %s", err)
 	}
 
-	result := f.Fly("launch --force-machines --name %s --region ord --copy-config", appName)
+	result := f.Fly("launch --force-machines --name %s --region ord --copy-config --org %s", appName, f.OrgSlug())
 	stdout := result.StdOut().String()
 	require.Contains(f, stdout, "Created app")
 	require.Contains(f, stdout, "Wrote config file fly.toml")
-
 }


### PR DESCRIPTION
Fix for 

```
=== RUN   TestAppsV2Config_ParseExperimental
  1:
DBGCMD: /home/daniel/src/flyctl/bin/flyctl orgs list --json
OUTPUT:
{
    "aligned-naar": "Aligned Naar",
    "fly": "Fly",
    "fly-builds": "fly-builds",
    "fly-test": "fly-test",
    "flyctl-tests": "flyctl-tests",
    "flyctl-tests-daniel": "flyctl-tests-daniel",
    "flyio-multitenant": "flyio-multitenant",
    "flyio-ui": "flyio-ui",
    "personal": "Daniel Graña"
}

  2:
DBGCMD: /home/daniel/src/flyctl/bin/flyctl launch --force-machines --name preflight-2023-03-pug3eviz --region ord --copy-config
OUTPUT:
An existing fly.toml file was found
Creating app in /tmp/TestAppsV2Config_ParseExperimental2882763645/001
Scanning source code
Could not find a Dockerfile, nor detect a runtime or framework from source code. Continuing with a blank app.

    test_env.go:255: expected successful zero exit code, got 1, for command: /home/daniel/src/flyctl/bin/flyctl launch --force-machines --name preflight-2023-03-pug3eviz --region ord --copy-config [stdout]: An existing fly.toml file was found
        Creating app in /tmp/TestAppsV2Config_ParseExperimental2882763645/001
        Scanning source code
        Could not find a Dockerfile, nor detect a runtime or framework from source code. Continuing with a blank app.
         [strderr]: Error org slug must be specified when not running interactively


--- FAIL: TestAppsV2Config_ParseExperimental (1.18s)
FAIL
FAIL    github.com/superfly/flyctl/test/preflight       406.488s
FAIL
make: *** [Makefile:25: preflight-test] Error 1
```

Fix shameless copied from @alichay's commit https://github.com/superfly/flyctl/commit/d70913b85fb0c0468c41f5f0fe70951b1e465cf5

```
$ make preflight-test T=TestAppsV2Config_ParseExperimental
Running Generate for Help and GraphQL client
go generate ./...
generating cli help
Running Build
go build -o bin/flyctl -ldflags="-X 'github.com/superfly/flyctl/internal/buildinfo.buildDate=2023-03-16T14:46:54Z' -X 'github.com/superfly/flyctl/internal/buildinfo.commit=1059733c2bcd28353dd477e8ccfb98e006e53014 (fix-preflight)'" .
if [ -r .direnv/preflight ]; then . .direnv/preflight; fi; \
go test ./test/preflight --tags=integration -v --run=TestAppsV2Config_ParseExperimental
=== RUN   TestAppsV2Config_ParseExperimental
--- PASS: TestAppsV2Config_ParseExperimental (4.24s)
PASS
ok      github.com/superfly/flyctl/test/preflight       4.249s
```