### PR TITLE
api: avoid logging if the logging is not configured

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -104,6 +104,8 @@ func (c *Client) Run(req *graphql.Request) (Query, error) {
 	return c.RunWithContext(context.Background(), req)
 }
 
+func (c *Client) Logger() Logger { return c.logger }
+
 // RunWithContext - Runs a GraphQL request within a Go context
 func (c *Client) RunWithContext(ctx context.Context, req *graphql.Request) (Query, error) {
 	var resp Query

--- a/api/http.go
+++ b/api/http.go
@@ -24,16 +24,18 @@ func NewHTTPClient(logger Logger, transport http.RoundTripper) (*http.Client, er
 		rehttp.ExpJitterDelay(100*time.Millisecond, 1*time.Second),
 	)
 
-	loggingTransport := &LoggingTransport{
-		InnerTransport: retryTransport,
-		Logger:         logger,
+	if logger != nil {
+		return &http.Client{
+			Transport: &LoggingTransport{
+				InnerTransport: retryTransport,
+				Logger:         logger,
+			},
+		}, nil
 	}
 
-	httpClient := &http.Client{
-		Transport: loggingTransport,
-	}
-
-	return httpClient, nil
+	return &http.Client{
+		Transport: retryTransport,
+	}, nil
 }
 
 type LoggingTransport struct {

--- a/api/http.go
+++ b/api/http.go
@@ -72,7 +72,7 @@ func (t *LoggingTransport) logRequest(req *http.Request) {
 		return
 	}
 
-	defer req.Body.Close()
+	defer func() { _ = req.Body.Close() }()
 
 	data, err := ioutil.ReadAll(req.Body)
 
@@ -91,7 +91,7 @@ func (t *LoggingTransport) logRequest(req *http.Request) {
 
 func (t *LoggingTransport) logResponse(resp *http.Response) {
 	ctx := resp.Request.Context()
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if start, ok := ctx.Value(contextKeyRequestStart).(time.Time); ok {
 		t.Logger.Debugf("<-- %d %s (%s)\n", resp.StatusCode, resp.Request.URL, shiftedDuration(time.Since(start), 2))


### PR DESCRIPTION
Because `internal/logger.MaybeFromContext()` can sometimes return a
nil logger, it is pluisble to, when constructing loggers outside of the
package, to get a nil logger.

as in: 

- https://github.com/superfly/flyctl/blob/master/flaps/flaps.go#L96

- https://github.com/superfly/flyctl/blob/master/flaps/flaps.go#L72