### PR TITLE
use empty struct since we don't care about the signal value

### DIFF
--- a/internal/command/machine/stop.go
+++ b/internal/command/machine/stop.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -101,17 +100,17 @@ func Stop(ctx context.Context, machineID string, signal string, timeout int) (er
 	return
 }
 
-var signalSyscallMap = map[string]syscall.Signal{
-	"SIGABRT": syscall.SIGABRT,
-	"SIGALRM": syscall.SIGALRM,
-	"SIGFPE":  syscall.SIGFPE,
-	"SIGILL":  syscall.SIGILL,
-	"SIGINT":  syscall.SIGINT,
-	"SIGKILL": syscall.SIGKILL,
-	"SIGPIPE": syscall.SIGPIPE,
-	"SIGQUIT": syscall.SIGQUIT,
-	"SIGSEGV": syscall.SIGSEGV,
-	"SIGTERM": syscall.SIGTERM,
-	"SIGTRAP": syscall.SIGTRAP,
-	"SIGUSR1": syscall.SIGUSR1,
+var signalSyscallMap = map[string]struct{}{
+	"SIGABRT": {},
+	"SIGALRM": {},
+	"SIGFPE":  {},
+	"SIGILL":  {},
+	"SIGINT":  {},
+	"SIGKILL": {},
+	"SIGPIPE": {},
+	"SIGQUIT": {},
+	"SIGSEGV": {},
+	"SIGTERM": {},
+	"SIGTRAP": {},
+	"SIGUSR1": {},
 }


### PR DESCRIPTION
Follow-up to https://github.com/superfly/flyctl/pull/2039 which resulted in a build failure once merged due to the `syscall` package and architecture support. Since we're not using the value in the map, it can be an empty struct for now.