### PR TITLE
Small output improvements

### DIFF
--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -96,8 +96,8 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 			if machineCheck.Port == nil {
 				if c.HTTPService == nil {
 					return nil, fmt.Errorf(
-						"Check '%s' for group '%s' has no internal port set and there is no http_service to refer to",
-						processGroup, checkName,
+						"Check '%s' for process group '%s' has no port set and the group has no http_service to take it from",
+						checkName, processGroup,
 					)
 				}
 				machineCheck.Port = &c.HTTPService.InternalPort

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -232,7 +232,7 @@ func TestToMachineConfig_defaultV2flytoml(t *testing.T) {
 	cfg.HTTPService = nil
 	got, err = cfg.ToMachineConfig("", nil)
 	assert.Nil(t, got)
-	assert.ErrorContains(t, err, "has no internal port set")
+	assert.ErrorContains(t, err, "has no port set")
 }
 
 func TestToReleaseMachineConfig_processGroupsAndMounts(t *testing.T) {

--- a/internal/command/secrets/secrets.go
+++ b/internal/command/secrets/secrets.go
@@ -64,7 +64,7 @@ func deployForSecrets(ctx context.Context, app *api.AppCompact, release *api.Rel
 	}
 
 	if !app.Deployed {
-		fmt.Fprint(out, "Secrets are staged for the first deployment")
+		fmt.Fprintln(out, "Secrets are staged for the first deployment")
 		return
 	}
 


### PR DESCRIPTION
For the error message when a top-level check has no `port` and there's no `http_service` to take it from:

* Fix ordering of format arguments
* Try to make the wording a bit clearer
  * `group` → `process group`
  * `internal port` → `port` since the actual TOML key is `port`
  * Try to make it clearer that the `http_service` is where we take the default `port` from

For `secrets` output:

* Add a missing newline