### PR TITLE
Bump golangci-lint on ci pipeline

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,24 +10,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: "go.mod"
       - uses: pre-commit/action@v3.0.0
         with:
           extra_args: --all-files --hook-stage=manual
-      - uses: golangci/golangci-lint-action@master
+      - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.52
+          # https://github.com/golangci/golangci-lint-action/issues/244
+          # precommit step already run go get and conflicts with golangci cache
+          skip-cache: true
 
   lint-api:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: "api/go.mod"
-      - uses: golangci/golangci-lint-action@master
+      - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.52
           working-directory: "api"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
 # because goalngci-lint github action is much more useful than the pre-commit action.
 # The trick is to run github action only for "manual" hook stage
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.51.2
+    rev: v1.52.2
     hooks:
     -   id: golangci-lint
         stages: [commit]


### PR DESCRIPTION
Cherry picked from #1983 

* Fixes a golangci-lint memory leak running on linux
* Prevents 40k log lines on CI pipeline due to Go file cache conflicts 