### PR TITLE
Set a default node version to satisfy node-build

### DIFF
--- a/scanner/node.go
+++ b/scanner/node.go
@@ -41,8 +41,11 @@ func configureNode(sourceDir string, config *ScannerConfig) (*SourceInfo, error)
 
 	vars := make(map[string]interface{})
 
-	var nodeVersion string = "latest"
 	var yarnVersion string = "latest"
+
+	// node-build requires a version, so either use the same version as install locally,
+	// or default to an LTS version
+	var nodeVersion string = "18.15.0"
 
 	out, err := exec.Command("node", "-v").Output()
 


### PR DESCRIPTION
This should fix internal CI where `node-build` does not understand `latest` tag. This would only affect environments where node is not installed locally.