### PR TITLE
Remove `fly apps releases` columns not used for v2 apps

### DIFF
--- a/internal/command/apps/releases.go
+++ b/internal/command/apps/releases.go
@@ -3,6 +3,7 @@ package apps
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -67,6 +68,10 @@ func runReleases(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed retrieving app releases %s: %w", appName, err)
 	}
+
+	sort.Slice(releases, func(i, j int) bool {
+		return releases[i].Version > releases[j].Version
+	})
 
 	out := iostreams.FromContext(ctx).Out
 	if config.FromContext(ctx).JSONOutput {


### PR DESCRIPTION
The easy part of #1980. "Stable" is derived from Nomad and isn't relevant for Apps v2. "Type" (which is "reason" in the backend) is from the Nomad job model and isn't being set for v2 apps either.

I'm keeping "status" and "description" in for now because I'm experimenting with having `fly deploy` update these itself (and because "description" currently defaults to "Release", so at least it's not a blank column).