### PR TITLE
Force dockerfile scanner.

### DIFF
--- a/internal/command/launch/sourceinfo.go
+++ b/internal/command/launch/sourceinfo.go
@@ -49,14 +49,12 @@ func determineSourceInfo(ctx context.Context, appConfig *appconfig.Config, copyC
 		fmt.Fprintln(io.Out, "Using dockerfile", dockerfile)
 		build.Dockerfile = dockerfile
 
-		// FIXME: Force the dockerfile scanner here and remove the condition
-		if dockerfile == "Dockerfile" {
-			// scan Dockerfile for port
-			srcInfo, err = scanner.Scan(workingDir, scannerConfig)
-			if err != nil {
-				return nil, nil, err
-			}
+		// scan Dockerfile for port
+		srcInfo, err = scanner.ConfigureDockerfile(workingDir, scannerConfig)
+		if err != nil {
+			return nil, nil, err
 		}
+
 		return srcInfo, build, nil
 	}
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -75,6 +75,10 @@ type ScannerConfig struct {
 	ExistingPort int
 }
 
+func ConfigureDockerfile(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
+	return configureDockerfile(sourceDir, config)
+}
+
 func Scan(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
 	scanners := []sourceScanner{
 		configureDjango,


### PR DESCRIPTION
See: https://community.fly.io/t/flyctl-trying-to-auto-detect-phoenix-even-though-i-specified-a-dockerfile/12394