### PR TITLE
Remove global flag for JSON output and move it to each supporting command.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,10 +40,6 @@ func NewRootCmd(client *client.Client) *cobra.Command {
 	err = viper.BindPFlag(flyctl.ConfigVerboseOutput, rootCmd.PersistentFlags().Lookup("verbose"))
 	checkErr(err)
 
-	rootCmd.PersistentFlags().BoolP("json", "j", false, "json output")
-	err = viper.BindPFlag(flyctl.ConfigJSONOutput, rootCmd.PersistentFlags().Lookup("json"))
-	checkErr(err)
-
 	rootCmd.PersistentFlags().String("builtinsfile", "", "Load builtins from named file")
 	err = viper.BindPFlag(flyctl.ConfigBuiltinsfile, rootCmd.PersistentFlags().Lookup("builtinsfile"))
 	checkErr(err)

--- a/internal/command/agent/ping.go
+++ b/internal/command/agent/ping.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -25,6 +26,7 @@ func newPing() (cmd *cobra.Command) {
 
 	cmd.Args = cobra.NoArgs
 
+	flag.Add(cmd, flag.JSONOutput())
 	return
 }
 

--- a/internal/command/agent/resolve.go
+++ b/internal/command/agent/resolve.go
@@ -28,6 +28,7 @@ func newResolve() (cmd *cobra.Command) {
 
 	cmd.Args = cobra.ExactArgs(2)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return
 }
 

--- a/internal/command/apps/create.go
+++ b/internal/command/apps/create.go
@@ -59,6 +59,7 @@ may be fetched with 'fly config save -a <app_name>'`
 		flag.Org(),
 	)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }
 

--- a/internal/command/apps/list.go
+++ b/internal/command/apps/list.go
@@ -31,6 +31,7 @@ be shown with its name, owner and when it was last deployed.
 		command.RequireSession,
 	)
 
+	flag.Add(cmd, flag.JSONOutput())
 	flag.Add(cmd, flag.Org())
 
 	return cmd

--- a/internal/command/apps/releases.go
+++ b/internal/command/apps/releases.go
@@ -38,6 +38,7 @@ including type, when, success/fail and which user triggered the release.
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 		flag.Bool{
 			Name:        "image",
 			Description: "Display the Docker image reference of the release",

--- a/internal/command/auth/token.go
+++ b/internal/command/auth/token.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -22,8 +23,11 @@ independent of flyctl.
 		short = "Show the current auth token"
 	)
 
-	return command.New("token", short, long, runAuthToken,
+	cmd := command.New("token", short, long, runAuthToken,
 		command.RequireSession)
+
+	flag.Add(cmd, flag.JSONOutput())
+	return cmd
 }
 
 func runAuthToken(ctx context.Context) error {

--- a/internal/command/auth/whoami.go
+++ b/internal/command/auth/whoami.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -22,8 +23,10 @@ authenticated and in use.
 		short = "Show the currently authenticated user"
 	)
 
-	return command.New("whoami", long, short, runWhoAmI,
+	cmd := command.New("whoami", long, short, runWhoAmI,
 		command.RequireSession)
+	flag.Add(cmd, flag.JSONOutput())
+	return cmd
 }
 
 func runWhoAmI(ctx context.Context) error {

--- a/internal/command/curl/curl.go
+++ b/internal/command/curl/curl.go
@@ -41,6 +41,7 @@ func New() (cmd *cobra.Command) {
 
 	cmd.Args = cobra.ExactArgs(1)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return
 }
 

--- a/internal/command/doctor/doctor.go
+++ b/internal/command/doctor/doctor.go
@@ -41,6 +41,7 @@ func New() (cmd *cobra.Command) {
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 		flag.Bool{
 			Name:        "verbose",
 			Shorthand:   "v",

--- a/internal/command/history/history.go
+++ b/internal/command/history/history.go
@@ -36,6 +36,7 @@ events and their results.
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 	)
 
 	return

--- a/internal/command/image/show.go
+++ b/internal/command/image/show.go
@@ -37,6 +37,7 @@ func newShow() *cobra.Command {
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 	)
 
 	return cmd

--- a/internal/command/ips/list.go
+++ b/internal/command/ips/list.go
@@ -27,6 +27,7 @@ func newList() *cobra.Command {
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 	)
 	return cmd
 }

--- a/internal/command/ips/private.go
+++ b/internal/command/ips/private.go
@@ -27,6 +27,7 @@ func newPrivate() *cobra.Command {
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 	)
 	return cmd
 }

--- a/internal/command/logs/logs.go
+++ b/internal/command/logs/logs.go
@@ -46,6 +46,7 @@ to all instances running in a specific region using the --region/-r flag.
 		flag.App(),
 		flag.AppConfig(),
 		flag.Region(),
+		flag.JSONOutput(),
 		flag.String{
 			Name:        "instance",
 			Shorthand:   "i",

--- a/internal/command/machine/exec.go
+++ b/internal/command/machine/exec.go
@@ -31,6 +31,7 @@ func newMachineExec() *cobra.Command {
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 		selectFlag,
 		flag.Int{
 			Name:        "timeout",

--- a/internal/command/machine/leases.go
+++ b/internal/command/machine/leases.go
@@ -55,6 +55,7 @@ func newLeaseView() *cobra.Command {
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 		selectFlag,
 	)
 

--- a/internal/command/machine/list.go
+++ b/internal/command/machine/list.go
@@ -36,6 +36,7 @@ func newList() *cobra.Command {
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 		flag.Bool{
 			Name:        "quiet",
 			Shorthand:   "q",

--- a/internal/command/orgs/appsv2/show.go
+++ b/internal/command/orgs/appsv2/show.go
@@ -21,6 +21,7 @@ func newShow() *cobra.Command {
 		command.RequireSession,
 	)
 	cmd.Args = cobra.ExactArgs(1)
+	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }
 

--- a/internal/command/orgs/create.go
+++ b/internal/command/orgs/create.go
@@ -38,6 +38,7 @@ organization later.
 	)
 	cmd.Args = cobra.MaximumNArgs(1)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }
 

--- a/internal/command/orgs/invite.go
+++ b/internal/command/orgs/invite.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -30,6 +31,7 @@ sent, and the user will be pending until they respond.
 
 	cmd.Args = cobra.MaximumNArgs(2)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }
 

--- a/internal/command/orgs/list.go
+++ b/internal/command/orgs/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -21,9 +22,12 @@ func newList() *cobra.Command {
 		short = "Lists organizations for current user"
 	)
 
-	return command.New("list", short, long, runList,
+	cmd := command.New("list", short, long, runList,
 		command.RequireSession,
 	)
+
+	flag.Add(cmd, flag.JSONOutput())
+	return cmd
 }
 
 func runList(ctx context.Context) error {

--- a/internal/command/orgs/show.go
+++ b/internal/command/orgs/show.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -31,6 +32,7 @@ associated member. Details full list of members and roles.
 
 	cmd.Args = cobra.MaximumNArgs(1)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }
 

--- a/internal/command/platform/regions.go
+++ b/internal/command/platform/regions.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -27,7 +28,7 @@ func newRegions() (cmd *cobra.Command) {
 	)
 
 	cmd.Args = cobra.NoArgs
-
+	flag.Add(cmd, flag.JSONOutput())
 	return
 }
 

--- a/internal/command/platform/status.go
+++ b/internal/command/platform/status.go
@@ -29,6 +29,7 @@ func newStatus() (cmd *cobra.Command) {
 
 	cmd = command.New("status [kind]", short, long, runStatus)
 	cmd.Args = cobra.MaximumNArgs(1)
+	flag.Add(cmd, flag.JSONOutput())
 	return
 }
 

--- a/internal/command/platform/vmsizes.go
+++ b/internal/command/platform/vmsizes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -28,6 +29,7 @@ func newVMSizes() (cmd *cobra.Command) {
 
 	cmd.Args = cobra.NoArgs
 
+	flag.Add(cmd, flag.JSONOutput())
 	return
 }
 

--- a/internal/command/postgres/db.go
+++ b/internal/command/postgres/db.go
@@ -31,6 +31,7 @@ func newDb() *cobra.Command {
 		newListDbs(),
 	)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }
 

--- a/internal/command/postgres/list.go
+++ b/internal/command/postgres/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/format"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -24,6 +25,7 @@ func newList() *cobra.Command {
 
 	cmd := command.New(usage, short, long, runList)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }
 

--- a/internal/command/postgres/users.go
+++ b/internal/command/postgres/users.go
@@ -33,6 +33,7 @@ func newUsers() *cobra.Command {
 		newListUsers(),
 	)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }
 

--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -83,7 +83,6 @@ func New() *cobra.Command {
 			fs := root.PersistentFlags()
 
 			_ = fs.StringP(flag.AccessTokenName, "t", "", "Fly API Access Token")
-			_ = fs.BoolP(flag.JSONOutputName, "j", false, "JSON output")
 			_ = fs.BoolP(flag.VerboseName, "v", false, "Verbose output")
 
 			root.AddCommand(

--- a/internal/command/secrets/list.go
+++ b/internal/command/secrets/list.go
@@ -28,6 +28,7 @@ actual value of the secret is only available to the application.`
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 	)
 
 	return cmd

