### PR TITLE
Warn about `http_service` `fly.toml` section for Nomad apps

### DIFF
--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -74,6 +74,13 @@ func (cfg *Config) ValidateForNomadPlatform(ctx context.Context) (err error, ext
 		return err, extra_info
 	}
 
+	if _, haveHTTPService := cfg.RawDefinition["http_service"]; haveHTTPService {
+		// TODO: eventually make this fail validation
+		msg := fmt.Sprintf("%s the http_service section is ignored for Nomad apps", aurora.Yellow("WARN"))
+		extra_info += msg + "\n"
+		sentry.CaptureException(errors.New(msg))
+	}
+
 	if serverCfg.Valid {
 		extra_info += fmt.Sprintf("%s Configuration is valid\n", aurora.Green("✓"))
 		return nil, extra_info


### PR DESCRIPTION
The existing behavior is to silently ignore this section, which can cause a confusing user experience. I think that's what happened [here](https://community.fly.io/t/inbound-connections-to-80-443-get-reset-on-ipv6-only-app/11567) on the forum.

Following existing code, I made this a warning with a Sentry exception with an eye toward eventually making this fail validation.