### PR TITLE
Propagate machine fields not managed by fly.toml

### DIFF
--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -47,7 +47,7 @@ func (c *Config) ToReleaseMachineConfig() (*api.MachineConfig, error) {
 	return mConfig, nil
 }
 
-//
+// updateMachineConfig applies configuration options from the optional MachineConfig passed in, then the base config, into a new MachineConfig
 func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig, error) {
 	processGroup := c.DefaultProcessName()
 

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -4,14 +4,15 @@ import (
 	"github.com/google/shlex"
 	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/helpers"
 )
 
-func (c *Config) ToMachineConfig(processGroup string) (*api.MachineConfig, error) {
+func (c *Config) ToMachineConfig(processGroup string, src *api.MachineConfig) (*api.MachineConfig, error) {
 	fc, err := c.Flatten(processGroup)
 	if err != nil {
 		return nil, err
 	}
-	return fc.defaultMachineConfig()
+	return fc.updateMachineConfig(src)
 }
 
 func (c *Config) ToReleaseMachineConfig() (*api.MachineConfig, error) {
@@ -46,58 +47,75 @@ func (c *Config) ToReleaseMachineConfig() (*api.MachineConfig, error) {
 	return machineConfig, nil
 }
 
-func (c *Config) defaultMachineConfig() (*api.MachineConfig, error) {
+//
+func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig, error) {
 	processGroup := c.DefaultProcessName()
 
+	mConfig := &api.MachineConfig{}
+	if src != nil {
+		mConfig = helpers.Clone(src)
+	}
+
+	mConfig.Metrics = c.Metrics
+
+	// Init
 	cmd, err := c.InitCmd(processGroup)
 	if err != nil {
 		return nil, err
 	}
+	mConfig.Init.Cmd = cmd
 
-	machineConfig := &api.MachineConfig{
-		Metrics: c.Metrics,
-		Init:    api.MachineInit{Cmd: cmd},
-		Metadata: map[string]string{
-			api.MachineConfigMetadataKeyFlyPlatformVersion: api.MachineFlyPlatformVersion2,
-			api.MachineConfigMetadataKeyFlyProcessGroup:    processGroup,
-		},
-		Env: lo.Assign(c.Env),
+	// Metadata
+	if mConfig.Metadata == nil {
+		mConfig.Metadata = map[string]string{}
 	}
+	mConfig.Metadata[api.MachineConfigMetadataKeyFlyPlatformVersion] = api.MachineFlyPlatformVersion2
+	mConfig.Metadata[api.MachineConfigMetadataKeyFlyProcessGroup] = processGroup
 
+	// Services
+	mConfig.Services = nil
 	if services := c.AllServices(); len(services) > 0 {
-		machineConfig.Services = lo.Map(services, func(s Service, _ int) api.MachineService {
+		mConfig.Services = lo.Map(services, func(s Service, _ int) api.MachineService {
 			return *s.toMachineService()
 		})
 	}
 
+	// Checks
+	mConfig.Checks = nil
 	if len(c.Checks) > 0 {
-		machineConfig.Checks = map[string]api.MachineCheck{}
+		mConfig.Checks = map[string]api.MachineCheck{}
 		for checkName, check := range c.Checks {
 			machineCheck, err := check.toMachineCheck()
 			if err != nil {
 				return nil, err
 			}
-			machineConfig.Checks[checkName] = *machineCheck
+			mConfig.Checks[checkName] = *machineCheck
 		}
 	}
 
+	// Env
+	mConfig.Env = lo.Assign(c.Env)
 	if c.PrimaryRegion != "" {
-		machineConfig.Env["PRIMARY_REGION"] = c.PrimaryRegion
+		mConfig.Env["PRIMARY_REGION"] = c.PrimaryRegion
 	}
 
+	// Statics
+	mConfig.Statics = nil
 	for _, s := range c.Statics {
-		machineConfig.Statics = append(machineConfig.Statics, &api.Static{
+		mConfig.Statics = append(mConfig.Statics, &api.Static{
 			GuestPath: s.GuestPath,
 			UrlPrefix: s.UrlPrefix,
 		})
 	}
 
+	// Mounts
+	mConfig.Mounts = nil
 	if c.Mounts != nil {
-		machineConfig.Mounts = []api.MachineMount{{
+		mConfig.Mounts = []api.MachineMount{{
 			Path: c.Mounts.Destination,
 			Name: c.Mounts.Source,
 		}}
 	}
 
-	return machineConfig, nil
+	return mConfig, nil
 }

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -21,7 +21,7 @@ func (c *Config) ToReleaseMachineConfig() (*api.MachineConfig, error) {
 		return nil, err
 	}
 
-	machineConfig := &api.MachineConfig{
+	mConfig := &api.MachineConfig{
 		Init: api.MachineInit{
 			Cmd: releaseCmd,
 		},
@@ -39,12 +39,12 @@ func (c *Config) ToReleaseMachineConfig() (*api.MachineConfig, error) {
 		Env: lo.Assign(c.Env),
 	}
 
-	machineConfig.Env["RELEASE_COMMAND"] = "1"
+	mConfig.Env["RELEASE_COMMAND"] = "1"
 	if c.PrimaryRegion != "" {
-		machineConfig.Env["PRIMARY_REGION"] = c.PrimaryRegion
+		mConfig.Env["PRIMARY_REGION"] = c.PrimaryRegion
 	}
 
-	return machineConfig, nil
+	return mConfig, nil
 }
 
 //
@@ -56,6 +56,7 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 		mConfig = helpers.Clone(src)
 	}
 
+	// Metrics
 	mConfig.Metrics = c.Metrics
 
 	// Init
@@ -66,11 +67,10 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 	mConfig.Init.Cmd = cmd
 
 	// Metadata
-	if mConfig.Metadata == nil {
-		mConfig.Metadata = map[string]string{}
-	}
-	mConfig.Metadata[api.MachineConfigMetadataKeyFlyPlatformVersion] = api.MachineFlyPlatformVersion2
-	mConfig.Metadata[api.MachineConfigMetadataKeyFlyProcessGroup] = processGroup
+	mConfig.Metadata = lo.Assign(mConfig.Metadata, map[string]string{
+		api.MachineConfigMetadataKeyFlyPlatformVersion: api.MachineFlyPlatformVersion2,
+		api.MachineConfigMetadataKeyFlyProcessGroup:    processGroup,
+	})
 
 	// Services
 	mConfig.Services = nil

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -72,7 +72,7 @@ func TestToMachineConfig(t *testing.T) {
 		},
 	}
 
-	got, err := cfg.ToMachineConfig("")
+	got, err := cfg.ToMachineConfig("", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
@@ -175,7 +175,7 @@ func TestToMachineConfig_multiProcessGroups(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := cfg.ToMachineConfig(tc.groupName)
+			got, err := cfg.ToMachineConfig(tc.groupName, nil)
 			require.NoError(t, err)
 			// We only care about fields that change for different process groups
 			assert.Equal(t, tc.groupName, got.Metadata["fly_process_group"])

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -200,7 +200,7 @@ func (cfg *Config) validateProcessesSection() (extraInfo string, err error) {
 
 func (cfg *Config) validateMachineConversion() (extraInfo string, err error) {
 	for _, name := range cfg.ProcessNames() {
-		if _, vErr := cfg.ToMachineConfig(name); err != nil {
+		if _, vErr := cfg.ToMachineConfig(name, nil); err != nil {
 			extraInfo += fmt.Sprintf("Converting to machine in process group '%s' will fail because of: %s", name, vErr)
 			err = ValidationError
 		}

--- a/internal/command/deploy/machines_releasecommand.go
+++ b/internal/command/deploy/machines_releasecommand.go
@@ -114,6 +114,7 @@ func (md *machineDeployment) launchInputForReleaseCommand(origMachineRaw *api.Ma
 	// if it can't split the command and we test that at initialization
 	mConfig, _ := md.appConfig.ToReleaseMachineConfig()
 	mConfig.Guest = md.inferReleaseCommandGuest()
+	mConfig.Image = md.img
 	md.setMachineReleaseData(mConfig)
 
 	return &api.LaunchMachineInput{

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -128,7 +128,7 @@ func runMachineClone(ctx context.Context) (err error) {
 		targetConfig.Metadata[api.MachineConfigMetadataKeyFlyProcessGroup] = targetProcessGroup
 
 		terminal.Infof("Setting process group to %s for new machine and updating cmd, services, and checks\n", targetProcessGroup)
-		mConfig, err := appConfig.ToMachineConfig(targetProcessGroup)
+		mConfig, err := appConfig.ToMachineConfig(targetProcessGroup, nil)
 		if err != nil {
 			return fmt.Errorf("failed to get process group config: %w", err)
 		}

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -854,7 +854,7 @@ func (m *v2PlatformMigrator) volumeForPrevAlloc(id string) (bool, *api.Volume) {
 }
 
 func (m *v2PlatformMigrator) resolveMachineFromAlloc(alloc *api.AllocationStatus) (*api.LaunchMachineInput, error) {
-	mConfig, err := m.appConfig.ToMachineConfig(alloc.TaskName)
+	mConfig, err := m.appConfig.ToMachineConfig(alloc.TaskName, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/scale/machine_defaults.go
+++ b/internal/command/scale/machine_defaults.go
@@ -70,7 +70,7 @@ func newDefaults(appConfig *appconfig.Config, machines []*api.Machine) *defaultV
 }
 
 func (d *defaultValues) ToMachineConfig(groupName string) (*api.MachineConfig, error) {
-	mc, err := d.appConfig.ToMachineConfig(groupName)
+	mc, err := d.appConfig.ToMachineConfig(groupName, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fields on MachineConfig type are of two kind, those that are set and updated on every deploy from information found in application configuration (aka fly.toml), and the others that can be set only using `fly machines update` command.

Until now we were cherry picking which fields of the later type propagated on `fly deploys`, in the past we missed a few like restart policies, autoscaling fields, vm size, guest, dns config, .... The recent addition of `standbys` field motivated this PR so adding new fields won't cause surprises with apps v2. 