### PR TITLE
Fix the formatting of "Failed attaching ... to the Postgres cluster"

### DIFF
--- a/internal/command/launch/databases.go
+++ b/internal/command/launch/databases.go
@@ -32,7 +32,7 @@ func LaunchPostgres(ctx context.Context, appName string, org *api.Organization, 
 		})
 
 		if err != nil {
-			msg := `Failed attaching %s to the Postgres cluster %s: %w.\nTry attaching manually with 'fly postgres attach --app %s %s'\n`
+			msg := "Failed attaching %s to the Postgres cluster %s: %s.\nTry attaching manually with 'fly postgres attach --app %s %s'\n"
 			fmt.Fprintf(io.Out, msg, appName, clusterAppName, err, appName, clusterAppName)
 
 		} else {

--- a/internal/command/launch/srcinfo.go
+++ b/internal/command/launch/srcinfo.go
@@ -177,7 +177,7 @@ func createDatabases(ctx context.Context, srcInfo *scanner.SourceInfo, appName s
 			})
 
 			if err != nil {
-				msg := `Failed attaching %s to the Postgres cluster %s: %w.\nTry attaching manually with 'fly postgres attach --app %s %s'\n`
+				msg := "Failed attaching %s to the Postgres cluster %s: %s.\nTry attaching manually with 'fly postgres attach --app %s %s'\n"
 				fmt.Fprintf(io.Out, msg, appName, db_app_name, err, appName, db_app_name)
 			} else {
 				fmt.Fprintf(io.Out, "Postgres cluster %s is now attached to %s\n", db_app_name, appName)


### PR DESCRIPTION
- `%w` only works in fmt.Errorf
- `\n` doesn't work in raw strings