### PR TITLE
`migrate-to-v2`: gate volume code behind whether we're using volumes

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -417,7 +417,7 @@ func (m *v2PlatformMigrator) Migrate(ctx context.Context) (err error) {
 		return abortedErr
 	}
 
-	if !m.isPostgres {
+	if !m.isPostgres && m.usesForkedVolumes {
 		tb.Detail("Making snapshots of volumes for the new machines")
 		err = m.migrateAppVolumes(ctx)
 		if err != nil {


### PR DESCRIPTION
prevents logging about volumes for apps without volumes, also just more hygienic