### PR TITLE
Don't output notifications of new versions if `--json` flag is used.

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -378,7 +378,8 @@ func shouldIgnore(ctx context.Context, cmds [][]string) bool {
 
 func promptToUpdate(ctx context.Context) (context.Context, error) {
 
-	if shouldIgnore(ctx, [][]string{
+	cfg := config.FromContext(ctx)
+	if cfg.JSONOutput || shouldIgnore(ctx, [][]string{
 		{"version", "update"},
 	}) {
 		return ctx, nil


### PR DESCRIPTION
Perhaps the existing notifications are fine since they output to stderr, and maybe this isn't the solution, but I do think there should be more explicit clarity about what `--json` does either in its help text or where it's accepted. This at least opts out of new version notifications if someone uses `--json`, which addresses one footgun.

Fixes #974 