### PR TITLE
Fly launch learns how to set initial VM size

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -72,6 +72,10 @@ var CommonFlags = flag.Set{
 		Description: "Use the Apps v2 platform built with Machines",
 		Default:     false,
 	},
+	flag.String{
+		Name:        "vm-size",
+		Description: `The VM size to use when deploying for the first time. See "fly platform vm-sizes" for valid values`,
+	},
 }
 
 func New() (cmd *cobra.Command) {
@@ -173,6 +177,7 @@ func deployToMachines(ctx context.Context, appConfig *appconfig.Config, appCompa
 		SkipHealthChecks:  flag.GetDetach(ctx),
 		WaitTimeout:       time.Duration(flag.GetInt(ctx, "wait-timeout")) * time.Second,
 		LeaseTimeout:      time.Duration(flag.GetInt(ctx, "lease-timeout")) * time.Second,
+		VMSize:            flag.GetString(ctx, "vm-size"),
 	})
 	if err != nil {
 		sentry.CaptureExceptionWithAppInfo(err, "deploy", appCompact)

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -323,6 +323,9 @@ func (md *machineDeployment) latestImage(ctx context.Context) (string, error) {
 }
 
 func (md *machineDeployment) setMachineGuest(vmSize string) error {
+	if vmSize == "" {
+		return nil
+	}
 	md.machineGuest = &api.MachineGuest{}
 	return md.machineGuest.SetSize(vmSize)
 }

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -204,7 +204,7 @@ func (md *machineDeployment) spawnMachineInGroup(ctx context.Context, groupName 
 		panic("spawnMachineInGroup requires a non-empty group name. this is a bug!")
 	}
 	fmt.Fprintf(md.io.Out, "No machines in group '%s', launching one new machine\n", md.colorize.Bold(groupName))
-	launchInput, err := md.launchInputForLaunch(groupName, nil)
+	launchInput, err := md.launchInputForLaunch(groupName, md.machineGuest)
 	if err != nil {
 		return fmt.Errorf("error creating machine configuration: %w", err)
 	}

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -254,3 +254,15 @@ func TestFlyLaunch_case07(t *testing.T) {
 
 	f.Fly("launch --now --copy-config -o %s --name %s --region %s --force-machines", f.OrgSlug(), appName, f.PrimaryRegion())
 }
+
+// test --vm-size sets the machine guest on first deploy
+func TestFlyLaunch_case08(t *testing.T) {
+	f := testlib.NewTestEnvFromEnv(t)
+	appName := f.CreateRandomAppName()
+
+	f.Fly("launch --detach --now -o %s --name %s --region %s --force-machines --image nginx --vm-size shared-cpu-4x", f.OrgSlug(), appName, f.PrimaryRegion())
+
+	ml := f.MachinesList(appName)
+	require.Equal(f, 1, len(ml))
+	require.Equal(f, "shared-cpu-4x", ml[0].Config.Guest.ToSize())
+}


### PR DESCRIPTION
```
$ fly launch --copy-config -o personal --name groupmounts --region scl --now --vm-size shared-cpu-2x
Creating app in /home/daniel/tt/aa
An existing fly.toml file was found for app groupmounts
Using build strategies '[the "nginx" docker image]'. Remove [build] from fly.toml to force a rescan
App will use 'scl' region as primary
Created app 'groupmounts' in organization 'personal'
Admin URL: https://fly.io/apps/groupmounts
Hostname: groupmounts.fly.dev
Wrote config file fly.toml
==> Building image
Searching for image 'nginx' remotely...
image found: img_3xdk4x0kg574go0e
Creating 1GB volume 'data' for process group 'app'. See `fly vol extend` to increase its size
Creating 1GB volume 'trashbin' for process group 'other'. See `fly vol extend` to increase its size
Process groups have changed. This will:
 * create 1 "app" machine
 * create 1 "backend" machine
 * create 1 "other" machine

No machines in group 'app', launching one new machine
  Machine 5683d331be578e [app] update finished: success
No machines in group 'backend', launching one new machine
  Machine 5683735a71098e [backend] update finished: success
No machines in group 'other', launching one new machine
  Machine 148ed559b20389 [other] update finished: success
Finished launching new machines
Updating existing machines in 'groupmounts' with rolling strategy
  Finished deploying
  
 $ fly scale show
VM Resources for app: groupmounts

Groups
NAME    COUNT   KIND    CPUS    MEMORY  REGIONS
app     1       shared  2       512 MB  scl
backend 1       shared  2       512 MB  scl
other   1       shared  2       512 MB  scl

```