### PR TITLE
Prompt app create on deploy if none is found

### DIFF
--- a/internal/command/apps/create.go
+++ b/internal/command/apps/create.go
@@ -78,7 +78,7 @@ func RunCreate(ctx context.Context) (err error) {
 	var name string
 	switch {
 	case aName != "" && fName != "" && areNamesClashing([]string{aName, fName, ctxName}):
-		err = fmt.Errorf("app names specified %s, %s %s, only one may be specified",
+		err = fmt.Errorf("app names specified via command argument %s, via flag %s and via fly.toml %s. Only one may be specified",
 			aName, fName, ctxName)
 
 		return

--- a/internal/command/apps/create.go
+++ b/internal/command/apps/create.go
@@ -77,9 +77,9 @@ func RunCreate(ctx context.Context) (err error) {
 
 	var name string
 	switch {
-	case aName != "" && fName != "" && aName != fName:
-		err = fmt.Errorf("two app names specified %s and %s, only one may be specified",
-			aName, fName)
+	case aName != "" && fName != "" && areNamesClashing([]string{aName, fName, ctxName}):
+		err = fmt.Errorf("app names specified %s, %s %s, only one may be specified",
+			aName, fName, ctxName)
 
 		return
 	case ctxName != "":
@@ -126,6 +126,16 @@ func RunCreate(ctx context.Context) (err error) {
 	}
 
 	return err
+}
+
+func areNamesClashing(a []string) bool {
+	keys := make(map[string]bool)
+	for _, name := range a {
+		if _, ok := keys[name]; !ok {
+			keys[name] = true
+		}
+	}
+	return len(keys) != len(a)
 }
 
 func shouldAppUseMachinesPlatform(ctx context.Context, apiClient *api.Client, orgSlug string) (bool, error) {

--- a/internal/command/apps/create.go
+++ b/internal/command/apps/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/iostreams"
 
+	"github.com/samber/lo"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -77,7 +78,7 @@ func RunCreate(ctx context.Context) (err error) {
 
 	var name string
 	switch {
-	case aName != "" && fName != "" && areNamesClashing([]string{aName, fName, ctxName}):
+	case len(lo.Compact([]string{aName, fName, ctxName})) != 1 && areNamesClashing([]string{aName, fName, ctxName}):
 		err = fmt.Errorf("app names specified via command argument %s, via flag %s and via fly.toml %s. Only one may be specified",
 			aName, fName, ctxName)
 

--- a/internal/command/apps/create.go
+++ b/internal/command/apps/create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -71,6 +72,7 @@ func RunCreate(ctx context.Context) (err error) {
 		fName         = flag.GetString(ctx, "name")
 		fGenerateName = flag.GetBool(ctx, "generate-name")
 		apiClient     = client.FromContext(ctx).API()
+		ctxName       = appconfig.NameFromContext(ctx)
 	)
 
 	var name string
@@ -80,6 +82,8 @@ func RunCreate(ctx context.Context) (err error) {
 			aName, fName)
 
 		return
+	case ctxName != "":
+		name = ctxName
 	case aName != "":
 		name = aName
 	case fName != "":

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -127,7 +127,7 @@ func run(ctx context.Context) error {
 	}
 	if strings.Contains(extra_info, "Could not find App") {
 		confirmation, err := prompt.Confirm(ctx,
-			fmt.Sprintf("the app name %s could not be found, do you want to create an app with that name?", appName))
+			fmt.Sprintf("the app name %s could not be found, do you want to create a new app with that name?", appName))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
There's some friction on app deploy if a user runs deploy without first creating an app. This reduces a step towards deploying an app, by removing the need to run a separate app creation command. 

![appcreateondeploy](https://user-images.githubusercontent.com/3229484/231269907-6d5cc3b0-6f5f-4df2-949c-b2efd5518f24.png)
