### PR TITLE
`helpers.Clone`: fix not actually cloning pointed-to values, just copying pointers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/heroku/heroku-go/v5 v5.4.0
 	github.com/inancgumus/screen v0.0.0-20190314163918-06e984b86ed3
-	github.com/jinzhu/copier v0.3.5
 	github.com/jpillora/backoff v1.0.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/mattn/go-colorable v0.1.13

--- a/go.sum
+++ b/go.sum
@@ -848,8 +848,6 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=
-github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
-github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
 github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/helpers/clone_test.go
+++ b/helpers/clone_test.go
@@ -7,23 +7,23 @@ import (
 )
 
 type child struct {
-	name string
+	Name string
 }
 
 type cloneable struct {
-	a string
-	b int
-	c float32
-	d child
+	A string
+	B int
+	C float32
+	D child
 }
 
 func TestClone(t *testing.T) {
 	cloneMe := cloneable{
-		a: "abcd",
-		b: 123,
-		c: 1.5,
-		d: child{
-			name: "aname",
+		A: "abcd",
+		B: 123,
+		C: 1.5,
+		D: child{
+			Name: "aname",
 		},
 	}
 
@@ -43,4 +43,26 @@ func TestClone(t *testing.T) {
 	clonedNil := Clone(clonedPtr)
 
 	assert.Empty(t, clonedNil)
+}
+
+func TestClonePointer(t *testing.T) {
+
+	type child struct {
+		S string
+	}
+	type cloned struct {
+		Ch *child
+	}
+
+	c := cloned{
+		Ch: &child{
+			S: "hello",
+		},
+	}
+
+	clonedObj := Clone(c)
+
+	c.Ch.S = "modified"
+
+	assert.NotEqualValues(t, c.Ch.S, clonedObj.Ch.S)
 }


### PR DESCRIPTION
Unfortunately, `copier.CopyWithOption(... {DeepCopy: true})` did not copy pointed-to valued, it just reused the pointer.

The solution to this, as much as I hate it, is probably just going round-trip through the json encoder.

Also, there's a regression test so this doesn't happen again. this could lead to nasty issues down the line if it's not checked.