### PR TITLE
`ips list`: support json output

### DIFF
--- a/internal/command/ips/list.go
+++ b/internal/command/ips/list.go
@@ -7,7 +7,10 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/render"
+	"github.com/superfly/flyctl/iostreams"
 )
 
 func newList() *cobra.Command {
@@ -29,12 +32,18 @@ func newList() *cobra.Command {
 }
 
 func runIPAddressesList(ctx context.Context) error {
+	cfg := config.FromContext(ctx)
 	client := client.FromContext(ctx).API()
 
 	appName := appconfig.NameFromContext(ctx)
 	ipAddresses, err := client.GetIPAddresses(ctx, appName)
 	if err != nil {
 		return err
+	}
+
+	if cfg.JSONOutput {
+		out := iostreams.FromContext(ctx).Out
+		return render.JSON(out, ipAddresses)
 	}
 
 	renderListTable(ctx, ipAddresses)


### PR DESCRIPTION
Closes #1967

Adds support to `fly ips list` for json output. The flag existed previously, but did nothing.

```sh
❯ flyctl ips list -a ali-test-app -j
VERSION IP                      TYPE            REGION  CREATED AT           
v6      2a09:8280:1::37:c0      public          global  2023-03-20T22:40:21Z    
v4      66.241.125.149          public (shared)                                 


flyctl on  bugfix/ips-list-json [$!] via 🐹 v1.20.2 
❯ bin/flyctl ips list -a ali-test-app -j
[
    {
        "ID": "ip_dqwk93rvw8x9o7nr",
        "Address": "2a09:8280:1::37:c0",
        "Type": "v6",
        "Region": "global",
        "CreatedAt": "2023-03-20T22:40:21Z"
    },
    {
        "ID": "",
        "Address": "66.241.125.149",
        "Type": "shared_v4",
        "Region": "",
        "CreatedAt": "0001-01-01T00:00:00Z"
    }
]

```