### PR TITLE
Improvements to Machines + Volumes UX

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -154,6 +154,12 @@ func runMachineClone(ctx context.Context) (err error) {
 		fmt.Fprintf(io.Out, "Auto destroy enabled and will destroy machine on exit. Use --clear-auto-destroy to remove this setting.\n")
 	}
 
+	if volID := flag.GetString(ctx, "attach-volume"); volID != "" {
+		if len(source.Config.Mounts) != 1 {
+			return fmt.Errorf("Can't attach the volume as the source machine doesn't have any volumes configured")
+		}
+	}
+
 	for _, mnt := range source.Config.Mounts {
 		var vol *api.Volume
 		if volID := flag.GetString(ctx, "attach-volume"); volID != "" {

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -60,11 +60,6 @@ var sharedFlags = flag.Set{
 		Shorthand:   "e",
 		Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
 	},
-	flag.StringSlice{
-		Name:        "volume",
-		Shorthand:   "v",
-		Description: "Volumes to mount in the form of <volume_id_or_name>:/path/inside/machine[:<options>]",
-	},
 	flag.String{
 		Name:        "entrypoint",
 		Description: "ENTRYPOINT replacement",
@@ -175,6 +170,11 @@ func newRun() *cobra.Command {
 		flag.Bool{
 			Name:        "rm",
 			Description: "Automatically remove the machine when it exits",
+		},
+		flag.StringSlice{
+			Name:        "volume",
+			Shorthand:   "v",
+			Description: "Volumes to mount in the form of <volume_id_or_name>:/path/inside/machine[:<options>]",
 		},
 		sharedFlags,
 	)

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -45,6 +45,10 @@ func newUpdate() *cobra.Command {
 			Shorthand:   "C",
 			Description: "Command to run",
 		},
+		flag.String{
+			Name:        "mount-point",
+			Description: "New volume mount point",
+		},
 	)
 
 	cmd.Args = cobra.RangeArgs(0, 1)
@@ -96,6 +100,13 @@ func runUpdate(ctx context.Context) (err error) {
 	machineConf, err := determineMachineConfig(ctx, *machine.Config, appName, imageOrPath, machine.Region)
 	if err != nil {
 		return err
+	}
+
+	if mp := flag.GetString(ctx, "mount-point"); mp != "" {
+		if len(machineConf.Mounts) != 1 {
+			return fmt.Errorf("Machine doesn't have a volume attached")
+		}
+		machineConf.Mounts[0].Path = mp
 	}
 
 	// Prompt user to confirm changes


### PR DESCRIPTION
- Drop '--volume' flag from 'fly machine update' command
- Add '--mount-point' flag to 'fly machine update' command
- Make 'fly machine clone --attach-volume' error if source doesn't have volumes
