### PR TITLE
Split dockerfile scan out so explicit launches don't use scanners

### DIFF
--- a/internal/command/launch/sourceinfo.go
+++ b/internal/command/launch/sourceinfo.go
@@ -49,13 +49,9 @@ func determineSourceInfo(ctx context.Context, appConfig *appconfig.Config, copyC
 		fmt.Fprintln(io.Out, "Using dockerfile", dockerfile)
 		build.Dockerfile = dockerfile
 
-		// FIXME: Force the dockerfile scanner here and remove the condition
-		if dockerfile == "Dockerfile" {
-			// scan Dockerfile for port
-			srcInfo, err = scanner.Scan(workingDir, scannerConfig)
-			if err != nil {
-				return nil, nil, err
-			}
+		srcInfo, err = scanner.ScanDockerfile(dockerfile, scannerConfig)
+		if err != nil {
+			return nil, nil, err
 		}
 		return srcInfo, build, nil
 	}

--- a/scanner/dockerfile.go
+++ b/scanner/dockerfile.go
@@ -11,17 +11,21 @@ const defaultPort = 8080
 
 var portRegex = regexp.MustCompile(`(?m)^EXPOSE\s+(?P<port>\d+)`)
 
-func configureDockerfile (sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
-	if !checksPass(sourceDir, fileExists("Dockerfile")) {
+func configureDockerfile(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
+	return ScanDockerfile(filepath.Join(sourceDir, "Dockerfile"), config)
+}
+
+func ScanDockerfile(dockerfilePath string, config *ScannerConfig) (*SourceInfo, error) {
+	if !absFileExists(dockerfilePath) {
 		return nil, nil
 	}
 
 	var portFromDockerfile int
 
 	s := &SourceInfo{
-		DockerfilePath: filepath.Join(sourceDir, "Dockerfile"),
+		DockerfilePath: dockerfilePath,
 		Family:         "Dockerfile",
-		Port : config.ExistingPort,
+		Port:           config.ExistingPort,
 	}
 
 	dockerfile, err := os.ReadFile(s.DockerfilePath)

--- a/scanner/helpers.go
+++ b/scanner/helpers.go
@@ -6,20 +6,28 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/samber/lo"
 )
+
+func absFileExists(filenames ...string) bool {
+	for _, filename := range filenames {
+		info, err := os.Stat(filename)
+		if err != nil {
+			continue
+		}
+		if !info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
 
 func fileExists(filenames ...string) checkFn {
 	return func(dir string) bool {
-		for _, filename := range filenames {
-			info, err := os.Stat(filepath.Join(dir, filename))
-			if err != nil {
-				continue
-			}
-			if !info.IsDir() {
-				return true
-			}
-		}
-		return false
+		return absFileExists(lo.Map(filenames, func(filename string, _ int) string {
+			return filepath.Join(dir, filename)
+		})...)
 	}
 }
 


### PR DESCRIPTION
When specifically `--dockerfile Dockerfile` was passed, `determineSourceInfo` would try to use scanners so that the Dockerfile scanner could load relevant data.

This PR a) makes this behavior work no matter the dockerfile name, and b) prevents [framework scanners from taking over when you pass in a dockerfile](https://community.fly.io/t/flyctl-trying-to-auto-detect-phoenix-even-though-i-specified-a-dockerfile/12394).

