### PR TITLE
Add helper to calculate app URLs, and output an app's URL on deploy

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -4,6 +4,7 @@ package appconfig
 
 import (
 	"fmt"
+	"net/url"
 	"reflect"
 
 	"github.com/superfly/flyctl/api"
@@ -196,4 +197,19 @@ func (cfg *Config) BuildStrategies() []string {
 	}
 
 	return strategies
+}
+
+func (cfg *Config) URL() (*url.URL, error) {
+	protocol := "http"
+	for _, service := range cfg.Services {
+		for _, port := range service.Ports {
+			for _, handler := range port.Handlers {
+				if handler == "tls" {
+					protocol = "https"
+					break
+				}
+			}
+		}
+	}
+	return url.Parse(protocol + "://" + cfg.AppName + ".fly.dev")
 }

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -211,5 +211,10 @@ func (cfg *Config) URL() (*url.URL, error) {
 			}
 		}
 	}
+
+	if protocol == "http" && cfg.HTTPService != nil && cfg.HTTPService.ForceHTTPS {
+		protocol = "https"
+	}
+
 	return url.Parse(protocol + "://" + cfg.AppName + ".fly.dev")
 }

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -1,6 +1,7 @@
 package appconfig
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -204,4 +205,36 @@ func TestHasNonHttpAndHttpsStandardServices(t *testing.T) {
 		{Port: &port443, Handlers: []string{"tls", "http"}},
 	}}}
 	assert.True(t, cfg6.HasNonHttpAndHttpsStandardServices())
+}
+
+func TestURLCalculation(t *testing.T) {
+	port80 := 80
+	port443 := 443
+
+	http, _ := url.Parse("http://test.fly.dev")
+	https, _ := url.Parse("https://test.fly.dev")
+
+	cfg := NewConfig()
+	cfg.AppName = "test"
+	cfg.Services = []Service{{Protocol: "tcp", Ports: []api.MachinePort{
+		{Port: &port80, Handlers: []string{"http"}},
+	}}}
+	url, _ := cfg.URL()
+	assert.Equal(t, http, url)
+
+	cfg = NewConfig()
+	cfg.AppName = "test"
+	cfg.Services = []Service{{Protocol: "tcp", Ports: []api.MachinePort{
+		{Port: &port443, Handlers: []string{"tls"}},
+	}}}
+	url, _ = cfg.URL()
+	assert.Equal(t, https, url)
+
+	cfg = NewConfig()
+	cfg.AppName = "test"
+	cfg.HTTPService = &HTTPService{
+		ForceHTTPS: true,
+	}
+	url, _ = cfg.URL()
+	assert.Equal(t, https, url)
 }

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -220,7 +220,7 @@ func TestURLCalculation(t *testing.T) {
 		{Port: &port80, Handlers: []string{"tls"}},
 	}}}
 	url, _ := cfg.URL()
-	assert.Equal(t, *url.URL((*url.URL)(nil)), url)
+	assert.Nil(t, url)
 
 	cfg = NewConfig()
 	cfg.AppName = "test"

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -217,15 +217,23 @@ func TestURLCalculation(t *testing.T) {
 	cfg := NewConfig()
 	cfg.AppName = "test"
 	cfg.Services = []Service{{Protocol: "tcp", Ports: []api.MachinePort{
-		{Port: &port80, Handlers: []string{"http"}},
+		{Port: &port80, Handlers: []string{"tls"}},
 	}}}
 	url, _ := cfg.URL()
+	assert.Equal(t, *url.URL((*url.URL)(nil)), url)
+
+	cfg = NewConfig()
+	cfg.AppName = "test"
+	cfg.Services = []Service{{Protocol: "tcp", Ports: []api.MachinePort{
+		{Port: &port80, Handlers: []string{"http"}},
+	}}}
+	url, _ = cfg.URL()
 	assert.Equal(t, http, url)
 
 	cfg = NewConfig()
 	cfg.AppName = "test"
 	cfg.Services = []Service{{Protocol: "tcp", Ports: []api.MachinePort{
-		{Port: &port443, Handlers: []string{"tls"}},
+		{Port: &port443, Handlers: []string{"tls", "http"}},
 	}}}
 	url, _ = cfg.URL()
 	assert.Equal(t, https, url)

--- a/internal/command/apps/open.go
+++ b/internal/command/apps/open.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
 
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
@@ -55,7 +54,8 @@ func runOpen(ctx context.Context) error {
 		return errors.New("app has not been deployed yet. Please try deploying your app first")
 	}
 
-	appURL, err := url.Parse("http://" + app.Hostname)
+	appConfig := appconfig.ConfigFromContext(ctx)
+	appURL, err := appConfig.URL()
 	if err != nil {
 		return fmt.Errorf("failed parsing app URL (hostname: %s): %w", app.Hostname, err)
 	}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -155,10 +155,10 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, args Dep
 	case err != nil:
 		return err
 	case isV2App:
-		if err = appConfig.EnsureV2Config(); err != nil {
+		if err := appConfig.EnsureV2Config(); err != nil {
 			return fmt.Errorf("Can't deploy an invalid v2 app config: %s", err)
 		}
-		err = deployToMachines(ctx, appConfig, appCompact, img)
+		err := deployToMachines(ctx, appConfig, appCompact, img)
 		if err != nil {
 			return err
 		}
@@ -170,7 +170,7 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, args Dep
 	}
 
 	url, err := appConfig.URL()
-	if err == nil {
+	if err == nil && url != nil {
 		fmt.Println("Visit your newly deployed app at", url)
 	}
 

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -158,10 +158,17 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, args Dep
 		if err := appConfig.EnsureV2Config(); err != nil {
 			return fmt.Errorf("Can't deploy an invalid v2 app config: %s", err)
 		}
-		return deployToMachines(ctx, appConfig, appCompact, img)
+		err = deployToMachines(ctx, appConfig, appCompact, img)
 	default:
-		return deployToNomad(ctx, appConfig, appCompact, img)
+		err = deployToNomad(ctx, appConfig, appCompact, img)
 	}
+
+	url, err := appConfig.URL()
+	if err == nil {
+		fmt.Println("Visit your newly deployed app at", url)
+	}
+
+	return err
 }
 
 func deployToMachines(ctx context.Context, appConfig *appconfig.Config, appCompact *api.AppCompact, img *imgsrc.DeploymentImage) error {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -163,6 +163,10 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, args Dep
 		err = deployToNomad(ctx, appConfig, appCompact, img)
 	}
 
+	if err != nil {
+		return err
+	}
+
 	url, err := appConfig.URL()
 	if err == nil {
 		fmt.Println("Visit your newly deployed app at", url)

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -155,16 +155,18 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, args Dep
 	case err != nil:
 		return err
 	case isV2App:
-		if err := appConfig.EnsureV2Config(); err != nil {
+		if err = appConfig.EnsureV2Config(); err != nil {
 			return fmt.Errorf("Can't deploy an invalid v2 app config: %s", err)
 		}
 		err = deployToMachines(ctx, appConfig, appCompact, img)
+		if err != nil {
+			return err
+		}
 	default:
 		err = deployToNomad(ctx, appConfig, appCompact, img)
-	}
-
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	url, err := appConfig.URL()


### PR DESCRIPTION
- Add `URL` helper for calculating an app's URL from `appconfig.Config`.
- Refactor `fly open` to use new URL helper.
- Output an app's URL on conclusion of `fly deploy`.
