### PR TITLE
V2 fly scale count

### DIFF
--- a/internal/command/scale/count.go
+++ b/internal/command/scale/count.go
@@ -29,6 +29,7 @@ For pricing, see https://fly.io/docs/about/pricing/`
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.Yes(),
 		flag.Int{Name: "max-per-region", Description: "Max number of VMs per region", Default: -1},
 	)
 	return cmd

--- a/internal/command/scale/count.go
+++ b/internal/command/scale/count.go
@@ -31,6 +31,7 @@ For pricing, see https://fly.io/docs/about/pricing/`
 		flag.AppConfig(),
 		flag.Yes(),
 		flag.Int{Name: "max-per-region", Description: "Max number of VMs per region", Default: -1},
+		flag.String{Name: "region", Description: "Comma separated list of regions to act on. Defaults to all regions where there is at least one machine running for the app"},
 	)
 	return cmd
 }

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -31,7 +31,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, expectedGroupCou
 	}
 	ctx = appconfig.WithConfig(ctx, appConfig)
 
-	machines, err := mach.AppV2ListActive(ctx)
+	machines, _, err := flapsClient.ListFlyAppsMachines(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -1,0 +1,112 @@
+package scale
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/appconfig"
+	mach "github.com/superfly/flyctl/internal/machine"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+type groupDiff struct {
+	Name            string
+	CurrentCount    int
+	CurrentMachines []*api.Machine
+
+	ExpectedCount    int
+	MachinesToAdd    []*api.MachineConfig
+	MachinesToDelete []*api.Machine
+}
+
+func runMachinesScaleCount(ctx context.Context, appName string, expectedGroupCounts map[string]int, maxPerRegion int) error {
+	io := iostreams.FromContext(ctx)
+
+	flapsClient, err := flaps.NewFromAppName(ctx, appName)
+	if err != nil {
+		return err
+	}
+	ctx = flaps.NewContext(ctx, flapsClient)
+
+	appConfig, err := appconfig.FromRemoteApp(ctx, appName)
+	if err != nil {
+		return err
+	}
+	regions := []string{appConfig.PrimaryRegion}
+
+	machines, err := mach.ListActive(ctx)
+	if err != nil {
+		return err
+	}
+
+	machines, releaseFunc, err := mach.AcquireLeases(ctx, machines)
+	defer releaseFunc(ctx, machines)
+	if err != nil {
+		return err
+	}
+
+	actions, err := computeActions(machines, expectedGroupCounts, regions, maxPerRegion)
+	if err != nil {
+		return err
+	}
+
+	for _, action := range actions {
+		fmt.Fprintf(io.Out, "group:%s region:%s delta:%d\n", action.GroupName, action.Region, action.Delta)
+	}
+
+	return nil
+}
+
+type regionAction struct {
+	GroupName     string
+	Region        string
+	MachineConfig *api.MachineConfig
+	Delta         int
+}
+
+func computeActions(machines []*api.Machine, expectedGroupCounts map[string]int, regions []string, maxPerRegion int) ([]*regionAction, error) {
+	// Group apps-v2 machines by process group
+	machineGroups := lo.GroupBy(
+		lo.Filter(machines, func(m *api.Machine, _ int) bool {
+			return m.IsFlyAppsPlatform()
+		}),
+		func(m *api.Machine) string {
+			return m.ProcessGroup()
+		},
+	)
+
+	actions := make([]*regionAction, 0)
+
+	seenGroups := make(map[string]bool)
+	for groupName, groupMachines := range machineGroups {
+		expected, ok := expectedGroupCounts[groupName]
+		// Ignore the group if it is not expected to change or already at expected count
+		if !ok {
+			continue
+		}
+		seenGroups[groupName] = true
+
+		actions = append(actions, &regionAction{
+			GroupName:     groupName,
+			Region:        regions[0],
+			MachineConfig: groupMachines[0].Config,
+			Delta:         expected - len(groupMachines),
+		})
+	}
+
+	for name, count := range expectedGroupCounts {
+		if !seenGroups[name] {
+			actions = append(actions, &regionAction{
+				GroupName:     name,
+				Region:        regions[0],
+				MachineConfig: machines[0].Config,
+				Delta:         count,
+			})
+		}
+	}
+
+	return actions, nil
+}

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
-	"github.com/briandowns/spinner"
 	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/flaps"
@@ -17,8 +15,6 @@ import (
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 )
-
-var spinnerChar = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 
 func runMachinesScaleCount(ctx context.Context, appName string, expectedGroupCounts map[string]int, maxPerRegion int) error {
 	io := iostreams.FromContext(ctx)

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -37,8 +37,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, expectedGroupCou
 	}
 
 	if len(machines) == 0 {
-		fmt.Fprintf(io.Out, "There are not active machines for this app. Did you ever `fly deploy`? if not, do it now\n")
-		return fmt.Errorf("Impossible to scale the app when there aren't running machines for this app")
+		return fmt.Errorf("there are no active machines for this app. Run `fly deploy` to create one and rerun this command")
 	}
 
 	var regions []string

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -83,6 +83,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, expectedGroupCou
 		}
 	}
 
