### PR TITLE
Don't clobber access_token in config with one from env

### DIFF
--- a/flyctl/flyctl.go
+++ b/flyctl/flyctl.go
@@ -55,6 +55,11 @@ func initConfigDir() error {
 	return nil
 }
 
+// viper keys that shouldn't be loaded from the environment
+var noEnvKeys = map[string]bool{
+	ConfigAPIToken: true,
+}
+
 func initViper() {
 	if err := loadConfig(); err != nil {
 		fmt.Println("Error loading config", err)
@@ -68,7 +73,13 @@ func initViper() {
 	viper.BindEnv(ConfigGQLErrorLogging, "GQLErrorLogging")
 
 	viper.SetEnvPrefix("FLY")
-	viper.AutomaticEnv()
+
+	for _, key := range viper.AllKeys() {
+		if noEnvKeys[key] {
+			continue
+		}
+		viper.BindEnv(key)
+	}
 
 	api.SetBaseURL(viper.GetString(ConfigAPIBaseURL))
 	api.SetErrorLog(viper.GetBool(ConfigGQLErrorLogging))


### PR DESCRIPTION
Running `flyctl` with the `FLY_ACCESS_TOKEN` environment variable set results in it being written to the config file. This is disruptive when trying to run a single command with a token. I tried a few ways of fixing this and I think we ultimately don't want to load this environment variable into the viper config and want to consistently use `GetAPIToken()` for getting the appropriate token for use when running a command. I double checked that nothing else is relying on fetching `ConfigAPIToken` directly from viper.