### PR TITLE
Restore underscore between OS and Arch

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,7 +40,7 @@ archives:
     name_template: >-
       {{ .ProjectName }}_{{ .Version}}_
       {{- if eq .Os "windows" }}Windows
-      {{- else }}{{ .Os }}{{- end }}
+      {{- else }}{{ .Os }}{{- end }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else }}{{ .Arch }}{{- end }}
     builds:
@@ -55,7 +55,7 @@ archives:
       {{ .ProjectName }}_{{ .Version}}_
       {{- if eq .Os "darwin" }}macOS
       {{- else if eq .Os "linux" }}Linux
-      {{- else }}{{ .Os }}{{- end }}
+      {{- else }}{{ .Os }}{{- end }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else }}{{ .Arch }}{{- end }}
     builds:


### PR DESCRIPTION
Reported at https://community.fly.io/t/flyctl-0-0-517-release-missing-in-filename/12196