### PR TITLE
Include a reference link to docs in generated fly.toml

### DIFF
--- a/internal/appconfig/serde.go
+++ b/internal/appconfig/serde.go
@@ -15,6 +15,12 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 )
 
+const flytomlHeader = `# fly.toml file generated for %s on %s\n\n", c.AppName, time.Now().Format(time.RFC3339))
+#
+# See https://fly.io/docs/reference/configuration/ for reference documentation about this file
+#
+`
+
 // LoadConfig loads the app config at the given path.
 func LoadConfig(path string) (cfg *Config, err error) {
 	buf, err := os.ReadFile(path)
@@ -37,7 +43,7 @@ func (c *Config) WriteTo(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(w, "# fly.toml file generated for %s on %s\n\n", c.AppName, time.Now().Format(time.RFC3339))
+	_, err = fmt.Fprintf(w, flytomlHeader, c.AppName, time.Now().Format(time.RFC3339))
 	if err != nil {
 		return err
 	}

--- a/internal/appconfig/serde.go
+++ b/internal/appconfig/serde.go
@@ -19,6 +19,7 @@ const flytomlHeader = `# fly.toml app configuration file generated for %s on %s
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
+
 `
 
 // LoadConfig loads the app config at the given path.

--- a/internal/appconfig/serde.go
+++ b/internal/appconfig/serde.go
@@ -15,9 +15,9 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 )
 
-const flytomlHeader = `# fly.toml file generated for %s on %s
+const flytomlHeader = `# fly.toml app configuration file generated for %s on %s
 #
-# See https://fly.io/docs/reference/configuration/ for  information about how to use this file.
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 `
 

--- a/internal/appconfig/serde.go
+++ b/internal/appconfig/serde.go
@@ -15,7 +15,7 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 )
 
-const flytomlHeader = `# fly.toml file generated for %s on %s\n\n", c.AppName, time.Now().Format(time.RFC3339))
+const flytomlHeader = `# fly.toml file generated for %s on %s
 #
 # See https://fly.io/docs/reference/configuration/ for  information about how to use this file.
 #

--- a/internal/appconfig/serde.go
+++ b/internal/appconfig/serde.go
@@ -17,7 +17,7 @@ import (
 
 const flytomlHeader = `# fly.toml file generated for %s on %s\n\n", c.AppName, time.Now().Format(time.RFC3339))
 #
-# See https://fly.io/docs/reference/configuration/ for reference documentation about this file
+# See https://fly.io/docs/reference/configuration/ for  information about how to use this file.
 #
 `
 


### PR DESCRIPTION
```toml
# fly.toml app configuration file generated for mounts-per-group on 2023-04-17T22:03:13Z
#
# See https://fly.io/docs/reference/configuration/ for reference documentation about this file
#
app = "mounts-per-group"
primary_region = "iad"

[http_service]
  internal_port = 8080
  force_https = true
  processes = ["app"]

[[mounts]]
  source = "webcache"
  destination = "/cache"
  processes = ["app"]

[[mounts]]
  source = "video_stage"
  destination = "/stage"
  processes = ["video"]

[processes]
  app = "/start webserver"
  notifier = "/start notifier"
  video = "/start video-converter"
```