+	fmt.Fprintf(io.Out, "Executing scale plan\n")
 	for _, action := range actions {
 		switch {
 		case action.Delta > 0:
@@ -91,7 +92,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, expectedGroupCou
 				if err != nil {
 					return err
 				}
-				fmt.Fprintf(io.Out, "Created %s group:%s region:%s size:%s\n", m.ID, action.GroupName, action.Region, m.Config.Guest.ToSize())
+				fmt.Fprintf(io.Out, "  Created %s group:%s region:%s size:%s\n", m.ID, action.GroupName, action.Region, m.Config.Guest.ToSize())
 			}
 		case action.Delta < 0:
 			for i := 0; i > action.Delta; i-- {
@@ -100,7 +101,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, expectedGroupCou
 				if err != nil {
 					return err
 				}
-				fmt.Fprintf(io.Out, "Destroyed %s group:%s region:%s size:%s\n", m.ID, action.GroupName, action.Region, m.Config.Guest.ToSize())
+				fmt.Fprintf(io.Out, "  Destroyed %s group:%s region:%s size:%s\n", m.ID, action.GroupName, action.Region, m.Config.Guest.ToSize())
 			}
 		}
 	}

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -34,14 +34,10 @@ func runMachinesScaleCount(ctx context.Context, appName string, expectedGroupCou
 		return err
 	}
 
-	machines, err := mach.ListActive(ctx)
+	machines, err := mach.AppV2ListActive(ctx)
 	if err != nil {
 		return err
 	}
