### PR TITLE
Don't use "Bearer" authorization scheme for new-style tokens

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // CLISessionAuth holds access information
@@ -71,4 +72,13 @@ func GetAccessTokenForCLISession(ctx context.Context, id string) (token string, 
 	}
 
 	return
+}
+
+const flyv1Scheme = "FlyV1"
+
+func AuthorizationHeader(token string) string {
+	if scheme, _, ok := strings.Cut(token, " "); ok && scheme == flyv1Scheme {
+		return token
+	}
+	return fmt.Sprintf("Bearer %s", token)
 }

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -1,0 +1,18 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestAuthorizationHeader(t *testing.T) {
+	check := func(input, expectedOutput string) {
+		t.Helper()
+		if hdr := AuthorizationHeader(input); hdr != expectedOutput {
+			t.Fatalf("expected header to be '%s', got '%s'", expectedOutput, hdr)
+		}
+	}
+
+	check("foobar", "Bearer foobar")
+	check("FlyV1 foobar", "FlyV1 foobar")
+	check("FlyV1foobar", "Bearer FlyV1foobar")
+}

--- a/api/client.go
+++ b/api/client.go
@@ -69,7 +69,7 @@ func (c *Client) Run(req *graphql.Request) (Query, error) {
 
 // RunWithContext - Runs a GraphQL request within a Go context
 func (c *Client) RunWithContext(ctx context.Context, req *graphql.Request) (Query, error) {
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.accessToken))
+	req.Header.Set("Authorization", AuthorizationHeader(c.accessToken))
 	req.Header.Set("User-Agent", c.userAgent)
 	if c.trace != "" {
 		req.Header.Set("Fly-Force-Trace", c.trace)
@@ -150,7 +150,7 @@ type Transport struct {
 }
 
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Add("Authorization", "Bearer "+t.Token)
+	req.Header.Add("Authorization", AuthorizationHeader(t.Token))
 	if t.EnableDebugTrace {
 		req.Header.Add("Fly-Force-Trace", "true")
 	}

--- a/api/resource_logs.go
+++ b/api/resource_logs.go
@@ -35,7 +35,7 @@ func (c *Client) GetAppLogs(ctx context.Context, appName, token, region, instanc
 		return
 	}
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.accessToken))
+	req.Header.Set("Authorization", AuthorizationHeader(c.accessToken))
 	if c.trace != "" {
 		req.Header.Set("Fly-Force-Trace", c.trace)
 	}

--- a/cmd/wireguard.go
+++ b/cmd/wireguard.go
@@ -535,7 +535,7 @@ func tokenRequest(method, path, token string, data interface{}) (*http.Response,
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("Authorization", api.AuthorizationHeader(token))
 	req.Header.Add("Content-Type", "application/json")
 
 	return (&http.Client{}).Do(req)

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -502,7 +502,7 @@ func (f *Client) NewRequest(ctx context.Context, method, path string, in interfa
 	}
 	req.Header = headers
 
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", f.authToken))
+	req.Header.Add("Authorization", api.AuthorizationHeader(f.authToken))
 
 	return req, nil
 }


### PR DESCRIPTION
Our new style of authentication tokens use `FlyV1` instead of the `Bearer` scheme in the `Authorization` header. This PR checks to see whether the `FLY_ACCESS_TOKEN` is prefixed with `FlyV1` before deciding to add `Bearer`.