### PR TITLE
Fix sentry FLYCTL-8D

### DIFF
--- a/internal/appconfig/from_machine_set.go
+++ b/internal/appconfig/from_machine_set.go
@@ -128,22 +128,17 @@ fly.toml only supports one mount per machine at this time. These mounts will be 
 			topLevelChecks[checkName] = topLevelCheckFromMachineCheck(machineCheck)
 		}
 	}
-	return &Config{
-		AppName:       appCompact.Name,
-		KillSignal:    "SIGINT",
-		KillTimeout:   5,
-		PrimaryRegion: primaryRegion,
-		Experimental:  nil,
-		Build:         nil,
-		Deploy:        nil,
-		Env:           m.Machine().Config.Env,
-		Metrics:       m.Machine().Config.Metrics,
-		Statics:       statics,
-		Mounts:        mounts,
-		Processes:     processGroups.processes,
-		Checks:        topLevelChecks,
-		Services:      processGroups.services,
-	}, warningMsg
+	cfg := NewConfig()
+	cfg.AppName = appCompact.Name
+	cfg.PrimaryRegion = primaryRegion
+	cfg.Env = m.Machine().Config.Env
+	cfg.Metrics = m.Machine().Config.Metrics
+	cfg.Statics = statics
+	cfg.Mounts = mounts
+	cfg.Processes = processGroups.processes
+	cfg.Checks = topLevelChecks
+	cfg.Services = processGroups.services
+	return cfg, warningMsg
 }
 
 const specialCharsToQuote = "!\"#$&'()*,;<=>?[]\\^`{}|~"

--- a/internal/appconfig/patches.go
+++ b/internal/appconfig/patches.go
@@ -27,7 +27,7 @@ func applyPatches(cfgMap map[string]any) (*Config, error) {
 }
 
 func mapToConfig(cfgMap map[string]any) (*Config, error) {
-	cfg := &Config{}
+	cfg := NewConfig()
 	newbuf, err := json.Marshal(cfgMap)
 	if err != nil {
 		return cfg, err


### PR DESCRIPTION
<img width="835" alt="image" src="https://user-images.githubusercontent.com/37369/229152090-43397293-25c8-49f3-b79a-1ac95836306b.png">

This is caused when`fly deploy` reconstruct the app config (aka fly.toml) from a remote machine, in that case the Config object had no RawDefinition map set.

I also removed KillSignal and KillTimeout because those are not supported by v2 apps. 