### PR TITLE
api/client: improve constructor configurability

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -42,23 +42,60 @@ type Client struct {
 
 // NewClient - creates a new Client, takes an access token
 func NewClient(accessToken, name, version string, logger Logger) *Client {
-	transport := &Transport{
-		UnderlyingTransport: http.DefaultTransport,
-		Token:               accessToken,
-		Ctx:                 context.Background(),
-		EnableDebugTrace:    !slices.Contains([]string{"", "0", "false"}, os.Getenv("FLY_FORCE_TRACE")),
-		UserAgent:           fmt.Sprintf("%s/%s", name, version),
+	return NewClientFromOptions(ClientOptions{
+		AccessToken: accessToken,
+		Name:        name,
+		Version:     version,
+		Logger:      logger,
+		BaseURL:     baseURL,
+	})
+}
+
+type ClientOptions struct {
+	AccessToken      string
+	Name             string
+	Version          string
+	BaseURL          string
+	Logger           Logger
+	EnableDebugTrace *bool
+	Transport        *Transport
+}
+
+func (t *Transport) setDefaults(opts ClientOptions) {
+	if t.UnderlyingTransport == nil {
+		t.UnderlyingTransport = http.DefaultTransport
 	}
+	if t.Token == "" {
+		t.Token = opts.AccessToken
+	}
+	if t.Ctx == nil {
+		t.Ctx = context.Background()
+	}
+	if t.UserAgent == "" {
+		t.UserAgent = fmt.Sprintf("%s/%s", opts.Name, opts.Version)
+	}
+	if opts.EnableDebugTrace != nil {
+		t.EnableDebugTrace = *opts.EnableDebugTrace
+	} else {
+		t.EnableDebugTrace = !slices.Contains([]string{"", "0", "false"}, os.Getenv("FLY_FORCE_TRACE"))
+	}
+}
 
-	httpClient, _ := NewHTTPClient(logger, transport)
+func NewClientFromOptions(opts ClientOptions) *Client {
+	var transport *Transport
+	if opts.Transport == nil {
+		transport = opts.Transport
+	} else {
+		transport = &Transport{}
+	}
+	transport.setDefaults(opts)
 
-	url := fmt.Sprintf("%s/graphql", baseURL)
-
+	httpClient, _ := NewHTTPClient(opts.Logger, transport)
+	url := fmt.Sprintf("%s/graphql", opts.BaseURL)
 	client := graphql.NewClient(url, graphql.WithHTTPClient(httpClient))
-
 	genqClient := genq.NewClient(url, httpClient)
 
-	return &Client{httpClient, client, genqClient, accessToken, logger}
+	return &Client{httpClient, client, genqClient, opts.AccessToken, opts.Logger}
 }
 
 // NewRequest - creates a new GraphQL request

--- a/api/client.go
+++ b/api/client.go
@@ -82,11 +82,9 @@ func (t *Transport) setDefaults(opts ClientOptions) {
 }
 
 func NewClientFromOptions(opts ClientOptions) *Client {
-	var transport *Transport
-	if opts.Transport == nil {
+	transport := &Transport{}
+	if opts.Transport != nil {
 		transport = opts.Transport
-	} else {
-		transport = &Transport{}
 	}
 	transport.setDefaults(opts)
 


### PR DESCRIPTION
I think being able to configure these options will make it easier to
reuse existing HTTP request infrastructure in our application and call
fly.io APIs from within our application.