### PR TITLE
`scale`: require --group if there are multiple process groups

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -3,11 +3,7 @@
 package appconfig
 
 import (
-	"strings"
-
-	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
-	"golang.org/x/exp/slices"
 )
 
 const (
@@ -171,22 +167,4 @@ func (c *Config) InternalPort() int {
 		return c.Services[0].InternalPort
 	}
 	return 0
-}
-
-// ProcessNames lists each key of c.Processes, sorted lexicographically
-// If c.Processes == nil, returns ["app"]
-func (c *Config) ProcessNames() []string {
-	if len(c.Processes) == 0 {
-		return []string{"app"}
-	}
-	keys := lo.Keys(c.Processes)
-	slices.Sort(keys)
-	return keys
-}
-
-// FormatProcessNames formats the process group list like `['foo', 'bar']`
-func (c *Config) FormatProcessNames() string {
-	return "[" + strings.Join(lo.Map(c.ProcessNames(), func(s string, _ int) string {
-		return "'" + s + "'"
-	}), ", ") + "]"
 }

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -2,7 +2,13 @@
 // configuration files.
 package appconfig
 
-import "github.com/superfly/flyctl/api"
+import (
+	"strings"
+
+	"github.com/samber/lo"
+	"github.com/superfly/flyctl/api"
+	"golang.org/x/exp/slices"
+)
 
 const (
 	// DefaultConfigFileName denotes the default application configuration file name.
@@ -156,7 +162,7 @@ func (c *Config) MountsDestination() string {
 	return c.Mounts.Destination
 }
 
-func (c Config) InternalPort() int {
+func (c *Config) InternalPort() int {
 	if c.HttpService != nil {
 		return c.HttpService.InternalPort
 	}
@@ -165,4 +171,22 @@ func (c Config) InternalPort() int {
 		return c.Services[0].InternalPort
 	}
 	return 0
+}
+
+// ProcessNames lists each key of c.Processes, sorted lexicographically
+// If c.Processes == nil, returns ["app"]
+func (c *Config) ProcessNames() []string {
+	if len(c.Processes) == 0 {
+		return []string{"app"}
+	}
+	keys := lo.Keys(c.Processes)
+	slices.Sort(keys)
+	return keys
+}
+
+// FormatProcessNames formats the process group list like `['foo', 'bar']`
+func (c *Config) FormatProcessNames() string {
+	return "[" + strings.Join(lo.Map(c.ProcessNames(), func(s string, _ int) string {
+		return "'" + s + "'"
+	}), ", ") + "]"
 }

--- a/internal/command/scale/machines.go
+++ b/internal/command/scale/machines.go
@@ -28,6 +28,9 @@ func v2ScaleVM(ctx context.Context, appName, group, sizeName string, memoryMB in
 		if err != nil {
 			return nil, err
 		}
+		if len(appConfig.Processes) > 1 {
+			return nil, fmt.Errorf("scaling an app with multiple process groups requires specifying a group with '--group <name>'\n * this app has the following process groups: %v", appConfig.FormatProcessNames())
+		}
 		group = appConfig.DefaultProcessName()
 	}
 


### PR DESCRIPTION
Would fix #1991

If there is one process group, like "app" or even "foo", it will just apply on that group automatically. If there are multiple, it says this:
```
Work/repro/process-groups
❯ ~/Work/flyctl/bin/flyctl scale memory 1024
Error scaling an app with multiple process groups requires specifying a group with '--group <name>'
 * this app has the following process groups: 'bar_web', 'web'
```

also, as a treat, this adds `Config.ProcessNames() []string` and `Config.FormatProcessNames() string` to keep process group references consistent (like how we've passing through various bits and adding key sorting lately). 