### PR TITLE
Add process groups to fly.toml on `fly launch`

### DIFF
--- a/internal/appconfig/serde.go
+++ b/internal/appconfig/serde.go
@@ -113,6 +113,9 @@ func (c *Config) marshalTOML(w io.Writer) error {
 	if c.HttpService != nil {
 		rawData["http_service"] = c.HttpService
 	}
+	if len(c.Processes) > 0 {
+		rawData["processes"] = c.Processes
+	}
 
 	if len(rawData) > 0 {
 		// roundtrip through json encoder to convert float64 numbers to json.Number, otherwise numbers are floats in toml

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -296,6 +296,12 @@ func run(ctx context.Context) (err error) {
 			newCfg.Build = appConfig.Build
 			newCfg.PrimaryRegion = appConfig.PrimaryRegion
 			appConfig = newCfg
+
+			// remove auto-rollback from machine fly.tomls
+			if shouldUseMachines {
+				appConfig.Experimental = nil
+			}
+
 		} else {
 			appConfig.AppName = createdApp.Name
 		}


### PR DESCRIPTION
This pull request spawned from https://github.com/superfly/flyctl/issues/1838 (I got an error trying to deploy without adding the "app" line to fly.toml). 

Causes: 
1. we weren't setting platform_version. or better put, we were [setting](https://github.com/superfly/flyctl/blob/cc4c187fa25a0f87f5a6235a122e6d0ea70986ee/internal/command/launch/launch.go#L278) it, but [overriding](https://github.com/superfly/flyctl/blob/cc4c187fa25a0f87f5a6235a122e6d0ea70986ee/internal/command/launch/launch.go#L305) it almost immediately. 
And so this [block](https://github.com/superfly/flyctl/blob/cc4c187fa25a0f87f5a6235a122e6d0ea70986ee/internal/appconfig/serde.go#L95) downstream, never run.

2. Even for nomad apps, we weren't adding it to rawData before writing to file. 

This pull request addresses both issues.