### PR TITLE
`deploy`: initial work on process group-specific mounts

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -20,7 +20,7 @@ func NewConfig() *Config {
 }
 
 // Config wraps the properties of app configuration.
-// NOTE: If you any new setting here, please also add a value for it at testdata/rull-reference.toml
+// NOTE: If you any new setting here, please also add a value for it at testdata/full-reference.toml
 type Config struct {
 	AppName       string                    `toml:"app,omitempty" json:"app,omitempty"`
 	KillSignal    string                    `toml:"kill_signal,omitempty" json:"kill_signal,omitempty"`
@@ -33,7 +33,7 @@ type Config struct {
 	HttpService   *HTTPService              `toml:"http_service,omitempty" json:"http_service,omitempty"`
 	Metrics       *api.MachineMetrics       `toml:"metrics,omitempty" json:"metrics,omitempty"`
 	Statics       []Static                  `toml:"statics,omitempty" json:"statics,omitempty"`
-	Mounts        *Volume                   `toml:"mounts,omitempty" json:"mounts,omitempty"`
+	Mounts        []Volume                  `toml:"mounts,omitempty" json:"mounts,omitempty"` // TODO(ali): Does is break anything that this is plural now?
 	Processes     map[string]string         `toml:"processes,omitempty" json:"processes,omitempty"`
 	Checks        map[string]*ToplevelCheck `toml:"checks,omitempty" json:"checks,omitempty"`
 	Services      []Service                 `toml:"services,omitempty" json:"services,omitempty"`
@@ -64,8 +64,9 @@ type Static struct {
 }
 
 type Volume struct {
-	Source      string `toml:"source,omitempty" json:"source,omitempty"`
-	Destination string `toml:"destination" json:"destination,omitempty"`
+	Source      string   `toml:"source,omitempty" json:"source,omitempty"`
+	Destination string   `toml:"destination" json:"destination,omitempty"`
+	Processes   []string `json:"processes,omitempty" toml:"processes,omitempty"`
 }
 
 type VM struct {

--- a/internal/appconfig/setters.go
+++ b/internal/appconfig/setters.go
@@ -239,11 +239,5 @@ func (c *Config) SetStatics(statics []Static) {
 
 func (c *Config) SetVolumes(volumes []Volume) {
 	c.RawDefinition["mounts"] = volumes
-	// FIXME: "mounts" section is confusing, it is plural but only allows one mount
-	if len(volumes) > 0 {
-		c.Mounts = &Volume{
-			Source:      volumes[0].Source,
-			Destination: volumes[0].Destination,
-		}
-	}
+	c.Mounts = volumes
 }

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -11,6 +11,11 @@ primary_region = "sea"
   enable_consul = true
   enable_etcd = true
 
+[processes]
+  app = "echo app"
+  web = "echo web"
+  some_job = "echo some job"
+
 [build]
   builder = "dockerfile"
   image = "foo/fighter"
@@ -53,9 +58,15 @@ primary_region = "sea"
   guest_path = "/path/to/statics"
   url_prefix = "/static-assets"
 
-[mounts]
+[[mounts]]
   source = "data"
   destination = "/data"
+  processes = ["app", "web"]
+
+[[mounts]]
+  source = "data-job"
+  destination = "/jobdata"
+  processes = ["some_job"]
 
 [processes]
   web = "run web"

--- a/internal/hashset/hashset.go
+++ b/internal/hashset/hashset.go
@@ -1,0 +1,73 @@
+package hashset
+
+type Set[K comparable] struct {
+	val map[K]struct{}
+}
+
+func New[K comparable](preallocate int) Set[K] {
+	if preallocate < 0 {
+		preallocate = 0
+	}
+	return Set[K]{
+		val: make(map[K]struct{}, preallocate),
+	}
+}
+
+// Insert an item into the set.
+// Returns true if the key was not already present
+func (s *Set[K]) Insert(key K) bool {
+	if _, ok := s.val[key]; ok {
+		return false
+	}
+	s.val[key] = struct{}{}
+	return true
+}
+
+// InsertMany items into the set.
+func (s *Set[K]) InsertMany(keys []K) {
+	for _, key := range keys {
+		s.Insert(key)
+	}
+}
+
+// Remove an item from the set.
+// Returns true if the item was removed, or false if it wasn't in the set.
+func (s *Set[K]) Remove(key K) bool {
+	if _, ok := s.val[key]; ok {
+		delete(s.val, key)
+		return true
+	}
+	return false
+}
+
+// RemoveMany items from the set.
+func (s *Set[K]) RemoveMany(keys []K) {
+	for _, key := range keys {
+		s.Remove(key)
+	}
+}
+
+// Contains returns true if a key is found in the set.
+func (s *Set[K]) Contains(key K) bool {
+	_, ok := s.val[key]
+	return ok
+}
+
+// Keys returns every value in the set.
+func (s *Set[K]) Keys() []K {
+	ret := make([]K, len(s.val))
+	for key := range s.val {
+		ret = append(ret, key)
+	}
+	return ret
+}
+
+// Size returns the number of entries in the set.
+func (s *Set[K]) Size() int {
+	return len(s.val)
+}
+
+// Empty returns true if the set has no values.
+func (s *Set[K]) Empty() bool {
+	return len(s.val) == 0
+}


### PR DESCRIPTION
Would fix #1938

An attempt to support having configurable volume mounts per-process group.
There are quite a few issues blocking this, so consider it more of a sketch than anything usable at this point.

Very WIP. It builds, but I don't have any faith in it working as-is