### PR TITLE
Warn if multiple build strategies are found

### DIFF
--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -41,3 +41,26 @@ func TestConfigDockerGetters(t *testing.T) {
 	assert.Equal(t, nilCfg.Ignorefile(), "")
 	assert.Equal(t, nilCfg.DockerBuildTarget(), "")
 }
+
+func TestOneBuildStrategy(t *testing.T) {
+	cfg := Config{
+		Build: &Build{
+			Builder: "heroku/buildpacks:20",
+		},
+	}
+
+	assert.Equal(t, 1, len(cfg.BuildStrategies()))
+}
+
+func TestManyBuildStrategies(t *testing.T) {
+	cfg := Config{
+		Build: &Build{
+			Dockerfile: "my-df",
+			Builder: "heroku/buildpacks:20",
+			Builtin: "node",
+			Image: "nginx",
+		},
+	}
+
+	assert.Equal(t, 4, len(cfg.BuildStrategies()))
+}

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -42,6 +42,19 @@ func TestConfigDockerGetters(t *testing.T) {
 	assert.Equal(t, nilCfg.DockerBuildTarget(), "")
 }
 
+func TestNilBuildStrategy(t *testing.T) {
+	var nilCfg *Config
+	assert.Equal(t, 0, len(nilCfg.BuildStrategies()))
+}
+
+func TestDefaultBuildStrategy(t *testing.T) {
+	cfg := Config{
+		Build: &Build{},
+	}
+
+	assert.Equal(t, 0, len(cfg.BuildStrategies()))
+}
+
 func TestOneBuildStrategy(t *testing.T) {
 	cfg := Config{
 		Build: &Build{

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -34,7 +34,10 @@ func (cfg *Config) Validate(ctx context.Context) (err error, extra_info string) 
 
 	buildStrats := cfg.BuildStrategies()
 	if len(buildStrats) > 1 {
-		sentry.CaptureException(fmt.Errorf("More than one build configuration found: [%s]", strings.Join(buildStrats, ", ")))
+		// TODO: validate that most users are not affected by this and/or fixing this, then make it fail validation
+		msg := fmt.Sprintf("%s more than one build configuration found: [%s]", aurora.Yellow("WARN"), strings.Join(buildStrats, ", "))
+		extra_info += msg + "\n"
+		sentry.CaptureException(errors.New(msg))
 	}
 
 	switch platformVersion {

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -19,7 +19,7 @@ func (cfg *Config) Validate(ctx context.Context) (err error, extra_info string) 
 		return errors.New("App config file not found"), ""
 	}
 
-	platformVersion := NomadPlatform
+	platformVersion := cfg.platformVersion
 	extra_info = fmt.Sprintf("Validating %s (%s)\n", cfg.ConfigFilePath(), platformVersion)
 
 	app, err := apiClient.GetAppBasic(ctx, appName)

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -31,7 +31,7 @@ func (cfg *Config) Validate(ctx context.Context) (err error, extra_info string) 
 		return err, extra_info
 	}
 
-	buildStrats := cfg.buildStrategies()
+	buildStrats := cfg.BuildStrategies()
 	if len(buildStrats) > 1 {
 		return fmt.Errorf("More than one build configuration found: [%s]", strings.Join(buildStrats, ", ")), extra_info
 	}
@@ -70,7 +70,7 @@ func (cfg *Config) Validate(ctx context.Context) (err error, extra_info string) 
 
 }
 
-func (cfg *Config) buildStrategies() []string {
+func (cfg *Config) BuildStrategies() []string {
 	strategies := []string{}
 
 	if cfg.Build == nil {

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/logrusorgru/aurora"
 	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/sentry"
 )
 
 func (cfg *Config) Validate(ctx context.Context) (err error, extra_info string) {
@@ -33,7 +34,7 @@ func (cfg *Config) Validate(ctx context.Context) (err error, extra_info string) 
 
 	buildStrats := cfg.BuildStrategies()
 	if len(buildStrats) > 1 {
-		return fmt.Errorf("More than one build configuration found: [%s]", strings.Join(buildStrats, ", ")), extra_info
+		sentry.CaptureException(fmt.Errorf("More than one build configuration found: [%s]", strings.Join(buildStrats, ", ")))
 	}
 
 	switch platformVersion {

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -27,12 +27,15 @@ func (cfg *Config) Validate(ctx context.Context) (err error, extra_info string) 
 		switch {
 		case err == nil:
 			platformVersion = app.PlatformVersion
+			extra_info += fmt.Sprintf("Platform: %s\n", platformVersion)
 		case strings.Contains(err.Error(), "Could not find App"):
 			platformVersion = NomadPlatform
 			extra_info += fmt.Sprintf("WARNING: Failed to fetch platform version: %s\n", err)
 		default:
 			return err, extra_info
 		}
+	} else {
+		extra_info += fmt.Sprintf("Platform: %s\n", platformVersion)
 	}
 
 	buildStrats := cfg.BuildStrategies()

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -456,8 +456,8 @@ func newCacheTag(appName string) string {
 	return fmt.Sprintf("%s/%s:%s", registry, appName, "cache")
 }
 
-// resolveDockerfile - Resolve the location of the dockerfile, allowing for upper and lowercase naming
-func resolveDockerfile(cwd string) string {
+// ResolveDockerfile - Resolve the location of the dockerfile, allowing for upper and lowercase naming
+func ResolveDockerfile(cwd string) string {
 	dockerfilePath := filepath.Join(cwd, "Dockerfile")
 	if helpers.FileExists(dockerfilePath) {
 		return dockerfilePath

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -456,8 +456,8 @@ func newCacheTag(appName string) string {
 	return fmt.Sprintf("%s/%s:%s", registry, appName, "cache")
 }
 
-// ResolveDockerfile - Resolve the location of the dockerfile, allowing for upper and lowercase naming
-func ResolveDockerfile(cwd string) string {
+// resolveDockerfile - Resolve the location of the dockerfile, allowing for upper and lowercase naming
+func resolveDockerfile(cwd string) string {
 	dockerfilePath := filepath.Join(cwd, "Dockerfile")
 	if helpers.FileExists(dockerfilePath) {
 		return dockerfilePath

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -71,7 +71,7 @@ func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 		}
 		dockerfile = opts.DockerfilePath
 	} else {
-		dockerfile = resolveDockerfile(opts.WorkingDir)
+		dockerfile = ResolveDockerfile(opts.WorkingDir)
 	}
 
 	if dockerfile == "" {

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -71,7 +71,7 @@ func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 		}
 		dockerfile = opts.DockerfilePath
 	} else {
-		dockerfile = ResolveDockerfile(opts.WorkingDir)
+		dockerfile = resolveDockerfile(opts.WorkingDir)
 	}
 
 	if dockerfile == "" {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -28,7 +28,6 @@ import (
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/watch"
-	"github.com/superfly/flyctl/terminal"
 )
 
 var CommonFlags = flag.Set{
@@ -308,13 +307,12 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgs
 	client := client.FromContext(ctx).API()
 	io := iostreams.FromContext(ctx)
 
-	if err := findConflictingBuildOptions(ctx, appConfig, daemonType); err != nil {
-		terminal.Warn(err)
-	}
-
 	resolver := imgsrc.NewResolver(daemonType, client, appConfig.AppName, io)
 
-	imageRef := fetchImageRef(ctx, appConfig)
+	var imageRef string
+	if imageRef, err = fetchImageRef(ctx, appConfig); err != nil {
+		return
+	}
 
 	// we're using a pre-built Docker image
 	if imageRef != "" {
@@ -447,18 +445,18 @@ func mergeBuildArgs(ctx context.Context, args map[string]string) (map[string]str
 	return args, nil
 }
 
-func fetchImageRef(ctx context.Context, cfg *appconfig.Config) string {
-	if ref := flag.GetString(ctx, "image"); ref != "" {
-		return ref
+func fetchImageRef(ctx context.Context, cfg *appconfig.Config) (ref string, err error) {
+	if ref = flag.GetString(ctx, "image"); ref != "" {
+		return
 	}
 
 	if cfg != nil && cfg.Build != nil {
-		if ref := cfg.Build.Image; ref != "" {
-			return ref
+		if ref = cfg.Build.Image; ref != "" {
+			return
 		}
 	}
 
-	return ""
+	return ref, nil
 }
 
 func createRelease(ctx context.Context, appConfig *appconfig.Config, img *imgsrc.DeploymentImage) (*api.Release, *api.ReleaseCommand, error) {
@@ -485,45 +483,4 @@ func createRelease(ctx context.Context, appConfig *appconfig.Config, img *imgsrc
 	}
 
 	return release, releaseCommand, err
-}
-
-func findConflictingBuildOptions(ctx context.Context, appConfig *appconfig.Config, daemonType imgsrc.DockerDaemonType) error {
-	build := appConfig.Build
-	if build == nil {
-		build = new(appconfig.Build)
-	}
-
-	imageRef := fetchImageRef(ctx, appConfig)
-	buildpack := build.Builder
-	builtin := build.Builtin
-	dockerfile, _ := resolveDockerfilePath(ctx, appConfig)
-	if dockerfile == "" {
-		dockerfile = imgsrc.ResolveDockerfile(state.WorkingDirectory(ctx))
-	}
-
-	strategies := []string{}
-
-	// These must be in the same order that we try when building
-	if imageRef != "" {
-		strategies = append(strategies, fmt.Sprintf("the \"%s\" docker image", imageRef))
-	}
-	if daemonType.UseNixpacks() {
-		strategies = append(strategies, "nixpacks")
-	}
-	if buildpack != "" {
-		strategies = append(strategies, "a buildpack")
-	}
-	if dockerfile != "" {
-		strategies = append(strategies, fmt.Sprintf("the \"%s\" dockerfile", dockerfile))
-	}
-	if builtin != "" {
-		strategies = append(strategies, fmt.Sprintf("the \"%s\" builtin image", builtin))
-	}
-
-	if len(strategies) > 1 {
-		lastIndex := len(strategies) - 1
-		return fmt.Errorf("found multiple ways to build this app: %s and %s. Using %s.", strings.Join(strategies[:lastIndex], ", "), strategies[lastIndex], strategies[0])
-	}
-
-	return nil
 }

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -292,7 +292,7 @@ func determineAppConfig(ctx context.Context) (cfg *appconfig.Config, err error) 
 
 	err, extraInfo := cfg.Validate(ctx)
 	if extraInfo != "" {
-		terminal.Info(extraInfo)
+		fmt.Print(extraInfo)
 	}
 	if err != nil {
 		return

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -290,7 +290,10 @@ func determineAppConfig(ctx context.Context) (cfg *appconfig.Config, err error) 
 		cfg.AppName = appNameFromContext
 	}
 
-	err, _ = cfg.Validate(ctx)
+	err, extraInfo := cfg.Validate(ctx)
+	if extraInfo != "" {
+		terminal.Info(extraInfo)
+	}
 	if err != nil {
 		return
 	}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/iostreams"
+	"github.com/superfly/flyctl/terminal"
 
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/flaps"
@@ -306,6 +307,14 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgs
 
 	client := client.FromContext(ctx).API()
 	io := iostreams.FromContext(ctx)
+
+	if len(appConfig.BuildStrategies()) > 0 {
+		foundDF := imgsrc.ResolveDockerfile(state.WorkingDirectory(ctx))
+		configDF, _ := resolveDockerfilePath(ctx, appConfig)
+		if foundDF != "" && foundDF != configDF {
+			terminal.Warnf("Ignoring %s due to config\n", foundDF)
+		}
+	}
 
 	resolver := imgsrc.NewResolver(daemonType, client, appConfig.AppName, io)
 


### PR DESCRIPTION
We see some people in the community forum getting confused when
troubleshooting their build configuration. (e.g. changing a dockerfile
having no effect). This PR prints a warning when multiple different
build strategies are detected.
