### PR TITLE
Enable autostart/stop in v2 app defaults

### DIFF
--- a/internal/command/launch/freshconfigs.go
+++ b/internal/command/launch/freshconfigs.go
@@ -17,8 +17,10 @@ func freshV2Config(appName string, srcCfg *appconfig.Config) (*appconfig.Config,
 	newCfg.Build = srcCfg.Build
 	newCfg.PrimaryRegion = srcCfg.PrimaryRegion
 	newCfg.HTTPService = &appconfig.HTTPService{
-		InternalPort: 8080,
-		ForceHTTPS:   true,
+		InternalPort:      8080,
+		ForceHTTPS:        true,
+		AutoStartMachines: api.Pointer(true),
+		AutoStopMachines:  api.Pointer(true),
 	}
 	newCfg.Checks = map[string]*appconfig.ToplevelCheck{
 		"alive": {


### PR DESCRIPTION
```
$ fly launch --no-deploy --image nginx -o personal -r ord --name dangra-m2
Creating app in /home/daniel/tt/tt
Using image nginx
App will use 'ord' region as primary
Created app 'dangra-m2' in organization 'personal'
Admin URL: https://fly.io/apps/dangra-m2
Hostname: dangra-m2.fly.dev
Your app is ready! Deploy with `flyctl deploy`
```

```toml
# fly.toml file generated for dangra-m2 on 2023-04-17T19:33:53Z

app = "dangra-m2"
primary_region = "ord"

[build]
  image = "nginx"

[http_service]
  internal_port = 8080
  force_https = true
  auto_stop_machines = true
  auto_start_machines = true

[checks]
  [checks.alive]
    type = "tcp"
    interval = "15s"
    timeout = "2s"
    grace_period = "5s"
```