### PR TITLE
Fail to json decode leads to empty token and crash

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -60,7 +60,7 @@ func GetAccessTokenForCLISession(ctx context.Context, id string) (string, error)
 	case http.StatusOK:
 		var auth CLISessionAuth
 		if err = json.NewDecoder(res.Body).Decode(&auth); err != nil {
-			return "", err
+			return "", fmt.Errorf("Failed to decode auth token, please try again: %w", err)
 		}
 		return auth.AccessToken, nil
 	case http.StatusNotFound:

--- a/internal/command/auth/auth.go
+++ b/internal/command/auth/auth.go
@@ -68,14 +68,12 @@ func runWebLogin(ctx context.Context, signup bool) error {
 
 	token, err := waitForCLISession(ctx, logger, io.ErrOut, auth.ID)
 	switch {
-	case err == nil:
-		break
 	case errors.Is(err, context.DeadlineExceeded):
 		return errors.New("Login expired, please try again")
+	case err != nil:
+		return err
 	case token == "":
 		return errors.New("failed to log in, please try again")
-	default:
-		return err
 	}
 
 	if err := persistAccessToken(ctx, token); err != nil {


### PR DESCRIPTION
Fixes FLYCTL-9C ([Sentry](https://flyio.sentry.io/issues/3987680462/?project=4492967&query=&referrer=issue-stream&sort=freq&statsPeriod=14d))

<img width="1187" alt="image" src="https://user-images.githubusercontent.com/37369/226364053-94838bb5-79ac-46ca-89ce-a920e9a56cfd.png">
