### PR TITLE
`version update`: execute the new binary to get its version

### DIFF
--- a/internal/command/version/update.go
+++ b/internal/command/version/update.go
@@ -2,8 +2,12 @@ package version
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/blang/semver"
 	"github.com/spf13/cobra"
@@ -50,6 +54,57 @@ func runUpdate(ctx context.Context) error {
 	if err = update.UpgradeInPlace(ctx, io, release.Prerelease); err != nil {
 		return err
 	}
-	fmt.Fprintf(io.Out, "Updated flyctl v%s -> v%s\n", buildinfo.Version(), latest)
+
+	return printVersionUpdate(ctx, buildinfo.Version())
+}
+
+// printVersionUpdate prints "Updated flyctl [oldVersion] -> [newVersion]"
+func printVersionUpdate(ctx context.Context, oldVersion semver.Version) error {
+	io := iostreams.FromContext(ctx)
+
+	currentVer, err := getNewVersion(ctx)
+	if err != nil {
+		if strings.Contains(err.Error(), "failed to parse version") {
+			// This is probably fine, likely a change between the two versions makes
+			// flyctl <-> flyctl communication incompatible
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	if currentVer.EQ(oldVersion) {
+		fmt.Fprintf(io.ErrOut, "Flyctl was updated, but the flyctl pointed to by '%s' is still version %s.\n", os.Args[0], currentVer.String())
+		fmt.Fprintf(io.ErrOut, "Please ensure that your PATH is set correctly!")
+		return nil
+	}
+
+	fmt.Fprintf(io.Out, "Updated flyctl v%s -> v%s\n", oldVersion.String(), currentVer.String())
 	return nil
+}
+
+// getNewVersion executes [os.Args[0], "version", "--json"] and parses the output into a semver.Version
+func getNewVersion(ctx context.Context) (semver.Version, error) {
+
+	var ver semver.Version
+
+	newVersionJson, err := exec.CommandContext(ctx, os.Args[0], "version", "--json").CombinedOutput()
+	if err != nil {
+		return ver, fmt.Errorf("failed to execute new flyctl binary: %w", err)
+	}
+	// Parsing into a map instead of the struct directly so that
+	// small changes in the version struct don't break this.
+	parsed := map[string]string{}
+	if err = json.Unmarshal(newVersionJson, &parsed); err != nil {
+		return ver, fmt.Errorf("failed to parse version of new flyctl binary: %w", err)
+	}
+	semverStr, ok := parsed["Version"]
+	if !ok {
+		return ver, errors.New("failed to parse version of new flyctl binary: field 'Version' not in output of 'fly version --json'")
+	}
+	ver, err = semver.ParseTolerant(semverStr)
+	if err != nil {
+		return ver, fmt.Errorf("failed to parse version of new flyctl binary: %w", err)
+	}
+	return ver, nil
 }


### PR DESCRIPTION
The version API can lag behind a bit, so if we just print the version it _says_ is current, we could be lying to users about what version they updated to on accident. Oops!

Fixes https://github.com/superfly/flyctl/pull/2032#discussion_r1161024911

Before this gets merged, I'd like to have this tested on Windows. I don't have a windows box handy, though. Any takers?