### PR TITLE
Create app with HA setup on first deploy

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -445,10 +445,6 @@ type MachineConfig struct {
 	Checks   map[string]MachineCheck `json:"checks,omitempty"`
 	Statics  []*Static               `json:"statics,omitempty"`
 
-	// Standbys enable a machine to be a standby for another. In the event of a hardware failure,
-	// the standby machine will be started.
-	Standbys []string `json:"standbys,omitempty"`
-
 	// Set by fly deploy or fly machines commands
 	Image string `json:"image,omitempty"`
 
@@ -461,7 +457,6 @@ type MachineConfig struct {
 	DNS         *DNSConfig       `json:"dns,omitempty"`
 	Processes   []MachineProcess `json:"processes,omitempty"`
 
-	// Not used by flyctl yet
 	// Standbys enable a machine to be a standby for another. In the event of a hardware failure,
 	// the standby machine will be started.
 	Standbys []string `json:"standbys,omitempty"`

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -524,12 +524,13 @@ type MachineStartResponse struct {
 }
 
 type LaunchMachineInput struct {
-	AppID   string         `json:"appId,omitempty"`
-	ID      string         `json:"id,omitempty"`
-	Name    string         `json:"name,omitempty"`
-	OrgSlug string         `json:"organizationId,omitempty"`
-	Region  string         `json:"region,omitempty"`
-	Config  *MachineConfig `json:"config,omitempty"`
+	AppID      string         `json:"appId,omitempty"`
+	ID         string         `json:"id,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	OrgSlug    string         `json:"organizationId,omitempty"`
+	Region     string         `json:"region,omitempty"`
+	Config     *MachineConfig `json:"config,omitempty"`
+	SkipLaunch bool           `json:"skip_launch,omitempty"`
 	// Client side only
 	SkipHealthChecks bool
 }

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -21,6 +21,7 @@ const (
 	MachineStateDestroying                     = "destroying"
 	MachineStateStarted                        = "started"
 	MachineStateStopped                        = "stopped"
+	MachineStateCreated                        = "created"
 )
 
 type Machine struct {
@@ -443,6 +444,10 @@ type MachineConfig struct {
 	Metrics  *MachineMetrics         `json:"metrics,omitempty"`
 	Checks   map[string]MachineCheck `json:"checks,omitempty"`
 	Statics  []*Static               `json:"statics,omitempty"`
+
+	// Standbys enable a machine to be a standby for another. In the event of a hardware failure,
+	// the standby machine will be started.
+	Standbys []string `json:"standbys,omitempty"`
 
 	// Set by fly deploy or fly machines commands
 	Image string `json:"image,omitempty"`

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -13,10 +13,10 @@ func (md *machineDeployment) provisionFirstDeploy(ctx context.Context) error {
 		return nil
 	}
 	if err := md.provisionIpsOnFirstDeploy(ctx); err != nil {
-		return nil
+		fmt.Fprintf(md.io.ErrOut, "Failed to provision IP addresses, use `fly ips` commands to remmediate it. ERROR: %s", err)
 	}
 	if err := md.provisionVolumesOnFirstDeploy(ctx); err != nil {
-		return nil
+		return fmt.Errorf("failed to provision seed volumes: %w", err)
 	}
 	return nil
 }

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -196,6 +196,17 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 			}
 		}
 
+		// Don't wait for Standby machines, they are updated but not started
+		if len(launchInput.Config.Standbys) > 0 {
+			md.logClearLinesAbove(1)
+			fmt.Fprintf(md.io.ErrOut, "  %s Machine %s update finished: %s\n",
+				indexStr,
+				md.colorize.Bold(lm.FormattedMachineId()),
+				md.colorize.Green("success"),
+			)
+			continue
+		}
+
 		if md.strategy == "immediate" {
 			continue
 		}

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -120,11 +120,12 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 	}
 
 	return &api.LaunchMachineInput{
-		ID:      mID,
-		AppID:   md.app.Name,
-		OrgSlug: md.app.Organization.ID,
-		Region:  origMachineRaw.Region,
-		Config:  mConfig,
+		ID:         mID,
+		AppID:      md.app.Name,
+		OrgSlug:    md.app.Organization.ID,
+		Region:     origMachineRaw.Region,
+		Config:     mConfig,
+		SkipLaunch: len(mConfig.Standbys) > 0,
 	}, nil
 }
 

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -23,7 +23,7 @@ func (md *machineDeployment) launchInputForRestart(origMachineRaw *api.Machine) 
 	}
 }
 
-func (md *machineDeployment) launchInputForLaunch(processGroup string, guest *api.MachineGuest) (*api.LaunchMachineInput, error) {
+func (md *machineDeployment) launchInputForLaunch(processGroup string, guest *api.MachineGuest, standbyFor []string) (*api.LaunchMachineInput, error) {
 	mConfig, err := md.appConfig.ToMachineConfig(processGroup, nil)
 	if err != nil {
 		return nil, err
@@ -42,11 +42,16 @@ func (md *machineDeployment) launchInputForLaunch(processGroup string, guest *ap
 		mount0.Volume = md.volumes[mount0.Name][0].ID
 	}
 
+	if len(standbyFor) > 0 {
+		mConfig.Standbys = standbyFor
+	}
+
 	return &api.LaunchMachineInput{
-		AppID:   md.app.Name,
-		OrgSlug: md.app.Organization.ID,
-		Region:  md.appConfig.PrimaryRegion,
-		Config:  mConfig,
+		AppID:      md.app.Name,
+		OrgSlug:    md.app.Organization.ID,
+		Region:     md.appConfig.PrimaryRegion,
+		Config:     mConfig,
+		SkipLaunch: len(standbyFor) > 0,
 	}, nil
 }
 

--- a/internal/command/deploy/machines_launchinput_test.go
+++ b/internal/command/deploy/machines_launchinput_test.go
@@ -42,7 +42,7 @@ func Test_launchInputFor_Basic(t *testing.T) {
 			},
 		},
 	}
-	li, err := md.launchInputForLaunch("", nil)
+	li, err := md.launchInputForLaunch("", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, want, li)
 
@@ -93,7 +93,7 @@ func Test_launchInputFor_onMounts(t *testing.T) {
 	}
 
 	// New machine must get a volume attached
-	li, err := md.launchInputForLaunch("", nil)
+	li, err := md.launchInputForLaunch("", nil, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, li.Config.Mounts)
 	assert.Equal(t, api.MachineMount{Volume: "vol_12345", Path: "/data", Name: "data"}, li.Config.Mounts[0])

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -34,7 +34,7 @@ func Test_resolveUpdatedMachineConfig_Basic(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	li, err := md.launchInputForLaunch("", nil)
+	li, err := md.launchInputForLaunch("", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, &api.LaunchMachineInput{
 		OrgSlug: "my-dangling-org",
@@ -97,7 +97,7 @@ func Test_resolveUpdatedMachineConfig_ReleaseCommand(t *testing.T) {
 	}
 
 	// New app machine
-	li, err := md.launchInputForLaunch("", nil)
+	li, err := md.launchInputForLaunch("", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, &api.LaunchMachineInput{
 		OrgSlug: "my-dangling-org",
@@ -231,7 +231,7 @@ func Test_resolveUpdatedMachineConfig_Mounts(t *testing.T) {
 	}
 
 	// New app machine
-	li, err := md.launchInputForLaunch("", nil)
+	li, err := md.launchInputForLaunch("", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, &api.LaunchMachineInput{
 		OrgSlug: "my-dangling-org",

--- a/internal/command/launch/freshconfigs.go
+++ b/internal/command/launch/freshconfigs.go
@@ -17,8 +17,10 @@ func freshV2Config(appName string, srcCfg *appconfig.Config) (*appconfig.Config,
 	newCfg.Build = srcCfg.Build
 	newCfg.PrimaryRegion = srcCfg.PrimaryRegion
 	newCfg.HTTPService = &appconfig.HTTPService{
-		InternalPort: 8080,
-		ForceHTTPS:   true,
+		InternalPort:      8080,
+		ForceHTTPS:        true,
+		AutoStartMachines: api.Pointer(true),
+		AutoStopMachines:  api.Pointer(true),
 	}
 	newCfg.Checks = map[string]*appconfig.ToplevelCheck{
 		"alive": {


### PR DESCRIPTION
`fly launch` will evaluate every process group (by default is just one) and:
* Create 2 machines for groups with services defined
* Create 1 always-on and 1 standby machine for groups without services
* Create only 1 machine if the group has mounts defined

For example, this fly.toml:
```toml
app = "standbys"
primary_region = "scl"

[build]
  image = "nginx"

[processes]
  app = ""
  disk = "sleep inf"
  task = "sleep inf"

[[mounts]]
  source = "disk"
  destination = "/data"
  processes = ["disk"]

[http_service]
  internal_port = 80
  force_https = true
  auto_stop_machines = true
  auto_start_machines = true
  processes = ["app"]

[checks]
  [checks.alive]
    type = "tcp"
    interval = "15s"
    timeout = "2s"
    grace_period = "5s"
    processes = ["app"]
```

first deploy is:

```
$ fly deploy
==> Verifying app config
Validating /home/daniel/tt/fly.toml
Platform: machines
✓ Configuration is valid
--> Verified app config
==> Building image
...
Creating 1GB volume 'disk' for process group 'disk'. See `fly vol extend` to increase its size
Process groups have changed. This will:
 * create 1 "app" machine
 * create 1 "disk" machine
 * create 1 "task" machine

No machines in group app, launching one new machine
  Machine e286374ce49686 [app] update finished: success
Creating a second machine for e286374ce49686
  Machine 32874540ad6785 [app] update finished: success
No machines in group disk, launching one new machine
  Machine 91850e6b452583 [disk] update finished: success
No machines in group task, launching one new machine
  Machine 91857226f92783 [task] update finished: success
Creating a standby machine for 91857226f92783
  Machine 5683735a767d8e [task] was created
Finished launching new machines
Updating existing machines in 'standbys' with rolling strategy
  Finished deploying
```

And it results in 5 machines, 2 started for app group, 1+1 for task and only 1 for disk.
```
$ fly status
App
  Name     = standbys
  Owner    = personal
  Hostname = standbys.fly.dev
  Image    = library/nginx:latest
  Platform = machines

Machines
ID              PROCESS VERSION REGION  STATE   HEALTH CHECKS           LAST UPDATED
32874540ad6785  app     1       scl     started 1 total, 1 passing      2023-04-18T21:30:48Z
5683735a767d8e  task    1       scl     stopped                         2023-04-18T21:31:20Z
91850e6b452583  disk    1       scl     started                         2023-04-18T21:31:09Z
91857226f92783  task    1       scl     started                         2023-04-18T21:31:13Z
e286374ce49686  app     1       scl     started 1 total, 1 passing      2023-04-18T21:30:34Z
```
