### PR TITLE
Don't replace empty restart policy of existing machines

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -737,8 +737,8 @@ func determineMachineConfig(ctx context.Context, input *determineMachineConfigIn
 	case "always":
 		machineConf.Restart.Policy = api.MachineRestartPolicyAlways
 	case "":
-		// Apply the default only if it's not already set.
-		if machineConf.Restart.Policy == "" {
+		// Apply the default only if this is a new machine.
+		if !input.updating {
 			machineConf.Restart.Policy = api.MachineRestartPolicyAlways
 		}
 	default:

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -737,8 +737,11 @@ func determineMachineConfig(ctx context.Context, input *determineMachineConfigIn
 	case "always":
 		machineConf.Restart.Policy = api.MachineRestartPolicyAlways
 	case "":
-		// Apply the default only if this is a new machine.
-		if !input.updating {
+		if flag.IsSpecified(ctx, "restart") {
+			// An empty policy was explicitly requested.
+			machineConf.Restart.Policy = ""
+		} else if !input.updating {
+			// This is a new machine; apply the default.
 			machineConf.Restart.Policy = api.MachineRestartPolicyAlways
 		}
 	default:

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -98,6 +98,7 @@ func runUpdate(ctx context.Context) (err error) {
 		appName:            appName,
 		imageOrPath:        imageOrPath,
 		region:             machine.Region,
+		updating:           true,
 	})
 	if err != nil {
 		return err

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -93,7 +93,12 @@ func runUpdate(ctx context.Context) (err error) {
 	}
 
 	// Identify configuration changes
-	machineConf, err := determineMachineConfig(ctx, *machine.Config, appName, imageOrPath, machine.Region)
+	machineConf, err := determineMachineConfig(ctx, &determineMachineConfigInput{
+		initialMachineConf: *machine.Config,
+		appName:            appName,
+		imageOrPath:        imageOrPath,
+		region:             machine.Region,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#1914 made it so that `m update` would change the restart policy to the machine default ("always") only if it were currently empty. However, Apps v2 deployments use the empty policy by default—IIRC @catflydotio's take on Discourse was that this is a fine choice—and now I see `fly m update` on Apps v2 machines wanting to change that to "always" unprompted.

So, to try to get it right the second time:

- Make it easy to distinguish between `m run` and `m update` in `determineMachineConfig`.
- Don't replace the empty restart policy of existing machines (by checking whether we're in `m run` or `m update`).
- Make `--restart ''` work in case people want to reset the restart policy to empty/unspecified.