### PR TITLE
bundle exec rackup for better results

### DIFF
--- a/scanner/templates/ruby/Dockerfile
+++ b/scanner/templates/ruby/Dockerfile
@@ -37,4 +37,4 @@ COPY . .
 
 # Start the server
 EXPOSE 8080
-CMD ["rackup", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["bundle", "exec", "rackup", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
This was required locally in order to start the hanami web server