### PR TITLE
feat(scanner/remix): skip database questions on Prisma detection

### DIFF
--- a/scanner/remix.go
+++ b/scanner/remix.go
@@ -19,6 +19,7 @@ func configureRemix(sourceDir string, config *ScannerConfig) (*SourceInfo, error
 		s.Files = templates("templates/remix_prisma")
 		s.DockerCommand = "start_with_migrations.sh"
 		s.DockerEntrypoint = "sh"
+		s.SkipDatabase = true
 		s.Volumes = []Volume{
 			{
 				Source:      "data",


### PR DESCRIPTION
You currently get the questions to set up Postgresql/Upstash Redis database, but Prisma/SQLite is already detected

```sh
? Would you like to set up a Postgresql database now? No
? Would you like to set up an Upstash Redis database now? No
Wrote config file fly.toml

This launch configuration uses SQLite on a single, dedicated volume. It will not scale beyond a single VM. Look into 'fly postgres' for a more robust production database.
```