### PR TITLE
`bump_version.sh`: check that repository is up-to-date

### DIFF
--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -29,6 +29,20 @@ if [[ "$BRANCH" != "master" && "$BRANCH" != "main" ]]; then
         echo Aborting.
         exit 1
     fi
+else
+  # This check is pretty naive, so it doesn't seem to work if you're releasing from a branch.
+  git fetch
+  if [[ "$(git rev-parse HEAD 2>&1)" != "$(git rev-parse '@{u}' 2>&1)" ]]; then
+    echo "There are upstream commits that won't be included in this release."
+    echo "You probably want to exit, run 'git pull', then release."
+    echo
+    read -p "Release anyway? " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[^Yy]$ ]]; then
+        echo Aborting.
+        exit 1
+    fi
+  fi
 fi
 
 dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
Nag people before allowing them to make a release if there seems to be unmerged commits in the remote repository