### PR TITLE
fix: Add latlon to platform regions

### DIFF
--- a/api/resource_platform.go
+++ b/api/resource_platform.go
@@ -10,6 +10,8 @@ func (c *Client) PlatformRegions(ctx context.Context) ([]Region, *Region, error)
 				regions {
 					name
 					code
+					latitude
+					longitude
 					gatewayAvailable
 					requiresPaidPlan
 				}


### PR DESCRIPTION
Addresses #1970

It seems that we weren't querying lat/lon in gql which made the values of those 0

<img width="390" alt="Screen Shot 2023-03-30 at 10 20 25 AM" src="https://user-images.githubusercontent.com/3229484/228884593-7ed9f838-ace9-4885-897c-5282fb25bee8.png">
