### PR TITLE
fix: remove paid feature prompt when allocating shared IPv4

### DIFF
--- a/internal/command/ips/allocate.go
+++ b/internal/command/ips/allocate.go
@@ -74,8 +74,7 @@ func runAllocateIPAddressV4(ctx context.Context) error {
 	addrType := "v4"
 	if flag.GetBool(ctx, "shared") {
 		addrType = "shared_v4"
-	}
-	if !flag.GetBool(ctx, "yes") {
+	} else if !flag.GetBool(ctx, "yes") {
 		switch confirmed, err := prompt.Confirm(ctx, "Looks like you're accessing a paid feature. Dedicated IPv4 addresses now costs $2/mo. Are you ok with this?"); {
 		case err == nil:
 			if !confirmed {


### PR DESCRIPTION
According to https://community.fly.io/t/announcement-shared-anycast-ipv4/9384, I believe the "Shared Anycast IPv4" is a free feature, so `flyctl ips allocate-v4 --shared` should not print any paid feature warning (It does nothing but make people nervous).