-	// Only machines that are part of apps-v2 platform
-	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
-		return m.IsFlyAppsPlatform()
-	})
 
 	var regions []string
 	if v := flag.GetRegion(ctx); v != "" {

--- a/internal/command/scale/count_machines_test.go
+++ b/internal/command/scale/count_machines_test.go
@@ -1,0 +1,139 @@
+package scale
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_convergeGroupCounts(t *testing.T) {
+	testcases := []struct {
+		name          string
+		want          map[string]int
+		expectedTotal int
+		current       map[string]int
+		regions       []string
+		maxPerRegion  int
+	}{
+		{
+			name:          "Spread instances across regions from nothing",
+			want:          map[string]int{"scl": 2, "iad": 1},
+			expectedTotal: 3,
+			regions:       []string{"scl", "iad"},
+			maxPerRegion:  -1,
+		},
+		{
+			name:          "Spread instances across regions from existing",
+			want:          map[string]int{"scl": 1},
+			current:       map[string]int{"scl": 1, "iad": 1},
+			expectedTotal: 3,
+			regions:       []string{"scl", "iad"},
+			maxPerRegion:  -1,
+		},
+		{
+			name:          "Act on all current regions if not region is passed",
+			want:          map[string]int{"scl": 2, "iad": 2},
+			current:       map[string]int{"scl": 1, "iad": 1},
+			expectedTotal: 6,
+			maxPerRegion:  -1,
+		},
+		{
+			name:          "Requirements already met",
+			want:          map[string]int{},
+			current:       map[string]int{"scl": 1, "iad": 1},
+			expectedTotal: 2,
+			regions:       []string{"scl", "iad"},
+			maxPerRegion:  -1,
+		},
+		{
+			name:          "Reduce the fleet",
+			want:          map[string]int{"iad": -1},
+			current:       map[string]int{"scl": 1, "iad": 1},
+			expectedTotal: 1,
+			regions:       []string{"scl", "iad"},
+			maxPerRegion:  -1,
+		},
+		{
+			name:          "Reduce the fleet (like previous but order of regions matters)",
+			want:          map[string]int{"scl": -1},
+			current:       map[string]int{"scl": 1, "iad": 1},
+			expectedTotal: 1,
+			regions:       []string{"iad", "scl"},
+			maxPerRegion:  -1,
+		},
+		// Ignore non-listed regions
+		{
+			name:          "Ignore non-listed regions while removing machines",
+			want:          map[string]int{"scl": -3, "iad": -3},
+			current:       map[string]int{"scl": 3, "iad": 5, "ord": 1, "sin": 10},
+			expectedTotal: 2,
+			regions:       []string{"scl", "iad"},
+			maxPerRegion:  -1,
+		},
+		{
+			name:          "Ignore non-listed regions while adding machines",
+			want:          map[string]int{"scl": 2, "iad": 2},
+			current:       map[string]int{"scl": 3, "iad": 5, "ord": 1, "sin": 10},
+			expectedTotal: 12,
+			regions:       []string{"scl", "iad"},
+			maxPerRegion:  -1,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := convergeGroupCounts(tc.expectedTotal, tc.current, tc.regions, tc.maxPerRegion)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func Test_convergeGroupCounts_maxPerRegion(t *testing.T) {
+	// maxPerRegion * len(regions) < expectedTotal must fail
+	_, err := convergeGroupCounts(10, nil, []string{"scl", "mia"}, 1)
+	assert.Equal(t, MaxPerRegionError, err)
+
+	// Happy path cases
+	testcases := []struct {
+		name          string
+		want          map[string]int
+		expectedTotal int
+		current       map[string]int
+		regions       []string
+		maxPerRegion  int
+	}{
+		{
+			name:          "Spread instances across regions respecting max per region",
+			want:          map[string]int{"scl": 1, "iad": 2},
+			current:       map[string]int{"scl": 2, "iad": 1},
+			expectedTotal: 6,
+			regions:       []string{"scl", "iad"},
+			maxPerRegion:  3,
+		},
+		{
+			name:          "Spread instances across regions respecting max per regioni with reductions",
+			want:          map[string]int{"scl": -5, "iad": 1, "ord": 2, "sin": 2},
+			current:       map[string]int{"scl": 7, "iad": 1},
+			expectedTotal: 8,
+			regions:       []string{"scl", "iad", "ord", "sin"},
+			maxPerRegion:  2,
+		},
+		{
+			name:          "Spread respecting unlisted regions",
+			want:          map[string]int{"scl": -5, "iad": 1, "ord": 2, "sin": 2},
+			current:       map[string]int{"scl": 7, "iad": 1, "mia": 10},
+			expectedTotal: 8,
+			regions:       []string{"scl", "iad", "ord", "sin"},
+			maxPerRegion:  2,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := convergeGroupCounts(tc.expectedTotal, tc.current, tc.regions, tc.maxPerRegion)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/command/scale/machine_defaults.go
+++ b/internal/command/scale/machine_defaults.go
@@ -1,0 +1,89 @@
+package scale
+
+import (
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/internal/appconfig"
+)
+
+type defaultValues struct {
+	image          string
+	guest          *api.MachineGuest
+	guestPerGroup  map[string]*api.MachineGuest
+	releaseId      string
+	releaseVersion string
+	appConfig      *appconfig.Config
+}
+
+func newDefaults(appConfig *appconfig.Config, machines []*api.Machine) *defaultValues {
+	var (
+		defaultGroupName = appConfig.DefaultProcessName()
+		guest            *api.MachineGuest
+		image            string
+		releaseId        string
+		releaseVersion   string
+		guestPerGroup    = make(map[string]*api.MachineGuest)
+	)
+
+	for _, m := range machines {
+		if len(m.Config.Metadata) > 0 {
+			if releaseId == "" {
+				releaseId = m.Config.Metadata[api.MachineConfigMetadataKeyFlyReleaseId]
+			}
+			if releaseVersion == "" {
+				releaseVersion = m.Config.Metadata[api.MachineConfigMetadataKeyFlyReleaseVersion]
+			}
+			if image == "" {
+				image = m.Config.Image
+			}
+		}
+
+		groupName := m.ProcessGroup()
+		if _, ok := guestPerGroup[groupName]; ok {
+			continue
+		} else if m.Config.Guest != nil {
+			guestPerGroup[groupName] = m.Config.Guest
+			if groupName == defaultGroupName {
+				guest = m.Config.Guest
+			}
+		}
+	}
+
+	// In case we haven't found a guest for the default,
+	// scan all the existing groups and pick the first
+	if guest == nil {
+		for _, name := range appConfig.ProcessNames() {
+			if v, ok := guestPerGroup[name]; ok {
+				guest = v
+				break
+			}
+		}
+	}
+
+	return &defaultValues{
+		image:          image,
+		guest:          guest,
+		guestPerGroup:  guestPerGroup,
+		releaseId:      releaseId,
+		releaseVersion: releaseVersion,
+		appConfig:      appConfig,
+	}
+}
+
+func (d *defaultValues) ToMachineConfig(groupName string) (*api.MachineConfig, error) {
+	mc, err := d.appConfig.ToMachineConfig(groupName)
+	if err != nil {
+		return nil, err
+	}
+
+	if guest, ok := d.guestPerGroup[groupName]; ok {
+		mc.Guest = guest
+	} else {
+		mc.Guest = d.guest
+	}
+
+	mc.Image = d.image
+	mc.Metadata[api.MachineConfigMetadataKeyFlyReleaseId] = d.releaseId
+	mc.Metadata[api.MachineConfigMetadataKeyFlyReleaseVersion] = d.releaseVersion
+
+	return mc, nil
+}

--- a/internal/command/scale/scale.go
+++ b/internal/command/scale/scale.go
@@ -1,11 +1,6 @@
 package scale
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/superfly/flyctl/client"
-	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 
 	"github.com/spf13/cobra"
@@ -24,18 +19,4 @@ func New() *cobra.Command {
 		newScaleCount(),
 	)
 	return cmd
-}
-
-func failOnMachinesApp(ctx context.Context) (context.Context, error) {
-	apiClient := client.FromContext(ctx).API()
-	appName := appconfig.NameFromContext(ctx)
-
-	app, err := apiClient.GetAppBasic(ctx, appName)
-	if err != nil {
-		return nil, err
-	} else if app.PlatformVersion == appconfig.MachinesPlatform {
-		return nil, fmt.Errorf("This command doesn't support V2 apps yet, use `fly machines update` and `fly machines clone` instead")
-	}
-
-	return ctx, nil
 }

--- a/internal/command/scale/show_machines.go
+++ b/internal/command/scale/show_machines.go
@@ -25,19 +25,15 @@ func runMachinesScaleShow(ctx context.Context) error {
 	}
 	ctx = flaps.NewContext(ctx, flapsClient)
 
-	machines, err := mach.ListActive(ctx)
+	machines, err := mach.AppV2ListActive(ctx)
 	if err != nil {
 		return err
 	}
 
-	machineGroups := lo.GroupBy(
-		lo.Filter(machines, func(m *api.Machine, _ int) bool {
-			return m.IsFlyAppsPlatform()
-		}),
-		func(m *api.Machine) string {
-			return m.ProcessGroup()
-		},
-	)
+	machineGroups := lo.GroupBy(machines, func(m *api.Machine) string {
+		return m.ProcessGroup()
+	})
+
 	// Deterministic output sorted by group name
 	groupNames := lo.Keys(machineGroups)
 	slices.Sort(groupNames)

--- a/internal/command/scale/show_machines.go
+++ b/internal/command/scale/show_machines.go
@@ -9,7 +9,6 @@ import (
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
-	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 	"golang.org/x/exp/slices"
@@ -25,7 +24,7 @@ func runMachinesScaleShow(ctx context.Context) error {
 	}
 	ctx = flaps.NewContext(ctx, flapsClient)
 
-	machines, err := mach.AppV2ListActive(ctx)
+	machines, _, err := flapsClient.ListFlyAppsMachines(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/machine/query.go
+++ b/internal/machine/query.go
@@ -22,3 +22,15 @@ func ListActive(ctx context.Context) ([]*api.Machine, error) {
 
 	return machines, nil
 }
+
+// AppV2ListActive lists machines that are part of v2 apps platform
+func AppV2ListActive(ctx context.Context) ([]*api.Machine, error) {
+	machines, err := ListActive(ctx)
+	if err != nil {
+		return nil, err
+	}
+	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
+		return m.IsFlyAppsPlatform()
+	})
+	return machines, nil
+}

--- a/internal/machine/query.go
+++ b/internal/machine/query.go
@@ -22,15 +22,3 @@ func ListActive(ctx context.Context) ([]*api.Machine, error) {
 
 	return machines, nil
 }
-
-// AppV2ListActive lists machines that are part of v2 apps platform
-func AppV2ListActive(ctx context.Context) ([]*api.Machine, error) {
-	machines, err := ListActive(ctx)
-	if err != nil {
-		return nil, err
-	}
-	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
-		return m.IsFlyAppsPlatform()
-	})
-	return machines, nil
-}


### PR DESCRIPTION

*NOTE: Scaling machines with mounts is not supported yet.*

```
$ fly scale show
VM Resources for app: scalecmd

Groups
NAME    COUNT   KIND            CPUS    MEMORY  REGIONS
app     3       shared          4       1024 MB mia,scl(2)
other   3       shared          4       1024 MB ord(2),scl
task    4       performance     1       2048 MB iad,mia,ord,scl
```

## Scale up a new region for default group:
```
$ fly scale count 3 --region ord -y
App 'scalecmd' is going to be scaled according to this plan:
  +3 machines for group 'app' on region 'ord' with size 'shared-cpu-4x'
Executing scale plan
  Created 6e8257da00de78 group:app region:ord size:shared-cpu-4x
  Created 5683566bd32938 group:app region:ord size:shared-cpu-4x
  Created 6e82947a232168 group:app region:ord size:shared-cpu-4x

$ fly scale show
VM Resources for app: scalecmd

Groups
NAME    COUNT   KIND            CPUS    MEMORY  REGIONS
app     6       shared          4       1024 MB mia,ord(3),scl(2)
other   3       shared          4       1024 MB ord(2),scl
task    4       performance     1       2048 MB iad,mia,ord,scl
```

## Scale up to 3 instances and one max per region
```
$ fly scale count app=3 --max-per-region 1 -y
App 'scalecmd' is going to be scaled according to this plan:
  -1 machines for group 'app' on region 'scl' with size 'shared-cpu-4x'
  -2 machines for group 'app' on region 'ord' with size 'shared-cpu-4x'
Executing scale plan
  Destroyed 73d8d97df9d989 group:app region:scl size:shared-cpu-4x
  Destroyed 6e82947a232168 group:app region:ord size:shared-cpu-4x
  Destroyed 6e8257da00de78 group:app region:ord size:shared-cpu-4x

$ fly scale show
VM Resources for app: scalecmd

Groups
NAME    COUNT   KIND            CPUS    MEMORY  REGIONS
app     3       shared          4       1024 MB mia,ord,scl
other   3       shared          4       1024 MB ord(2),scl
task    4       performance     1       2048 MB iad,mia,ord,scl
```

## Max per region works on different groups at the same time
```
$ fly scale count other=1 task=2 --max-per-region 1 -y
App 'scalecmd' is going to be scaled according to this plan:
  -2 machines for group 'other' on region 'ord' with size 'shared-cpu-4x'
  -1 machines for group 'task' on region 'mia' with size 'performance-1x'
  -1 machines for group 'task' on region 'iad' with size 'performance-1x'
Executing scale plan
  Destroyed 5683939cd077d8 group:other region:ord size:shared-cpu-4x
  Destroyed e784921cee0d78 group:other region:ord size:shared-cpu-4x
  Destroyed 9080d13f699287 group:task region:mia size:performance-1x
  Destroyed 328744eef01e78 group:task region:iad size:performance-1x

$ fly scale show
VM Resources for app: scalecmd

Groups
NAME    COUNT   KIND            CPUS    MEMORY  REGIONS
app     3       shared          4       1024 MB mia,ord,scl
other   1       shared          4       1024 MB scl
task    2       performance     1       2048 MB ord,scl
```

## Scaling to zero and back up on multiple regions
```
$ fly scale count app=0
App 'scalecmd' is going to be scaled according to this plan:
  -1 machines for group 'app' on region 'mia' with size 'shared-cpu-4x'
  -1 machines for group 'app' on region 'ord' with size 'shared-cpu-4x'
  -1 machines for group 'app' on region 'scl' with size 'shared-cpu-4x'
? Scale app scalecmd? Yes
Executing scale plan
  Destroyed 3d8d549ae50489 group:app region:mia size:shared-cpu-4x
  Destroyed 5683566bd32938 group:app region:ord size:shared-cpu-4x
  Destroyed e286369be9e286 group:app region:scl size:shared-cpu-4x

$ fly scale count app=5 --region scl,ord,iad
App 'scalecmd' is going to be scaled according to this plan:
  +1 machines for group 'app' on region 'iad' with size 'shared-cpu-4x'
  +2 machines for group 'app' on region 'scl' with size 'shared-cpu-4x'
  +2 machines for group 'app' on region 'ord' with size 'shared-cpu-4x'
? Scale app scalecmd? Yes
Executing scale plan
  Created 91857709a43328 group:app region:iad size:shared-cpu-4x
  Created 24d89106f25487 group:app region:scl size:shared-cpu-4x
  Created e78473df2dd983 group:app region:scl size:shared-cpu-4x
  Created 1781969c53ede8 group:app region:ord size:shared-cpu-4x
  Created 908017ea11d008 group:app region:ord size:shared-cpu-4x

$ fly scale show
VM Resources for app: scalecmd

Groups
NAME    COUNT   KIND            CPUS    MEMORY  REGIONS
app     5       shared          4       1024 MB iad,ord(2),scl(2)
other   1       shared          4       1024 MB scl
task    2       performance     1       2048 MB ord,scl
```