### PR TITLE
Fix a crash when fly deploy has to pull config from remote machine

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -107,6 +107,13 @@ func New() (cmd *cobra.Command) {
 }
 
 func run(ctx context.Context) error {
+	appName := appconfig.NameFromContext(ctx)
+	flapsClient, err := flaps.NewFromAppName(ctx, appName)
+	if err != nil {
+		return fmt.Errorf("could not create flaps client: %w", err)
+	}
+	ctx = flaps.NewContext(ctx, flapsClient)
+
 	appConfig, err := determineAppConfig(ctx)
 	if err != nil {
 		return err
@@ -251,32 +258,22 @@ func useMachines(ctx context.Context, appConfig *appconfig.Config, appCompact *a
 
 // determineAppConfig fetches the app config from a local file, or in its absence, from the API
 func determineAppConfig(ctx context.Context) (cfg *appconfig.Config, err error) {
+	io := iostreams.FromContext(ctx)
 	tb := render.NewTextBlock(ctx, "Verifying app config")
-	appNameFromContext := appconfig.NameFromContext(ctx)
+	appName := appconfig.NameFromContext(ctx)
+
 	if cfg = appconfig.ConfigFromContext(ctx); cfg == nil {
-		logger := logger.FromContext(ctx)
-		logger.Debug("no local app config detected; fetching from backend ...")
-
-		var flapsClient *flaps.Client
-		flapsClient, err = flaps.NewFromAppName(ctx, appNameFromContext)
+		cfg, err = appconfig.FromRemoteApp(ctx, appName)
 		if err != nil {
-			return nil, fmt.Errorf("could not create flaps client: %w", err)
-		}
-		ctx = flaps.NewContext(ctx, flapsClient)
-
-		cfg, err = appconfig.FromRemoteApp(ctx, appNameFromContext)
-		if err != nil {
-			return
+			return nil, err
 		}
 
 	}
 
 	if env := flag.GetStringSlice(ctx, "env"); len(env) > 0 {
-		var parsedEnv map[string]string
-		if parsedEnv, err = cmdutil.ParseKVStringsToMap(env); err != nil {
-			err = fmt.Errorf("failed parsing environment: %w", err)
-
-			return
+		parsedEnv, err := cmdutil.ParseKVStringsToMap(env)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing environment: %w", err)
 		}
 		cfg.SetEnvVariables(parsedEnv)
 	}
@@ -286,20 +283,20 @@ func determineAppConfig(ctx context.Context) (cfg *appconfig.Config, err error) 
 	}
 
 	// Always prefer the app name passed via --app
-	if appNameFromContext != "" {
-		cfg.AppName = appNameFromContext
+	if appName != "" {
+		cfg.AppName = appName
 	}
 
 	err, extraInfo := cfg.Validate(ctx)
 	if extraInfo != "" {
-		fmt.Print(extraInfo)
+		fmt.Fprintf(io.Out, extraInfo)
 	}
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	tb.Done("Verified app config")
-	return
+	return cfg, nil
 }
 
 // determineImage picks the deployment strategy, builds the image and returns a


### PR DESCRIPTION
`fly deploy` crashes when the app contains a machine and no releases

```
~$ fly apps create -o personal --name dangra-testrun
New app created: dangra-testrun

~$ fly m run nginx -a dangra-testrun
Searching for image 'nginx' remotely...
image found: img_e1zd4m90oynv02yw
Image: registry-1.docker.io/library/nginx:latest
Image size: 57 MB

Success! A machine has been successfully launched in app dangra-testrun, waiting for it to be started
 Machine ID: 178176ea955789
 Instance ID: 01GX476RBK6T02SGQDAT2ZP30V
 State: created

 Attempting to start machine...

==> Monitoring health checks
No health checks found

Machine started, you can connect via the following private ip
  fdaa:0:5ea6:a7b:d33d:5f63:2e0a:2

~$ fly m list -a dangra-testrun
1 machines have been retrieved from app dangra-testrun.
View them in the UI here (​https://fly.io/apps/dangra-testrun/machines/)

dangra-testrun
ID              NAME            STATE   REGION  IMAGE                   IP ADDRESS                              VOLUME  CREATED                 LAST UPDATED            APP PLATFORM    PROCESS GROUP
178176ea955789  damp-leaf-2677  started scl     library/nginx:latest    fdaa:0:5ea6:a7b:d33d:5f63:2e0a:2                2023-04-03T18:48:53Z    2023-04-03T18:48:59Z

~$ fly deploy -a dangra-testrun --image nginx:stable
==> Verifying app config
Validating
Platform: machines
✓ Configuration is valid
--> Verified app config
==> Building image
Searching for image 'nginx:stable' remotely...
image found: img_8y6w4z5eoe047rn3
panic: interface conversion: interface {} is nil, not *flaps.Client

goroutine 1 [running]:
github.com/superfly/flyctl/flaps.FromContext(...)
        /Users/daniel/src/flyio/flyctl/flaps/context.go:15
github.com/superfly/flyctl/internal/appconfig.getAppV2ConfigFromMachines({0x28f9848, 0xc000b554a0}, 0xc000b554a0?, 0xc000458538)
        /Users/daniel/src/flyio/flyctl/internal/appconfig/remote.go:61 +0x4a5
github.com/superfly/flyctl/internal/appconfig.FromRemoteApp({0x28f9848, 0xc000b554a0}, {0x7ff7bfefead6, 0xe})
        /Users/daniel/src/flyio/flyctl/internal/appconfig/remote.go:41 +0x2a9
github.com/superfly/flyctl/internal/command/deploy.determineAppConfigForMachines({0x28f9848, 0xc000b554a0}, {0x351ea60, 0x0, 0x0}, {0x0, 0x0})
        /Users/daniel/src/flyio/flyctl/internal/command/deploy/machines.go:764 +0x165
github.com/superfly/flyctl/internal/command/deploy.NewMachineDeployment({0x28f9848, 0xc000b554a0}, {0xc000b97a38, 0xc000727470, {0x0, 0x0}, {0x351ea60, 0x0, 0x0}, {0x0, ...}, ...})
        /Users/daniel/src/flyio/flyctl/internal/command/deploy/machines.go:89 +0xd1
github.com/superfly/flyctl/internal/command/deploy.DeployWithConfig({0x28f9848, 0xc000b554a0}, 0xc0007f64b0, {0xc?, 0x0?, 0x0?})
        /Users/daniel/src/flyio/flyctl/internal/command/deploy/deploy.go:171 +0x573
github.com/superfly/flyctl/internal/command/deploy.run({0x28f9848, 0xc000b554a0})
        /Users/daniel/src/flyio/flyctl/internal/command/deploy/deploy.go:115 +0xbb
github.com/superfly/flyctl/internal/command.newRunE.func1(0xc000c77900, {0xc000b2ef00?, 0x4?, 0x4?})
        /Users/daniel/src/flyio/flyctl/internal/command/command.go:110 +0x17e
github.com/spf13/cobra.(*Command).execute(0xc000c77900, {0xc000b2eec0, 0x4, 0x4})
        /Users/daniel/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0xc000b4e780)
        /Users/daniel/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).ExecuteContextC(...)
        /Users/daniel/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:911
github.com/superfly/flyctl/internal/cli.Run({0x28fa4f8?, 0xc0006ad900?}, 0xc000c48000, {0xc0001aa130, 0x5, 0x5})
        /Users/daniel/src/flyio/flyctl/internal/cli/cli.go:36 +0x21e
main.run()
        /Users/daniel/src/flyio/flyctl/main.go:45 +0x117
main.main()
        /Users/daniel/src/flyio/flyctl/main.go:26 +0x1e
```


After the fix, it returns the expected output:
```
l$ fly deploy -a dangra-testrun --image nginx:stable
==> Verifying app config
Validating
Platform: machines
✓ Configuration is valid
--> Verified app config
==> Building image
Searching for image 'nginx:stable' remotely...
image found: img_8y6w4z5eoe047rn3
Error found 1 machines that are unmanaged. `fly deploy` only updates machines with fly_platform_version=v2 in their metadata. Use `fly machine list` to list machines and `fly machine update --metadata fly_platform_version=v2` to update individual machines with the metadata. Once done, `fly deploy` will update machines with the metadata based on your fly.toml app configuration
```