### PR TITLE
Laravel - update Node version to 18 and fixes error during build when running `npm ci`

### DIFF
--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -61,7 +61,7 @@ func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 
 	s.BuildArgs = map[string]string{
 		"PHP_VERSION":  phpVersion,
-		"NODE_VERSION": "14",
+		"NODE_VERSION": "18",
 	}
 
 	return s, nil

--- a/scanner/templates/laravel/Dockerfile
+++ b/scanner/templates/laravel/Dockerfile
@@ -4,7 +4,7 @@
 # the PHP version from the user (wherever `flyctl launch` is run)
 # Valid version values are PHP 7.4+
 ARG PHP_VERSION=8.2
-ARG NODE_VERSION=14
+ARG NODE_VERSION=18
 FROM fideloper/fly-laravel:${PHP_VERSION} as base
 
 # PHP_VERSION needs to be repeated here


### PR DESCRIPTION
This updates Node version from 14 to 18 when running `fly launch` and a Laravel app is detected.

Updating the version has 2 benefits:
- Node 14 is EOL by the end of the month
- Node 14 comes with NPM v6, which uses a different package-lock.json structure compared to recent versions. 

You can see the difference here : [v6](https://docs.npmjs.com/cli/v6/configuring-npm/package-lock-json?v=true) and [v9](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json?v=true). The important bit is that the in the format of v6 dependencies are under `dependencies`, in newer versions they are under `packages`. If you generate a lock file on your machine with the latest version, during the build `npm ci` fails

https://github.com/superfly/flyctl/blob/d960682f7ba52142a66893ce8b8699a9574a85f3/scanner/templates/laravel/Dockerfile#L67

because dependencies is not in the lock file. It produces errors such as  **cannot read property 'package name' of undefined**, where package name is the first in the list.

Lock files generated with older NPM versions that have the dependencies key should still supported in v9 to guarantee backwards compatibility, so nothing should break.

