### PR TITLE
`fly console`

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -17,7 +17,7 @@ const (
 	MachineFlyPlatformVersion2                 = "v2"
 	MachineProcessGroupApp                     = "app"
 	MachineProcessGroupFlyAppReleaseCommand    = "fly_app_release_command"
-	MachineProcessGroupFlyAppEphemeralRunner   = "fly_app_ephemeral_runner"
+	MachineProcessGroupFlyAppConsole           = "fly_app_console"
 	MachineStateDestroyed                      = "destroyed"
 	MachineStateDestroying                     = "destroying"
 	MachineStateStarted                        = "started"
@@ -82,8 +82,8 @@ func (m *Machine) IsFlyAppsReleaseCommand() bool {
 	return m.IsFlyAppsPlatform() && m.IsReleaseCommandMachine()
 }
 
-func (m *Machine) IsFlyAppsEphemeralRunner() bool {
-	return m.IsFlyAppsPlatform() && m.HasProcessGroup(MachineProcessGroupFlyAppEphemeralRunner)
+func (m *Machine) IsFlyAppsConsole() bool {
+	return m.IsFlyAppsPlatform() && m.HasProcessGroup(MachineProcessGroupFlyAppConsole)
 }
 
 func (m *Machine) IsActive() bool {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -17,6 +17,7 @@ const (
 	MachineFlyPlatformVersion2                 = "v2"
 	MachineProcessGroupApp                     = "app"
 	MachineProcessGroupFlyAppReleaseCommand    = "fly_app_release_command"
+	MachineProcessGroupFlyAppEphemeralRunner   = "fly_app_ephemeral_runner"
 	MachineStateDestroyed                      = "destroyed"
 	MachineStateDestroying                     = "destroying"
 	MachineStateStarted                        = "started"
@@ -79,6 +80,10 @@ func (m *Machine) IsFlyAppsPlatform() bool {
 
 func (m *Machine) IsFlyAppsReleaseCommand() bool {
 	return m.IsFlyAppsPlatform() && m.IsReleaseCommandMachine()
+}
+
+func (m *Machine) IsFlyAppsEphemeralRunner() bool {
+	return m.IsFlyAppsPlatform() && m.HasProcessGroup(MachineProcessGroupFlyAppEphemeralRunner)
 }
 
 func (m *Machine) IsActive() bool {

--- a/api/resource_releases.go
+++ b/api/resource_releases.go
@@ -105,3 +105,37 @@ func (c *Client) GetAppReleaseNomad(ctx context.Context, appName string, id stri
 
 	return data.App.Release, nil
 }
+
+func (c *Client) GetAppCurrentReleaseMachines(ctx context.Context, appName string) (*Release, error) {
+	query := `
+		query ($appName: String!) {
+			app(name: $appName) {
+				currentRelease: currentReleaseUnprocessed {
+					id
+					version
+					description
+					reason
+					status
+					imageRef
+					stable
+					user {
+						id
+						email
+						name
+					}
+					createdAt
+				}
+			}
+		}
+	`
+
+	req := c.NewRequest(query)
+	req.Var("appName", appName)
+
+	data, err := c.RunWithContext(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.App.CurrentRelease, nil
+}

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -341,14 +341,14 @@ func (f *Client) ListActive(ctx context.Context) ([]*api.Machine, error) {
 	}
 
 	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
-		return !m.IsReleaseCommandMachine() && !m.IsFlyAppsEphemeralRunner() && m.IsActive()
+		return !m.IsReleaseCommandMachine() && !m.IsFlyAppsConsole() && m.IsActive()
 	})
 
 	return machines, nil
 }
 
 // returns apps that are part of the fly apps platform that are not destroyed,
-// excluding ephemeral runners
+// excluding console machines
 func (f *Client) ListFlyAppsMachines(ctx context.Context) ([]*api.Machine, *api.Machine, error) {
 	allMachines := make([]*api.Machine, 0)
 	err := f.sendRequest(ctx, http.MethodGet, "", nil, &allMachines, nil)
@@ -358,7 +358,7 @@ func (f *Client) ListFlyAppsMachines(ctx context.Context) ([]*api.Machine, *api.
 	var releaseCmdMachine *api.Machine
 	machines := make([]*api.Machine, 0)
 	for _, m := range allMachines {
-		if m.IsFlyAppsPlatform() && m.IsActive() && !m.IsFlyAppsReleaseCommand() && !m.IsFlyAppsEphemeralRunner() {
+		if m.IsFlyAppsPlatform() && m.IsActive() && !m.IsFlyAppsReleaseCommand() && !m.IsFlyAppsConsole() {
 			machines = append(machines, m)
 		} else if m.IsFlyAppsReleaseCommand() {
 			releaseCmdMachine = m

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -341,13 +341,14 @@ func (f *Client) ListActive(ctx context.Context) ([]*api.Machine, error) {
 	}
 
 	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
-		return !m.IsReleaseCommandMachine() && m.IsActive()
+		return !m.IsReleaseCommandMachine() && !m.IsFlyAppsEphemeralRunner() && m.IsActive()
 	})
 
 	return machines, nil
 }
 
-// returns apps that are part of the fly apps platform that are not destroyed
+// returns apps that are part of the fly apps platform that are not destroyed,
+// excluding ephemeral runners
 func (f *Client) ListFlyAppsMachines(ctx context.Context) ([]*api.Machine, *api.Machine, error) {
 	allMachines := make([]*api.Machine, 0)
 	err := f.sendRequest(ctx, http.MethodGet, "", nil, &allMachines, nil)
@@ -357,7 +358,7 @@ func (f *Client) ListFlyAppsMachines(ctx context.Context) ([]*api.Machine, *api.
 	var releaseCmdMachine *api.Machine
 	machines := make([]*api.Machine, 0)
 	for _, m := range allMachines {
-		if m.IsFlyAppsPlatform() && m.IsActive() && !m.IsFlyAppsReleaseCommand() {
+		if m.IsFlyAppsPlatform() && m.IsActive() && !m.IsFlyAppsReleaseCommand() && !m.IsFlyAppsEphemeralRunner() {
 			machines = append(machines, m)
 		} else if m.IsFlyAppsReleaseCommand() {
 			releaseCmdMachine = m

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -32,10 +32,11 @@ func NewConfig() *Config {
 // Config wraps the properties of app configuration.
 // NOTE: If you any new setting here, please also add a value for it at testdata/rull-reference.toml
 type Config struct {
-	AppName       string        `toml:"app,omitempty" json:"app,omitempty"`
-	PrimaryRegion string        `toml:"primary_region,omitempty" json:"primary_region,omitempty"`
-	KillSignal    *string       `toml:"kill_signal,omitempty" json:"kill_signal,omitempty"`
-	KillTimeout   *api.Duration `toml:"kill_timeout,omitempty" json:"kill_timeout,omitempty"`
+	AppName        string        `toml:"app,omitempty" json:"app,omitempty"`
+	PrimaryRegion  string        `toml:"primary_region,omitempty" json:"primary_region,omitempty"`
+	KillSignal     *string       `toml:"kill_signal,omitempty" json:"kill_signal,omitempty"`
+	KillTimeout    *api.Duration `toml:"kill_timeout,omitempty" json:"kill_timeout,omitempty"`
+	ConsoleCommand string        `toml:"console_command,omitempty" json:"console_command,omitempty"`
 
 	// Sections that are typically short and benefit from being on top
 	Experimental *Experimental     `toml:"experimental,omitempty" json:"experimental,omitempty"`

--- a/internal/appconfig/definition.go
+++ b/internal/appconfig/definition.go
@@ -37,5 +37,6 @@ func (c *Config) SanitizedDefinition() map[string]any {
 	delete(definition, "build")
 	delete(definition, "primary_region")
 	delete(definition, "http_service")
+	delete(definition, "console_command")
 	return definition
 }

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -163,10 +163,11 @@ func TestToDefinition(t *testing.T) {
 	definition, err := cfg.ToDefinition()
 	assert.NoError(t, err)
 	assert.Equal(t, &api.Definition{
-		"app":            "foo",
-		"primary_region": "sea",
-		"kill_signal":    "SIGTERM",
-		"kill_timeout":   "3s",
+		"app":             "foo",
+		"primary_region":  "sea",
+		"kill_signal":     "SIGTERM",
+		"kill_timeout":    "3s",
+		"console_command": "/bin/bash",
 
 		"build": map[string]any{
 			"builder":      "dockerfile",

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -53,7 +53,7 @@ func (c *Config) ToReleaseMachineConfig() (*api.MachineConfig, error) {
 	return mConfig, nil
 }
 
-func (c *Config) ToEphemeralRunnerMachineConfig() (*api.MachineConfig, error) {
+func (c *Config) ToConsoleMachineConfig() (*api.MachineConfig, error) {
 	mConfig := &api.MachineConfig{
 		Init: api.MachineInit{
 			// TODO: it would be better to configure init to run no
@@ -71,12 +71,12 @@ func (c *Config) ToEphemeralRunnerMachineConfig() (*api.MachineConfig, error) {
 		},
 		Metadata: map[string]string{
 			api.MachineConfigMetadataKeyFlyPlatformVersion: api.MachineFlyPlatformVersion2,
-			api.MachineConfigMetadataKeyFlyProcessGroup:    api.MachineProcessGroupFlyAppEphemeralRunner,
+			api.MachineConfigMetadataKeyFlyProcessGroup:    api.MachineProcessGroupFlyAppConsole,
 		},
 		Env: lo.Assign(c.Env),
 	}
 
-	mConfig.Env["FLY_PROCESS_GROUP"] = api.MachineProcessGroupFlyAppEphemeralRunner
+	mConfig.Env["FLY_PROCESS_GROUP"] = api.MachineProcessGroupFlyAppConsole
 	if c.PrimaryRegion != "" {
 		mConfig.Env["PRIMARY_REGION"] = c.PrimaryRegion
 	}

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -59,8 +59,7 @@ func (c *Config) ToEphemeralRunnerMachineConfig() (*api.MachineConfig, error) {
 			// FIXME: this is an ugly hack, abusing Hallpass as a
 			// stand-in for `/bin/sleep infinity`, simply because it
 			// should always be available.
-			Cmd:        []string{"dummy", "to", "keep", "machine", "running"}, // just to clear the CMD; Hallpass ignores it
-			Entrypoint: []string{"/.fly/hallpass"},
+			Exec: []string{"/.fly/hallpass", "dummy", "to", "keep", "machine", "running"},
 		},
 		Restart: api.MachineRestart{
 			Policy: api.MachineRestartPolicyNo,

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -56,10 +56,11 @@ func (c *Config) ToReleaseMachineConfig() (*api.MachineConfig, error) {
 func (c *Config) ToEphemeralRunnerMachineConfig() (*api.MachineConfig, error) {
 	mConfig := &api.MachineConfig{
 		Init: api.MachineInit{
-			// FIXME: this is an ugly hack, abusing Hallpass as a
-			// stand-in for `/bin/sleep infinity`, simply because it
-			// should always be available.
-			Exec: []string{"/.fly/hallpass", "dummy", "to", "keep", "machine", "running"},
+			// TODO: it would be better to configure init to run no
+			// command at all. That way we don't rely on /bin/sleep
+			// being available and working right. However, there's no
+			// way to do that yet.
+			Exec: []string{"/bin/sleep", "inf"},
 		},
 		Restart: api.MachineRestart{
 			Policy: api.MachineRestartPolicyNo,
@@ -74,9 +75,6 @@ func (c *Config) ToEphemeralRunnerMachineConfig() (*api.MachineConfig, error) {
 		},
 		Env: lo.Assign(c.Env),
 	}
-
-	// FIXME: ugly hack; see above
-	mConfig.Env["SSH_LISTEN"] = "[::1]:22"
 
 	mConfig.Env["FLY_PROCESS_GROUP"] = api.MachineProcessGroupFlyAppEphemeralRunner
 	if c.PrimaryRegion != "" {

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -69,15 +69,17 @@ func (c *Config) ToEphemeralRunnerMachineConfig() (*api.MachineConfig, error) {
 		DNS: &api.DNSConfig{
 			SkipRegistration: true,
 		},
-		// TODO: we need to set metadata on these machines
+		Metadata: map[string]string{
+			api.MachineConfigMetadataKeyFlyPlatformVersion: api.MachineFlyPlatformVersion2,
+			api.MachineConfigMetadataKeyFlyProcessGroup:    api.MachineProcessGroupFlyAppEphemeralRunner,
+		},
 		Env: lo.Assign(c.Env),
 	}
 
 	// FIXME: ugly hack; see above
 	mConfig.Env["SSH_LISTEN"] = "[::1]:22"
 
-	// TODO set process group here
-
+	mConfig.Env["FLY_PROCESS_GROUP"] = api.MachineProcessGroupFlyAppEphemeralRunner
 	if c.PrimaryRegion != "" {
 		mConfig.Env["PRIMARY_REGION"] = c.PrimaryRegion
 	}

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -357,6 +357,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 		KillSignal:       api.Pointer("SIGTERM"),
 		KillTimeout:      api.MustParseDuration("3s"),
 		PrimaryRegion:    "sea",
+		ConsoleCommand:   "/bin/bash",
 		Experimental: &Experimental{
 			Cmd:          []string{"cmd"},
 			Entrypoint:   []string{"entrypoint"},

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -2,6 +2,7 @@ app = "foo"
 kill_signal = "SIGTERM"
 kill_timeout = "3s"
 primary_region = "sea"
+console_command = "/bin/bash"
 
 [experimental]
   cmd = ["cmd"]

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -95,6 +95,7 @@ func (cfg *Config) ValidateForMachinesPlatform(ctx context.Context) (err error, 
 		cfg.validateServicesSection,
 		cfg.validateProcessesSection,
 		cfg.validateMachineConversion,
+		cfg.validateConsoleCommand,
 	}
 
 	for _, vFunc := range validators {
@@ -216,6 +217,14 @@ func (cfg *Config) validateMachineConversion() (extraInfo string, err error) {
 			extraInfo += fmt.Sprintf("Converting to machine in process group '%s' will fail because of: %s", name, vErr)
 			err = ValidationError
 		}
+	}
+	return
+}
+
+func (cfg *Config) validateConsoleCommand() (extraInfo string, err error) {
+	if _, vErr := shlex.Split(cfg.ConsoleCommand); vErr != nil {
+		extraInfo += fmt.Sprintf("Can't shell split console command: '%s'\n", cfg.ConsoleCommand)
+		err = ValidationError
 	}
 	return
 }

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -39,7 +39,7 @@ func New() *cobra.Command {
 		flag.AppConfig(),
 		flag.String{
 			Name:        "machine",
-			Description: "ID of the machine to connect to",
+			Description: "Run the console in the existing machine with the specified ID",
 		},
 		flag.Bool{
 			Name:        "select",

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -168,7 +168,7 @@ func promptForMachine(ctx context.Context, app *api.AppCompact, appConfig *appco
 		return nil, false, err
 	}
 	machines = lo.Filter(machines, func(machine *api.Machine, _ int) bool {
-		return machine.State == api.MachineStateStarted && !machine.IsFlyAppsReleaseCommand()
+		return machine.State == api.MachineStateStarted
 	})
 
 	options := []string{"create an ephemeral shared-cpu-1x machine"}

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -1,0 +1,122 @@
+package console
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/command/ssh"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func New() *cobra.Command {
+	const (
+		usage = "console --machine <id>"
+		short = "Run a console in an existing machine"
+		long  = short
+	)
+	cmd := command.New(usage, short, long, runConsole, command.RequireSession, command.RequireAppName)
+
+	cmd.Args = cobra.NoArgs
+	flag.Add(
+		cmd,
+		flag.App(),
+		flag.AppConfig(),
+		flag.String{
+			Name:        "machine",
+			Description: "ID of the machine to connect to",
+		},
+		flag.String{
+			Name:        "user",
+			Shorthand:   "u",
+			Description: "Unix username to connect as",
+			Default:     ssh.DefaultSshUsername,
+		},
+	)
+	cmd.MarkFlagRequired("machine")
+
+	return cmd
+}
+
+func runConsole(ctx context.Context) error {
+	appName := appconfig.NameFromContext(ctx)
+	apiClient := client.FromContext(ctx).API()
+
+	app, err := apiClient.GetAppCompact(ctx, appName)
+	if err != nil {
+		return fmt.Errorf("failed to get app: %w", err)
+	}
+
+	if app.PlatformVersion != "machines" {
+		return errors.New("console is only supported for the machines platform")
+	}
+
+	flapsClient, err := flaps.New(ctx, app)
+	if err != nil {
+		return fmt.Errorf("failed to create flaps client: %w", err)
+	}
+	ctx = flaps.NewContext(ctx, flapsClient)
+
+	appConfig := appconfig.ConfigFromContext(ctx)
+	if appConfig == nil {
+		appConfig, err = appconfig.FromRemoteApp(ctx, appName)
+		if err != nil {
+			return fmt.Errorf("failed to fetch app config from backend: %w", err)
+		}
+	}
+
+	if err, extraInfo := appConfig.ValidateForMachinesPlatform(ctx); err != nil {
+		fmt.Fprintln(iostreams.FromContext(ctx).ErrOut, extraInfo)
+		return err
+	}
+
+	machine, err := selectMachine(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, dialer, err := ssh.BringUpAgent(ctx, apiClient, app, false)
+	if err != nil {
+		return err
+	}
+
+	params := &ssh.ConnectParams{
+		Ctx:            ctx,
+		Org:            app.Organization,
+		Dialer:         dialer,
+		Username:       flag.GetString(ctx, "user"),
+		DisableSpinner: false,
+	}
+	sshClient, err := ssh.Connect(params, machine.PrivateIP)
+	if err != nil {
+		return err
+	}
+
+	return ssh.Console(ctx, sshClient, appConfig.ConsoleCommand, true)
+}
+
+func selectMachine(ctx context.Context) (*api.Machine, error) {
+	flapsClient := flaps.FromContext(ctx)
+
+	machineID := flag.GetString(ctx, "machine")
+	machine, err := flapsClient.Get(ctx, machineID)
+	if err != nil {
+		return nil, err
+	}
+	if machine.State != api.MachineStateStarted {
+		return nil, fmt.Errorf("machine %s is not started", machineID)
+	}
+	if machine.IsFlyAppsReleaseCommand() {
+		return nil, fmt.Errorf("machine %s is a release command machine", machineID)
+	}
+
+	return machine, nil
+}

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
@@ -17,13 +18,17 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
+	"github.com/superfly/flyctl/terminal"
 )
 
 func New() *cobra.Command {
 	const (
-		usage = "console --machine <id>"
-		short = "Run a console in an existing machine"
-		long  = short
+		usage = "console"
+		short = "Run a console in a new or existing machine"
+		long  = "Run a console in a new or existing machine. The console command is\n" +
+			"specified by the `console_command` configuration field. By default, a\n" +
+			"new machine is created by default using the app's most recently deployed\n" +
+			"image. An existing machine can be used instead with --machine."
 	)
 	cmd := command.New(usage, short, long, runConsole, command.RequireSession, command.RequireAppName)
 
@@ -54,8 +59,12 @@ func New() *cobra.Command {
 }
 
 func runConsole(ctx context.Context) error {
-	appName := appconfig.NameFromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	var (
+		io        = iostreams.FromContext(ctx)
+		colorize  = io.ColorScheme()
+		appName   = appconfig.NameFromContext(ctx)
+		apiClient = client.FromContext(ctx).API()
+	)
 
 	app, err := apiClient.GetAppCompact(ctx, appName)
 	if err != nil {
@@ -81,13 +90,41 @@ func runConsole(ctx context.Context) error {
 	}
 
 	if err, extraInfo := appConfig.ValidateForMachinesPlatform(ctx); err != nil {
-		fmt.Fprintln(iostreams.FromContext(ctx).ErrOut, extraInfo)
+		fmt.Fprintln(io.ErrOut, extraInfo)
 		return err
 	}
 
-	machine, err := selectMachine(ctx)
+	machine, ephemeral, err := selectMachine(ctx, app, appConfig)
 	if err != nil {
 		return err
+	}
+
+	if ephemeral {
+		defer func() {
+			const stopTimeout = 5 * time.Second
+
+			stopCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
+			defer cancel()
+
+			stopInput := api.StopMachineInput{
+				ID:      machine.ID,
+				Timeout: api.Duration{Duration: stopTimeout},
+			}
+			if err := flapsClient.Stop(stopCtx, stopInput, ""); err != nil {
+				terminal.Warnf("Failed to stop ephemeral runner machine: %v\n", err)
+				terminal.Warn("You may need to destroy it manually (`fly machine destroy`).")
+				return
+			}
+
+			fmt.Fprintf(io.Out, "Waiting for ephemeral runner machine %s to be destroyed ...", colorize.Bold(machine.ID))
+			if err := flapsClient.Wait(stopCtx, machine, api.MachineStateDestroyed, stopTimeout); err != nil {
+				fmt.Fprintf(io.Out, " %s!\n", colorize.Red("failed"))
+				terminal.Warnf("Failed to wait for ephemeral runner machine to be destroyed: %v\n", err)
+				terminal.Warn("You may need to destroy it manually (`fly machine destroy`).")
+			} else {
+				fmt.Fprintf(io.Out, " %s.\n", colorize.Green("done"))
+			}
+		}()
 	}
 
 	_, dialer, err := ssh.BringUpAgent(ctx, apiClient, app, false)
@@ -110,31 +147,31 @@ func runConsole(ctx context.Context) error {
 	return ssh.Console(ctx, sshClient, appConfig.ConsoleCommand, true)
 }
 
-func selectMachine(ctx context.Context) (*api.Machine, error) {
+func selectMachine(ctx context.Context, app *api.AppCompact, appConfig *appconfig.Config) (*api.Machine, bool, error) {
 	if flag.GetBool(ctx, "select") {
 		return promptForMachine(ctx)
 	} else if flag.IsSpecified(ctx, "machine") {
 		return getMachineByID(ctx)
 	} else {
-		return nil, errors.New("a machine ID must be provided with --machine unless -s/--select is used")
+		return makeEphemeralRunnerMachine(ctx, app, appConfig)
 	}
 }
 
-func promptForMachine(ctx context.Context) (*api.Machine, error) {
+func promptForMachine(ctx context.Context) (*api.Machine, bool, error) {
 	if flag.IsSpecified(ctx, "machine") {
-		return nil, errors.New("--machine can't be used with -s/--select")
+		return nil, false, errors.New("--machine can't be used with -s/--select")
 	}
 
 	flapsClient := flaps.FromContext(ctx)
 	machines, err := flapsClient.ListActive(ctx)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	machines = lo.Filter(machines, func(machine *api.Machine, _ int) bool {
 		return machine.State == api.MachineStateStarted && !machine.IsFlyAppsReleaseCommand()
 	})
 	if len(machines) == 0 {
-		return nil, errors.New("no machines are available")
+		return nil, false, errors.New("no machines are available")
 	}
 
 	options := []string{}
@@ -144,24 +181,108 @@ func promptForMachine(ctx context.Context) (*api.Machine, error) {
 
 	index := 0
 	if err := prompt.Select(ctx, &index, "Select a machine:", "", options...); err != nil {
-		return nil, fmt.Errorf("failed to prompt for a machine: %w", err)
+		return nil, false, fmt.Errorf("failed to prompt for a machine: %w", err)
 	}
-	return machines[index], nil
+	return machines[index], false, nil
 }
 
-func getMachineByID(ctx context.Context) (*api.Machine, error) {
+func getMachineByID(ctx context.Context) (*api.Machine, bool, error) {
 	flapsClient := flaps.FromContext(ctx)
 	machineID := flag.GetString(ctx, "machine")
 	machine, err := flapsClient.Get(ctx, machineID)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if machine.State != api.MachineStateStarted {
-		return nil, fmt.Errorf("machine %s is not started", machineID)
+		return nil, false, fmt.Errorf("machine %s is not started", machineID)
 	}
 	if machine.IsFlyAppsReleaseCommand() {
-		return nil, fmt.Errorf("machine %s is a release command machine", machineID)
+		return nil, false, fmt.Errorf("machine %s is a release command machine", machineID)
 	}
 
-	return machine, nil
+	return machine, false, nil
+}
+
+func makeEphemeralRunnerMachine(ctx context.Context, app *api.AppCompact, appConfig *appconfig.Config) (*api.Machine, bool, error) {
+	var (
+		io          = iostreams.FromContext(ctx)
+		colorize    = io.ColorScheme()
+		apiClient   = client.FromContext(ctx).API()
+		flapsClient = flaps.FromContext(ctx)
+	)
+
+	currentRelease, err := apiClient.GetAppCurrentReleaseMachines(ctx, app.Name)
+	if err != nil {
+		return nil, false, err
+	}
+	if currentRelease == nil {
+		return nil, false, errors.New("can't create an ephemeral runner machine since the app has not yet been released")
+	}
+
+	machConfig, err := appConfig.ToEphemeralRunnerMachineConfig()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to generate ephemeral runner machine configuration: %w", err)
+	}
+	machConfig.Image = currentRelease.ImageRef
+	machConfig.Guest = api.MachinePresets["shared-cpu-1x"] // TODO: infer size like with release commands?
+
+	launchInput := api.LaunchMachineInput{
+		Config: machConfig,
+	}
+	machine, err := flapsClient.Launch(ctx, launchInput)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to launch ephemeral runner machine: %w", err)
+	}
+	fmt.Fprintf(io.Out, "Created an ephemeral machine %s to run the console.\n", colorize.Bold(machine.ID))
+
+	const waitTimeout = 15 * time.Second
+	fmt.Fprintf(io.Out, "Waiting for %s to start ...", colorize.Bold(machine.ID))
+	err = flapsClient.Wait(ctx, machine, api.MachineStateStarted, waitTimeout)
+	if err == nil {
+		fmt.Fprintf(io.Out, " %s.\n", colorize.Green("done"))
+		return machine, true, nil
+	}
+
+	fmt.Fprintf(io.Out, " %s!\n", colorize.Red("failed"))
+	var flapsErr *flaps.FlapsError
+	destroyed := false
+	if errors.As(err, &flapsErr) && flapsErr.ResponseStatusCode == 404 {
+		destroyed, err = checkMachineDestruction(ctx, machine, err)
+	}
+
+	if !destroyed {
+		terminal.Warn("You may need to destroy the machine manually (`fly machine destroy`).")
+	}
+	return nil, false, err
+}
+
+func checkMachineDestruction(ctx context.Context, machine *api.Machine, firstErr error) (bool, error) {
+	flapsClient := flaps.FromContext(ctx)
+	machine, err := flapsClient.Get(ctx, machine.ID)
+	if err != nil {
+		return false, fmt.Errorf("failed to check status of machine: %w", err)
+	}
+
+	if machine.State != api.MachineStateDestroyed && machine.State != api.MachineStateDestroying {
+		return false, firstErr
+	}
+
+	var exitEvent *api.MachineEvent
+	for _, event := range machine.Events {
+		if event.Type == "exit" {
+			exitEvent = event
+			break
+		}
+	}
+
+	if exitEvent == nil || exitEvent.Request == nil {
+		return true, errors.New("machine was destroyed unexpectedly")
+	}
+
+	exitCode, err := exitEvent.Request.GetExitCode()
+	if err != nil {
+		return true, errors.New("machine exited unexpectedly")
+	}
+
+	return true, fmt.Errorf("machine exited unexpectedly with code %v", exitCode)
 }

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -170,9 +170,6 @@ func promptForMachine(ctx context.Context, app *api.AppCompact, appConfig *appco
 	machines = lo.Filter(machines, func(machine *api.Machine, _ int) bool {
 		return machine.State == api.MachineStateStarted && !machine.IsFlyAppsReleaseCommand()
 	})
-	if len(machines) == 0 {
-		return nil, false, errors.New("no machines are available")
-	}
 
 	options := []string{"create an ephemeral shared-cpu-1x machine"}
 	for _, machine := range machines {

--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/certificates"
 	"github.com/superfly/flyctl/internal/command/checks"
 	"github.com/superfly/flyctl/internal/command/config"
+	"github.com/superfly/flyctl/internal/command/console"
 	"github.com/superfly/flyctl/internal/command/consul"
 	"github.com/superfly/flyctl/internal/command/create"
 	"github.com/superfly/flyctl/internal/command/curl"
@@ -154,6 +155,7 @@ To read more, use the docs command to view Fly's help on the web.
 		wireguard.New(),
 		autoscale.New(),
 		domains.New(),
+		console.New(),
 	)
 
 	// if os.Getenv("DEV") != "" {

--- a/internal/command/ssh/connect.go
+++ b/internal/command/ssh/connect.go
@@ -1,0 +1,140 @@
+package ssh
+
+import (
+	"context"
+	"crypto/ed25519"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/pkg/errors"
+	"github.com/superfly/flyctl/agent"
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/helpers"
+	"github.com/superfly/flyctl/iostreams"
+	"github.com/superfly/flyctl/ssh"
+	"github.com/superfly/flyctl/terminal"
+)
+
+const DefaultSshUsername = "root"
+
+func BringUpAgent(ctx context.Context, client *api.Client, app *api.AppCompact, quiet bool) (*agent.Client, agent.Dialer, error) {
+	io := iostreams.FromContext(ctx)
+
+	agentclient, err := agent.Establish(ctx, client)
+	if err != nil {
+		captureError(err, app)
+		return nil, nil, errors.Wrap(err, "can't establish agent")
+	}
+
+	dialer, err := agentclient.Dialer(ctx, app.Organization.Slug)
+	if err != nil {
+		captureError(err, app)
+		return nil, nil, fmt.Errorf("ssh: can't build tunnel for %s: %s\n", app.Organization.Slug, err)
+	}
+
+	if !quiet {
+		io.StartProgressIndicatorMsg("Connecting to tunnel")
+	}
+	if err := agentclient.WaitForTunnel(ctx, app.Organization.Slug); err != nil {
+		captureError(err, app)
+		return nil, nil, errors.Wrapf(err, "tunnel unavailable")
+	}
+	if !quiet {
+		io.StopProgressIndicator()
+	}
+
+	return agentclient, dialer, nil
+}
+
+type ConnectParams struct {
+	Ctx            context.Context
+	Org            api.OrganizationImpl
+	Username       string
+	Dialer         agent.Dialer
+	DisableSpinner bool
+}
+
+func Connect(p *ConnectParams, addr string) (*ssh.Client, error) {
+	terminal.Debugf("Fetching certificate for %s\n", addr)
+
+	cert, pk, err := singleUseSSHCertificate(p.Ctx, p.Org)
+	if err != nil {
+		return nil, fmt.Errorf("create ssh certificate: %w (if you haven't created a key for your org yet, try `flyctl ssh issue`)", err)
+	}
+
+	pemkey := ssh.MarshalED25519PrivateKey(pk, "single-use certificate")
+
+	terminal.Debugf("Keys for %s configured; connecting...\n", addr)
+
+	sshClient := &ssh.Client{
+		Addr: net.JoinHostPort(addr, "22"),
+		User: p.Username,
+
+		Dial: p.Dialer.DialContext,
+
+		Certificate: cert.Certificate,
+		PrivateKey:  string(pemkey),
+	}
+
+	var endSpin context.CancelFunc
+	if !p.DisableSpinner {
+		endSpin = spin(fmt.Sprintf("Connecting to %s...", addr),
+			fmt.Sprintf("Connecting to %s... complete\n", addr))
+		defer endSpin()
+	}
+
+	if err := sshClient.Connect(p.Ctx); err != nil {
+		return nil, errors.Wrap(err, "error connecting to SSH server")
+	}
+
+	terminal.Debugf("Connection completed.\n", addr)
+
+	if !p.DisableSpinner {
+		endSpin()
+	}
+
+	return sshClient, nil
+}
+
+func singleUseSSHCertificate(ctx context.Context, org api.OrganizationImpl) (*api.IssuedCertificate, ed25519.PrivateKey, error) {
+	client := client.FromContext(ctx).API()
+	hours := 1
+
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	icert, err := client.IssueSSHCertificate(ctx, org, []string{DefaultSshUsername, "fly"}, nil, &hours, pub)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return icert, priv, nil
+}
+
+func spin(in, out string) context.CancelFunc {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if !helpers.IsTerminal() {
+		fmt.Fprintln(os.Stderr, in)
+		return cancel
+	}
+
+	go func() {
+		s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
+		s.Writer = os.Stderr
+		s.Prefix = in
+		s.FinalMSG = out
+		s.Start()
+		defer s.Stop()
+
+		<-ctx.Done()
+	}()
+
+	return cancel
+}

--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -181,6 +181,15 @@ func runConsole(ctx context.Context) error {
 		return err
 	}
 
+	if err := Console(ctx, sshc, cmd, allocPTY); err != nil {
+		captureError(err, app)
+		return err
+	}
+
+	return nil
+}
+
+func Console(ctx context.Context, sshClient *ssh.Client, cmd string, allocPTY bool) error {
 	sessIO := &ssh.SessionIO{
 		Stdin:    os.Stdin,
 		Stdout:   ioutils.NewWriteCloserWrapper(colorable.NewColorableStdout(), func() error { return nil }),
@@ -197,8 +206,7 @@ func runConsole(ctx context.Context) error {
 		return nil
 	}()
 
-	if err := sshc.Shell(ctx, sessIO, cmd); err != nil {
-		captureError(err, app)
+	if err := sshClient.Shell(ctx, sessIO, cmd); err != nil {
 		return errors.Wrap(err, "ssh shell")
 	}
 

--- a/internal/command/ssh/sftp.go
+++ b/internal/command/ssh/sftp.go
@@ -94,7 +94,7 @@ func newSFTPConnection(ctx context.Context) (*sftp.Client, error) {
 		return nil, fmt.Errorf("get app: %w", err)
 	}
 
-	agentclient, dialer, err := bringUp(ctx, client, app)
+	agentclient, dialer, err := BringUpAgent(ctx, client, app, quiet(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -104,19 +104,15 @@ func newSFTPConnection(ctx context.Context) (*sftp.Client, error) {
 		return nil, err
 	}
 
-	params := &SSHParams{
+	params := &ConnectParams{
 		Ctx:            ctx,
 		Org:            app.Organization,
 		Dialer:         dialer,
-		App:            appName,
 		Username:       DefaultSshUsername,
-		Stdin:          os.Stdin,
-		Stdout:         os.Stdout,
-		Stderr:         os.Stderr,
 		DisableSpinner: true,
 	}
 
-	conn, err := sshConnect(params, addr)
+	conn, err := Connect(params, addr)
 	if err != nil {
 		captureError(err, app)
 		return nil, err

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -91,7 +91,7 @@ func (lm *leasableMachine) FormattedMachineId() string {
 		return res
 	}
 	procGroup := lm.Machine().ProcessGroup()
-	if procGroup == "" || lm.Machine().IsFlyAppsReleaseCommand() {
+	if procGroup == "" || lm.Machine().IsFlyAppsReleaseCommand() || lm.Machine().IsFlyAppsEphemeralRunner() {
 		return res
 	}
 	return fmt.Sprintf("%s [%s]", res, procGroup)

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -91,7 +91,7 @@ func (lm *leasableMachine) FormattedMachineId() string {
 		return res
 	}
 	procGroup := lm.Machine().ProcessGroup()
-	if procGroup == "" || lm.Machine().IsFlyAppsReleaseCommand() || lm.Machine().IsFlyAppsEphemeralRunner() {
+	if procGroup == "" || lm.Machine().IsFlyAppsReleaseCommand() || lm.Machine().IsFlyAppsConsole() {
 		return res
 	}
 	return fmt.Sprintf("%s [%s]", res, procGroup)

--- a/internal/machine/query.go
+++ b/internal/machine/query.go
@@ -17,7 +17,7 @@ func ListActive(ctx context.Context) ([]*api.Machine, error) {
 	}
 
 	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
-		return m.Config != nil && m.IsActive() && !m.IsReleaseCommandMachine()
+		return m.Config != nil && m.IsActive() && !m.IsReleaseCommandMachine() && !m.IsFlyAppsEphemeralRunner()
 	})
 
 	return machines, nil

--- a/internal/machine/query.go
+++ b/internal/machine/query.go
@@ -17,7 +17,7 @@ func ListActive(ctx context.Context) ([]*api.Machine, error) {
 	}
 
 	machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
-		return m.Config != nil && m.IsActive() && !m.IsReleaseCommandMachine() && !m.IsFlyAppsEphemeralRunner()
+		return m.Config != nil && m.IsActive() && !m.IsReleaseCommandMachine() && !m.IsFlyAppsConsole()
 	})
 
 	return machines, nil


### PR DESCRIPTION
Here's an experimental, very hacky version of `fly console`.

* `fly console`: run the `console_command` from your `fly.toml` (or `/bin/sh` if none is set) in a new `shared-cpu-1x` machine
* `fly console <machine id>`: run the `console_command` in the specified existing machine
* `fly console --select`: show a menu to decide what machine to run the `console_command` in, then do it