### PR TITLE
`deploy`: prefix machine updates with [n/total]

### DIFF
--- a/internal/command/deploy/machines_releasecommand.go
+++ b/internal/command/deploy/machines_releasecommand.go
@@ -85,7 +85,7 @@ func (md *machineDeployment) updateReleaseCommandMachine(ctx context.Context) er
 	releaseCmdMachine := md.releaseCommandMachine.GetMachines()[0]
 	fmt.Fprintf(md.io.ErrOut, "  Updating release_command machine %s\n", md.colorize.Bold(releaseCmdMachine.Machine().ID))
 
-	if err := releaseCmdMachine.WaitForState(ctx, api.MachineStateStopped, md.waitTimeout); err != nil {
+	if err := releaseCmdMachine.WaitForState(ctx, api.MachineStateStopped, md.waitTimeout, ""); err != nil {
 		return err
 	}
 
@@ -151,7 +151,7 @@ func (md *machineDeployment) inferReleaseCommandGuest() *api.MachineGuest {
 }
 
 func (md *machineDeployment) waitForReleaseCommandToFinish(ctx context.Context, releaseCmdMachine machine.LeasableMachine) error {
-	err := releaseCmdMachine.WaitForState(ctx, api.MachineStateStarted, md.waitTimeout)
+	err := releaseCmdMachine.WaitForState(ctx, api.MachineStateStarted, md.waitTimeout, "")
 	if err != nil {
 		var flapsErr *flaps.FlapsError
 		if errors.As(err, &flapsErr) && flapsErr.ResponseStatusCode == http.StatusNotFound {
@@ -160,7 +160,7 @@ func (md *machineDeployment) waitForReleaseCommandToFinish(ctx context.Context, 
 		}
 		return fmt.Errorf("error waiting for release_command machine %s to start: %w", releaseCmdMachine.Machine().ID, err)
 	}
-	err = releaseCmdMachine.WaitForState(ctx, api.MachineStateDestroyed, md.waitTimeout)
+	err = releaseCmdMachine.WaitForState(ctx, api.MachineStateDestroyed, md.waitTimeout, "")
 	if err != nil {
 		return fmt.Errorf("error waiting for release_command machine %s to finish running: %w", releaseCmdMachine.Machine().ID, err)
 	}


### PR DESCRIPTION
This lets people know how far into a deploy they are - especially helpful if something goes wrong!
```
❯ ~/Work/flyctl/bin/flyctl deploy --image nginx
==> Verifying app config
Validating /Users/alichay/Work/repro/vol-migr-test/fly.toml
Platform: machines
✓ Configuration is valid
--> Verified app config
==> Building image
Searching for image 'nginx' remotely...
image found: img_3xdk4x0kg574go0e
Updating existing machines in 'ali-vol-test-3' with rolling strategy
  [1/3] Machine 3d8d9795ce9378 [app] update finished: success
  [2/3] Machine e28656d9be7908 [app] update finished: success
  [3/3] Machine e28656ddae74d8 [app] update finished: success
  Finished deploying
```