### PR TITLE
`os.Args[0]` may not point this exact binary

### DIFF
--- a/agent/start.go
+++ b/agent/start.go
@@ -35,7 +35,11 @@ func StartDaemon(ctx context.Context) (*Client, error) {
 		return nil, err
 	}
 
-	cmd := exec.Command(os.Args[0], "agent", "run", logFile)
+	flyctl, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(flyctl, "agent", "run", logFile)
 
 	env := os.Environ()
 	env = append(env, "FLY_NO_UPDATE_CHECK=1")


### PR DESCRIPTION
If you run flyctl like below, during development;

```
make && ./bin/flyctl deploy ~/someapp
```

flyctl will chdir to ~/someapp, hence cannot find `./bin/flyctl` from there.