### PR TITLE
`deploy`: promote group-less machines into "app" group

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -185,6 +185,14 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 		}
 	}
 
+	for _, m := range machines {
+		if m.Config != nil && m.Config.Metadata != nil {
+			if m.Config.Metadata[api.MachineConfigMetadataKeyFlyProcessGroup] == "" {
+				m.Config.Metadata[api.MachineConfigMetadataKeyFlyProcessGroup] = api.MachineProcessGroupApp
+			}
+		}
+	}
+
 	md.machineSet = machine.NewMachineSet(md.flapsClient, md.io, machines)
 	var releaseCmdSet []*api.Machine
 	if releaseCmdMachine != nil {

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -188,7 +188,7 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 	for _, m := range machines {
 		if m.Config != nil && m.Config.Metadata != nil {
 			if m.Config.Metadata[api.MachineConfigMetadataKeyFlyProcessGroup] == "" {
-				m.Config.Metadata[api.MachineConfigMetadataKeyFlyProcessGroup] = api.MachineProcessGroupApp
+				m.Config.Metadata[api.MachineConfigMetadataKeyFlyProcessGroup] = md.appConfig.DefaultProcessName()
 			}
 		}
 	}


### PR DESCRIPTION
This makes machines with no process group set (e.g. machines migrated to the platform with `m update`) take on the group "app".

If there are two machines in "app", and you just updated a machine to use the platform, so its group is "", after a deploy you'd have three "app" machines.