### PR TITLE
`bump_version.sh`: confirm if pushing from non-standard branch

### DIFF
--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -21,6 +21,16 @@ elif [[ $(git status --porcelain -b | grep -e "ahead" -e "behind") != "" ]]; the
   exit 1
 fi
 
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$BRANCH" != "master" && "$BRANCH" != "main" ]]; then
+    read -p "You are pushing from a branch ('$BRANCH'), are you sure? " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[^Yy]$ ]]; then
+        echo Aborting.
+        exit 1
+    fi
+fi
+
 dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 previous_version="$("$dir"/../scripts/version.sh -s)"


### PR DESCRIPTION
this is an easy mistake to make, it's nice to have an extra safeguard here.

I totally didn't just do this. (#1915)