### PR TITLE
Support mounts with multiple processes on first deploy

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -230,6 +230,16 @@ func (md *machineDeployment) setVolumes(ctx context.Context) error {
 	return nil
 }
 
+func (md *machineDeployment) popVolumeFor(name string) *api.Volume {
+	volumes, ok := md.volumes[name]
+	if !ok {
+		return nil
+	}
+	var vol api.Volume
+	vol, md.volumes[name] = volumes[0], volumes[1:]
+	return &vol
+}
+
 func (md *machineDeployment) validateVolumeConfig() error {
 	machineGroups := lo.GroupBy(
 		lo.Map(md.machineSet.GetMachines(), func(lm machine.LeasableMachine, _ int) *api.Machine {

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -133,18 +133,22 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	if err := md.setMachinesForDeployment(ctx); err != nil {
 		return nil, err
 	}
-	if err := md.setFirstDeploy(ctx); err != nil {
-		return nil, err
-	}
-	if err := md.provisionFirstDeploy(ctx); err != nil {
+	if err := md.setVolumes(ctx); err != nil {
 		return nil, err
 	}
 	if err := md.setImg(ctx); err != nil {
 		return nil, err
 	}
-	if err := md.setVolumeConfig(ctx); err != nil {
+	if err := md.setFirstDeploy(ctx); err != nil {
 		return nil, err
 	}
+
+	// Provisioning must come after setVolumes
+	if err := md.provisionFirstDeploy(ctx); err != nil {
+		return nil, err
+	}
+
+	// validations must happen after every else
 	if err := md.validateVolumeConfig(); err != nil {
 		return nil, err
 	}
@@ -206,7 +210,7 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 	return nil
 }
 
-func (md *machineDeployment) setVolumeConfig(ctx context.Context) error {
+func (md *machineDeployment) setVolumes(ctx context.Context) error {
 	if len(md.appConfig.Mounts) == 0 {
 		return nil
 	}

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -90,12 +90,13 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 			// The expected volume name for the machine and fly.toml are out sync
 			// As we can't change the volume for a running machine, the only
 			// way is to destroy the current machine and launch a new one with the new volume attached
-			terminal.Warnf("Machine %s has volume '%s' attached but fly.toml have a different name: '%s'\n", mID, oMounts[0].Name, mMounts[0].Name)
-			vol := md.popVolumeFor(mMounts[0].Name)
-			if vol != nil {
-				return nil, fmt.Errorf("machine in group '%s' needs an unattached volume named '%s'", processGroup, mMounts[0].Name)
+			mount0 := &mMounts[0]
+			terminal.Warnf("Machine %s has volume '%s' attached but fly.toml have a different name: '%s'\n", mID, oMounts[0].Name, mount0.Name)
+			vol := md.popVolumeFor(mount0.Name)
+			if vol == nil {
+				return nil, fmt.Errorf("machine in group '%s' needs an unattached volume named '%s'", processGroup, mount0.Name)
 			}
-			mMounts[0].Volume = vol.ID
+			mount0.Volume = vol.ID
 			mID = "" // Forces machine replacement
 		case mMounts[0].Path != oMounts[0].Path:
 			// The volume is the same but its mount path changed. Not a big deal.

--- a/internal/command/deploy/machines_launchinput_test.go
+++ b/internal/command/deploy/machines_launchinput_test.go
@@ -89,14 +89,18 @@ func Test_launchInputFor_onMounts(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	md.volumes = map[string][]api.Volume{
-		"data": {{ID: "vol_12345", Name: "data"}},
+		"data": {
+			{ID: "vol_10001", Name: "data"},
+			{ID: "vol_10002", Name: "data"},
+			{ID: "vol_10003", Name: "data"},
+		},
 	}
 
 	// New machine must get a volume attached
 	li, err := md.launchInputForLaunch("", nil, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, li.Config.Mounts)
-	assert.Equal(t, api.MachineMount{Volume: "vol_12345", Path: "/data", Name: "data"}, li.Config.Mounts[0])
+	assert.Equal(t, api.MachineMount{Volume: "vol_10001", Path: "/data", Name: "data"}, li.Config.Mounts[0])
 
 	// The machine already has a volume that matches fly.toml [mounts] section
 	li, err = md.launchInputForUpdate(&api.Machine{
@@ -144,7 +148,7 @@ func Test_launchInputFor_onMounts(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, li.Config.Mounts)
 	assert.Equal(t, "", li.ID)
-	assert.Equal(t, api.MachineMount{Volume: "vol_12345", Path: "/data", Name: "data"}, li.Config.Mounts[0])
+	assert.Equal(t, api.MachineMount{Volume: "vol_10002", Path: "/data", Name: "data"}, li.Config.Mounts[0])
 
 	// Updating a machine with an attached volume should trigger a replacement if fly.toml doesn't define one.
 	md.appConfig.Mounts = nil

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -317,3 +317,29 @@ func TestFlyLaunch_case09(t *testing.T) {
 	require.Equal(f, 0, lo.CountBy(groups["task"], hasServices))
 	require.Equal(f, 0, lo.CountBy(groups["disk"], hasServices))
 }
+
+// test first deploy with single mount for multiple processes
+func TestFlyLaunch_case10(t *testing.T) {
+	f := testlib.NewTestEnvFromEnv(t)
+	appName := f.CreateRandomAppName()
+
+	f.WriteFlyToml(`
+[build]
+  image = "nginx"
+
+[processes]
+	app = ""
+	task = ""
+
+[[mounts]]
+  source = "data"
+	destination = "/data"
+	processes = ["app", "task"]
+`)
+
+	f.Fly("launch --now --copy-config -o %s --name %s --region %s --force-machines", f.OrgSlug(), appName, f.PrimaryRegion())
+	ml := f.MachinesList(appName)
+	require.Equal(f, 2, len(ml))
+	vl := f.VolumeList(appName)
+	require.Equal(f, 2, len(vl))
+}

--- a/test/preflight/testlib/test_env.go
+++ b/test/preflight/testlib/test_env.go
@@ -234,6 +234,15 @@ func (f *FlyctlTestEnv) MachinesList(appName string) []*api.Machine {
 	return machList
 }
 
+func (f *FlyctlTestEnv) VolumeList(appName string) []*api.Volume {
+	cmdResult := f.Fly("volume list --app %s --json", appName)
+	var list []*api.Volume
+	if err := json.Unmarshal(cmdResult.stdOut.Bytes(), &list); err != nil {
+		f.t.Fatalf("failed to unmarshal machines list json for app %s:\n%s", appName, cmdResult.stdOut.String())
+	}
+	return list
+}
+
 func (f *FlyctlTestEnv) WriteFile(path string, format string, vals ...any) {
 	fn := filepath.Join(f.WorkDir(), path)
 	content := fmt.Sprintf(format, vals...)


### PR DESCRIPTION
Using the same mount for many processes was failing because it tried to allocate the same volume  twice

this works now:
```toml
[processes]
app = ""
task = "sleep inf"

[[mounts]]
source = "data"
destination = "/data"
processes = ["app", "task"]
```

It also prevents extra volume creation when retrying a "first deploy" due to errors.