### PR TITLE
machine/exec: make sure stderr is printed in case of error

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -540,7 +540,7 @@ type MachineExecRequest struct {
 }
 
 type MachineExecResponse struct {
-	ExitCode int32   `json:"exit_code,omitempty"`
-	StdOut   *string `json:"stdout,omitempty"`
-	StdErr   *string `json:"stderr,omitempty"`
+	ExitCode int32  `json:"exit_code,omitempty"`
+	StdOut   string `json:"stdout,omitempty"`
+	StdErr   string `json:"stderr,omitempty"`
 }

--- a/internal/command/machine/exec.go
+++ b/internal/command/machine/exec.go
@@ -89,10 +89,10 @@ func runMachineExec(ctx context.Context) (err error) {
 	}
 
 	switch {
-	case out.StdOut != nil:
-		fmt.Fprint(io.Out, *out.StdOut)
-	case out.StdErr != nil:
-		fmt.Fprint(io.ErrOut, *out.StdErr)
+	case out.StdOut != "":
+		fmt.Fprint(io.Out, out.StdOut)
+	case out.StdErr != "":
+		fmt.Fprint(io.ErrOut, out.StdErr)
 	}
 
 	return

--- a/internal/command/machine/exec.go
+++ b/internal/command/machine/exec.go
@@ -88,10 +88,10 @@ func runMachineExec(ctx context.Context) (err error) {
 		fmt.Fprintf(io.Out, "Exit code: %d\n", out.ExitCode)
 	}
 
-	switch {
-	case out.StdOut != "":
+	if out.StdOut != "" {
 		fmt.Fprint(io.Out, out.StdOut)
-	case out.StdErr != "":
+	}
+	if out.StdErr != "" {
 		fmt.Fprint(io.ErrOut, out.StdErr)
 	}
 


### PR DESCRIPTION
flaps never omits empty fields due to custom JSON marshaler. So an
empty string will have non-nil pointer in MachineExecResponse on
flyctl side. Thus, even if stdout is empty, we never print stderr
as the pointer is never nil.

So, since flaps never omits strings, we don't really need pointers
to strings and can simply check for empty strings.
