### PR TITLE
Fix crashes when calling `appconfig.FromRemoteApp`

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
 	"github.com/superfly/flyctl/internal/command"
@@ -254,6 +255,13 @@ func determineAppConfig(ctx context.Context) (cfg *appconfig.Config, err error) 
 	if cfg = appconfig.ConfigFromContext(ctx); cfg == nil {
 		logger := logger.FromContext(ctx)
 		logger.Debug("no local app config detected; fetching from backend ...")
+
+		var flapsClient *flaps.Client
+		flapsClient, err = flaps.NewFromAppName(ctx, appNameFromContext)
+		if err != nil {
+			return nil, fmt.Errorf("could not create flaps client: %w", err)
+		}
+		ctx = flaps.NewContext(ctx, flapsClient)
 
 		cfg, err = appconfig.FromRemoteApp(ctx, appNameFromContext)
 		if err != nil {

--- a/internal/command/secrets/secrets.go
+++ b/internal/command/secrets/secrets.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/deploy"
@@ -68,6 +69,12 @@ func deployForSecrets(ctx context.Context, app *api.AppCompact, release *api.Rel
 	}
 
 	if app.PlatformVersion == "machines" {
+		flapsClient, err := flaps.New(ctx, app)
+		if err != nil {
+			return fmt.Errorf("could not create flaps client: %w", err)
+		}
+		ctx = flaps.NewContext(ctx, flapsClient)
+
 		// It would be confusing for setting secrets to deploy the current fly.toml file.
 		// Instead, we always grab the currently deployed app config
 		cfg, err := appconfig.FromRemoteApp(ctx, app.Name)


### PR DESCRIPTION
This fixes two crashes that occur because a `flaps.Client` is not available from the context in `appconfig.FromRemoteApp`.