### PR TITLE
Add `fly app` and `fly ip` aliases

### DIFF
--- a/internal/command/apps/apps.go
+++ b/internal/command/apps/apps.go
@@ -28,6 +28,7 @@ The LIST command will list all currently registered applications.
 	// TODO: list should also accept the --platform param
 
 	apps := command.New("apps", short, long, nil)
+	apps.Aliases = []string{"app"}
 
 	apps.AddCommand(
 		newList(),

--- a/internal/command/ips/ips.go
+++ b/internal/command/ips/ips.go
@@ -13,6 +13,7 @@ func New() *cobra.Command {
 	)
 
 	cmd := command.New("ips", short, long, nil)
+	cmd.Aliases = []string{"ip"}
 	cmd.AddCommand(
 		newList(),
 		newAllocatev4(),


### PR DESCRIPTION
- Add `app` alias for `apps` command.
- Add `ip` alias for `ips` command.
