### PR TITLE
enable scanners to handle files encoding in utf-16 encodings

### DIFF
--- a/scanner/helpers.go
+++ b/scanner/helpers.go
@@ -29,7 +29,7 @@ func fileContains(path string, pattern string) bool {
 		return false
 	}
 
-	defer file.Close()
+	defer file.Close() //skipcq: GO-S2307
 
 	scanner := bufio.NewScanner(file)
 


### PR DESCRIPTION
Particularly useful on Windows.

Fixes #1925

Tested with a utf-16 encoded requirements.txt file from:
  https://community.fly.io/t/force-recognizing-a-django-build-during-fly-launch/11561