### PR TITLE
`helpers.Clone`: go back to `jinzhu/copier` so Config can be cloned

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/heroku/heroku-go/v5 v5.4.0
 	github.com/inancgumus/screen v0.0.0-20190314163918-06e984b86ed3
+	github.com/jinzhu/copier v0.3.5
 	github.com/jpillora/backoff v1.0.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/mattn/go-colorable v0.1.13

--- a/go.sum
+++ b/go.sum
@@ -848,6 +848,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jingyugao/rowserrcheck v0.0.0-20191204022205-72ab7603b68a/go.mod h1:xRskid8CManxVta/ALEhJha/pweKBaVG6fWgc0yH25s=
+github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
+github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jirfag/go-printf-func-name v0.0.0-20191110105641-45db9963cdd3/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
 github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af/go.mod h1:HEWGJkRDzjJY2sqdDwxccsGicWEf9BQOZsq2tV+xzM0=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -149,10 +149,18 @@ func TestCloneAppconfig(t *testing.T) {
 			Source:      "src",
 			Destination: "dst",
 		},
+		HttpService: &HTTPService{
+			InternalPort: 100,
+		},
 		defaultGroupName: "some-group",
 	}
 
 	cloned := helpers.Clone(config)
 
 	assert.Equal(t, config, cloned)
+
+	config.HttpService.InternalPort = 50
+
+	assert.Equal(t, 100, cloned.HttpService.InternalPort,
+		"expected deep copy, but cloned object was modified by change to original config")
 }

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/superfly/flyctl/helpers"
 )
 
 func TestGetAndSetEnvVariables(t *testing.T) {
@@ -125,4 +126,33 @@ func TestConfigPortGetter(t *testing.T) {
 			assert.Equal(t, tc.expectedPort, tc.config.InternalPort())
 		})
 	}
+}
+
+// This can't go in helpers/clone_test.go because of an import cycle
+func TestCloneAppconfig(t *testing.T) {
+
+	config := &Config{
+		AppName: "testcfg",
+		RawDefinition: map[string]any{
+			"mounts": []Volume{
+				{
+					Source:      "src-raw",
+					Destination: "dst-raw",
+				},
+				{
+					Source:      "src2",
+					Destination: "dst2",
+				},
+			},
+		},
+		Mounts: &Volume{
+			Source:      "src",
+			Destination: "dst",
+		},
+		defaultGroupName: "some-group",
+	}
+
+	cloned := helpers.Clone(config)
+
+	assert.Equal(t, config, cloned)
 }


### PR DESCRIPTION
We do magic when serializing appconfig.Config to json, which broke object cloning