### PR TITLE
`deploy`: fix bug in display of removed machines

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -231,7 +231,7 @@ func (md *machineDeployment) resolveProcessGroupChanges() ProcessGroupsDiff {
 			}
 		}
 		if groupMatch == "" {
-			output.groupsToRemove[groupMatch] += 1
+			output.groupsToRemove[machGroup] += 1
 			output.machinesToRemove = append(output.machinesToRemove, leasableMachine)
 		} else {
 			groupHasMachine[groupMatch] = true
@@ -277,6 +277,10 @@ func (md *machineDeployment) warnAboutProcessGroupChanges(ctx context.Context, d
 }
 
 func (md *machineDeployment) spawnMachineInGroup(ctx context.Context, groupName string) error {
+	if groupName == "" {
+		// If the group is unspecified, it should have been translated to "app" by this point
+		panic("spawnMachineInGroup requires a non-empty group name. this is a bug!")
+	}
 	fmt.Fprintf(md.io.Out, "No machines in group '%s', launching one new machine\n", md.colorize.Bold(groupName))
 	machBase := &api.Machine{
 		Region: md.appConfig.PrimaryRegion,


### PR DESCRIPTION
Would fix #1917 

Also adds incorporates testing in the process groups preflight test for these sorts of messages:
```
 * destroy 1 "web" machine
 * destroy 1 "bar_web" machine
 * create 1 "app" machine
```

I also snuck that message into the initial deploy - it should have been there from the start.