### PR TITLE
fix typo intenral->internal

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -122,7 +122,7 @@ var sharedFlags = flag.Set{
 	},
 	flag.Bool{
 		Name:        "skip-dns-registration",
-		Description: "Do not register the machine's 6PN IP with the intenral DNS system",
+		Description: "Do not register the machine's 6PN IP with the internal DNS system",
 	},
 	flag.Bool{
 		Name:        "autostart",


### PR DESCRIPTION
Spotted a minor typo in the docs via `fly machine run --help` - 

```
fly machine run --help
Run a machine

Usage:
  flyctl machine run <image> [command] [flags]

Flags:
...
      --skip-dns-registration   Do not register the machine's 6PN IP with the intenral DNS system
```

