### PR TITLE
Remove dependecy of flyctl/api on flyctl

### DIFF
--- a/api/casting.go
+++ b/api/casting.go
@@ -1,7 +1,5 @@
 package api
 
-import "encoding/json"
-
 // IntPointer - Returns a pointer to an int
 func IntPointer(val int) *int {
 	return &val
@@ -20,17 +18,4 @@ func StringPointer(val string) *string {
 // Pointer - Returns a pointer to a any type
 func Pointer[T any](val T) *T {
 	return &val
-}
-
-func InterfaceToMapOfStringInterface(val interface{}) (map[string]interface{}, error) {
-	jsonString, err := json.Marshal(val)
-	if err != nil {
-		return nil, err
-	}
-	var outputMap map[string]interface{}
-	err = json.Unmarshal(jsonString, &outputMap)
-	if err != nil {
-		return nil, err
-	}
-	return outputMap, nil
 }

--- a/api/resource_organizations.go
+++ b/api/resource_organizations.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/graphql"
 )
 
@@ -300,9 +299,7 @@ func (c *Client) DeleteOrganizationMembership(ctx context.Context, orgId, userId
 }
 
 func (c *Client) UpdateRemoteBuilder(ctx context.Context, orgName string, image string) (*Organization, error) {
-
 	org, err := c.GetOrganizationBySlug(ctx, orgName)
-
 	if err != nil {
 		return nil, err
 	}
@@ -335,17 +332,21 @@ func (c *Client) UpdateRemoteBuilder(ctx context.Context, orgName string, image 
 const appsV2DefaultOnSettingsKey = "apps_v2_default_on"
 
 func (c *Client) GetAppsV2DefaultOnForOrg(ctx context.Context, orgSlug string) (bool, error) {
-	_ = `# @genqlient
-	query GetOrgSettings($orgSlug:String!) {
-		organization(slug:$orgSlug) {
+	query := `
+	query($slug: String!) {
+		organization(slug: $slug) {
 			settings
 		}
 	}
 	`
-	resp, err := gql.GetOrgSettings(ctx, c.GenqClient, orgSlug)
+	req := c.NewRequest(query)
+	req.Var("slug", orgSlug)
+
+	resp, err := c.RunWithContext(ctx, req)
 	if err != nil {
 		return false, err
 	}
+
 	settingsMap, err := InterfaceToMapOfStringInterface(resp.Organization.Settings)
 	if err != nil {
 		return false, fmt.Errorf("failed to convert settings from to map with string keys error: %w original interface: %v", err, resp.Organization.Settings)

--- a/api/resource_organizations.go
+++ b/api/resource_organizations.go
@@ -347,11 +347,7 @@ func (c *Client) GetAppsV2DefaultOnForOrg(ctx context.Context, orgSlug string) (
 		return false, err
 	}
 
-	settingsMap, err := InterfaceToMapOfStringInterface(resp.Organization.Settings)
-	if err != nil {
-		return false, fmt.Errorf("failed to convert settings from to map with string keys error: %w original interface: %v", err, resp.Organization.Settings)
-	}
-	if val, present := settingsMap[appsV2DefaultOnSettingsKey]; !present {
+	if val, present := resp.Organization.Settings[appsV2DefaultOnSettingsKey]; !present {
 		return false, nil
 	} else if appsV2DefaultOn, ok := val.(bool); !ok {
 		return false, fmt.Errorf("failed to convert '%v' to boolean value for %s org setting", val, appsV2DefaultOnSettingsKey)

--- a/api/types.go
+++ b/api/types.go
@@ -540,6 +540,7 @@ type Organization struct {
 	Slug               string
 	Type               string
 	PaidPlan           bool
+	Settings           map[string]any
 
 	Domains struct {
 		Nodes *[]*Domain

--- a/gql/generated.go
+++ b/gql/generated.go
@@ -689,23 +689,6 @@ type GetAddOnResponse struct {
 // GetAddOn returns GetAddOnResponse.AddOn, and is useful for accessing the field via an interface.
 func (v *GetAddOnResponse) GetAddOn() GetAddOnAddOn { return v.AddOn }
 
-// GetOrgSettingsOrganization includes the requested fields of the GraphQL type Organization.
-type GetOrgSettingsOrganization struct {
-	Settings interface{} `json:"settings"`
-}
-
-// GetSettings returns GetOrgSettingsOrganization.Settings, and is useful for accessing the field via an interface.
-func (v *GetOrgSettingsOrganization) GetSettings() interface{} { return v.Settings }
-
-// GetOrgSettingsResponse is returned by GetOrgSettings on success.
-type GetOrgSettingsResponse struct {
-	// Find an organization by ID
-	Organization GetOrgSettingsOrganization `json:"organization"`
-}
-
-// GetOrganization returns GetOrgSettingsResponse.Organization, and is useful for accessing the field via an interface.
-func (v *GetOrgSettingsResponse) GetOrganization() GetOrgSettingsOrganization { return v.Organization }
-
 // GetOrganizationOrganization includes the requested fields of the GraphQL type Organization.
 type GetOrganizationOrganization struct {
 	Id string `json:"id"`
@@ -1164,14 +1147,6 @@ type __GetAddOnProviderInput struct {
 // GetName returns __GetAddOnProviderInput.Name, and is useful for accessing the field via an interface.
 func (v *__GetAddOnProviderInput) GetName() string { return v.Name }
 
-// __GetOrgSettingsInput is used internally by genqlient
-type __GetOrgSettingsInput struct {
-	OrgSlug string `json:"orgSlug"`
-}
-
-// GetOrgSlug returns __GetOrgSettingsInput.OrgSlug, and is useful for accessing the field via an interface.
-func (v *__GetOrgSettingsInput) GetOrgSlug() string { return v.OrgSlug }
-
 // __GetOrganizationInput is used internally by genqlient
 type __GetOrganizationInput struct {
 	Slug string `json:"slug"`
@@ -1486,38 +1461,6 @@ query GetAddOnProvider ($name: String!) {
 	var err error
 
 	var data GetAddOnProviderResponse
-	resp := &graphql.Response{Data: &data}
-
-	err = client.MakeRequest(
-		ctx,
-		req,
-		resp,
-	)
-
-	return &data, err
-}
-
-func GetOrgSettings(
-	ctx context.Context,
-	client graphql.Client,
-	orgSlug string,
-) (*GetOrgSettingsResponse, error) {
-	req := &graphql.Request{
-		OpName: "GetOrgSettings",
-		Query: `
-query GetOrgSettings ($orgSlug: String!) {
-	organization(slug: $orgSlug) {
-		settings
-	}
-}
-`,
-		Variables: &__GetOrgSettingsInput{
-			OrgSlug: orgSlug,
-		},
-	}
-	var err error
-
-	var data GetOrgSettingsResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/internal/appconfig/remote.go
+++ b/internal/appconfig/remote.go
@@ -90,16 +90,18 @@ func getAppV2ConfigFromReleases(ctx context.Context, apiClient *api.Client, appN
 	if err != nil {
 		return nil, err
 	}
+
 	configDefinition := resp.App.CurrentReleaseUnprocessed.ConfigDefinition
 	if configDefinition == nil {
 		return nil, nil
 	}
-	configMapDefinition, err := api.InterfaceToMapOfStringInterface(configDefinition)
-	if err != nil {
-		return nil, fmt.Errorf("likely a bug, could not convert config definition to api definition error: %w", err)
+
+	configMapDefinition, ok := configDefinition.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("likely a bug, could not convert config definition of type %T to api map[string]any", configDefinition)
 	}
-	apiDefinition := api.DefinitionPtr(configMapDefinition)
-	appConfig, err := FromDefinition(apiDefinition)
+
+	appConfig, err := FromDefinition(api.DefinitionPtr(configMapDefinition))
 	if err != nil {
 		return nil, fmt.Errorf("error creating appv2 Config from api definition: %w", err)
 	}


### PR DESCRIPTION
flyctl/api module can't depend on flyctl or it pulls the large list of flyctl dependencies into projects using the api Go bindings.