### PR TITLE
`migrate-to-v2`: volumes general availability

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -54,11 +54,6 @@ func newMigrateToV2() *cobra.Command {
 		flag.Yes(),
 		flag.App(),
 		flag.AppConfig(),
-		flag.Bool{
-			// Note: This is referenced in a preflight test, make sure to remove that when removing this flag!
-			Name:        "experimental-volume-migration",
-			Description: "Migrate apps with volumes. Causes brief downtime. Experimental feature, use at your own risk!",
-		},
 		flag.String{
 			Name:        "primary-region",
 			Description: "Specify primary region if one is not set in fly.toml",

--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -8,7 +8,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/internal/appconfig"
-	"github.com/superfly/flyctl/internal/flag"
 	"golang.org/x/exp/slices"
 )
 
@@ -21,11 +20,6 @@ func (m *v2PlatformMigrator) validateVolumes(ctx context.Context) error {
 		return nil
 	}
 	numMounts := len(m.appConfig.Mounts)
-	if numMounts > 0 && !flag.GetBool(ctx, "experimental-volume-migration") {
-		return fmt.Errorf(`migration for apps with volumes is experimental, and gated behind the --experimental-volume-migration flag
-please do not use this on important/production apps yet
-for updates, watch https://community.fly.io for announcements about volume migrations becoming stable`)
-	}
 	m.usesForkedVolumes = numMounts != 0
 
 	volsPerProcess := map[string]int{}

--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -3,6 +3,7 @@ package migrate_to_v2
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
@@ -26,8 +27,28 @@ please do not use this on important/production apps yet
 for updates, watch https://community.fly.io for announcements about volume migrations becoming stable`)
 	}
 	m.usesForkedVolumes = numMounts != 0
-	if numMounts > 1 {
-		return fmt.Errorf("cannot migrate app %s because it uses multiple [[mounts]], which are not yet supported on Apps V2.\nwatch https://community.fly.io for announcements about multiple volume mounts for Apps V2", m.appFull.Name)
+
+	volsPerProcess := map[string]int{}
+	for _, m := range m.appConfig.Mounts {
+		for _, p := range m.Processes {
+			volsPerProcess[p]++
+		}
+	}
+	unmigratableProcesses := lo.FilterMap(lo.Keys(volsPerProcess), func(k string, _ int) (string, bool) {
+		if volsPerProcess[k] > 1 {
+			return fmt.Sprintf("%s (%d)", k, volsPerProcess[k]), true
+		}
+		return "", false
+	})
+	if len(unmigratableProcesses) != 0 {
+		slices.Sort(unmigratableProcesses)
+		processesInfo := ""
+		if len(unmigratableProcesses) == 1 {
+			processesInfo = fmt.Sprintf("process %s", unmigratableProcesses[0])
+		} else {
+			processesInfo = fmt.Sprintf("processes %s", strings.Join(unmigratableProcesses, ", "))
+		}
+		return fmt.Errorf("cannot migrate app %s because it uses multiple mounts for %s, which are not yet supported on Apps V2.\nwatch https://community.fly.io for announcements about multiple volume mounts for Apps V2", m.appFull.Name, processesInfo)
 	}
 	for _, a := range m.oldAllocs {
 		if len(a.AttachedVolumes.Nodes) > 1 {
@@ -38,13 +59,7 @@ for updates, watch https://community.fly.io for announcements about volume migra
 }
 
 func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
-	// NOTE: appconfig.Volume doesn't support the rare "processes" key on mounts
-	//       this is extremely rarely used, and seemingly undocumented,
-	//       but because of this rollback stores a copy of the old appconfig now
-	//       and deploys the original config if something goes wrong.
-	//       That said, once an app gets moved to V2, that mapping gets wiped.
-	// (not an issue now, because we don't even support multiple volumes on v2,
-	//  but it's worth documenting here nonetheless)
+
 	m.appConfig.SetMounts(lo.Map(m.appConfig.Mounts, func(v appconfig.Mount, _ int) appconfig.Mount {
 		v.Source = nomadVolNameToV2VolName(v.Source)
 		return v
@@ -57,22 +72,21 @@ func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 			AppID:          m.appFull.ID,
 			SourceVolumeID: vol.ID,
 			MachinesOnly:   true,
-			// TODO(ali): Do we want to rename their volumes?
-			//            Currently, this adds a `_machines` suffix to the names
-			Name:   nomadVolNameToV2VolName(vol.Name),
-			LockID: m.appLock,
+			Name:           nomadVolNameToV2VolName(vol.Name),
+			LockID:         m.appLock,
 		})
 		if err != nil {
 			return err
 		}
 
 		allocId := ""
+		path := ""
 		if alloc := vol.AttachedAllocation; alloc != nil {
 			allocId = alloc.ID
-		}
-		path := m.nomadVolPath(&vol)
-		if path == "" && allocId != "" {
-			return fmt.Errorf("volume %s[%s] is mounted on alloc %s, but has no mountpoint", vol.Name, vol.ID, allocId)
+			path = m.nomadVolPath(&vol, alloc.TaskName)
+			if path == "" {
+				return fmt.Errorf("volume %s[%s] is mounted on alloc %s, but has no mountpoint", vol.Name, vol.ID, allocId)
+			}
 		}
 		m.createdVolumes = append(m.createdVolumes, &NewVolume{
 			vol:             newVol,
@@ -84,7 +98,7 @@ func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 	return nil
 }
 
-func (m *v2PlatformMigrator) nomadVolPath(v *api.Volume) string {
+func (m *v2PlatformMigrator) nomadVolPath(v *api.Volume, group string) string {
 	if v.AttachedAllocation == nil {
 		return ""
 	}
@@ -93,9 +107,9 @@ func (m *v2PlatformMigrator) nomadVolPath(v *api.Volume) string {
 	// so we have to account for that here
 	name := nomadVolNameToV2VolName(v.Name)
 
-	// TODO(ali): Process group-specific volumes likely change the logic here
 	for _, mount := range m.appConfig.Mounts {
-		if mount.Source == name {
+		inGroup := len(mount.Processes) == 0 || lo.Contains(mount.Processes, group)
+		if mount.Source == name && inGroup {
 			return mount.Destination
 		}
 	}

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -632,7 +632,7 @@ func TestAppsV2MigrateToV2_Volumes(t *testing.T) {
 	assertHasFlag()
 
 	time.Sleep(6 * time.Second)
-	f.Fly("migrate-to-v2 --primary-region %s --yes --experimental-volume-migration", f.PrimaryRegion())
+	f.Fly("migrate-to-v2 --primary-region %s --yes", f.PrimaryRegion())
 	result := f.Fly("status --json")
 
 	var statusMap map[string]any


### PR DESCRIPTION
Removes the experimental flag from volume migrations, and adds support for migrating apps with multiple* volumes
<sup>*one per process group</sup>