### PR TITLE
[django] Detect STATIC_ROOT in settings.py to run collectstatic

### DIFF
--- a/scanner/django.go
+++ b/scanner/django.go
@@ -49,21 +49,22 @@ func configureDjango(sourceDir string, config *ScannerConfig) (*SourceInfo, erro
 	    vars["venv"] = true
 	}
 
-    wsgis, err := zglob.Glob(`./**/wsgi.py`)
+    wsgiFiles, err := zglob.Glob(`./**/wsgi.py`)
 
-    if err == nil && len(wsgis) > 0 {
-        wsgiLen := len(wsgis)
-        dirPath, _ := path.Split(wsgis[wsgiLen-1])
+    if err == nil && len(wsgiFiles) > 0 {
+        wsgiFilesLen := len(wsgiFiles)
+        dirPath, _ := path.Split(wsgiFiles[wsgiFilesLen-1])
         dirName := path.Base(dirPath)
         vars["wsgiName"] = dirName;
         vars["wsgiFound"] = true;
-        if wsgiLen > 1 {
+        if wsgiFilesLen > 1 {
             // warning: multiple wsgi.py files found
             s.DeployDocs = s.DeployDocs + fmt.Sprintf(`
-Multiple wsgi.py files were found!
-Before proceeding, make sure '%s' is the module containing a WSGI application object named 'application'.
+Multiple wsgi.py files were found in your Django application:
+[%s]
+Before proceeding, make sure '%s' is the module containing a WSGI application object named 'application'. If not, update your Dockefile.
 This module is used on Dockerfile to start the Gunicorn server process.
-`, dirPath)
+`, strings.Join(wsgiFiles, ", "), dirPath)
         }
     }
 

--- a/scanner/django.go
+++ b/scanner/django.go
@@ -66,6 +66,18 @@ This module is used on Dockerfile to start the Gunicorn server process.
         }
     }
 
+    settings, err := zglob.Glob(`./**/settings.py`)
+
+    if err == nil && len(settings) == 1 {
+        settingsPath := settings[0]
+
+        // check if STATIC_ROOT is set on settings.py
+        if checksPass(sourceDir, dirContains(settingsPath, "STATIC_ROOT")) {
+           vars["collectStatic"] = true
+           s.DeployDocs = `STATIC_ROOT was detected in your settings.py! Dockerfile will collect the static files.`
+       }
+    }
+
     s.Files = templatesExecute("templates/django", vars)
 
 	// check if project has a postgres dependency

--- a/scanner/templates/django/Dockerfile
+++ b/scanner/templates/django/Dockerfile
@@ -28,6 +28,9 @@ RUN set -ex && \
 
 COPY . /code
 {{ if .collectStatic }}
+{{ if not .hasRandomSecretKey -}}
+ENV SECRET_KEY "{{ .randomSecretKey }}"
+{{ end -}}
 RUN python manage.py collectstatic --noinput
 {{ end }}
 EXPOSE 8000

--- a/scanner/templates/django/Dockerfile
+++ b/scanner/templates/django/Dockerfile
@@ -27,9 +27,9 @@ RUN set -ex && \
 {{ end -}}
 
 COPY . /code
-
+{{ if .collectStatic }}
 RUN python manage.py collectstatic --noinput
-
+{{ end }}
 EXPOSE 8000
 
 {{ if .wsgiFound -}}


### PR DESCRIPTION
Check for `settings.py` files or files `*prod*.py` inside `settings/` folder (e.g. production.py, prod.py, settings_prod.py, etc.).

If any of those files contain `STATIC_ROOT` setting , we set on Dockerfile:
```
{{ if .collectStatic }}
...
RUN python manage.py collectstatic --noinput
{{ end }}
```

If the file containing `STATIC_ROOT` setting does not set a default value foe SECRET_KEY (`django.core.management.utils.get_random_secret_key()`), generate a 50 character random string usable as a SECRET_KEY setting value on Dockerfile:
```
ENV SECRET_KEY "{{ .randomSecretKey }}"
```

Add all the necessary information on DeployDocs.