--- a/internal/command/ssh/log.go
+++ b/internal/command/ssh/log.go
@@ -26,6 +26,7 @@ func newLog() *cobra.Command {
 	cmd := command.New(usage, short, long, runLog, command.RequireSession)
 
 	flag.Add(cmd,
+		flag.JSONOutput(),
 		flag.Org(),
 	)
 

--- a/internal/command/status/instance.go
+++ b/internal/command/status/instance.go
@@ -39,6 +39,7 @@ func newInstance() (cmd *cobra.Command) {
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 	)
 
 	return

--- a/internal/command/status/status.go
+++ b/internal/command/status/status.go
@@ -46,6 +46,7 @@ currently allocated.
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 		flag.Bool{
 			Name:        "all",
 			Description: "Show completed instances",

--- a/internal/command/tokens/create.go
+++ b/internal/command/tokens/create.go
@@ -46,6 +46,7 @@ func newDeploy() *cobra.Command {
 
 	flag.Add(cmd,
 		flag.App(),
+		flag.JSONOutput(),
 		flag.String{
 			Name:        "name",
 			Shorthand:   "n",

--- a/internal/command/version/version.go
+++ b/internal/command/version/version.go
@@ -44,6 +44,7 @@ number and build date.`
 		newUpdate(),
 	)
 
+	flag.Add(version, flag.JSONOutput())
 	return version
 }
 

--- a/internal/command/volumes/create.go
+++ b/internal/command/volumes/create.go
@@ -63,6 +63,7 @@ sets the size as the number of gigabytes the volume will consume.`
 		flag.Yes(),
 	)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }
 

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -50,6 +50,7 @@ func newExtend() *cobra.Command {
 		},
 	)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }
 

--- a/internal/command/volumes/list.go
+++ b/internal/command/volumes/list.go
@@ -35,6 +35,7 @@ func newList() *cobra.Command {
 		flag.AppConfig(),
 	)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }
 

--- a/internal/command/volumes/show.go
+++ b/internal/command/volumes/show.go
@@ -28,6 +28,7 @@ number to operate. This can be found through the volumes list command`
 	)
 	cmd.Args = cobra.ExactArgs(1)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return
 }
 

--- a/internal/command/volumes/snapshots/list.go
+++ b/internal/command/volumes/snapshots/list.go
@@ -31,6 +31,7 @@ func newList() *cobra.Command {
 
 	cmd.Args = cobra.ExactArgs(1)
 
+	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }
 

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -402,3 +402,12 @@ func Strategy() String {
 		Description: "The strategy for replacing running instances. Options are canary, rolling, bluegreen, or immediate. Default is canary, or rolling when max-per-region is set.",
 	}
 }
+
+func JSONOutput() Bool {
+	return Bool{
+		Name:        JSONOutputName,
+		Shorthand:   "j",
+		Description: "JSON output",
+		Default:     false,
+	}
+}


### PR DESCRIPTION
It's possible that I either missed commands or missed places where this change needs to happen. Please let me know if that's the case.

Fixes #1966, fixes #1359