### PR TITLE
Restore `--json` flag for commands under /cmd

### DIFF
--- a/cmd/autoscaling.go
+++ b/cmd/autoscaling.go
@@ -24,13 +24,16 @@ func newAutoscaleCommand(client *client.Client) *Command {
 	disableCmdStrings := docstrings.Get("autoscale.disable")
 	disableCmd := BuildCommand(cmd, runDisableAutoscaling, disableCmdStrings.Usage, disableCmdStrings.Short, disableCmdStrings.Long, client, requireSession, requireAppName)
 	disableCmd.Args = cobra.RangeArgs(0, 2)
+	disableCmd.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
 
 	setCmdStrings := docstrings.Get("autoscale.set")
 	setCmd := BuildCommand(cmd, runSetParams, setCmdStrings.Usage, setCmdStrings.Short, setCmdStrings.Long, client, requireSession, requireAppName)
 	setCmd.Args = cobra.RangeArgs(0, 2)
+	setCmd.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
 
 	showCmdStrings := docstrings.Get("autoscale.show")
-	BuildCommand(cmd, runAutoscalingShow, showCmdStrings.Usage, showCmdStrings.Short, showCmdStrings.Long, client, requireSession, requireAppName)
+	showCmd := BuildCommand(cmd, runAutoscalingShow, showCmdStrings.Usage, showCmdStrings.Short, showCmdStrings.Long, client, requireSession, requireAppName)
+	showCmd.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
 
 	return cmd
 }

--- a/cmd/certificates.go
+++ b/cmd/certificates.go
@@ -31,7 +31,8 @@ func newCertificatesCommand(client *client.Client) *Command {
 	cmd := BuildCommandKS(nil, nil, certsStrings, client, requireAppName, requireSession)
 
 	certsListStrings := docstrings.Get("certs.list")
-	BuildCommandKS(cmd, runCertsList, certsListStrings, client, requireSession, requireAppName)
+	listCmd := BuildCommandKS(cmd, runCertsList, certsListStrings, client, requireSession, requireAppName)
+	listCmd.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
 
 	certsCreateStrings := docstrings.Get("certs.add")
 	createCmd := BuildCommandKS(cmd, runCertAdd, certsCreateStrings, client, requireSession, requireAppName)
@@ -47,10 +48,12 @@ func newCertificatesCommand(client *client.Client) *Command {
 	certsShowStrings := docstrings.Get("certs.show")
 	show := BuildCommandKS(cmd, runCertShow, certsShowStrings, client, requireSession, requireAppName)
 	show.Command.Args = cobra.ExactArgs(1)
+	show.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
 
 	certsCheckStrings := docstrings.Get("certs.check")
 	check := BuildCommandKS(cmd, runCertCheck, certsCheckStrings, client, requireSession, requireAppName)
 	check.Command.Args = cobra.ExactArgs(1)
+	check.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
 
 	return cmd
 }

--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -23,9 +23,11 @@ func newDomainsCommand(client *client.Client) *Command {
 	listStrings := docstrings.Get("domains.list")
 	listCmd := BuildCommandKS(cmd, runDomainsList, listStrings, client, requireSession)
 	listCmd.Args = cobra.MaximumNArgs(1)
+	listCmd.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
 
 	showCmd := BuildCommandKS(cmd, runDomainsShow, docstrings.Get("domains.show"), client, requireSession)
 	showCmd.Args = cobra.ExactArgs(1)
+	showCmd.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
 
 	addCmd := BuildCommandKS(cmd, runDomainsCreate, docstrings.Get("domains.add"), client, requireSession)
 	addCmd.Args = cobra.MaximumNArgs(2)

--- a/cmd/regions.go
+++ b/cmd/regions.go
@@ -27,6 +27,7 @@ func newRegionsCommand(client *client.Client) *Command {
 		Default:     "",
 	})
 	addCmd.AddBoolFlag(BoolFlagOpts{Name: "yes", Shorthand: "y", Description: "accept all confirmations"})
+	addCmd.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
 
 	removeStrings := docstrings.Get("regions.remove")
 	removeCmd := BuildCommandKS(cmd, runRegionsRemove, removeStrings, client, requireSession, requireAppName)
@@ -37,6 +38,7 @@ func newRegionsCommand(client *client.Client) *Command {
 		Default:     "",
 	})
 	removeCmd.AddBoolFlag(BoolFlagOpts{Name: "yes", Shorthand: "y", Description: "accept all confirmations"})
