### PR TITLE
Do not force set DisableMachineAutostart to false

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -758,7 +758,10 @@ func determineMachineConfig(ctx context.Context, input *determineMachineConfigIn
 		return machineConf, err
 	}
 	machineConf.Image = img.Tag
-	machineConf.DisableMachineAutostart = api.Pointer(!flag.GetBool(ctx, "autostart"))
+
+	if flag.IsSpecified(ctx, "autostart") {
+		machineConf.DisableMachineAutostart = api.Pointer(!flag.GetBool(ctx, "autostart"))
+	}
 
 	return machineConf, nil
 }


### PR DESCRIPTION
Do not force set the deprecated field to its default on machine updates.

Until now, no matter what, all new machine updates will ask for this change. But `DisableMachineAutostart` is deprecated, and false it is default anyways.

```
l$ fly m update 148ee20f7d2489 -a myapp
....

Configuration changes to be applied to machine: 148ee20f7d2489 (throbbing-flower-6273)

        ... // 54 identical lines
          },
          "dns": {},
-         "size": "performance-2x"
+         "size": "performance-2x",
+         "disable_machine_autostart": false
        }

? Apply changes? No
No changes to apply
```

With this PR:
```
$ fly m update 148ee20f7d2489 -a flocast
...

Error no config changes found
```