### PR TITLE
Image compressed size should be a BigInt

### DIFF
--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -5275,7 +5275,7 @@ type Identity {
 
 type Image {
   absoluteRef: String!
-  compressedSize: Int!
+  compressedSize: BigInt!
   config: JSON!
   configDigest: JSON!
   createdAt: ISO8601DateTime!


### PR DESCRIPTION
Everything else in flyctl is already using uint64 and int64

Companion PR: https://github.com/superfly/web/pull/1327