### PR TITLE
Clarify deploy error when app name is missing from config or has not been created

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -536,7 +536,7 @@ func RequireAppName(ctx context.Context) (context.Context, error) {
 	}
 
 	if name == "" {
-		err := fmt.Errorf("we found a fly.toml file but it looks like the app has not been created, did you create this app with fly apps create?", buildinfo.Name())
+		err := fmt.Errorf("the config for your app is missing an app name, did you add it in the fly.toml file or via -a? %s", buildinfo.Name())
 		return nil, err
 	}
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -536,7 +536,8 @@ func RequireAppName(ctx context.Context) (context.Context, error) {
 	}
 
 	if name == "" {
-		return nil, errRequireAppName
+		err := fmt.Errorf("we found a fly.toml file but it looks like the app has not been created, did you create this app with fly apps create?", buildinfo.Name())
+		return nil, err
 	}
 
 	return appconfig.WithName(ctx, name), nil

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -119,6 +119,14 @@ func run(ctx context.Context) error {
 		return err
 	}
 
+	err, extra_info := appConfig.Validate(ctx)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(extra_info, "Could not find App") {
+		return fmt.Errorf("app config is missing app name, did you include this in the fly.toml file or via -a?")
+	}
+
 	return DeployWithConfig(ctx, appConfig, DeployWithConfigArgs{
 		ForceNomad:    flag.GetBool(ctx, "force-nomad"),
 		ForceMachines: flag.GetBool(ctx, "force-machines"),

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -124,7 +124,7 @@ func run(ctx context.Context) error {
 		return err
 	}
 	if strings.Contains(extra_info, "Could not find App") {
-		return fmt.Errorf("app config is missing app name, did you include this in the fly.toml file or via -a?")
+		return fmt.Errorf("app config has an incorrect app name, did you create the app or misspell it in the fly.toml file or via -a?")
 	}
 
 	return DeployWithConfig(ctx, appConfig, DeployWithConfigArgs{

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -124,7 +124,7 @@ func run(ctx context.Context) error {
 		return err
 	}
 	if strings.Contains(extra_info, "Could not find App") {
-		return fmt.Errorf("app config has an incorrect app name, did you create the app or misspell it in the fly.toml file or via -a?")
+		return fmt.Errorf("the app name %s could not be found, did you create the app or misspell it in the fly.toml file or via -a?", appConfig.AppName)
 	}
 
 	return DeployWithConfig(ctx, appConfig, DeployWithConfigArgs{


### PR DESCRIPTION
Currently fly deploy on a dir with fly.toml but missing app name gives a `couldn't find a fly.toml` error, which is misleading.
<img width="1120" alt="Screen Shot 2023-04-04 at 4 52 58 PM" src="https://user-images.githubusercontent.com/3229484/229930936-e20dede9-875b-4ba9-98a9-50a430d169a2.png">

This PR updates the error messaging for greater clarity to the user.

<img width="1119" alt="appnotadded" src="https://user-images.githubusercontent.com/3229484/229930472-2c65eef1-eed7-4463-b34b-3b58133229c7.png">
<img width="1119" alt="appnamenotfound" src="https://user-images.githubusercontent.com/3229484/229930483-ff18f8de-748e-4c11-942e-7aee494ee845.png">