+	removeCmd.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
 
 	setStrings := docstrings.Get("regions.set")
 	setCmd := BuildCommandKS(cmd, runRegionsSet, setStrings, client, requireSession, requireAppName)
@@ -47,14 +49,17 @@ func newRegionsCommand(client *client.Client) *Command {
 		Default:     "",
 	})
 	setCmd.AddBoolFlag(BoolFlagOpts{Name: "yes", Shorthand: "y", Description: "accept all confirmations"})
+	setCmd.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
 
 	setBackupStrings := docstrings.Get("regions.backup")
 	setBackupCmd := BuildCommand(cmd, runBackupRegionsSet, setBackupStrings.Usage, setBackupStrings.Short, setBackupStrings.Long, client, requireSession, requireAppName)
 	setBackupCmd.Args = cobra.MinimumNArgs(1)
 	setBackupCmd.AddBoolFlag(BoolFlagOpts{Name: "yes", Shorthand: "y", Description: "accept all confirmations"})
+	setBackupCmd.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
 
 	listStrings := docstrings.Get("regions.list")
-	BuildCommand(cmd, runRegionsList, listStrings.Usage, listStrings.Short, listStrings.Long, client, requireSession, requireAppName)
+	listCmd := BuildCommand(cmd, runRegionsList, listStrings.Usage, listStrings.Short, listStrings.Long, client, requireSession, requireAppName)
+	listCmd.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
 
 	return cmd
 }

--- a/cmd/wireguard.go
+++ b/cmd/wireguard.go
@@ -35,7 +35,10 @@ func newWireGuardCommand(client *client.Client) *Command {
 		return BuildCommandKS(parent, fn, docstrings.Get(ds), client, requireSession)
 	}
 
-	child(cmd, runWireGuardList, "wireguard.list").Args = cobra.MaximumNArgs(1)
+	list := child(cmd, runWireGuardList, "wireguard.list")
+	list.Args = cobra.MaximumNArgs(1)
+	list.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
+
 	child(cmd, runWireGuardCreate, "wireguard.create").Args = cobra.MaximumNArgs(4)
 	child(cmd, runWireGuardRemove, "wireguard.remove").Args = cobra.MaximumNArgs(2)
 	child(cmd, runWireGuardStat, "wireguard.status").Args = cobra.MaximumNArgs(2)
@@ -44,7 +47,10 @@ func newWireGuardCommand(client *client.Client) *Command {
 
 	tokens := child(cmd, nil, "wireguard.token")
 
-	child(tokens, runWireGuardTokenList, "wireguard.token.list").Args = cobra.MaximumNArgs(1)
+	tokensList := child(tokens, runWireGuardTokenList, "wireguard.token.list")
+	tokensList.Args = cobra.MaximumNArgs(1)
+	tokensList.AddBoolFlag(BoolFlagOpts{Name: "json", Shorthand: "j", Description: "JSON output"})
+
 	child(tokens, runWireGuardTokenCreate, "wireguard.token.create").Args = cobra.MaximumNArgs(2)
 	child(tokens, runWireGuardTokenDelete, "wireguard.token.delete").Args = cobra.MaximumNArgs(3)
 

--- a/cmdctx/cmdcontext.go
+++ b/cmdctx/cmdcontext.go
@@ -231,5 +231,5 @@ func (commandContext *CmdContext) WriteJSON(myData interface{}) {
 }
 
 func (commandContext *CmdContext) OutputJSON() bool {
-	return commandContext.GlobalConfig.GetBool(flyctl.ConfigJSONOutput)
+	return commandContext.Config.GetBool("json")
 }

--- a/flyctl/config.go
+++ b/flyctl/config.go
@@ -10,7 +10,6 @@ const (
 	ConfigFlapsBaseUrl    = "flaps_base_url"
 	ConfigAppName         = "app"
 	ConfigVerboseOutput   = "verbose"
-	ConfigJSONOutput      = "json"
 	ConfigBuiltinsfile    = "builtins_file"
 	ConfigGQLErrorLogging = "gqlerrorlogging"
 	ConfigInstaller       = "installer"


### PR DESCRIPTION
Should fix #2119. Looks like several old commands in `/cmd` lost `--json`.