### PR TITLE
Local volume forks

### DIFF
--- a/internal/command/volumes/fork.go
+++ b/internal/command/volumes/fork.go
@@ -19,8 +19,8 @@ import (
 
 func newFork() *cobra.Command {
 	const (
-		long = `Volume forking is a feature that allows creating an independent copy of the specified storage volume for
-		backup, testing, and experimentation purposes without altering the original data.`
+		long = `Volume forking creates an independent copy of a storage volume for backup, testing, and experimentation without altering the original data,
+but is currently restricted to same-host forks and may not be available for near-capacity hosts.`
 		short = "Forks the specified volume"
 		usage = "fork <id>"
 	)

--- a/internal/command/volumes/fork.go
+++ b/internal/command/volumes/fork.go
@@ -19,7 +19,7 @@ import (
 
 func newFork() *cobra.Command {
 	const (
-		long = `Volume forking is a feature that allows creating an independent copy of a storage volume for
+		long = `Volume forking is a feature that allows creating an independent copy of the specified storage volume for
 		backup, testing, and experimentation purposes without altering the original data.`
 		short = "Forks the specified volume"
 		usage = "fork <id>"

--- a/internal/command/volumes/fork.go
+++ b/internal/command/volumes/fork.go
@@ -1,0 +1,89 @@
+package volumes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/iostreams"
+
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/render"
+)
+
+func newFork() *cobra.Command {
+	const (
+		long = `Volume forking is a feature that allows creating an independent copy of a storage volume for
+		backup, testing, and experimentation purposes without altering the original data.`
+		short = "Forks the specified volume"
+		usage = "fork <id>"
+	)
+
+	cmd := command.New(usage, short, long, runFork,
+		command.RequireSession,
+		command.RequireAppName,
+	)
+
+	cmd.Args = cobra.ExactArgs(1)
+
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+	)
+
+	flag.Add(cmd, flag.JSONOutput())
+	return cmd
+}
+
+func runFork(ctx context.Context) error {
+	var (
+		cfg     = config.FromContext(ctx)
+		appName = appconfig.NameFromContext(ctx)
+		client  = client.FromContext(ctx).API()
+		volID   = flag.FirstArg(ctx)
+	)
+
+	app, err := client.GetAppCompact(ctx, appName)
+	if err != nil {
+		return err
+	}
+
+	if app.IsPostgresApp() {
+		return fmt.Errorf("This feature is not available for Postgres apps")
+	}
+
+	vol, err := client.GetVolume(ctx, volID)
+	if err != nil {
+		return fmt.Errorf("failed to get volume: %w", err)
+	}
+
+	input := api.ForkVolumeInput{
+		AppID:          app.ID,
+		SourceVolumeID: vol.ID,
+		Name:           vol.Name,
+		MachinesOnly:   app.PlatformVersion == "machines",
+	}
+
+	volume, err := client.ForkVolume(ctx, input)
+	if err != nil {
+		return fmt.Errorf("failed to fork volume: %w", err)
+	}
+
+	out := iostreams.FromContext(ctx).Out
+
+	if cfg.JSONOutput {
+		return render.JSON(out, volume)
+	}
+
+	if err := printVolume(out, volume); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/command/volumes/volumes.go
+++ b/internal/command/volumes/volumes.go
@@ -35,6 +35,7 @@ func New() *cobra.Command {
 		newDestroy(),
 		newExtend(),
 		newShow(),
+		newFork(),
 		snapshots.New(),
 	)
 


### PR DESCRIPTION
Exposes local volume forks.  This feature is currently not available for PG apps, but an alternative solution will be made available for these users soon. 

```
Volume forking is a feature that creates an independent copy of the specified storage volume for backup, testing, and
experimentation purposes without altering the original data. Please note that volume forking is currently restricted to same-host forks
and this feature may not be available for volumes residing on hosts that are at or near capacity.

Usage:
  flyctl volumes fork <id> [flags]

Flags:
  -a, --app string      Application name
  -c, --config string   Path to application configuration file
  -h, --help            help for fork
  -j, --json            JSON output

Global Flags:
  -t, --access-token string   Fly API Access Token
      --verbose               verbose output
```