### PR TITLE
Update homebrew release once per day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,18 +74,6 @@ jobs:
       - name: Run tests
         run: make test
 
-  release_homebrew:
-    needs: test
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev-') && !contains(github.ref, 'pre')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Bump homebrew formula
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: Homebrew Bump Formula
-          token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
-          inputs: '{ "version": "${{ github.ref_name }}", "sha": "${{ github.sha }}" }'
-
   release:
     needs: test
     if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev-')

--- a/.github/workflows/homebrew_bump.yml
+++ b/.github/workflows/homebrew_bump.yml
@@ -14,35 +14,34 @@ jobs:
     name: Bump Homebrew formula
     runs-on: macos-latest
     steps:
-      - run: 'echo "ERROR: temporarily disabled see: https://github.com/superfly/flyctl/issues/2044" ; false'
-      # - uses: dawidd6/action-homebrew-bump-formula@v3
-      #   with:
-      #     token: ${{ secrets.FLYIO_FLYCTL_BOT_GITHUB_TOKEN }}
-      #     formula: flyctl
-      #     tag: ${{ github.event.inputs.version }}
-      #     revision: ${{ github.event.inputs.sha }}
-      #     force: true
-      # - name: Check for slack secret
-      #   if: ${{ failure() }}
-      #   env:
-      #     SLACK_WEBHOOK_EXISTS: ${{ secrets.HOMEBREW_SLACK_WEBHOOK_URL != '' }}
-      #   run: if [ ${{ env.SLACK_WEBHOOK_EXISTS }} != "true" ] ; then echo "No webhook url :-(" ; fi
-      # - name: Post failure to slack
-      #   if: ${{ failure() }}
-      #   uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.HOMEBREW_SLACK_WEBHOOK_URL }}
-      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-      #   with:
-      #     payload: |
-      #       {
-      #         "blocks": [
-      #           {
-      #             "type": "section",
-      #             "text": {
-      #               "type": "mrkdwn",
-      #               "text": ":fire: flyctl bump homebrew formula failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-      #             }
-      #           }
-      #         ]
-      #       }
+      - uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{ secrets.FLYIO_FLYCTL_BOT_GITHUB_TOKEN }}
+          formula: flyctl
+          tag: ${{ github.event.inputs.version }}
+          revision: ${{ github.event.inputs.sha }}
+          force: true
+      - name: Check for slack secret
+        if: ${{ failure() }}
+        env:
+          SLACK_WEBHOOK_EXISTS: ${{ secrets.HOMEBREW_SLACK_WEBHOOK_URL != '' }}
+        run: if [ ${{ env.SLACK_WEBHOOK_EXISTS }} != "true" ] ; then echo "No webhook url :-(" ; fi
+      - name: Post failure to slack
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.HOMEBREW_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":fire: flyctl bump homebrew formula failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/homebrew_bump.yml
+++ b/.github/workflows/homebrew_bump.yml
@@ -1,26 +1,25 @@
 name: Homebrew Bump Formula
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        required: true
-        description: "flyctl release version"
-      sha:
-        required: true
-        description: "flyctl release git SHA"
+  schedule:
+    - cron: '23 17 * * *'
 
 jobs:
   homebrew:
     name: Bump Homebrew formula
     runs-on: macos-latest
     steps:
+      - id: latest_release
+        uses: pozetroninc/github-action-get-latest-release@v0.7.0
+        with:
+          repository: ${{ github.repository }}
+          excludes: prerelease, draft
       - uses: dawidd6/action-homebrew-bump-formula@v3
         with:
           token: ${{ secrets.FLYIO_FLYCTL_BOT_GITHUB_TOKEN }}
           formula: flyctl
-          tag: ${{ github.event.inputs.version }}
-          revision: ${{ github.event.inputs.sha }}
-          force: true
+          tag: ${{ steps.latest_release.outputs.version }}
+          revision: ${{ steps.latest_release.outputs.sha }}
+          force: false
       - name: Check for slack secret
         if: ${{ failure() }}
         env:


### PR DESCRIPTION
Previously we updated the homebrew release every time a new release was created. This overwhelmed the Homebrew maintainers. https://github.com/superfly/flyctl/issues/2044

With this change, we run a github action once per day at 17:23 UTC and update homebrew with the latest release. This will fail if the previous homebrew release has not yet been merged.
