### PR TITLE
Make machine exec more like docker/ssh exec

### DIFF
--- a/internal/command/machine/exec.go
+++ b/internal/command/machine/exec.go
@@ -84,12 +84,15 @@ func runMachineExec(ctx context.Context) (err error) {
 		return render.JSON(io.Out, out)
 	}
 
-	fmt.Fprintf(io.Out, "Exit code: %d\n", out.ExitCode)
+	if out.ExitCode != 0 {
+		fmt.Fprintf(io.Out, "Exit code: %d\n", out.ExitCode)
+	}
+
 	switch {
 	case out.StdOut != nil:
-		fmt.Fprintf(io.Out, "Stdout: %s\n", *out.StdOut)
+		fmt.Fprint(io.Out, *out.StdOut)
 	case out.StdErr != nil:
-		fmt.Fprintf(io.Out, "Stderr: %s\n", *out.StdErr)
+		fmt.Fprint(io.ErrOut, *out.StdErr)
 	}
 
 	return


### PR DESCRIPTION
This PR pipes machine exec stdout/err to client stdout/err, and only prints non-zero exit codes. This makes output easier to understand and filter using standard approaches like `fly m exec cmd 2>/dev/null`.