### PR TITLE
Fly proxy ctrl

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -446,7 +446,7 @@ type MachineConfig struct {
 	AutoDestroy             bool                    `json:"auto_destroy,omitempty"`
 	DNS                     *DNSConfig              `json:"dns,omitempty"`
 	Statics                 []*Static               `json:"statics,omitempty"`
-	DisableMachineAutostart *bool                    `json:"disable_machine_autostart,omitempty"`
+	DisableMachineAutostart *bool                   `json:"disable_machine_autostart,omitempty"`
 	FlyProxy                *MachineFlyProxy        `json:"fly_proxy,omitempty"`
 }
 

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -424,6 +424,11 @@ type MachineServiceConcurrency struct {
 	SoftLimit int    `json:"soft_limit,omitempty" toml:"soft_limit,omitempty"`
 }
 
+type MachineFlyProxy struct {
+	AutostartMachine bool `json:"autostart_machine,omitempty"`
+	AutostopMachine  bool `json:"autostop_machine,omitempty"`
+}
+
 type MachineConfig struct {
 	Env                     map[string]string       `json:"env,omitempty"`
 	Init                    MachineInit             `json:"init,omitempty"`
@@ -442,6 +447,7 @@ type MachineConfig struct {
 	DNS                     *DNSConfig              `json:"dns,omitempty"`
 	Statics                 []*Static               `json:"statics,omitempty"`
 	DisableMachineAutostart bool                    `json:"disable_machine_autostart,omitempty"`
+	FlyProxy                *MachineFlyProxy        `json:"fly_proxy,omitempty"`
 }
 
 func (c *MachineConfig) ProcessGroup() string {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -425,8 +425,8 @@ type MachineServiceConcurrency struct {
 }
 
 type MachineFlyProxy struct {
-	AutostartMachine bool `json:"autostart_machine,omitempty"`
-	AutostopMachine  bool `json:"autostop_machine,omitempty"`
+	AutostartMachine bool `json:"autostart_machine"`
+	AutostopMachine  bool `json:"autostop_machine"`
 }
 
 type MachineConfig struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -425,8 +425,8 @@ type MachineServiceConcurrency struct {
 }
 
 type MachineFlyProxy struct {
-	AutostartMachine bool `json:"autostart_machine"`
-	AutostopMachine  bool `json:"autostop_machine"`
+	AutostartMachine *bool `json:"autostart_machine,omitempty"`
+	AutostopMachine  *bool `json:"autostop_machine,omitempty"`
 }
 
 type MachineConfig struct {
@@ -446,7 +446,7 @@ type MachineConfig struct {
 	AutoDestroy             bool                    `json:"auto_destroy,omitempty"`
 	DNS                     *DNSConfig              `json:"dns,omitempty"`
 	Statics                 []*Static               `json:"statics,omitempty"`
-	DisableMachineAutostart bool                    `json:"disable_machine_autostart,omitempty"`
+	DisableMachineAutostart *bool                    `json:"disable_machine_autostart,omitempty"`
 	FlyProxy                *MachineFlyProxy        `json:"fly_proxy,omitempty"`
 }
 

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -188,7 +188,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 			Volume: vol.ID,
 			Path:   volumePath,
 		})
-		machineConf.DisableMachineAutostart = !config.Autostart
+		*machineConf.DisableMachineAutostart = !config.Autostart
 
 		launchInput := api.LaunchMachineInput{
 			AppID:   app.ID,

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -188,7 +188,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 			Volume: vol.ID,
 			Path:   volumePath,
 		})
-		*machineConf.DisableMachineAutostart = !config.Autostart
+		machineConf.DisableMachineAutostart = api.Pointer(!config.Autostart)
 
 		launchInput := api.LaunchMachineInput{
 			AppID:   app.ID,

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -746,7 +746,7 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 		return machineConf, err
 	}
 	machineConf.Image = img.Tag
-	machineConf.DisableMachineAutostart = !flag.GetBool(ctx, "autostart")
+	*machineConf.DisableMachineAutostart = !flag.GetBool(ctx, "autostart")
 
 	return machineConf, nil
 }

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -746,7 +746,7 @@ func determineMachineConfig(ctx context.Context, initialMachineConf api.MachineC
 		return machineConf, err
 	}
 	machineConf.Image = img.Tag
-	*machineConf.DisableMachineAutostart = !flag.GetBool(ctx, "autostart")
+	machineConf.DisableMachineAutostart = api.Pointer(!flag.GetBool(ctx, "autostart"))
 
 	return machineConf, nil
 }


### PR DESCRIPTION
Adds the `fly_proxy` machines option which is used to configure behaviour of the proxy specifically for machines