### PR TITLE
scale command for v2 apps

### DIFF
--- a/api/machine_types_test.go
+++ b/api/machine_types_test.go
@@ -117,3 +117,29 @@ func TestGetProcessGroup(t *testing.T) {
 		}
 	}
 }
+
+func TestMachineGuest_SetSize(t *testing.T) {
+	var guest MachineGuest
+
+	if err := guest.SetSize("unknown"); err == nil {
+		t.Error("want error for invalid kind")
+	}
+
+	if err := guest.SetSize("shared-cpu-3x"); err == nil {
+		t.Error("want error for invalid preset name")
+	}
+
+	if err := guest.SetSize("performance-4x"); err != nil {
+		t.Errorf("got error for valid preset name: %v", err)
+	} else {
+		if guest.CPUs != 4 {
+			t.Errorf("Expected 4 cpus, got: %v", guest.CPUs)
+		}
+		if guest.CPUKind != "performance" {
+			t.Errorf("Expected performance cpu kind, got: %v", guest.CPUKind)
+		}
+		if guest.MemoryMB != 8192 {
+			t.Errorf("Expected 8192 MB of memory , got: %v", guest.MemoryMB)
+		}
+	}
+}

--- a/api/machine_types_test.go
+++ b/api/machine_types_test.go
@@ -143,3 +143,17 @@ func TestMachineGuest_SetSize(t *testing.T) {
 		}
 	}
 }
