### PR TITLE
Mounts per process group

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	HTTPService   *HTTPService              `toml:"http_service,omitempty" json:"http_service,omitempty"`
 	Metrics       *api.MachineMetrics       `toml:"metrics,omitempty" json:"metrics,omitempty"`
 	Statics       []Static                  `toml:"statics,omitempty" json:"statics,omitempty"`
-	Mounts        *Mount                    `toml:"mounts,omitempty" json:"mounts,omitempty"`
+	Mounts        []Mount                   `toml:"mounts,omitempty" json:"mounts,omitempty"`
 	Processes     map[string]string         `toml:"processes,omitempty" json:"processes,omitempty"`
 	Checks        map[string]*ToplevelCheck `toml:"checks,omitempty" json:"checks,omitempty"`
 	Services      []Service                 `toml:"services,omitempty" json:"services,omitempty"`
@@ -196,8 +196,5 @@ func (c *Config) Volumes() []Mount {
 			return arr
 		}
 	}
-	if c.Mounts != nil {
-		return []Mount{*c.Mounts}
-	}
-	return nil
+	return c.Mounts
 }

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -73,8 +73,9 @@ type Static struct {
 }
 
 type Mount struct {
-	Source      string `toml:"source,omitempty" json:"source,omitempty"`
-	Destination string `toml:"destination" json:"destination,omitempty"`
+	Source      string   `toml:"source,omitempty" json:"source,omitempty"`
+	Destination string   `toml:"destination" json:"destination,omitempty"`
+	Processes   []string `json:"processes,omitempty" toml:"processes,omitempty"`
 }
 
 type Build struct {

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	HTTPService   *HTTPService              `toml:"http_service,omitempty" json:"http_service,omitempty"`
 	Metrics       *api.MachineMetrics       `toml:"metrics,omitempty" json:"metrics,omitempty"`
 	Statics       []Static                  `toml:"statics,omitempty" json:"statics,omitempty"`
-	Mounts        *Volume                   `toml:"mounts,omitempty" json:"mounts,omitempty"`
+	Mounts        *Mount                    `toml:"mounts,omitempty" json:"mounts,omitempty"`
 	Processes     map[string]string         `toml:"processes,omitempty" json:"processes,omitempty"`
 	Checks        map[string]*ToplevelCheck `toml:"checks,omitempty" json:"checks,omitempty"`
 	Services      []Service                 `toml:"services,omitempty" json:"services,omitempty"`
@@ -72,7 +72,7 @@ type Static struct {
 	UrlPrefix string `toml:"url_prefix" json:"url_prefix,omitempty" validate:"required"`
 }
 
-type Volume struct {
+type Mount struct {
 	Source      string `toml:"source,omitempty" json:"source,omitempty"`
 	Destination string `toml:"destination" json:"destination,omitempty"`
 }
@@ -190,14 +190,14 @@ func (cfg *Config) BuildStrategies() []string {
 	return strategies
 }
 
-func (c *Config) Volumes() []Volume {
+func (c *Config) Volumes() []Mount {
 	if mounts, ok := c.RawDefinition["mounts"]; ok {
-		if arr, ok := mounts.([]Volume); ok {
+		if arr, ok := mounts.([]Mount); ok {
 			return arr
 		}
 	}
 	if c.Mounts != nil {
-		return []Volume{*c.Mounts}
+		return []Mount{*c.Mounts}
 	}
 	return nil
 }

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -133,7 +133,7 @@ func TestCloneAppconfig(t *testing.T) {
 	config := &Config{
 		AppName: "testcfg",
 		RawDefinition: map[string]any{
-			"mounts": []Volume{
+			"mounts": []Mount{
 				{
 					Source:      "src-raw",
 					Destination: "dst-raw",
@@ -144,7 +144,7 @@ func TestCloneAppconfig(t *testing.T) {
 				},
 			},
 		},
-		Mounts: &Volume{
+		Mounts: &Mount{
 			Source:      "src",
 			Destination: "dst",
 		},

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -144,10 +144,10 @@ func TestCloneAppconfig(t *testing.T) {
 				},
 			},
 		},
-		Mounts: &Mount{
+		Mounts: []Mount{{
 			Source:      "src",
 			Destination: "dst",
-		},
+		}},
 		HTTPService: &HTTPService{
 			InternalPort: 100,
 		},

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -220,10 +220,10 @@ func TestToDefinition(t *testing.T) {
 				"url_prefix": "/static-assets",
 			},
 		},
-		"mounts": map[string]any{
+		"mounts": []map[string]any{{
 			"source":      "data",
 			"destination": "/data",
-		},
+		}},
 		"processes": map[string]any{
 			"web":  "run web",
 			"task": "task all day",

--- a/internal/appconfig/from_machine_set.go
+++ b/internal/appconfig/from_machine_set.go
@@ -92,7 +92,7 @@ func fromAppAndOneMachine(appCompact *api.AppCompact, m machine.LeasableMachine,
 		warningMsg     string
 		primaryRegion  string
 		statics        []Static
-		mounts         *Mount
+		mounts         []Mount
 		topLevelChecks map[string]*ToplevelCheck
 	)
 	for k, v := range m.Machine().Config.Env {
@@ -108,10 +108,10 @@ func fromAppAndOneMachine(appCompact *api.AppCompact, m machine.LeasableMachine,
 		})
 	}
 	if len(m.Machine().Config.Mounts) > 0 {
-		mounts = &Mount{
-			Destination: m.Machine().Config.Mounts[0].Path,
-		}
+		mount := m.Machine().Config.Mounts[0]
+		mounts = append(mounts, Mount{Source: mount.Name, Destination: mount.Path})
 	}
+
 	if len(m.Machine().Config.Mounts) > 1 {
 		var otherMounts string
 		for _, mnt := range m.Machine().Config.Mounts {

--- a/internal/appconfig/from_machine_set.go
+++ b/internal/appconfig/from_machine_set.go
@@ -92,7 +92,7 @@ func fromAppAndOneMachine(appCompact *api.AppCompact, m machine.LeasableMachine,
 		warningMsg     string
 		primaryRegion  string
 		statics        []Static
-		mounts         *Volume
+		mounts         *Mount
 		topLevelChecks map[string]*ToplevelCheck
 	)
 	for k, v := range m.Machine().Config.Env {
@@ -108,7 +108,7 @@ func fromAppAndOneMachine(appCompact *api.AppCompact, m machine.LeasableMachine,
 		})
 	}
 	if len(m.Machine().Config.Mounts) > 0 {
-		mounts = &Volume{
+		mounts = &Mount{
 			Destination: m.Machine().Config.Mounts[0].Path,
 		}
 	}

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -121,11 +121,11 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 
 	// Mounts
 	mConfig.Mounts = nil
-	if c.Mounts != nil {
-		mConfig.Mounts = []api.MachineMount{{
-			Path: c.Mounts.Destination,
-			Name: c.Mounts.Source,
-		}}
+	for _, m := range c.Mounts {
+		mConfig.Mounts = append(mConfig.Mounts, api.MachineMount{
+			Path: m.Destination,
+			Name: m.Source,
+		})
 	}
 
 	return mConfig, nil

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -236,3 +236,24 @@ func TestToMachineConfig_defaultV2flytoml(t *testing.T) {
 	assert.Nil(t, got)
 	assert.ErrorContains(t, err, "has no internal port set")
 }
+
+func TestToReleaseMachineConfig_processGroupsAndMounts(t *testing.T) {
+	cfg, err := LoadConfig("./testdata/tomachine-mounts.toml")
+	require.NoError(t, err)
+
+	got, err := cfg.ToMachineConfig("", nil)
+	require.NoError(t, err)
+	assert.Equal(t, []api.MachineMount{{Name: "data", Path: "/data"}}, got.Mounts)
+
+	got, err = cfg.ToMachineConfig("app", nil)
+	require.NoError(t, err)
+	assert.Equal(t, []api.MachineMount{{Name: "data", Path: "/data"}}, got.Mounts)
+
+	got, err = cfg.ToMachineConfig("back", nil)
+	require.NoError(t, err)
+	assert.Equal(t, []api.MachineMount{{Name: "trash", Path: "/trash"}}, got.Mounts)
+
+	got, err = cfg.ToMachineConfig("hola", nil)
+	require.NoError(t, err)
+	assert.Empty(t, got.Mounts)
+}

--- a/internal/appconfig/patches.go
+++ b/internal/appconfig/patches.go
@@ -119,23 +119,17 @@ func patchExperimental(cfg map[string]any) (map[string]any, error) {
 }
 
 func patchMounts(cfg map[string]any) (map[string]any, error) {
-	if mount, ok := cfg["mount"]; ok {
-		cfg["mounts"] = mount
-		delete(cfg, "mount")
-	}
-
-	if raw, ok := cfg["mounts"]; ok {
-		mounts, err := ensureArrayOfMap(raw)
-		if err != nil {
-			return nil, fmt.Errorf("Error processing mounts: %w", err)
-		}
-		if len(mounts) > 0 {
-			cfg["mounts"] = mounts[0]
-		} else {
-			delete(cfg, "mounts")
+	var mounts []map[string]any
+	for _, k := range []string{"mount", "mounts"} {
+		if raw, ok := cfg[k]; ok {
+			cast, err := ensureArrayOfMap(raw)
+			if err != nil {
+				return nil, fmt.Errorf("Error processing mounts: %w", err)
+			}
+			mounts = append(mounts, cast...)
 		}
 	}
-
+	cfg["mounts"] = mounts
 	return cfg, nil
 }
 

--- a/internal/appconfig/processgroups.go
+++ b/internal/appconfig/processgroups.go
@@ -141,6 +141,11 @@ func (c *Config) Flatten(groupName string) (*Config, error) {
 		return matchesGroups(s.Processes)
 	})
 
+	// [[Mounts]]
+	dst.Mounts = lo.Filter(c.Mounts, func(x Mount, _ int) bool {
+		return matchesGroups(x.Processes)
+	})
+
 	return dst, nil
 }
 

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -145,7 +145,7 @@ func TestLoadTOMLAppConfigMountsArray(t *testing.T) {
 		configFilePath:   "./testdata/mounts-array.toml",
 		defaultGroupName: "app",
 		AppName:          "foo",
-		Mounts: &Volume{
+		Mounts: &Mount{
 			Source:      "pg_data",
 			Destination: "/data",
 		},
@@ -171,7 +171,7 @@ func TestLoadTOMLAppConfigOldFormat(t *testing.T) {
 			"FOO": "STRING",
 			"BAR": "123",
 		},
-		Mounts: &Volume{
+		Mounts: &Mount{
 			Source:      "data",
 			Destination: "/data",
 		},
@@ -345,7 +345,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 			},
 		},
 
-		Mounts: &Volume{
+		Mounts: &Mount{
 			Source:      "data",
 			Destination: "/data",
 		},

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -145,10 +145,10 @@ func TestLoadTOMLAppConfigMountsArray(t *testing.T) {
 		configFilePath:   "./testdata/mounts-array.toml",
 		defaultGroupName: "app",
 		AppName:          "foo",
-		Mounts: &Mount{
+		Mounts: []Mount{{
 			Source:      "pg_data",
 			Destination: "/data",
-		},
+		}},
 		RawDefinition: map[string]any{
 			"app": "foo",
 			"mounts": []map[string]any{{
@@ -171,10 +171,10 @@ func TestLoadTOMLAppConfigOldFormat(t *testing.T) {
 			"FOO": "STRING",
 			"BAR": "123",
 		},
-		Mounts: &Mount{
+		Mounts: []Mount{{
 			Source:      "data",
 			Destination: "/data",
-		},
+		}},
 		Services: []Service{
 			{
 				InternalPort: 8080,
@@ -345,10 +345,10 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 			},
 		},
 
-		Mounts: &Mount{
+		Mounts: []Mount{{
 			Source:      "data",
 			Destination: "/data",
-		},
+		}},
 
 		Processes: map[string]string{
 			"web":  "run web",

--- a/internal/appconfig/setters.go
+++ b/internal/appconfig/setters.go
@@ -261,11 +261,11 @@ func (c *Config) SetStatics(statics []Static) {
 	}
 }
 
-func (c *Config) SetVolumes(volumes []Volume) {
+func (c *Config) SetVolumes(volumes []Mount) {
 	c.RawDefinition["mounts"] = volumes
 	// FIXME: "mounts" section is confusing, it is plural but only allows one mount
 	if len(volumes) > 0 {
-		c.Mounts = &Volume{
+		c.Mounts = &Mount{
 			Source:      volumes[0].Source,
 			Destination: volumes[0].Destination,
 		}

--- a/internal/appconfig/setters.go
+++ b/internal/appconfig/setters.go
@@ -265,9 +265,9 @@ func (c *Config) SetVolumes(volumes []Mount) {
 	c.RawDefinition["mounts"] = volumes
 	// FIXME: "mounts" section is confusing, it is plural but only allows one mount
 	if len(volumes) > 0 {
-		c.Mounts = &Mount{
+		c.Mounts = []Mount{{
 			Source:      volumes[0].Source,
 			Destination: volumes[0].Destination,
-		}
+		}}
 	}
 }

--- a/internal/appconfig/setters.go
+++ b/internal/appconfig/setters.go
@@ -263,11 +263,5 @@ func (c *Config) SetStatics(statics []Static) {
 
 func (c *Config) SetMounts(volumes []Mount) {
 	c.RawDefinition["mounts"] = volumes
-	// FIXME: "mounts" section is confusing, it is plural but only allows one mount
-	if len(volumes) > 0 {
-		c.Mounts = []Mount{{
-			Source:      volumes[0].Source,
-			Destination: volumes[0].Destination,
-		}}
-	}
+	c.Mounts = volumes
 }

--- a/internal/appconfig/setters.go
+++ b/internal/appconfig/setters.go
@@ -261,7 +261,7 @@ func (c *Config) SetStatics(statics []Static) {
 	}
 }
 
-func (c *Config) SetVolumes(volumes []Mount) {
+func (c *Config) SetMounts(volumes []Mount) {
 	c.RawDefinition["mounts"] = volumes
 	// FIXME: "mounts" section is confusing, it is plural but only allows one mount
 	if len(volumes) > 0 {

--- a/internal/appconfig/setters_test.go
+++ b/internal/appconfig/setters_test.go
@@ -240,7 +240,7 @@ func TestSetStatics(t *testing.T) {
 func TestSetVolumes(t *testing.T) {
 	cfg := NewConfig()
 	cfg.SetVolumes([]Mount{{Source: "data", Destination: "/data"}})
-	assert.Equal(t, cfg.Mounts, &Mount{Source: "data", Destination: "/data"})
+	assert.Equal(t, cfg.Mounts, []Mount{{Source: "data", Destination: "/data"}})
 	assert.Equal(t, cfg.RawDefinition, map[string]any{
 		"mounts": []Mount{
 			{Source: "data", Destination: "/data"},

--- a/internal/appconfig/setters_test.go
+++ b/internal/appconfig/setters_test.go
@@ -239,10 +239,10 @@ func TestSetStatics(t *testing.T) {
 
 func TestSetVolumes(t *testing.T) {
 	cfg := NewConfig()
-	cfg.SetVolumes([]Volume{{Source: "data", Destination: "/data"}})
-	assert.Equal(t, cfg.Mounts, &Volume{Source: "data", Destination: "/data"})
+	cfg.SetVolumes([]Mount{{Source: "data", Destination: "/data"}})
+	assert.Equal(t, cfg.Mounts, &Mount{Source: "data", Destination: "/data"})
 	assert.Equal(t, cfg.RawDefinition, map[string]any{
-		"mounts": []Volume{
+		"mounts": []Mount{
 			{Source: "data", Destination: "/data"},
 		},
 	})

--- a/internal/appconfig/setters_test.go
+++ b/internal/appconfig/setters_test.go
@@ -239,7 +239,7 @@ func TestSetStatics(t *testing.T) {
 
 func TestSetVolumes(t *testing.T) {
 	cfg := NewConfig()
-	cfg.SetVolumes([]Mount{{Source: "data", Destination: "/data"}})
+	cfg.SetMounts([]Mount{{Source: "data", Destination: "/data"}})
 	assert.Equal(t, cfg.Mounts, []Mount{{Source: "data", Destination: "/data"}})
 	assert.Equal(t, cfg.RawDefinition, map[string]any{
 		"mounts": []Mount{

--- a/internal/appconfig/testdata/tomachine-mounts.toml
+++ b/internal/appconfig/testdata/tomachine-mounts.toml
@@ -1,0 +1,15 @@
+app = "foo"
+
+[processes]
+  app = ""
+  back = "back"
+  hola = "hi!"
+
+[[mounts]]
+  source = "data"
+  destination = "/data"
+
+[[mounts]]
+  source = "trash"
+  destination = "/trash"
+  processes = ["back"]

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -109,10 +109,10 @@ func run(ctx context.Context) error {
 	ctx = flaps.NewContext(ctx, flapsClient)
 
 	appConfig, err := determineAppConfig(ctx)
-	switch {
-	case strings.Contains(err.Error(), "Could not find App"):
-		return fmt.Errorf("the app name %s could not be found, did you create the app or misspell it in the fly.toml file or via -a?", appName)
-	case err != nil:
+	if err != nil {
+		if strings.Contains(err.Error(), "Could not find App") {
+			return fmt.Errorf("the app name %s could not be found, did you create the app or misspell it in the fly.toml file or via -a?", appName)
+		}
 		return err
 	}
 

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -109,16 +109,11 @@ func run(ctx context.Context) error {
 	ctx = flaps.NewContext(ctx, flapsClient)
 
 	appConfig, err := determineAppConfig(ctx)
-	if err != nil {
+	switch {
+	case strings.Contains(err.Error(), "Could not find App"):
+		return fmt.Errorf("the app name %s could not be found, did you create the app or misspell it in the fly.toml file or via -a?", appName)
+	case err != nil:
 		return err
-	}
-
-	err, extra_info := appConfig.Validate(ctx)
-	if err != nil {
-		return err
-	}
-	if strings.Contains(extra_info, "Could not find App") {
-		return fmt.Errorf("the app name %s could not be found, did you create the app or misspell it in the fly.toml file or via -a?", appConfig.AppName)
 	}
 
 	return DeployWithConfig(ctx, appConfig, DeployWithConfigArgs{
@@ -266,7 +261,6 @@ func determineAppConfig(ctx context.Context) (cfg *appconfig.Config, err error) 
 		if err != nil {
 			return nil, err
 		}
-
 	}
 
 	if env := flag.GetStringSlice(ctx, "env"); len(env) > 0 {

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -1,0 +1,115 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/internal/prompt"
+)
+
+func (md *machineDeployment) provisionFirstDeploy(ctx context.Context) error {
+	if !md.isFirstDeploy || md.restartOnly {
+		return nil
+	}
+	if err := md.provisionIpsOnFirstDeploy(ctx); err != nil {
+		return nil
+	}
+	if err := md.provisionVolumesOnFirstDeploy(ctx); err != nil {
+		return nil
+	}
+	return nil
+}
+
+func (md *machineDeployment) provisionIpsOnFirstDeploy(ctx context.Context) error {
+	// Provision only if the app hasn't been deployed and have services defined
+	if !md.isFirstDeploy || len(md.appConfig.AllServices()) == 0 {
+		return nil
+	}
+
+	// Do not touch IPs if there are already allocated
+	ipAddrs, err := md.apiClient.GetIPAddresses(ctx, md.app.Name)
+	if err != nil {
+		return fmt.Errorf("error detecting ip addresses allocated to %s app: %w", md.app.Name, err)
+	}
+	if len(ipAddrs) > 0 {
+		return nil
+	}
+
+	switch md.appConfig.HasNonHttpAndHttpsStandardServices() {
+	case true:
+		hasUdpService := md.appConfig.HasUdpService()
+
+		ipStuffStr := "a dedicated ipv4 address"
+		if !hasUdpService {
+			ipStuffStr = "dedicated ipv4 and ipv6 addresses"
+		}
+
+		confirmDedicatedIp, err := prompt.Confirmf(ctx, "Would you like to allocate %s now?", ipStuffStr)
+		if confirmDedicatedIp && err == nil {
+			v4Dedicated, err := md.apiClient.AllocateIPAddress(ctx, md.app.Name, "v4", "", nil, "")
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(md.io.Out, "Allocated dedicated ipv4: %s\n", v4Dedicated.Address)
+
+			if !hasUdpService {
+				v6Dedicated, err := md.apiClient.AllocateIPAddress(ctx, md.app.Name, "v6", "", nil, "")
+				if err != nil {
+					return err
+				}
+				fmt.Fprintf(md.io.Out, "Allocated dedicated ipv6: %s\n", v6Dedicated.Address)
+			}
+		}
+
+	case false:
+		fmt.Fprintf(md.io.Out, "Provisioning ips for %s\n", md.colorize.Bold(md.app.Name))
+		v6Addr, err := md.apiClient.AllocateIPAddress(ctx, md.app.Name, "v6", "", nil, "")
+		if err != nil {
+			return fmt.Errorf("error allocating ipv6 after detecting first deploy and presence of services: %w", err)
+		}
+		fmt.Fprintf(md.io.Out, "  Dedicated ipv6: %s\n", v6Addr.Address)
+
+		v4Shared, err := md.apiClient.AllocateSharedIPAddress(ctx, md.app.Name)
+		if err != nil {
+			return fmt.Errorf("error allocating shared ipv4 after detecting first deploy and presence of services: %w", err)
+		}
+		fmt.Fprintf(md.io.Out, "  Shared ipv4: %s\n", v4Shared)
+		fmt.Fprintf(md.io.Out, "  Add a dedicated ipv4 with: fly ips allocate-v4\n")
+	}
+
+	return nil
+}
+
+func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) error {
+	// Provision only if the app hasn't been deployed and have mounts defined
+	if !md.isFirstDeploy || len(md.appConfig.Mounts) == 0 {
+		return nil
+	}
+
+	// The logic here is to provision one volume per process group that needs it only on the primary region
+	for _, groupName := range md.appConfig.ProcessNames() {
+		groupConfig, err := md.appConfig.Flatten(groupName)
+		if err != nil {
+			return err
+		}
+
+		for _, m := range groupConfig.Mounts {
+			fmt.Fprintf(md.io.Out, "Creating 1GB volume '%s' for process group '%s'. See `fly vol extend` to increase its size\n", m.Source, groupName)
+
+			input := api.CreateVolumeInput{
+				AppID:     md.app.ID,
+				Name:      m.Source,
+				Region:    groupConfig.PrimaryRegion,
+				SizeGb:    1,
+				Encrypted: true,
+			}
+
+			_, err := md.apiClient.CreateVolume(ctx, input)
+			if err != nil {
+				return fmt.Errorf("failed creating volume: %w", err)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -78,8 +78,8 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	if err != nil {
 		return nil, err
 	}
-	if args.NewVolumeName != "" && appConfig.Mounts != nil {
-		appConfig.Mounts.Source = args.NewVolumeName
+	if args.NewVolumeName != "" && len(appConfig.Mounts) > 0 {
+		appConfig.Mounts[0].Source = args.NewVolumeName
 	}
 	err, _ = appConfig.Validate(ctx)
 	if err != nil {
@@ -194,7 +194,7 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 }
 
 func (md *machineDeployment) setVolumeConfig(ctx context.Context) error {
-	if md.appConfig.Mounts == nil {
+	if len(md.appConfig.Mounts) == 0 {
 		return nil
 	}
 
@@ -204,15 +204,15 @@ func (md *machineDeployment) setVolumeConfig(ctx context.Context) error {
 	}
 
 	md.volumes = lo.Filter(volumes, func(v api.Volume, _ int) bool {
-		return v.Name == md.appConfig.Mounts.Source && v.AttachedAllocation == nil && v.AttachedMachine == nil
+		return v.Name == md.appConfig.Mounts[0].Source && v.AttachedAllocation == nil && v.AttachedMachine == nil
 	})
 	return nil
 }
 
 func (md *machineDeployment) validateVolumeConfig() error {
 	volumeDestination := ""
-	if md.appConfig.Mounts != nil {
-		volumeDestination = md.appConfig.Mounts.Destination
+	if len(md.appConfig.Mounts) != 0 {
+		volumeDestination = md.appConfig.Mounts[0].Destination
 	}
 
 	for _, m := range md.machineSet.GetMachines() {
@@ -231,7 +231,7 @@ func (md *machineDeployment) validateVolumeConfig() error {
 
 	if md.machineSet.IsEmpty() && volumeDestination != "" && len(md.volumes) == 0 {
 		return fmt.Errorf("error new machine requires an unattached volume named '%s' on mount destination '%s'",
-			md.appConfig.Mounts.Source, volumeDestination)
+			md.appConfig.Mounts[0].Source, volumeDestination)
 	}
 	return nil
 }

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -56,7 +56,7 @@ type machineDeployment struct {
 	img                   string
 	machineSet            machine.MachineSet
 	releaseCommandMachine machine.MachineSet
-	volumes               []api.Volume
+	volumes               map[string][]api.Volume
 	strategy              string
 	releaseId             string
 	releaseVersion        int
@@ -65,6 +65,7 @@ type machineDeployment struct {
 	waitTimeout           time.Duration
 	leaseTimeout          time.Duration
 	leaseDelayBetween     time.Duration
+	isFirstDeploy         bool
 }
 
 func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (MachineDeployment, error) {
@@ -135,6 +136,9 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	if err != nil {
 		return nil, err
 	}
+	if err := md.setFirstDeploy(ctx); err != nil {
+		return nil, err
+	}
 	err = md.setImg(ctx)
 	if err != nil {
 		return nil, err
@@ -156,6 +160,11 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		return nil, err
 	}
 	return md, nil
+}
+
+func (md *machineDeployment) setFirstDeploy(ctx context.Context) error {
+	md.isFirstDeploy = !md.app.Deployed || md.machineSet.IsEmpty()
+	return nil
 }
 
 func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error {
@@ -203,36 +212,83 @@ func (md *machineDeployment) setVolumeConfig(ctx context.Context) error {
 		return fmt.Errorf("Error fetching application volumes: %w", err)
 	}
 
-	md.volumes = lo.Filter(volumes, func(v api.Volume, _ int) bool {
-		return v.Name == md.appConfig.Mounts[0].Source && v.AttachedAllocation == nil && v.AttachedMachine == nil
+	unattached := lo.Filter(volumes, func(v api.Volume, _ int) bool {
+		return v.AttachedAllocation == nil && v.AttachedMachine == nil
+	})
+
+	md.volumes = lo.GroupBy(unattached, func(v api.Volume) string {
+		return v.Name
 	})
 	return nil
 }
 
 func (md *machineDeployment) validateVolumeConfig() error {
-	volumeDestination := ""
-	if len(md.appConfig.Mounts) != 0 {
-		volumeDestination = md.appConfig.Mounts[0].Destination
+	machineGroups := lo.GroupBy(
+		lo.Map(md.machineSet.GetMachines(), func(lm machine.LeasableMachine, _ int) *api.Machine {
+			return lm.Machine()
+		}),
+		func(m *api.Machine) string {
+			return m.ProcessGroup()
+		})
+
+	for _, groupName := range md.appConfig.ProcessNames() {
+		groupConfig, err := md.appConfig.Flatten(groupName)
+		if err != nil {
+			return err
+		}
+
+		switch ms := machineGroups[groupName]; len(ms) > 0 {
+		case true:
+			// For groups with machines, check the attached volumes match expected mounts
+			var mntSrc, mntDst string
+			if len(groupConfig.Mounts) > 0 {
+				mntSrc = groupConfig.Mounts[0].Source
+				mntDst = groupConfig.Mounts[0].Destination
+			}
+
+			for _, m := range ms {
+				if mntDst == "" && len(m.Config.Mounts) != 0 {
+					// TODO: Detaching a volume from a machine is possible, but it usually means a missconfiguration.
+					// We should show a warning and ask the user for confirmation and let it happen instead of failing here.
+					return fmt.Errorf(
+						"machine %s [%s] has a volume mounted but app config does not specify a volume; "+
+							"remove the volume from the machine or add a [mounts] section to fly.toml",
+						m.ID, groupName,
+					)
+				}
+
+				if mntDst != "" && len(m.Config.Mounts) == 0 {
+					// TODO: Attaching a volume to an existing machine is not possible, but it could replace the machine
+					// by another running on the same zone than the volume.
+					return fmt.Errorf(
+						"machine %s [%s] does not have a volume configured and fly.toml expects one with destination %s; "+
+							"remove the [mounts] configuration in fly.toml or use the machines API to add a volume to this machine",
+						m.ID, groupName, mntDst,
+					)
+				}
+
+				if mms := m.Config.Mounts; len(mms) > 0 && mntSrc != "" && mms[0].Name != "" && mntSrc != mms[0].Name {
+					// TODO: Changed the attached volume to an existing machine is not possible, but it could replace the machine
+					// by another running on the same zone than the new volume.
+					return fmt.Errorf(
+						"machine %s [%s] can't update the attached volume %s with name '%s' by '%s'",
+						m.ID, groupName, mntSrc, mms[0].Volume, mms[0].Name,
+					)
+				}
+			}
+
+		case false:
+			// Check if there are unattached volumes for new groups with mounts
+			for _, m := range groupConfig.Mounts {
+				if vs := md.volumes[m.Source]; len(vs) == 0 {
+					return fmt.Errorf(
+						"creating a new machine in group '%s' requires an unattached '%s' volume. Create it with `fly volume create %s`",
+						groupName, m.Source, m.Source)
+				}
+			}
+		}
 	}
 
-	for _, m := range md.machineSet.GetMachines() {
-		mid := m.Machine().ID
-		mountsConfig := m.Machine().Config.Mounts
-		if len(mountsConfig) > 1 {
-			return fmt.Errorf("error machine %s has %d mounts and expected 1", mid, len(mountsConfig))
-		}
-		if volumeDestination == "" && len(mountsConfig) != 0 {
-			return fmt.Errorf("error machine %s has a volume mounted and app config does not specify a volume; remove the volume from the machine or add a [mounts] configuration to fly.toml", mid)
-		}
-		if volumeDestination != "" && len(mountsConfig) == 0 {
-			return fmt.Errorf("error machine %s does not have a volume configured and fly.toml expects one with destination %s; remove the [mounts] configuration in fly.toml or use the machines API to add a volume to this machine", mid, volumeDestination)
-		}
-	}
-
-	if md.machineSet.IsEmpty() && volumeDestination != "" && len(md.volumes) == 0 {
-		return fmt.Errorf("error new machine requires an unattached volume named '%s' on mount destination '%s'",
-			md.appConfig.Mounts[0].Source, volumeDestination)
-	}
 	return nil
 }
 
@@ -338,7 +394,7 @@ func (md *machineDeployment) updateReleaseInBackend(ctx context.Context, status 
 
 func (md *machineDeployment) provisionIpsOnFirstDeploy(ctx context.Context) error {
 	// Provision only if the app hasn't been deployed and have defined services
-	if md.app.Deployed || !md.machineSet.IsEmpty() || len(md.appConfig.AllServices()) == 0 {
+	if !md.isFirstDeploy || len(md.appConfig.AllServices()) == 0 {
 		return nil
 	}
 

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -401,10 +401,9 @@ func determineAppConfigForMachines(ctx context.Context, envFromFlags []string, p
 
 	if len(envFromFlags) > 0 {
 		var parsedEnv map[string]string
-		if parsedEnv, err = cmdutil.ParseKVStringsToMap(envFromFlags); err != nil {
-			err = fmt.Errorf("failed parsing environment: %w", err)
-
-			return
+		parsedEnv, err := cmdutil.ParseKVStringsToMap(envFromFlags)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing environment: %w", err)
 		}
 		appConfig.SetEnvVariables(parsedEnv)
 	}
@@ -420,5 +419,5 @@ func determineAppConfigForMachines(ctx context.Context, envFromFlags []string, p
 		appConfig.AppName = appName
 	}
 
-	return
+	return appConfig, nil
 }

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -410,7 +410,7 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 		}
 
 		for _, m := range groupConfig.Mounts {
-			fmt.Fprintf(md.io.Out, "Creating volume '%s' for process group '%s'\n", m.Source, groupName)
+			fmt.Fprintf(md.io.Out, "Creating 1GB volume '%s' for process group '%s'. See `fly vol extend` to increase its size\n", m.Source, groupName)
 
 			input := api.CreateVolumeInput{
 				AppID:     md.app.ID,

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -42,7 +42,6 @@ type MachineDeploymentArgs struct {
 	RestartOnly       bool
 	WaitTimeout       time.Duration
 	LeaseTimeout      time.Duration
-	NewVolumeName     string
 }
 
 type machineDeployment struct {
@@ -78,9 +77,6 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	appConfig, err := determineAppConfigForMachines(ctx, args.EnvFromFlags, args.PrimaryRegionFlag)
 	if err != nil {
 		return nil, err
-	}
-	if args.NewVolumeName != "" && len(appConfig.Mounts) > 0 {
-		appConfig.Mounts[0].Source = args.NewVolumeName
 	}
 	err, _ = appConfig.Validate(ctx)
 	if err != nil {

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -16,9 +16,7 @@ import (
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/cmdutil"
-	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/machine"
-	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/terminal"
 )
@@ -135,15 +133,10 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	if err := md.setFirstDeploy(ctx); err != nil {
 		return nil, err
 	}
+	if err := md.provisionFirstDeploy(ctx); err != nil {
+		return nil, err
+	}
 	err = md.setImg(ctx)
-	if err != nil {
-		return nil, err
-	}
-	err = md.provisionIpsOnFirstDeploy(ctx)
-	if err != nil {
-		return nil, err
-	}
-	err = md.provisionVolumesOnFirstDeploy(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -389,99 +382,6 @@ func (md *machineDeployment) updateReleaseInBackend(ctx context.Context, status 
 	if err != nil {
 		return err
 	}
-	return nil
-}
-
-func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) error {
-	// Provision only if the app hasn't been deployed and have mounts defined
-	if !md.isFirstDeploy || len(md.appConfig.Mounts) == 0 {
-		return nil
-	}
-
-	// The logic here is to provision one volume per process group that needs it only on the primary region
-	for _, groupName := range md.appConfig.ProcessNames() {
-		groupConfig, err := md.appConfig.Flatten(groupName)
-		if err != nil {
-			return err
-		}
-
-		for _, m := range groupConfig.Mounts {
-			fmt.Fprintf(md.io.Out, "Creating 1GB volume '%s' for process group '%s'. See `fly vol extend` to increase its size\n", m.Source, groupName)
-
-			input := api.CreateVolumeInput{
-				AppID:     md.app.ID,
-				Name:      m.Source,
-				Region:    groupConfig.PrimaryRegion,
-				SizeGb:    1,
-				Encrypted: true,
-			}
-
-			_, err := md.apiClient.CreateVolume(ctx, input)
-			if err != nil {
-				return fmt.Errorf("failed creating volume: %w", err)
-			}
-		}
-	}
-	return nil
-}
-
-func (md *machineDeployment) provisionIpsOnFirstDeploy(ctx context.Context) error {
-	// Provision only if the app hasn't been deployed and have services defined
-	if !md.isFirstDeploy || len(md.appConfig.AllServices()) == 0 {
-		return nil
-	}
-
-	// Do not touch IPs if there are already allocated
-	ipAddrs, err := md.apiClient.GetIPAddresses(ctx, md.app.Name)
-	if err != nil {
-		return fmt.Errorf("error detecting ip addresses allocated to %s app: %w", md.app.Name, err)
-	}
-	if len(ipAddrs) > 0 {
-		return nil
-	}
-
-	switch md.appConfig.HasNonHttpAndHttpsStandardServices() {
-	case true:
-		hasUdpService := md.appConfig.HasUdpService()
-
-		ipStuffStr := "a dedicated ipv4 address"
-		if !hasUdpService {
-			ipStuffStr = "dedicated ipv4 and ipv6 addresses"
-		}
-
-		confirmDedicatedIp, err := prompt.Confirmf(ctx, "Would you like to allocate %s now?", ipStuffStr)
-		if confirmDedicatedIp && err == nil {
-			v4Dedicated, err := md.apiClient.AllocateIPAddress(ctx, md.app.Name, "v4", "", nil, "")
-			if err != nil {
-				return err
-			}
-			fmt.Fprintf(md.io.Out, "Allocated dedicated ipv4: %s\n", v4Dedicated.Address)
-
-			if !hasUdpService {
-				v6Dedicated, err := md.apiClient.AllocateIPAddress(ctx, md.app.Name, "v6", "", nil, "")
-				if err != nil {
-					return err
-				}
-				fmt.Fprintf(md.io.Out, "Allocated dedicated ipv6: %s\n", v6Dedicated.Address)
-			}
-		}
-
-	case false:
-		fmt.Fprintf(md.io.Out, "Provisioning ips for %s\n", md.colorize.Bold(md.app.Name))
-		v6Addr, err := md.apiClient.AllocateIPAddress(ctx, md.app.Name, "v6", "", nil, "")
-		if err != nil {
-			return fmt.Errorf("error allocating ipv6 after detecting first deploy and presence of services: %w", err)
-		}
-		fmt.Fprintf(md.io.Out, "  Dedicated ipv6: %s\n", v6Addr.Address)
-
-		v4Shared, err := md.apiClient.AllocateSharedIPAddress(ctx, md.app.Name)
-		if err != nil {
-			return fmt.Errorf("error allocating shared ipv4 after detecting first deploy and presence of services: %w", err)
-		}
-		fmt.Fprintf(md.io.Out, "  Shared ipv4: %s\n", v4Shared)
-		fmt.Fprintf(md.io.Out, "  Add a dedicated ipv4 with: fly ips allocate-v4\n")
-	}
-
 	return nil
 }
 

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -37,7 +37,6 @@ func (md *machineDeployment) launchInputForLaunch(processGroup string, guest *ap
 	if len(mConfig.Mounts) > 0 {
 		mount0 := &mConfig.Mounts[0]
 		if len(md.volumes[mount0.Name]) == 0 {
-			fmt.Println(md.volumes)
 			return nil, fmt.Errorf("New machine in group '%s' needs an unattached volume named '%s'", processGroup, mount0.Name)
 		}
 		mount0.Volume = md.volumes[mount0.Name][0].ID

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -31,12 +31,16 @@ func (md *machineDeployment) launchInputForLaunch(processGroup string, guest *ap
 	mConfig.Guest = guest
 	mConfig.Image = md.img
 	md.setMachineReleaseData(mConfig)
+	// Get the final process group and prevent empty string
+	processGroup = mConfig.ProcessGroup()
 
-	if len(mConfig.Mounts) != 0 {
-		if len(md.volumes) == 0 {
-			return nil, fmt.Errorf("New machine in group '%s' needs an unattached volume named '%s'", processGroup, mConfig.Mounts[0].Name)
+	if len(mConfig.Mounts) > 0 {
+		mount0 := &mConfig.Mounts[0]
+		if len(md.volumes[mount0.Name]) == 0 {
+			fmt.Println(md.volumes)
+			return nil, fmt.Errorf("New machine in group '%s' needs an unattached volume named '%s'", processGroup, mount0.Name)
 		}
-		mConfig.Mounts[0].Volume = md.volumes[0].ID
+		mount0.Volume = md.volumes[mount0.Name][0].ID
 	}
 
 	return &api.LaunchMachineInput{
@@ -57,6 +61,8 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 	}
 	mConfig.Image = md.img
 	md.setMachineReleaseData(mConfig)
+	// Get the final process group and prevent empty string
+	processGroup = mConfig.ProcessGroup()
 
 	// Mounts needs special treatment:
 	//   * Volumes attached to existings machines can't be swapped by other volumes
@@ -80,10 +86,10 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 			// As we can't change the volume for a running machine, the only
 			// way is to destroy the current machine and launch a new one with the new volume attached
 			terminal.Warnf("Machine %s has volume '%s' attached but fly.toml have a different name: '%s'\n", mID, oMounts[0].Name, mMounts[0].Name)
-			if len(md.volumes) == 0 {
+			if len(md.volumes[mMounts[0].Name]) == 0 {
 				return nil, fmt.Errorf("machine in group '%s' needs an unattached volume named '%s'", processGroup, mMounts[0].Name)
 			}
-			mMounts[0].Volume = md.volumes[0].ID
+			mMounts[0].Volume = md.volumes[mMounts[0].Name][0].ID
 			mID = "" // Forces machine replacement
 		case mMounts[0].Path != oMounts[0].Path:
 			// The volume is the same but its mount path changed. Not a big deal.
@@ -101,10 +107,11 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 		// Replace the machine because [mounts] section was added to fly.toml
 		// and it is not possible to attach a volume to an existing machine.
 		// The volume could be in a different zone than the machine.
-		if len(md.volumes) == 0 {
+		mount0 := &mMounts[0]
+		if len(md.volumes[mount0.Name]) == 0 {
 			return nil, fmt.Errorf("machine in group '%s' needs an unattached volume named '%s'", processGroup, mMounts[0].Name)
 		}
-		mMounts[0].Volume = md.volumes[0].ID
+		mount0.Volume = md.volumes[mount0.Name][0].ID
 		mID = "" // Forces machine replacement
 	}
 

--- a/internal/command/deploy/machines_launchinput_test.go
+++ b/internal/command/deploy/machines_launchinput_test.go
@@ -84,7 +84,7 @@ func Test_launchInputFor_Basic(t *testing.T) {
 // Test Mounts
 func Test_launchInputFor_onMounts(t *testing.T) {
 	md, err := stabMachineDeployment(&appconfig.Config{
-		Mounts: &appconfig.Mount{Source: "data", Destination: "/data"},
+		Mounts: []appconfig.Mount{{Source: "data", Destination: "/data"}},
 	})
 	assert.NoError(t, err)
 	md.volumes = []api.Volume{{ID: "vol_12345", Name: "data"}}

--- a/internal/command/deploy/machines_launchinput_test.go
+++ b/internal/command/deploy/machines_launchinput_test.go
@@ -84,7 +84,7 @@ func Test_launchInputFor_Basic(t *testing.T) {
 // Test Mounts
 func Test_launchInputFor_onMounts(t *testing.T) {
 	md, err := stabMachineDeployment(&appconfig.Config{
-		Mounts: &appconfig.Volume{Source: "data", Destination: "/data"},
+		Mounts: &appconfig.Mount{Source: "data", Destination: "/data"},
 	})
 	assert.NoError(t, err)
 	md.volumes = []api.Volume{{ID: "vol_12345", Name: "data"}}

--- a/internal/command/deploy/machines_launchinput_test.go
+++ b/internal/command/deploy/machines_launchinput_test.go
@@ -87,7 +87,9 @@ func Test_launchInputFor_onMounts(t *testing.T) {
 		Mounts: []appconfig.Mount{{Source: "data", Destination: "/data"}},
 	})
 	assert.NoError(t, err)
-	md.volumes = []api.Volume{{ID: "vol_12345", Name: "data"}}
+	md.volumes = map[string][]api.Volume{
+		"data": {{ID: "vol_12345", Name: "data"}},
+	}
 
 	// New machine must get a volume attached
 	li, err := md.launchInputForLaunch("", nil)

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -90,7 +90,10 @@ func Test_resolveUpdatedMachineConfig_ReleaseCommand(t *testing.T) {
 		}},
 	})
 	require.NoError(t, err)
-	md.volumes = []api.Volume{{ID: "vol_12345"}}
+
+	md.volumes = map[string][]api.Volume{
+		"data": {{ID: "vol_12345"}},
+	}
 
 	// New app machine
 	li, err := md.launchInputForLaunch("", nil)
@@ -219,7 +222,9 @@ func Test_resolveUpdatedMachineConfig_Mounts(t *testing.T) {
 		}},
 	})
 	require.NoError(t, err)
-	md.volumes = []api.Volume{{ID: "vol_12345"}}
+	md.volumes = map[string][]api.Volume{
+		"data": {{ID: "vol_12345"}},
+	}
 
 	// New app machine
 	li, err := md.launchInputForLaunch("", nil)

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -70,10 +70,10 @@ func Test_resolveUpdatedMachineConfig_ReleaseCommand(t *testing.T) {
 		Deploy: &appconfig.Deploy{
 			ReleaseCommand: "touch sky",
 		},
-		Mounts: &appconfig.Mount{
+		Mounts: []appconfig.Mount{{
 			Source:      "data",
 			Destination: "/data",
-		},
+		}},
 		Checks: map[string]*appconfig.ToplevelCheck{
 			"alive": {
 				Port: api.Pointer(8080),
@@ -213,10 +213,10 @@ func Test_resolveUpdatedMachineConfig_ReleaseCommand(t *testing.T) {
 // Test Mounts
 func Test_resolveUpdatedMachineConfig_Mounts(t *testing.T) {
 	md, err := stabMachineDeployment(&appconfig.Config{
-		Mounts: &appconfig.Mount{
+		Mounts: []appconfig.Mount{{
 			Source:      "data",
 			Destination: "/data",
-		},
+		}},
 	})
 	require.NoError(t, err)
 	md.volumes = []api.Volume{{ID: "vol_12345"}}
@@ -280,10 +280,10 @@ func Test_resolveUpdatedMachineConfig_restartOnly(t *testing.T) {
 		Env: map[string]string{
 			"Ignore": "me",
 		},
-		Mounts: &appconfig.Mount{
+		Mounts: []appconfig.Mount{{
 			Source:      "data",
 			Destination: "/data",
-		},
+		}},
 	})
 	assert.NoError(t, err)
 	md.img = "SHOULD-NOT-USE-THIS-TAG"
@@ -316,10 +316,10 @@ func Test_resolveUpdatedMachineConfig_restartOnlyProcessGroup(t *testing.T) {
 		Env: map[string]string{
 			"Ignore": "me",
 		},
-		Mounts: &appconfig.Mount{
+		Mounts: []appconfig.Mount{{
 			Source:      "data",
 			Destination: "/data",
-		},
+		}},
 	})
 	md.releaseVersion = 2
 	assert.NoError(t, err)

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -70,7 +70,7 @@ func Test_resolveUpdatedMachineConfig_ReleaseCommand(t *testing.T) {
 		Deploy: &appconfig.Deploy{
 			ReleaseCommand: "touch sky",
 		},
-		Mounts: &appconfig.Volume{
+		Mounts: &appconfig.Mount{
 			Source:      "data",
 			Destination: "/data",
 		},
@@ -213,7 +213,7 @@ func Test_resolveUpdatedMachineConfig_ReleaseCommand(t *testing.T) {
 // Test Mounts
 func Test_resolveUpdatedMachineConfig_Mounts(t *testing.T) {
 	md, err := stabMachineDeployment(&appconfig.Config{
-		Mounts: &appconfig.Volume{
+		Mounts: &appconfig.Mount{
 			Source:      "data",
 			Destination: "/data",
 		},
@@ -280,7 +280,7 @@ func Test_resolveUpdatedMachineConfig_restartOnly(t *testing.T) {
 		Env: map[string]string{
 			"Ignore": "me",
 		},
-		Mounts: &appconfig.Volume{
+		Mounts: &appconfig.Mount{
 			Source:      "data",
 			Destination: "/data",
 		},
@@ -316,7 +316,7 @@ func Test_resolveUpdatedMachineConfig_restartOnlyProcessGroup(t *testing.T) {
 		Env: map[string]string{
 			"Ignore": "me",
 		},
-		Mounts: &appconfig.Volume{
+		Mounts: &appconfig.Mount{
 			Source:      "data",
 			Destination: "/data",
 		},

--- a/internal/command/launch/sourceinfo.go
+++ b/internal/command/launch/sourceinfo.go
@@ -61,7 +61,7 @@ func determineSourceInfo(ctx context.Context, appConfig *appconfig.Config, copyC
 	}
 
 	if strategies := appConfig.BuildStrategies(); len(strategies) > 0 {
-		fmt.Fprintf(io.Out, "Using build strategies '%s'. Remove [build] from fly.toml to force a rescan", aurora.Yellow(strategies))
+		fmt.Fprintf(io.Out, "Using build strategies '%s'. Remove [build] from fly.toml to force a rescan\n", aurora.Yellow(strategies))
 		return srcInfo, appConfig.Build, nil
 	}
 

--- a/internal/command/launch/srcinfo.go
+++ b/internal/command/launch/srcinfo.go
@@ -261,7 +261,7 @@ func setAppconfigFromSrcinfo(ctx context.Context, srcInfo *scanner.SourceInfo, a
 				Destination: v.Destination,
 			})
 		}
-		appConfig.SetVolumes(appVolumes)
+		appConfig.SetMounts(appVolumes)
 	}
 
 	for procName, procCommand := range srcInfo.Processes {

--- a/internal/command/launch/srcinfo.go
+++ b/internal/command/launch/srcinfo.go
@@ -254,9 +254,9 @@ func setAppconfigFromSrcinfo(ctx context.Context, srcInfo *scanner.SourceInfo, a
 	}
 
 	if len(srcInfo.Volumes) > 0 {
-		var appVolumes []appconfig.Volume
+		var appVolumes []appconfig.Mount
 		for _, v := range srcInfo.Volumes {
-			appVolumes = append(appVolumes, appconfig.Volume{
+			appVolumes = append(appVolumes, appconfig.Mount{
 				Source:      v.Source,
 				Destination: v.Destination,
 			})

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -685,7 +685,10 @@ func (m *v2PlatformMigrator) deployApp(ctx context.Context) error {
 		RestartOnly: true,
 	}
 	if m.isPostgres {
-		input.NewVolumeName = "pg_data_machines"
+		appConfig := appconfig.ConfigFromContext(ctx)
+		if len(appConfig.Mounts) > 0 {
+			appConfig.Mounts[0].Source = "pg_data_machines"
+		}
 	}
 	md, err := deploy.NewMachineDeployment(ctx, input)
 	if err != nil {

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -685,11 +685,12 @@ func (m *v2PlatformMigrator) deployApp(ctx context.Context) error {
 		RestartOnly: true,
 	}
 	if m.isPostgres {
-		appConfig := appconfig.ConfigFromContext(ctx)
-		if len(appConfig.Mounts) > 0 {
-			appConfig.Mounts[0].Source = "pg_data_machines"
+		if len(m.appConfig.Mounts) > 0 {
+			m.appConfig.Mounts[0].Source = "pg_data_machines"
 		}
 	}
+	// Feed appConfig into the context so MachineDeployment can reuse it
+	ctx = appconfig.WithConfig(ctx, m.appConfig)
 	md, err := deploy.NewMachineDeployment(ctx, input)
 	if err != nil {
 		sentry.CaptureExceptionWithAppInfo(err, "migrate-to-v2", m.appCompact)
@@ -818,10 +819,7 @@ func (m *v2PlatformMigrator) ConfirmChanges(ctx context.Context) (bool, error) {
 }
 
 func determineAppConfigForMachines(ctx context.Context) (*appconfig.Config, error) {
-	var (
-		err                error
-		appNameFromContext = appconfig.NameFromContext(ctx)
-	)
+	appNameFromContext := appconfig.NameFromContext(ctx)
 	cfg, err := appconfig.FromRemoteApp(ctx, appNameFromContext)
 	if err != nil {
 		return nil, err

--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -38,7 +38,6 @@ for updates, watch https://community.fly.io for announcements about volume migra
 }
 
 func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
-
 	// NOTE: appconfig.Volume doesn't support the rare "processes" key on mounts
 	//       this is extremely rarely used, and seemingly undocumented,
 	//       but because of this rollback stores a copy of the old appconfig now
@@ -46,7 +45,7 @@ func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 	//       That said, once an app gets moved to V2, that mapping gets wiped.
 	// (not an issue now, because we don't even support multiple volumes on v2,
 	//  but it's worth documenting here nonetheless)
-	m.appConfig.SetVolumes(lo.Map(m.appConfig.Volumes(), func(v appconfig.Volume, _ int) appconfig.Volume {
+	m.appConfig.SetVolumes(lo.Map(m.appConfig.Volumes(), func(v appconfig.Mount, _ int) appconfig.Mount {
 		v.Source = nomadVolNameToV2VolName(v.Source)
 		return v
 	}))

--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -45,7 +45,7 @@ func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 	//       That said, once an app gets moved to V2, that mapping gets wiped.
 	// (not an issue now, because we don't even support multiple volumes on v2,
 	//  but it's worth documenting here nonetheless)
-	m.appConfig.SetVolumes(lo.Map(m.appConfig.Volumes(), func(v appconfig.Mount, _ int) appconfig.Mount {
+	m.appConfig.SetMounts(lo.Map(m.appConfig.Volumes(), func(v appconfig.Mount, _ int) appconfig.Mount {
 		v.Source = nomadVolNameToV2VolName(v.Source)
 		return v
 	}))

--- a/internal/command/turboku/turboku.go
+++ b/internal/command/turboku/turboku.go
@@ -217,6 +217,7 @@ func run(ctx context.Context) error {
 	fmt.Fprintln(io.Out, "Dockerfile created")
 
 	appConfig.AppName = createdApp.Name
+	appConfig.PrimaryRegion = regionCode
 	ctx = appconfig.WithName(ctx, appConfig.AppName)
 	ctx = appconfig.WithConfig(ctx, appConfig)
 

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -252,6 +252,5 @@ func TestFlyLaunch_case07(t *testing.T) {
 	processes = ["other"]
 `)
 
-	f.Fly("version")
 	f.Fly("launch --now --copy-config -o %s --name %s --region %s --force-machines", f.OrgSlug(), appName, f.PrimaryRegion())
 }

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -226,3 +226,32 @@ primary_region = "%s"
 	})
 	require.NotEqual(f, appName3, toml["app"])
 }
+
+// test volumes are created on first launch
+func TestFlyLaunch_case07(t *testing.T) {
+	f := testlib.NewTestEnvFromEnv(t)
+	appName := f.CreateRandomAppName()
+
+	f.WriteFlyToml(`
+[build]
+  image = "nginx"
+
+[processes]
+	app = ""
+	other = "sleep inf"
+	backend = "sleep 1h"
+
+[[mounts]]
+  source = "data"
+	destination = "/data"
+	processes = ["app"]
+
+[[mounts]]
+  source = "trashbin"
+	destination = "/data"
+	processes = ["other"]
+`)
+
+	f.Fly("version")
+	f.Fly("launch --now --copy-config -o %s --name %s --region %s --force-machines", f.OrgSlug(), appName, f.PrimaryRegion())
+}


### PR DESCRIPTION
Brings "Mounts per process group"'s Nomad feature to machines, but also creates needed volumes on `fly launch`  

Fixes https://github.com/superfly/flyctl/issues/1179 and https://github.com/superfly/flyctl/issues/729

For instance this fly.toml (3 process, 2 mounts) just work on first `fly launch`
```toml
[build]
  image = "nginx"

[processes]
  app = ""
  other = "sleep 1h"
  backend = "sleep inf"

[http_service]
  internal_port = 80
  force_https = true
  processes = ["app"]

[[mounts]]
  source = "data"
  destination = "/data"
  processes = ["app"]

[[mounts]]
  source = "trashbin"
  destination = "/data"
  processes = ["other"]
```

It does all in one shot 🔫 
```
$ fly launch --copy-config -o personal --name groupmounts --region scl --now
Creating app in /home/daniel/tt/aa
An existing fly.toml file was found for app groupmounts
Using build strategies '[the "nginx" docker image]'. Remove [build] from fly.toml to force a rescan
App will use 'scl' region as primary
Created app 'groupmounts' in organization 'personal'
Admin URL: https://fly.io/apps/groupmounts
Hostname: groupmounts.fly.dev
Wrote config file fly.toml
==> Building image
Searching for image 'nginx' remotely...
image found: img_3xdk4x0kg574go0e
Provisioning ips for groupmounts
  Dedicated ipv6: 2a09:8280:1::15:d5b
  Shared ipv4: 66.241.124.148
  Add a dedicated ipv4 with: fly ips allocate-v4
Creating volume 'data' for process group 'app'
Creating volume 'trashbin' for process group 'other'
Process groups have changed. This will:
 * create 1 "other" machine
 * create 1 "app" machine
 * create 1 "backend" machine

No machines in group 'app', launching one new machine
  Machine 3d8d9790b75789 [app] update finished: success
No machines in group 'backend', launching one new machine
  Machine 6e82d441bd3487 [backend] update finished: success
No machines in group 'other', launching one new machine
  Machine 4d891d15a71387 [other] update finished: success
Finished launching new machines
Updating existing machines in 'groupmounts' with rolling strategy
  Finished deploying
```