### PR TITLE
docs: add argument guide to error message

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -174,7 +174,7 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 		}
 		if len(activeMachines) > 0 {
 			return fmt.Errorf(
-				"found %d machines that are unmanaged. `fly deploy` only updates machines with %s=%s in their metadata. Use `fly machine list` to list machines and `fly machine update --metadata %s=%s` to update individual machines with the metadata. Once done, `fly deploy` will update machines with the metadata based on your %s app configuration",
+				"found %d machines that are unmanaged. `fly deploy` only updates machines with %s=%s in their metadata. Use `fly machine list` to list machines and `fly machine update --metadata %s=%s <machine id>` to update individual machines with the metadata. Once done, `fly deploy` will update machines with the metadata based on your %s app configuration",
 				len(activeMachines),
 				api.MachineConfigMetadataKeyFlyPlatformVersion,
 				api.MachineFlyPlatformVersion2,


### PR DESCRIPTION
Added argument guideline to error message as follows:

**Before**
```
Use `fly machine list` to list machines and 
`fly machine update --metadata fly_platform_version=v2` 
to update individual machines with the metadata. 
```

**After**
```
Use `fly machine list` to list machines and 
`fly machine update --metadata fly_platform_version=v2 <machine id>` 
to update individual machines with the metadata.
```
