### PR TITLE
Serialize nomad config

### DIFF
--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -1,7 +1,6 @@
 package appconfig
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,11 +12,9 @@ func TestGetAndSetEnvVariables(t *testing.T) {
 	cfg.SetEnvVariable("C", "D")
 	assert.Equal(t, map[string]string{"A": "B", "C": "D"}, cfg.Env)
 
-	buf := &bytes.Buffer{}
-	if err := cfg.marshalTOML(buf); err != nil {
-		assert.NoError(t, err)
-	}
-	cfg2, err := unmarshalTOML(buf.Bytes())
+	bytes, err := cfg.marshalTOML()
+	assert.NoError(t, err)
+	cfg2, err := unmarshalTOML(bytes)
 	assert.NoError(t, err)
 	assert.Equal(t, cfg.Env, cfg2.Env)
 }
@@ -79,7 +76,6 @@ func TestManyBuildStrategies(t *testing.T) {
 }
 
 func TestConfigPortGetter(t *testing.T) {
-
 	type testcase struct {
 		name         string
 		config       Config
@@ -129,5 +125,4 @@ func TestConfigPortGetter(t *testing.T) {
 			assert.Equal(t, tc.expectedPort, tc.config.InternalPort())
 		})
 	}
-
 }

--- a/internal/appconfig/from_machine_set.go
+++ b/internal/appconfig/from_machine_set.go
@@ -30,11 +30,11 @@ func FromAppAndMachineSet(ctx context.Context, appCompact *api.AppCompact, machi
 	for _, m := range machines.GetMachines() {
 		appConfig, machineWarning := fromAppAndOneMachine(appCompact, m, processGroups)
 		warnings = append(warnings, machineWarning)
-		tomlString, err := appConfig.toTOMLString()
+		tomlString, err := appConfig.marshalTOML()
 		if err != nil {
 			warnings = append(warnings, warning("parse error", "error marshalling synthesized app config to fly.toml file for machine %s", m.Machine().ID))
 		} else {
-			tomlCounter.Capture(tomlString, &machineConfigPair{
+			tomlCounter.Capture(string(tomlString), &machineConfigPair{
 				appConfig: appConfig,
 				machine:   m,
 			})
@@ -47,10 +47,10 @@ func FromAppAndMachineSet(ctx context.Context, appCompact *api.AppCompact, machi
 	mostCommonConfig := report.mostCommonValues[0].appConfig
 	if len(report.others) > 0 {
 		for _, other := range report.otherValues {
-			otherToml, err := other.appConfig.toTOMLString()
+			otherToml, err := other.appConfig.marshalTOML()
 			if err == nil {
 				warnings = append(warnings, warning("fly.toml", `Machine %s currently has a config that will change with the new fly.toml. This is what will change:
-%s`, other.machine.Machine().ID, prettyDiff(otherToml, report.mostCommon, colorize)))
+%s`, other.machine.Machine().ID, prettyDiff(string(otherToml), report.mostCommon, colorize)))
 			}
 		}
 	}

--- a/internal/appconfig/serde.go
+++ b/internal/appconfig/serde.go
@@ -91,7 +91,7 @@ func (c *Config) MarshalJSON() ([]byte, error) {
 // NOTES:
 //   * It can't be called `MarshalTOML` because toml libraries don't support marshaler interface on root values
 //   * Needs to reimplements most of MarshalJSON to enforce order of fields
-//   * Instead of this, you usually need one WriteTo(), WriteToFile() or WriteToDsik()
+//   * Instead of this, you usually need one WriteTo(), WriteToFile() or WriteToDisk()
 //
 func (c *Config) marshalTOML() ([]byte, error) {
 	var b bytes.Buffer

--- a/internal/appconfig/serde.go
+++ b/internal/appconfig/serde.go
@@ -31,6 +31,10 @@ func LoadConfig(path string) (cfg *Config, err error) {
 	return cfg, nil
 }
 
+func (c *Config) WriteTo(w io.Writer) error {
+	return c.marshalTOML(w)
+}
+
 func (c *Config) WriteToFile(filename string) (err error) {
 	if err = helpers.MkdirAll(filename); err != nil {
 		return

--- a/internal/command/config/show.go
+++ b/internal/command/config/show.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -49,5 +50,10 @@ func runShow(ctx context.Context) error {
 		return err
 	}
 
-	return cfg.WriteTo(io.Out)
+	b, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(io.Out, string(b))
+	return nil
 }


### PR DESCRIPTION
The initial intention of this PR was to fix `fly config show` for nomads that whose configuration couldn't be parsed as V2 compatible.  Notably old PG nomad clusters.

The win here is that appconfig.Config implements json.Marshaler interface now so can be serialized no matter what platform is used