### PR TITLE
Fix preflight socket path length limit

### DIFF
--- a/test/preflight/testlib/helpers.go
+++ b/test/preflight/testlib/helpers.go
@@ -71,7 +71,7 @@ func randomName(t testingTWrapper, prefix string) string {
 // https://github.com/golang/go/issues/6895#issuecomment-66088946
 func socketSafeTempDir(t testing.TB) string {
 	tempDir := t.TempDir()
-	maxLen := 104 - len(filepath.Join(".fly", "fly-agent.sock"))
+	maxLen := 103 - len(filepath.Join(".fly", "fly-agent.sock"))
 	if len(tempDir) < maxLen {
 		return tempDir
 	}


### PR DESCRIPTION
On macOS the socket path field is 104 bytes in size. Since it's null-terminated, I believe that actually means we have 103 usable characters. And as luck would have it, for the `TestAppsV2MigrateToV2` test on my machine the agent kept trying to bind a path of 104 characters! 😆 