### PR TITLE
Reorder config so processes goes before other sections that depends on them

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -29,21 +29,27 @@ func NewConfig() *Config {
 // Config wraps the properties of app configuration.
 // NOTE: If you any new setting here, please also add a value for it at testdata/rull-reference.toml
 type Config struct {
-	AppName       string                    `toml:"app,omitempty" json:"app,omitempty"`
-	KillSignal    *string                   `toml:"kill_signal,omitempty" json:"kill_signal,omitempty"`
-	KillTimeout   *int                      `toml:"kill_timeout,omitempty" json:"kill_timeout,omitempty"`
-	PrimaryRegion string                    `toml:"primary_region,omitempty" json:"primary_region,omitempty"`
-	Experimental  *Experimental             `toml:"experimental,omitempty" json:"experimental,omitempty"`
-	Build         *Build                    `toml:"build,omitempty" json:"build,omitempty"`
-	Deploy        *Deploy                   `toml:"deploy, omitempty" json:"deploy,omitempty"`
-	Env           map[string]string         `toml:"env,omitempty" json:"env,omitempty"`
-	HTTPService   *HTTPService              `toml:"http_service,omitempty" json:"http_service,omitempty"`
-	Metrics       *api.MachineMetrics       `toml:"metrics,omitempty" json:"metrics,omitempty"`
-	Statics       []Static                  `toml:"statics,omitempty" json:"statics,omitempty"`
-	Mounts        []Mount                   `toml:"mounts,omitempty" json:"mounts,omitempty"`
-	Processes     map[string]string         `toml:"processes,omitempty" json:"processes,omitempty"`
-	Checks        map[string]*ToplevelCheck `toml:"checks,omitempty" json:"checks,omitempty"`
-	Services      []Service                 `toml:"services,omitempty" json:"services,omitempty"`
+	AppName       string  `toml:"app,omitempty" json:"app,omitempty"`
+	PrimaryRegion string  `toml:"primary_region,omitempty" json:"primary_region,omitempty"`
+	KillSignal    *string `toml:"kill_signal,omitempty" json:"kill_signal,omitempty"`
+	KillTimeout   *int    `toml:"kill_timeout,omitempty" json:"kill_timeout,omitempty"`
+
+	// Sections that are typically short and benefit from being on top
+	Experimental *Experimental     `toml:"experimental,omitempty" json:"experimental,omitempty"`
+	Build        *Build            `toml:"build,omitempty" json:"build,omitempty"`
+	Deploy       *Deploy           `toml:"deploy, omitempty" json:"deploy,omitempty"`
+	Env          map[string]string `toml:"env,omitempty" json:"env,omitempty"`
+
+	// Fields that are process group aware must come after Processes
+	Processes   map[string]string         `toml:"processes,omitempty" json:"processes,omitempty"`
+	Mounts      []Mount                   `toml:"mounts,omitempty" json:"mounts,omitempty"`
+	HTTPService *HTTPService              `toml:"http_service,omitempty" json:"http_service,omitempty"`
+	Services    []Service                 `toml:"services,omitempty" json:"services,omitempty"`
+	Checks      map[string]*ToplevelCheck `toml:"checks,omitempty" json:"checks,omitempty"`
+
+	// Others, less important.
+	Statics []Static            `toml:"statics,omitempty" json:"statics,omitempty"`
+	Metrics *api.MachineMetrics `toml:"metrics,omitempty" json:"metrics,omitempty"`
 
 	// RawDefinition contains fly.toml parsed as-is
 	// If you add any config field that is v2 specific, be sure to remove it in SanitizeDefinition()


### PR DESCRIPTION
The idea is that sections that depends on processes come after the section that defines them.

Oh, it works because JSON and TOML marshaling respects the order of struct fields.

```toml
app = "mounts-per-group"
primary_region = "iad"

[processes]
  app = "/start webserver"
  notifier = "/start notifier"
  video = "/start video-converter"

[[mounts]]
  source = "webcache"
  destination = "/cache"
  processes = ["app"]

[[mounts]]
  source = "video_stage"
  destination = "/stage"
  processes = ["video"]

[http_service]
  internal_port = 8080
  force_https = true
  processes = ["app"]
```