### PR TITLE
Max replication slots

### DIFF
--- a/internal/command/postgres/config.go
+++ b/internal/command/postgres/config.go
@@ -16,6 +16,7 @@ var pgSettings = map[string]string{
 	"log-statement":              "log_statement",
 	"log-min-duration-statement": "log_min_duration_statement",
 	"shared-preload-libraries":   "shared_preload_libraries",
+	"max-replication-slots":      "max_replication_slots",
 }
 
 func newConfig() (cmd *cobra.Command) {

--- a/internal/command/postgres/config.go
+++ b/internal/command/postgres/config.go
@@ -11,12 +11,12 @@ import (
 var pgSettings = map[string]string{
 	"wal-level":                  "wal_level",
 	"max-wal-senders":            "max_wal_senders",
+	"max-replication-slots":      "max_replication_slots",
 	"max-connections":            "max_connections",
 	"shared-buffers":             "shared_buffers",
 	"log-statement":              "log_statement",
 	"log-min-duration-statement": "log_min_duration_statement",
 	"shared-preload-libraries":   "shared_preload_libraries",
-	"max-replication-slots":      "max_replication_slots",
 }
 
 func newConfig() (cmd *cobra.Command) {

--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -56,7 +56,7 @@ func newConfigUpdate() (cmd *cobra.Command) {
 			Description: "Maximum number of concurrent connections from standby servers or streaming backup clients. (0 disables replication)",
 		},
 		flag.String{
-			Name:        "max_replication_slots",
+			Name:        "max-replication-slots",
 			Description: "Specifies the maximum number of replication slots. This should typically match max_wal_senders.",
 		},
 		flag.String{
@@ -217,6 +217,8 @@ func updateFlexConfig(ctx context.Context, app *api.AppCompact, leaderIP string)
 	if err != nil {
 		return false, err
 	}
+
+	fmt.Printf("Changes: %+v\n", changes)
 
 	fmt.Fprintln(io.Out, "Performing update...")
 	leaderClient := flypg.NewFromInstance(leaderIP, dialer)

--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -218,8 +218,6 @@ func updateFlexConfig(ctx context.Context, app *api.AppCompact, leaderIP string)
 		return false, err
 	}
 
-	fmt.Printf("Changes: %+v\n", changes)
-
 	fmt.Fprintln(io.Out, "Performing update...")
 	leaderClient := flypg.NewFromInstance(leaderIP, dialer)
 

--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -56,6 +56,10 @@ func newConfigUpdate() (cmd *cobra.Command) {
 			Description: "Maximum number of concurrent connections from standby servers or streaming backup clients. (0 disables replication)",
 		},
 		flag.String{
+			Name:        "max_replication_slots",
+			Description: "Specifies the maximum number of replication slots. This should typically match max_wal_senders.",
+		},
+		flag.String{
 			Name:        "log-statement",
 			Description: "Sets the type of statements logged. (none, ddl, mod, all)",
 		},


### PR DESCRIPTION
Allow PG setups to tune `max_replication_slots`.