### PR TITLE
image builder: prevent close-after-close on channel

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -391,7 +391,7 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgs
 
 	// finally, build the image
 	heartbeat := resolver.StartHeartbeat(ctx)
-	defer resolver.StopHeartbeat(heartbeat)
+	defer heartbeat.Stop()
 	if img, err = resolver.BuildImage(ctx, io, opts); err == nil && img == nil {
 		err = errors.New("no image specified")
 	}


### PR DESCRIPTION
Would fix #1953

Use a `sync.Once` to guard closing the channel, and close the channel on the sender side to avoid a go anti-pattern.
(sending to a closed channel panics, but reading from a closed channel does not)