+
+func TestMachineGuest_ToSize(t *testing.T) {
+	for want, guest := range MachinePresets {
+		got := guest.ToSize()
+		if want != got {
+			t.Errorf("want '%s', got '%s'", want, got)
+		}
+	}
+
+	got := (&MachineGuest{}).ToSize()
+	if got != "unknown" {
+		t.Errorf("want 'unknown', got '%s'", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/pelletier/go-toml v1.9.4
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.5
-	github.com/samber/lo v1.27.0
+	github.com/samber/lo v1.38.1
 	github.com/segmentio/textio v1.2.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1213,8 +1213,8 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/sabhiram/go-gitignore v0.0.0-20201211074657-223ce5d391b0 h1:4Q/TASkyjpqyR5DL5+6c2FGSDpHM5bTMSspcXr7J6R8=
 github.com/sabhiram/go-gitignore v0.0.0-20201211074657-223ce5d391b0/go.mod h1:b18R55ulyQ/h3RaWyloPyER7fWQVZvimKKhnI5OfrJQ=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
-github.com/samber/lo v1.27.0 h1:GOyDWxsblvqYobqsmUuMddPa2/mMzkKyojlXol4+LaQ=
-github.com/samber/lo v1.27.0/go.mod h1:it33p9UtPMS7z72fP4gw/EIfQB2eI8ke7GR2wc6+Rhg=
+github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
+github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:am+Fp8Bt506lA3Rk3QCmSqmYmLMnPDhdDUcosQCAx+I=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
@@ -1318,7 +1318,6 @@ github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tetafro/godot v0.3.7/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
 github.com/tetafro/godot v0.4.2/go.mod h1:/7NLHhv08H1+8DNj0MElpAACw1ajsCuf3TKNQxA5S+0=
-github.com/thoas/go-funk v0.9.1 h1:O549iLZqPpTUQ10ykd26sZhzD+rmR5pWhuElrhbC20M=
 github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -301,13 +301,14 @@ func initTaskManager(ctx context.Context) (context.Context, error) {
 	return task.NewContext(ctx, tm), nil
 }
 
-func CheckPlatform(apiClient *api.Client, ctx context.Context, appName string) (bool, error) {
-	app, err := apiClient.GetApp(ctx, appName)
+func IsMachinesPlatform(ctx context.Context, appName string) (bool, error) {
+	apiClient := client.FromContext(ctx).API()
+	app, err := apiClient.GetAppBasic(ctx, appName)
 	if err != nil {
 		return false, fmt.Errorf("failed to retrieve app: %w", err)
 	}
 
-	return app.PlatformVersion == "machines", nil
+	return app.PlatformVersion == appconfig.MachinesPlatform, nil
 }
 
 func startQueryingForNewRelease(ctx context.Context) (context.Context, error) {

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -625,30 +624,10 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 	machineConf := mach.CloneConfig(&initialMachineConf)
 
 	if guestSize := flag.GetString(ctx, "size"); guestSize != "" {
-		guest, ok := api.MachinePresets[guestSize]
-
-		if !ok {
-			var machine_type string
-
-			if strings.HasPrefix(guestSize, "shared") {
-				machine_type = "shared"
-			} else if strings.HasPrefix(guestSize, "performance") {
-				machine_type = "performance"
-			} else {
-				return machineConf, fmt.Errorf("invalid machine preset requested, '%s', expected to start with 'shared' or 'performance'", guestSize)
-			}
-
-			validSizes := []string{}
-			for size := range api.MachinePresets {
-				if strings.HasPrefix(size, machine_type) {
-					validSizes = append(validSizes, size)
-				}
-			}
-			sort.Strings(validSizes)
-			return machineConf, fmt.Errorf("invalid machine size requested, '%s', available:\n%s", guestSize, strings.Join(validSizes, "\n"))
+		err := machineConf.Guest.SetSize(guestSize)
+		if err != nil {
+			return nil, err
 		}
-		guest.KernelArgs = machineConf.Guest.KernelArgs
-		machineConf.Guest = guest
 	}
 
 	// Potential overrides for Guest

--- a/internal/command/scale/machines.go
+++ b/internal/command/scale/machines.go
@@ -1,0 +1,90 @@
+package scale
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/appconfig"
+	mach "github.com/superfly/flyctl/internal/machine"
+)
+
+func v2ScaleVM(ctx context.Context, appName, group, sizeName string, memoryMB int) (*api.VMSize, error) {
+	flapsClient, err := flaps.NewFromAppName(ctx, appName)
+	if err != nil {
+		return nil, err
+	}
+	ctx = flaps.NewContext(ctx, flapsClient)
+
+	// Quickly validate sizeName before any network call
+	if err := (&api.MachineGuest{}).SetSize(sizeName); err != nil && sizeName != "" {
+		return nil, err
+	}
+
+	if group == "" {
+		appConfig, err := appconfig.FromRemoteApp(ctx, appName)
+		if err != nil {
+			return nil, err
+		}
+		group = appConfig.DefaultProcessName()
+	}
+
+	machines, err := listMachinesWithGroup(ctx, group)
+	if err != nil {
+		return nil, err
+	}
+	if len(machines) == 0 {
+		return nil, fmt.Errorf("No active machines in process group '%s', check `fly status` output", group)
+	}
+
+	machines, releaseFunc, err := mach.AcquireLeases(ctx, machines)
+	defer releaseFunc(ctx, machines)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, machine := range machines {
+		if sizeName != "" {
+			machine.Config.Guest.SetSize(sizeName)
+		}
+		if memoryMB > 0 {
+			machine.Config.Guest.MemoryMB = memoryMB
+		}
+
+		input := &api.LaunchMachineInput{
+			ID:               machine.ID,
+			AppID:            appName,
+			Name:             machine.Name,
+			Region:           machine.Region,
+			Config:           machine.Config,
+			SkipHealthChecks: false,
+		}
+		if err := mach.Update(ctx, machine, input); err != nil {
+			return nil, err
+		}
+	}
+
+	// Return api.VMSize to remain compatible with v1 scale app signature
+	size := &api.VMSize{
+		Name:     machines[0].Config.Guest.ToSize(),
+		MemoryMB: machines[0].Config.Guest.MemoryMB,
+		CPUCores: float32(machines[0].Config.Guest.CPUs),
+	}
+
+	return size, nil
+}
+
+func listMachinesWithGroup(ctx context.Context, group string) ([]*api.Machine, error) {
+	machines, err := mach.ListActive(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
+		return m.ProcessGroup() == group
+	})
+
+	return machines, nil
+}

--- a/internal/command/scale/memory.go
+++ b/internal/command/scale/memory.go
@@ -2,16 +2,11 @@ package scale
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/flyctl/api"
-	"github.com/superfly/flyctl/client"
-	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
-	"github.com/superfly/flyctl/iostreams"
 )
 
 func newScaleMemory() *cobra.Command {
@@ -22,21 +17,17 @@ func newScaleMemory() *cobra.Command {
 	cmd := command.New("memory [memoryMB]", short, long, runScaleMemory,
 		command.RequireSession,
 		command.RequireAppName,
-		failOnMachinesApp,
 	)
 	cmd.Args = cobra.ExactArgs(1)
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
-		flag.String{Name: "group", Description: "The process group to apply the VM size to", Default: ""},
+		flag.String{Name: "group", Description: "The process group to apply the VM size to"},
 	)
 	return cmd
 }
 
 func runScaleMemory(ctx context.Context) error {
-	io := iostreams.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
-	appName := appconfig.NameFromContext(ctx)
 	group := flag.GetString(ctx, "group")
 
 	memoryMB, err := strconv.ParseInt(flag.FirstArg(ctx), 10, 64)
@@ -44,34 +35,5 @@ func runScaleMemory(ctx context.Context) error {
 		return err
 	}
 
-	// API doesn't allow memory setting on own yet, so get get the current size for the mutation
-	currentsize, _, _, err := apiClient.AppVMResources(ctx, appName)
-	if err != nil {
-		return err
-	}
-
-	size, err := apiClient.SetAppVMSize(ctx, appName, group, currentsize.Name, memoryMB)
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintf(io.Out, "Scaled VM Memory size to %s\n", formatMemory(size))
-	fmt.Fprintf(io.Out, "%15s: %s\n", "CPU Cores", formatCores(size))
-	fmt.Fprintf(io.Out, "%15s: %s\n", "Memory", formatMemory(size))
-
-	return nil
-}
-
-func formatCores(size api.VMSize) string {
-	if size.CPUCores < 1.0 {
-		return fmt.Sprintf("%.2f", size.CPUCores)
-	}
-	return fmt.Sprintf("%d", int(size.CPUCores))
-}
-
-func formatMemory(size api.VMSize) string {
-	if size.MemoryGB < 1.0 {
-		return fmt.Sprintf("%d MB", size.MemoryMB)
-	}
-	return fmt.Sprintf("%d GB", int(size.MemoryGB))
+	return scaleVertically(ctx, group, "", int(memoryMB))
 }

--- a/internal/command/scale/show.go
+++ b/internal/command/scale/show.go
@@ -23,7 +23,6 @@ func newScaleShow() *cobra.Command {
 	cmd := command.New("show", short, long, runScaleShow,
 		command.RequireSession,
 		command.RequireAppName,
-		failOnMachinesApp,
 	)
 	cmd.Args = cobra.NoArgs
 	flag.Add(cmd,
@@ -34,6 +33,19 @@ func newScaleShow() *cobra.Command {
 }
 
 func runScaleShow(ctx context.Context) error {
+	appName := appconfig.NameFromContext(ctx)
+
+	isV2, err := command.IsMachinesPlatform(ctx, appName)
+	if err != nil {
+		return err
+	}
+	if isV2 {
+		return runMachinesScaleShow(ctx)
+	}
+	return runNomadScaleShow(ctx)
+}
+
+func runNomadScaleShow(ctx context.Context) error {
 	apiClient := client.FromContext(ctx).API()
 	appName := appconfig.NameFromContext(ctx)
 

--- a/internal/command/scale/show_machines.go
+++ b/internal/command/scale/show_machines.go
@@ -1,0 +1,62 @@
+package scale
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/appconfig"
+	mach "github.com/superfly/flyctl/internal/machine"
+	"github.com/superfly/flyctl/internal/render"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+type tableRow struct {
+	Group string
+	Count int
+	Guest *api.MachineGuest
+}
+
+func runMachinesScaleShow(ctx context.Context) error {
+	io := iostreams.FromContext(ctx)
+	appName := appconfig.NameFromContext(ctx)
+
+	flapsClient, err := flaps.NewFromAppName(ctx, appName)
+	if err != nil {
+		return err
+	}
+	ctx = flaps.NewContext(ctx, flapsClient)
+
+	machines, err := mach.ListActive(ctx)
+	if err != nil {
+		return err
+	}
+
+	machineGroups := lo.GroupBy(
+		lo.Filter(machines, func(m *api.Machine, _ int) bool {
+			return m.IsFlyAppsPlatform()
+		}),
+		func(m *api.Machine) string {
+			return m.ProcessGroup()
+		},
+	)
+
+	rows := make([][]string, 0, len(machineGroups))
+	for groupName, machines := range machineGroups {
+		guest := machines[0].Config.Guest
+		rows = append(rows, []string{
+			groupName,
+			fmt.Sprintf("%d", len(machines)),
+			guest.CPUKind,
+			fmt.Sprintf("%d", guest.CPUs),
+			fmt.Sprintf("%d", guest.MemoryMB),
+		})
+	}
+
+	fmt.Fprintf(io.Out, "VM Resources for app: %s\n\n", appName)
+	render.Table(io.Out, "Groups", rows, "Name", "Count", "Kind", "CPUs", "Memory MB")
+
+	return nil
+}

--- a/internal/command/scale/show_machines.go
+++ b/internal/command/scale/show_machines.go
@@ -13,12 +13,6 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 )
 
-type tableRow struct {
-	Group string
-	Count int
-	Guest *api.MachineGuest
-}
-
 func runMachinesScaleShow(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
@@ -51,12 +45,12 @@ func runMachinesScaleShow(ctx context.Context) error {
 			fmt.Sprintf("%d", len(machines)),
 			guest.CPUKind,
 			fmt.Sprintf("%d", guest.CPUs),
-			fmt.Sprintf("%d", guest.MemoryMB),
+			fmt.Sprintf("%d MB", guest.MemoryMB),
 		})
 	}
 
 	fmt.Fprintf(io.Out, "VM Resources for app: %s\n\n", appName)
-	render.Table(io.Out, "Groups", rows, "Name", "Count", "Kind", "CPUs", "Memory MB")
+	render.Table(io.Out, "Groups", rows, "Name", "Count", "Kind", "CPUs", "Memory")
 
 	return nil
 }

--- a/internal/command/scale/show_machines.go
+++ b/internal/command/scale/show_machines.go
@@ -42,7 +42,6 @@ func runMachinesScaleShow(ctx context.Context) error {
 	rows := make([][]string, 0, len(machineGroups))
 	for groupName, machines := range machineGroups {
 		guest := machines[0].Config.Guest
-		regions := formatRegions(machines)
 
 		rows = append(rows, []string{
 			groupName,
@@ -50,7 +49,7 @@ func runMachinesScaleShow(ctx context.Context) error {
 			guest.CPUKind,
 			fmt.Sprintf("%d", guest.CPUs),
 			fmt.Sprintf("%d MB", guest.MemoryMB),
-			strings.Join(regions, ","),
+			formatRegions(machines),
 		})
 	}
 
@@ -60,7 +59,7 @@ func runMachinesScaleShow(ctx context.Context) error {
 	return nil
 }
 
-func formatRegions(machines []*api.Machine) []string {
+func formatRegions(machines []*api.Machine) string {
 	regions := lo.Map(
 		lo.Entries(lo.CountValues(lo.Map(machines, func(m *api.Machine, _ int) string {
 			return m.Region
@@ -73,5 +72,5 @@ func formatRegions(machines []*api.Machine) []string {
 		},
 	)
 	slices.Sort(regions)
-	return regions
+	return strings.Join(regions, ",")
 }

--- a/internal/command/scale/show_machines.go
+++ b/internal/command/scale/show_machines.go
@@ -3,6 +3,7 @@ package scale
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
@@ -11,6 +12,7 @@ import (
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
+	"golang.org/x/exp/slices"
 )
 
 func runMachinesScaleShow(ctx context.Context) error {
@@ -40,17 +42,36 @@ func runMachinesScaleShow(ctx context.Context) error {
 	rows := make([][]string, 0, len(machineGroups))
 	for groupName, machines := range machineGroups {
 		guest := machines[0].Config.Guest
+		regions := formatRegions(machines)
+
 		rows = append(rows, []string{
 			groupName,
 			fmt.Sprintf("%d", len(machines)),
 			guest.CPUKind,
 			fmt.Sprintf("%d", guest.CPUs),
 			fmt.Sprintf("%d MB", guest.MemoryMB),
+			strings.Join(regions, ","),
 		})
 	}
 
 	fmt.Fprintf(io.Out, "VM Resources for app: %s\n\n", appName)
-	render.Table(io.Out, "Groups", rows, "Name", "Count", "Kind", "CPUs", "Memory")
+	render.Table(io.Out, "Groups", rows, "Name", "Count", "Kind", "CPUs", "Memory", "Regions")
 
 	return nil
+}
+
+func formatRegions(machines []*api.Machine) []string {
+	regions := lo.Map(
+		lo.Entries(lo.CountValues(lo.Map(machines, func(m *api.Machine, _ int) string {
+			return m.Region
+		}))),
+		func(e lo.Entry[string, int], _ int) string {
+			if e.Value > 1 {
+				return fmt.Sprintf("%s(%d)", e.Key, e.Value)
+			}
+			return e.Key
+		},
+	)
+	slices.Sort(regions)
+	return regions
 }

--- a/internal/command/scale/show_machines_test.go
+++ b/internal/command/scale/show_machines_test.go
@@ -1,0 +1,22 @@
+package scale
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/superfly/flyctl/api"
+)
+
+func Test_formatRegions(t *testing.T) {
+	assert.Equal(t,
+		formatRegions([]*api.Machine{
+			{Region: "fra"},
+			{Region: "fra"},
+			{Region: "fra"},
+			{Region: "scl"},
+			{Region: "scl"},
+			{Region: "mia"},
+		}),
+		"fra(3),mia,scl(2)",
+	)
+}

--- a/internal/command/scale/vm.go
+++ b/internal/command/scale/vm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -29,27 +30,39 @@ For pricing, see https://fly.io/docs/about/pricing/`
 	cmd := command.New("vm [size]", short, long, runScaleVM,
 		command.RequireSession,
 		command.RequireAppName,
-		failOnMachinesApp,
 	)
 	cmd.Args = cobra.ExactArgs(1)
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
 		flag.Int{Name: "memory", Description: "Memory in MB for the VM", Default: 0},
-		flag.String{Name: "group", Description: "The process group to apply the VM size to", Default: ""},
+		flag.String{Name: "group", Description: "The process group to apply the VM size to"},
 	)
 	return cmd
 }
 
 func runScaleVM(ctx context.Context) error {
-	io := iostreams.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
-	appName := appconfig.NameFromContext(ctx)
 	sizeName := flag.FirstArg(ctx)
+	memoryMB := flag.GetInt(ctx, "memory")
 	group := flag.GetString(ctx, "group")
-	memoryMB := int64(flag.GetInt(ctx, "memory"))
+	return scaleVertically(ctx, group, sizeName, memoryMB)
+}
 
-	size, err := apiClient.SetAppVMSize(ctx, appName, group, sizeName, memoryMB)
+func scaleVertically(ctx context.Context, group, sizeName string, memoryMB int) error {
+	io := iostreams.FromContext(ctx)
+	appName := appconfig.NameFromContext(ctx)
+
+	isV2, err := command.IsMachinesPlatform(ctx, appName)
+	if err != nil {
+		return err
+	}
+
+	var size *api.VMSize
+	if isV2 {
+		size, err = v2ScaleVM(ctx, appName, group, sizeName, memoryMB)
+	} else {
+		size, err = v1ScaleVM(ctx, appName, group, sizeName, memoryMB)
+	}
 	if err != nil {
 		return err
 	}
@@ -59,7 +72,38 @@ func runScaleVM(ctx context.Context) error {
 	} else {
 		fmt.Fprintf(io.Out, "Scaled VM Type for '%s' to '%s'\n", group, size.Name)
 	}
-	fmt.Fprintf(io.Out, "%15s: %s\n", "CPU Cores", formatCores(size))
-	fmt.Fprintf(io.Out, "%15s: %s\n", "Memory", formatMemory(size))
+
+	fmt.Fprintf(io.Out, "%15s: %s\n", "CPU Cores", formatCores(*size))
+	fmt.Fprintf(io.Out, "%15s: %s\n", "Memory", formatMemory(*size))
 	return nil
+}
+
+func formatCores(size api.VMSize) string {
+	if size.CPUCores < 1.0 {
+		return fmt.Sprintf("%.2f", size.CPUCores)
+	}
+	return fmt.Sprintf("%d", int(size.CPUCores))
+}
+
+func formatMemory(size api.VMSize) string {
+	if size.MemoryGB < 1.0 {
+		return fmt.Sprintf("%d MB", size.MemoryMB)
+	}
+	return fmt.Sprintf("%d GB", int(size.MemoryGB))
+}
+
+func v1ScaleVM(ctx context.Context, appName, group, sizeName string, memoryMB int) (*api.VMSize, error) {
+	apiClient := client.FromContext(ctx).API()
+
+	// API doesn't allow memory setting on own yet, so get get the current size for the mutation
+	if sizeName == "" {
+		currentsize, _, _, err := apiClient.AppVMResources(ctx, appName)
+		if err != nil {
+			return nil, err
+		}
+		sizeName = currentsize.Name
+	}
+
+	size, err := apiClient.SetAppVMSize(ctx, appName, group, sizeName, int64(memoryMB))
+	return &size, err
 }

--- a/internal/command/vm/status.go
+++ b/internal/command/vm/status.go
@@ -45,7 +45,7 @@ func runStatus(ctx context.Context) (err error) {
 	)
 
 	// vm status is not supported for machines
-	isMachine, err := command.CheckPlatform(client, ctx, appName)
+	isMachine, err := command.IsMachinesPlatform(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("failed to check platform version %w", err)
 	}

--- a/internal/machine/update.go
+++ b/internal/machine/update.go
@@ -33,9 +33,9 @@ func Update(ctx context.Context, m *api.Machine, input *api.LaunchMachineInput) 
 		// Check that there's a valid number of CPUs
 		validNumCpus, ok := cpusPerKind[input.Config.Guest.CPUKind]
 		if !ok {
-			return fmt.Errorf("invalid config: invalid CPU kind '%s'. Valid values are %v\n"+viewMoreMsg, input.Config.Guest.CPUKind, maps.Keys(cpusPerKind))
+			return fmt.Errorf("invalid config: invalid CPU kind '%s'. Valid values are %v\n%s", input.Config.Guest.CPUKind, maps.Keys(cpusPerKind), viewMoreMsg)
 		} else if !slices.Contains(validNumCpus, input.Config.Guest.CPUs) {
-			return fmt.Errorf("invalid config: invalid number of CPUs for %s guest. Valid numbers are %v\n"+viewMoreMsg, input.Config.Guest.CPUKind, validNumCpus)
+			return fmt.Errorf("invalid config: invalid number of CPUs for %s guest. Valid numbers are %v\n%s", input.Config.Guest.CPUKind, validNumCpus, viewMoreMsg)
 		}
 
 		if input.Config.Guest.CPUKind == "shared" && input.Config.Guest.MemoryMB%256 != 0 {
@@ -43,13 +43,13 @@ func Update(ctx context.Context, m *api.Machine, input *api.LaunchMachineInput) 
 			if suggestion == 0 {
 				suggestion = 256
 			}
-			return fmt.Errorf("invalid config: invalid memory size %d; must be in 256 MiB increment (%d would work)\n"+viewMoreMsg, input.Config.Guest.MemoryMB, suggestion)
+			return fmt.Errorf("invalid config: invalid memory size %d; must be in 256 MiB increment (%d would work)\n%s", input.Config.Guest.MemoryMB, suggestion, viewMoreMsg)
 		} else if input.Config.Guest.CPUKind == "performance" && input.Config.Guest.MemoryMB%1024 != 0 {
 			suggestion := input.Config.Guest.MemoryMB - (input.Config.Guest.MemoryMB % 1024)
 			if suggestion == 0 {
 				suggestion = 1024
 			}
-			return fmt.Errorf("invalid config: invalid memory size %d; must be in 1024 MiB increment (%d would work)\n"+viewMoreMsg, input.Config.Guest.MemoryMB, suggestion)
+			return fmt.Errorf("invalid config: invalid memory size %d; must be in 1024 MiB increment (%d would work)\n%s", input.Config.Guest.MemoryMB, suggestion, viewMoreMsg)
 		}
 
 		// Check memory sizes
@@ -62,7 +62,7 @@ func Update(ctx context.Context, m *api.Machine, input *api.LaunchMachineInput) 
 		}
 
 		if min_memory_size > input.Config.Guest.MemoryMB {
-			return fmt.Errorf("invalid config: for machines with %d CPUs, the minimum amount of memory is %d MiB\n"+viewMoreMsg, input.Config.Guest.CPUs, min_memory_size)
+			return fmt.Errorf("invalid config: for machines with %d CPUs, the minimum amount of memory is %d MiB\n%s", input.Config.Guest.CPUs, min_memory_size, viewMoreMsg)
 		}
 
 		var maxMemory int
@@ -74,7 +74,7 @@ func Update(ctx context.Context, m *api.Machine, input *api.LaunchMachineInput) 
 		}
 
 		if input.Config.Guest.MemoryMB > maxMemory {
-			return fmt.Errorf("invalid config: for machines with %d CPUs, the maximum amount of memory is %d MiB\n"+viewMoreMsg, input.Config.Guest.CPUs, maxMemory)
+			return fmt.Errorf("invalid config: for machines with %d CPUs, the maximum amount of memory is %d MiB\n%s", input.Config.Guest.CPUs, maxMemory, viewMoreMsg)
 		}
 
 	}

--- a/internal/machine/update.go
+++ b/internal/machine/update.go
@@ -9,7 +9,16 @@ import (
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/watch"
 	"github.com/superfly/flyctl/iostreams"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 )
+
+const viewMoreMsg = "View more information here: https://fly.io/docs/about/pricing/#machines"
+
+var cpusPerKind = map[string][]int{
+	"shared":      {1, 2, 4, 6, 8},
+	"performance": {1, 2, 4, 6, 8, 10, 12, 14, 16},
+}
 
 func Update(ctx context.Context, m *api.Machine, input *api.LaunchMachineInput) error {
 	var (
@@ -22,29 +31,11 @@ func Update(ctx context.Context, m *api.Machine, input *api.LaunchMachineInput) 
 
 	if input != nil && input.Config != nil && input.Config.Guest != nil {
 		// Check that there's a valid number of CPUs
-		var validNumCpus []int
-
-		if input.Config.Guest.CPUKind == "shared" {
-			validNumCpus = append(validNumCpus, 1, 2, 4, 6, 8)
-
-		} else if input.Config.Guest.CPUKind == "performance" {
-			validNumCpus = append(validNumCpus, 1, 2, 4, 6, 8, 10, 12, 14, 16)
-
-		}
-
-		validCpuNum := false
-
-		for _, num := range validNumCpus {
-			if num == input.Config.Guest.CPUs {
-				validCpuNum = true
-				break
-
-			}
-		}
-
-		if !validCpuNum {
-			return fmt.Errorf("invalid config: invalid number of CPUs for %s guest. Valid numbers are %v\nView more information here: https://fly.io/docs/about/pricing/#machines", input.Config.Guest.CPUKind, validNumCpus)
-
+		validNumCpus, ok := cpusPerKind[input.Config.Guest.CPUKind]
+		if !ok {
+			return fmt.Errorf("invalid config: invalid CPU kind '%s'. Valid values are %v\n"+viewMoreMsg, input.Config.Guest.CPUKind, maps.Keys(cpusPerKind))
+		} else if !slices.Contains(validNumCpus, input.Config.Guest.CPUs) {
+			return fmt.Errorf("invalid config: invalid number of CPUs for %s guest. Valid numbers are %v\n"+viewMoreMsg, input.Config.Guest.CPUKind, validNumCpus)
 		}
 
 		if input.Config.Guest.CPUKind == "shared" && input.Config.Guest.MemoryMB%256 != 0 {
@@ -52,13 +43,13 @@ func Update(ctx context.Context, m *api.Machine, input *api.LaunchMachineInput) 
 			if suggestion == 0 {
 				suggestion = 256
 			}
-			return fmt.Errorf("invalid config: invalid memory size %d; must be in 256 MiB increment (%d would work)\nView more information here: https://fly.io/docs/about/pricing/#machines", input.Config.Guest.MemoryMB, suggestion)
+			return fmt.Errorf("invalid config: invalid memory size %d; must be in 256 MiB increment (%d would work)\n"+viewMoreMsg, input.Config.Guest.MemoryMB, suggestion)
 		} else if input.Config.Guest.CPUKind == "performance" && input.Config.Guest.MemoryMB%1024 != 0 {
 			suggestion := input.Config.Guest.MemoryMB - (input.Config.Guest.MemoryMB % 1024)
 			if suggestion == 0 {
 				suggestion = 1024
 			}
-			return fmt.Errorf("invalid config: invalid memory size %d; must be in 1024 MiB increment (%d would work)\nView more information here: https://fly.io/docs/about/pricing/#machines", input.Config.Guest.MemoryMB, suggestion)
+			return fmt.Errorf("invalid config: invalid memory size %d; must be in 1024 MiB increment (%d would work)\n"+viewMoreMsg, input.Config.Guest.MemoryMB, suggestion)
 		}
 
 		// Check memory sizes
@@ -71,8 +62,7 @@ func Update(ctx context.Context, m *api.Machine, input *api.LaunchMachineInput) 
 		}
 
 		if min_memory_size > input.Config.Guest.MemoryMB {
-			return fmt.Errorf("invalid config: for machines with %d CPUs, the minimum amount of memory is %d MiB\nView more information here: https://fly.io/docs/about/pricing/#machines", input.Config.Guest.CPUs, min_memory_size)
-
+			return fmt.Errorf("invalid config: for machines with %d CPUs, the minimum amount of memory is %d MiB\n"+viewMoreMsg, input.Config.Guest.CPUs, min_memory_size)
 		}
 
 		var maxMemory int
@@ -84,8 +74,7 @@ func Update(ctx context.Context, m *api.Machine, input *api.LaunchMachineInput) 
 		}
 
 		if input.Config.Guest.MemoryMB > maxMemory {
-			return fmt.Errorf("invalid config: for machines with %d CPUs, the maximum amount of memory is %d MiB\nView more information here: https://fly.io/docs/about/pricing/#machines", input.Config.Guest.CPUs, maxMemory)
-
+			return fmt.Errorf("invalid config: for machines with %d CPUs, the maximum amount of memory is %d MiB\n"+viewMoreMsg, input.Config.Guest.CPUs, maxMemory)
 		}
 
 	}


### PR DESCRIPTION
TODO:
- [x] fly scale show
- [x] fly scale vm
- [x] fly scale memory

In prep for early shipping I am going to add `fly scale count` support in another PR

```
$ fly scale show
VM Resources for app: scalecmd

Groups
NAME    COUNT   KIND    CPUS    MEMORY  REGIONS
other   3       shared  1       256 MB  ord(2),scl
task    1       shared  1       256 MB  scl
app     1       shared  2       512 MB  scl

$ fly scale vm performance-1x --group task --memory 2048
Updating machine 3287e52a00e185
No health checks found
Machine 3287e52a00e185 updated successfully!
Scaled VM Type for 'task' to 'performance-1x'
      CPU Cores: 1
         Memory: 2048 MB

$ fly scale show
VM Resources for app: scalecmd

Groups
NAME    COUNT   KIND            CPUS    MEMORY  REGIONS
task    1       performance     1       2048 MB scl
other   3       shared          1       256 MB  ord(2),scl
app     1       shared          2       512 MB  scl

$ fly scale vm shared-cpu-4x --group other
Updating machine 4d891d15a20d87
No health checks found
Machine 4d891d15a20d87 updated successfully!
Updating machine 5683939cd077d8
No health checks found
Machine 5683939cd077d8 updated successfully!
Updating machine e784921cee0d78
No health checks found
Machine e784921cee0d78 updated successfully!
Scaled VM Type for 'other' to 'shared-cpu-4x'
      CPU Cores: 4
         Memory: 1024 MB

$ fly scale show
VM Resources for app: scalecmd

Groups
NAME    COUNT   KIND            CPUS    MEMORY  REGIONS
other   3       shared          4       1024 MB ord(2),scl
task    1       performance     1       2048 MB scl
app     1       shared          2       512 MB  scl
```