### PR TITLE
Introducing Postgres Forks

### DIFF
--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -269,8 +269,6 @@ func CreateCluster(ctx context.Context, org *api.Organization, region *api.Regio
 
 	var config *PostgresConfiguration
 
-	fmt.Printf("Pre-custom: %+v", params.PostgresConfiguration)
-
 	if !customConfig {
 		fmt.Fprintf(io.Out, "For pricing information visit: https://fly.io/docs/about/pricing/#postgresql-clusters")
 

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -299,8 +299,6 @@ func CreateCluster(ctx context.Context, org *api.Organization, region *api.Regio
 		}
 	}
 
-	fmt.Printf("%+v", params.PostgresConfiguration)
-
 	if customConfig {
 		// Resolve cluster size
 		if params.PostgresConfiguration.InitialClusterSize == 0 {

--- a/internal/flag/context.go
+++ b/internal/flag/context.go
@@ -44,6 +44,11 @@ func GetString(ctx context.Context, name string) string {
 	}
 }
 
+// SetString sets the value of the named string flag ctx carries.
+func SetString(ctx context.Context, name, value string) error {
+	return FromContext(ctx).Set(name, value)
+}
+
 // GetInt returns the value of the named int flag ctx carries. It panics
 // in case ctx carries no flags or in case the named flag isn't an int one.
 func GetInt(ctx context.Context, name string) int {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/sort"
 )
 
@@ -327,6 +328,9 @@ func Region(ctx context.Context, splitPaid bool, params RegionParams) (*api.Regi
 	}
 
 	slug := config.FromContext(ctx).Region
+	if slug == "" {
+		slug = flag.GetString(ctx, "region")
+	}
 
 	switch {
 	case slug != "":

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -327,9 +327,9 @@ func Region(ctx context.Context, splitPaid bool, params RegionParams) (*api.Regi
 		regions = sortAndCleanRegions(availableRegions, params.ExcludedRegionCodes)
 	}
 
-	slug := config.FromContext(ctx).Region
+	slug := flag.GetString(ctx, "region")
 	if slug == "" {
-		slug = flag.GetString(ctx, "region")
+		slug = config.FromContext(ctx).Region
 	}
 
 	switch {


### PR DESCRIPTION
This introduces the `--fork-from`  flag that can be called on Postgres provision.  Functionally, the end-result is the same as snapshotting the target volume and restoring into a new application.  The primary difference being that we are actually forking the underlying storage device and copying those blocks into a new logical volume on the same host.  It's the same result, just significantly faster. 

The downside is that this feature is currently restricted to same-host forks, which means that some volumes may not be eligible due to capacity issues with the host the target volume is residing on.  The bright side is that as long as you're replicas are sync'd, there's no reason you can't just fork a volume associated with one of your replicas.   

This flag can be specified in one of two formats:

**Option 1:**  `--fork-from <app-name>` 
This will evaluate the target app and attempt to resolve the volume associated with the primary to use as a fork target.

**Option 2:** `--fork-from <app-name>:<volume-id>`
This should be used if there's a specific volume you wish to fork from.  This is useful in the event you're unable to fork the primary due to host capacity issues, or maybe you want to fork your application into a new region.
  