### PR TITLE
Ignore the heartbeat if the endpoint is 404

### DIFF
--- a/internal/build/imgsrc/resolver_test.go
+++ b/internal/build/imgsrc/resolver_test.go
@@ -1,0 +1,22 @@
+package imgsrc
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeartbeat(t *testing.T) {
+	dc, err := client.NewClientWithOpts();
+	assert.NoError(t, err)
+
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "", http.NoBody)
+	assert.NoError(t, err)
+
+	err = heartbeat(dc, req)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
baad948e7f76a0b1ef58b07c62d2a1a06eab0689 assumed that all remote builders have /extendDeadline, but a lot of them don't yet.