### PR TITLE
fly launch --ha=false

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test: FORCE
 # to run one test, use: make preflight-test T=TestAppsV2ConfigSave
 preflight-test: build
 	if [ -r .direnv/preflight ]; then . .direnv/preflight; fi; \
-	go test ./test/preflight --tags=integration -v --run=$(T)
+	go test ./test/preflight --tags=integration -v -timeout 30m --run=$(T)
 
 cmddocs: generate
 	@echo Running Docs Generation

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -76,6 +76,11 @@ var CommonFlags = flag.Set{
 		Name:        "vm-size",
 		Description: `The VM size to use when deploying for the first time. See "fly platform vm-sizes" for valid values`,
 	},
+	flag.Bool{
+		Name:        "ha",
+		Description: "Create spare machines that increases app availability",
+		Default:     true,
+	},
 }
 
 func New() (cmd *cobra.Command) {
@@ -187,15 +192,16 @@ func deployToMachines(ctx context.Context, appConfig *appconfig.Config, appCompa
 	}()
 
 	md, err := NewMachineDeployment(ctx, MachineDeploymentArgs{
-		AppCompact:        appCompact,
-		DeploymentImage:   img.Tag,
-		Strategy:          flag.GetString(ctx, "strategy"),
-		EnvFromFlags:      flag.GetStringSlice(ctx, "env"),
-		PrimaryRegionFlag: appConfig.PrimaryRegion,
-		SkipHealthChecks:  flag.GetDetach(ctx),
-		WaitTimeout:       time.Duration(flag.GetInt(ctx, "wait-timeout")) * time.Second,
-		LeaseTimeout:      time.Duration(flag.GetInt(ctx, "lease-timeout")) * time.Second,
-		VMSize:            flag.GetString(ctx, "vm-size"),
+		AppCompact:            appCompact,
+		DeploymentImage:       img.Tag,
+		Strategy:              flag.GetString(ctx, "strategy"),
+		EnvFromFlags:          flag.GetStringSlice(ctx, "env"),
+		PrimaryRegionFlag:     appConfig.PrimaryRegion,
+		SkipHealthChecks:      flag.GetDetach(ctx),
+		WaitTimeout:           time.Duration(flag.GetInt(ctx, "wait-timeout")) * time.Second,
+		LeaseTimeout:          time.Duration(flag.GetInt(ctx, "lease-timeout")) * time.Second,
+		VMSize:                flag.GetString(ctx, "vm-size"),
+		IncreasedAvailability: flag.GetBool(ctx, "ha"),
 	})
 	if err != nil {
 		sentry.CaptureExceptionWithAppInfo(err, "deploy", appCompact)

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -31,16 +31,17 @@ type MachineDeployment interface {
 }
 
 type MachineDeploymentArgs struct {
-	AppCompact        *api.AppCompact
-	DeploymentImage   string
-	Strategy          string
-	EnvFromFlags      []string
-	PrimaryRegionFlag string
-	SkipHealthChecks  bool
-	RestartOnly       bool
-	WaitTimeout       time.Duration
-	LeaseTimeout      time.Duration
-	VMSize            string
+	AppCompact            *api.AppCompact
+	DeploymentImage       string
+	Strategy              string
+	EnvFromFlags          []string
+	PrimaryRegionFlag     string
+	SkipHealthChecks      bool
+	RestartOnly           bool
+	WaitTimeout           time.Duration
+	LeaseTimeout          time.Duration
+	VMSize                string
+	IncreasedAvailability bool
 }
 
 type machineDeployment struct {
@@ -65,6 +66,7 @@ type machineDeployment struct {
 	leaseDelayBetween     time.Duration
 	isFirstDeploy         bool
 	machineGuest          *api.MachineGuest
+	increasedAvailability bool
 }
 
 func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (MachineDeployment, error) {
@@ -110,19 +112,20 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	io := iostreams.FromContext(ctx)
 	apiClient := client.FromContext(ctx).API()
 	md := &machineDeployment{
-		apiClient:         apiClient,
-		gqlClient:         apiClient.GenqClient,
-		flapsClient:       flapsClient,
-		io:                io,
-		colorize:          io.ColorScheme(),
-		app:               args.AppCompact,
-		appConfig:         appConfig,
-		img:               args.DeploymentImage,
-		skipHealthChecks:  args.SkipHealthChecks,
-		restartOnly:       args.RestartOnly,
-		waitTimeout:       waitTimeout,
-		leaseTimeout:      leaseTimeout,
-		leaseDelayBetween: leaseDelayBetween,
+		apiClient:             apiClient,
+		gqlClient:             apiClient.GenqClient,
+		flapsClient:           flapsClient,
+		io:                    io,
+		colorize:              io.ColorScheme(),
+		app:                   args.AppCompact,
+		appConfig:             appConfig,
+		img:                   args.DeploymentImage,
+		skipHealthChecks:      args.SkipHealthChecks,
+		restartOnly:           args.RestartOnly,
+		waitTimeout:           waitTimeout,
+		leaseTimeout:          leaseTimeout,
+		leaseDelayBetween:     leaseDelayBetween,
+		increasedAvailability: args.IncreasedAvailability,
 	}
 	if err := md.setStrategy(args.Strategy); err != nil {
 		return nil, err

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -130,6 +130,11 @@ func (md *machineDeployment) deployMachinesApp(ctx context.Context) error {
 				}
 			}
 
+			// Create spare machines that increases availability unless --ha=false was used
+			if !md.increasedAvailability {
+				continue
+			}
+
 			// We strive to provide a HA setup according to:
 			// - Create only 1 machine if the group has mounts
 			// - Create 2 machines for groups with services

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -291,10 +291,14 @@ func runMachineRun(ctx context.Context) error {
 
 	id, instanceID, state, privateIP := machine.ID, machine.InstanceID, machine.State, machine.PrivateIP
 
-	fmt.Fprintf(io.Out, "Success! A machine has been successfully launched in app %s, waiting for it to be started\n", appName)
+	fmt.Fprintf(io.Out, "Success! A machine has been successfully launched in app %s\n", appName)
 	fmt.Fprintf(io.Out, " Machine ID: %s\n", id)
 	fmt.Fprintf(io.Out, " Instance ID: %s\n", instanceID)
 	fmt.Fprintf(io.Out, " State: %s\n", state)
+
+	if input.SkipLaunch {
+		return nil
+	}
 
 	fmt.Fprintf(io.Out, "\n Attempting to start machine...\n\n")
 	s.Start()
@@ -788,9 +792,9 @@ func determineMachineConfig(ctx context.Context, input *determineMachineConfigIn
 	}
 
 	// Standby machine
-	standbys := flag.GetStringSlice(ctx, "standby-for")
-	if len(standbys) > 0 {
-		machineConf.Standbys = standbys
+	if flag.IsSpecified(ctx, "standby-for") {
+		standbys := flag.GetStringSlice(ctx, "standby-for")
+		machineConf.Standbys = lo.Ternary(len(standbys) > 0, standbys, nil)
 	}
 
 	return machineConf, nil

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -141,7 +141,7 @@ func runUpdate(ctx context.Context) (err error) {
 		return err
 	}
 
-	if !flag.GetDetach(ctx) {
+	if !(input.SkipLaunch || flag.GetDetach(ctx)) {
 		fmt.Fprintln(io.Out, colorize.Green("==> "+"Monitoring health checks"))
 
 		if err := watch.MachinesChecks(ctx, []*api.Machine{machine}); err != nil {

--- a/internal/machine/update.go
+++ b/internal/machine/update.go
@@ -88,17 +88,18 @@ func Update(ctx context.Context, m *api.Machine, input *api.LaunchMachineInput) 
 	}
 
 	waitForAction := "start"
-	if m.Config.Schedule != "" {
+	if input.SkipLaunch || m.Config.Schedule != "" {
 		waitForAction = "stop"
 	}
-
 	if err := WaitForStartOrStop(ctx, updatedMachine, waitForAction, time.Minute*5); err != nil {
 		return err
 	}
 
-	if !input.SkipHealthChecks {
-		if err := watch.MachinesChecks(ctx, []*api.Machine{updatedMachine}); err != nil {
-			return fmt.Errorf("failed to wait for health checks to pass: %w", err)
+	if !input.SkipLaunch {
+		if !input.SkipHealthChecks {
+			if err := watch.MachinesChecks(ctx, []*api.Machine{updatedMachine}); err != nil {
+				return fmt.Errorf("failed to wait for health checks to pass: %w", err)
+			}
 		}
 	}
 

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -32,7 +32,10 @@ func TestAppsV2Example(t *testing.T) {
 		appUrl  = fmt.Sprintf("https://%s.fly.dev", appName)
 	)
 
-	result = f.Fly("launch --org %s --name %s --region %s --image nginx --force-machines --internal-port 80 --now --auto-confirm --ha=false", f.OrgSlug(), appName, f.PrimaryRegion())
+	result = f.Fly(
+		"launch --org %s --name %s --region %s --image nginx --force-machines --internal-port 80 --now --auto-confirm --ha=false",
+		f.OrgSlug(), appName, f.PrimaryRegion(),
+	)
 	require.Contains(f, result.StdOut().String(), "Using image nginx")
 	require.Contains(f, result.StdOut().String(), fmt.Sprintf("Created app '%s' in organization '%s'", appName, f.OrgSlug()))
 	require.Contains(f, result.StdOut().String(), "Wrote config file fly.toml")
@@ -195,47 +198,81 @@ func TestAppsV2ConfigSave_OneMachineNoAppConfig(t *testing.T) {
 }
 
 func TestAppsV2ConfigSave_PostgresSingleNode(t *testing.T) {
-	var (
-		err            error
-		f              = testlib.NewTestEnvFromEnv(t)
-		appName        = f.CreateRandomAppName()
-		configFilePath = filepath.Join(f.WorkDir(), appconfig.DefaultConfigFileName)
+	f := testlib.NewTestEnvFromEnv(t)
+	appName := f.CreateRandomAppName()
+
+	f.Fly(
+		"pg create --org %s --name %s --region %s --initial-cluster-size 1 --vm-size shared-cpu-1x --volume-size 1",
+		f.OrgSlug(), appName, f.PrimaryRegion(),
 	)
-	f.Fly("pg create --org %s --name %s --region %s --initial-cluster-size 1 --vm-size shared-cpu-1x --volume-size 1", f.OrgSlug(), appName, f.PrimaryRegion())
 	f.Fly("status -a %s", appName)
 	f.Fly("config save -a %s", appName)
-	configFileBytes, err := os.ReadFile(configFilePath)
-	if err != nil {
-		f.Fatalf("error trying to read %s after running fly config save: %v", configFilePath, err)
+	flyToml := f.UnmarshalFlyToml()
+	want := map[string]any{
+		"app":            appName,
+		"primary_region": f.PrimaryRegion(),
+		"env": map[string]any{
+			"PRIMARY_REGION": f.PrimaryRegion(),
+		},
+		"metrics": map[string]any{
+			"port": int64(9187),
+			"path": "/metrics",
+		},
+		"mounts": []map[string]any{{
+			"source":      "pg_data",
+			"destination": "/data",
+		}},
+		"services": []map[string]any{
+			{
+				"internal_port": int64(5432),
+				"protocol":      "tcp",
+				"concurrency": map[string]any{
+					"type":       "connections",
+					"soft_limit": int64(1000),
+					"hard_limit": int64(1000),
+				},
+				"ports": []map[string]any{
+					{"handlers": []any{"pg_tls"}, "port": int64(5432)},
+				},
+			},
+			{
+				"internal_port": int64(5433),
+				"protocol":      "tcp",
+				"concurrency": map[string]any{
+					"type":       "connections",
+					"soft_limit": int64(1000),
+					"hard_limit": int64(1000),
+				},
+				"ports": []map[string]any{
+					{"handlers": []any{"pg_tls"}, "port": int64(5433)},
+				},
+			},
+		},
+		"checks": map[string]any{
+			"pg": map[string]any{
+				"type":     "http",
+				"port":     int64(5500),
+				"path":     "/flycheck/pg",
+				"interval": "15s",
+				"timeout":  "10s",
+			},
+			"role": map[string]any{
+				"type":     "http",
+				"port":     int64(5500),
+				"path":     "/flycheck/role",
+				"interval": "15s",
+				"timeout":  "10s",
+			},
+			"vm": map[string]any{
+				"type":     "http",
+				"port":     int64(5500),
+				"path":     "/flycheck/vm",
+				"interval": "15s",
+				"timeout":  "10s",
+			},
+		},
 	}
-	configFileContent := string(configFileBytes)
-	require.Contains(f, configFileContent, fmt.Sprintf(`primary_region = "%s"`, f.PrimaryRegion()))
-	require.Contains(f, configFileContent, `[env]`)
-	require.Contains(f, configFileContent, fmt.Sprintf(`PRIMARY_REGION = "%s"`, f.PrimaryRegion()))
-	require.Contains(f, configFileContent, `[metrics]
-  port = 9187
-  path = "/metrics"`)
-	require.Contains(f, configFileContent, `[mounts]
-  destination = "/data"`)
-	require.Contains(f, configFileContent, `[checks]
-  [checks.pg]
-    port = 5500
-    type = "http"
-    interval = "15s"
-    timeout = "10s"
-    path = "/flycheck/pg"
-  [checks.role]
-    port = 5500
-    type = "http"
-    interval = "15s"
-    timeout = "10s"
-    path = "/flycheck/role"
-  [checks.vm]
-    port = 5500
-    type = "http"
-    interval = "15s"
-    timeout = "10s"
-    path = "/flycheck/vm"`)
+	require.Equal(f, want, flyToml)
 }
 
 func TestAppsV2_PostgresAutostart(t *testing.T) {
@@ -313,47 +350,84 @@ func TestAppsV2_PostgresNoMachines(t *testing.T) {
 }
 
 func TestAppsV2ConfigSave_PostgresHA(t *testing.T) {
-	var (
-		err            error
-		f              = testlib.NewTestEnvFromEnv(t)
-		appName        = f.CreateRandomAppName()
-		configFilePath = filepath.Join(f.WorkDir(), appconfig.DefaultConfigFileName)
+	f := testlib.NewTestEnvFromEnv(t)
+	appName := f.CreateRandomAppName()
+
+	f.Fly(
+		"pg create --org %s --name %s --region %s --initial-cluster-size 3 --vm-size shared-cpu-1x --volume-size 1",
+		f.OrgSlug(), appName, f.PrimaryRegion(),
 	)
-	f.Fly("pg create --org %s --name %s --region %s --initial-cluster-size 3 --vm-size shared-cpu-1x --volume-size 1", f.OrgSlug(), appName, f.PrimaryRegion())
 	f.Fly("status -a %s", appName)
 	f.Fly("config save -a %s", appName)
-	configFileBytes, err := os.ReadFile(configFilePath)
-	if err != nil {
-		f.Fatalf("error trying to read %s after running fly config save: %v", configFilePath, err)
+	ml := f.MachinesList(appName)
+	require.Equal(f, 3, len(ml))
+	flyToml := f.UnmarshalFlyToml()
+	require.Equal(f, "shared-cpu-1x", ml[0].Config.Guest.ToSize())
+	want := map[string]any{
+		"app":            appName,
+		"primary_region": f.PrimaryRegion(),
+		"env": map[string]any{
+			"PRIMARY_REGION": f.PrimaryRegion(),
+		},
+		"metrics": map[string]any{
+			"port": int64(9187),
+			"path": "/metrics",
+		},
+		"mounts": []map[string]any{{
+			"source":      "pg_data",
+			"destination": "/data",
+		}},
+		"services": []map[string]any{
+			{
+				"internal_port": int64(5432),
+				"protocol":      "tcp",
+				"concurrency": map[string]any{
+					"type":       "connections",
+					"soft_limit": int64(1000),
+					"hard_limit": int64(1000),
+				},
+				"ports": []map[string]any{
+					{"handlers": []any{"pg_tls"}, "port": int64(5432)},
+				},
+			},
+			{
+				"internal_port": int64(5433),
+				"protocol":      "tcp",
+				"concurrency": map[string]any{
+					"type":       "connections",
+					"soft_limit": int64(1000),
+					"hard_limit": int64(1000),
+				},
+				"ports": []map[string]any{
+					{"handlers": []any{"pg_tls"}, "port": int64(5433)},
+				},
+			},
+		},
+		"checks": map[string]any{
+			"pg": map[string]any{
+				"type":     "http",
+				"port":     int64(5500),
+				"path":     "/flycheck/pg",
+				"interval": "15s",
+				"timeout":  "10s",
+			},
+			"role": map[string]any{
+				"type":     "http",
+				"port":     int64(5500),
+				"path":     "/flycheck/role",
+				"interval": "15s",
+				"timeout":  "10s",
+			},
+			"vm": map[string]any{
+				"type":     "http",
+				"port":     int64(5500),
+				"path":     "/flycheck/vm",
+				"interval": "15s",
+				"timeout":  "10s",
+			},
+		},
 	}
-	configFileContent := string(configFileBytes)
-	require.Contains(f, configFileContent, fmt.Sprintf(`primary_region = "%s"`, f.PrimaryRegion()))
-	require.Contains(f, configFileContent, fmt.Sprintf(`[env]
-  PRIMARY_REGION = "%s"`, f.PrimaryRegion()))
-	require.Contains(f, configFileContent, `[metrics]
-  port = 9187
-  path = "/metrics"`)
-	require.Contains(f, configFileContent, `[mounts]
-  destination = "/data"`)
-	require.Contains(f, configFileContent, `[checks]
-  [checks.pg]
-    port = 5500
-    type = "http"
-    interval = "15s"
-    timeout = "10s"
-    path = "/flycheck/pg"
-  [checks.role]
-    port = 5500
-    type = "http"
-    interval = "15s"
-    timeout = "10s"
-    path = "/flycheck/role"
-  [checks.vm]
-    port = 5500
-    type = "http"
-    interval = "15s"
-    timeout = "10s"
-    path = "/flycheck/vm"`)
+	require.Equal(f, want, flyToml)
 }
 
 func TestAppsV2Config_ParseExperimental(t *testing.T) {

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -267,7 +267,10 @@ func TestFlyLaunch_case08(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
-	f.Fly("launch --detach --now -o %s --name %s --region %s --force-machines --image nginx --vm-size shared-cpu-4x", f.OrgSlug(), appName, f.PrimaryRegion())
+	f.Fly(
+		"launch --ha=false --detach --now -o %s --name %s --region %s --force-machines --image nginx --vm-size shared-cpu-4x",
+		f.OrgSlug(), appName, f.PrimaryRegion(),
+	)
 
 	ml := f.MachinesList(appName)
 	require.Equal(f, 1, len(ml))

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -36,7 +36,12 @@ func TestFlyLaunch_case01(t *testing.T) {
 		"app":            appName,
 		"primary_region": f.PrimaryRegion(),
 		"build":          map[string]any{"image": "nginx"},
-		"http_service":   map[string]any{"force_https": true, "internal_port": int64(8080)},
+		"http_service": map[string]any{
+			"force_https":         true,
+			"internal_port":       int64(8080),
+			"auto_stop_machines":  true,
+			"auto_start_machines": true,
+		},
 		"checks": map[string]any{
 			"alive": map[string]any{
 				"type":         "tcp",

--- a/test/preflight/fly_machine_test.go
+++ b/test/preflight/fly_machine_test.go
@@ -28,7 +28,7 @@ func TestFlyMachineRun_autoStartStop(t *testing.T) {
 		Autostop:     api.Pointer(true),
 		Ports: []api.MachinePort{{
 			Port:       api.Pointer(80),
-			ForceHttps: false,
+			ForceHTTPS: false,
 		}},
 	}}
 	require.Nil(f, m.Config.DisableMachineAutostart)
@@ -43,7 +43,7 @@ func TestFlyMachineRun_autoStartStop(t *testing.T) {
 		Autostop:     api.Pointer(true),
 		Ports: []api.MachinePort{{
 			Port:       api.Pointer(80),
-			ForceHttps: false,
+			ForceHTTPS: false,
 		}},
 	}}
 	require.Nil(f, m.Config.DisableMachineAutostart)
@@ -58,7 +58,7 @@ func TestFlyMachineRun_autoStartStop(t *testing.T) {
 		Autostop:     api.Pointer(false),
 		Ports: []api.MachinePort{{
 			Port:       api.Pointer(80),
-			ForceHttps: false,
+			ForceHTTPS: false,
 		}},
 	}}
 	require.Nil(f, m.Config.DisableMachineAutostart)

--- a/test/preflight/fly_machine_test.go
+++ b/test/preflight/fly_machine_test.go
@@ -78,6 +78,14 @@ func TestFlyMachineRun_standbyFor(t *testing.T) {
 		}
 		return nil
 	}
+	findMachineByID := func(machineList []*api.Machine, ID string) *api.Machine {
+		for _, m := range machineList {
+			if m.ID == ID {
+				return m
+			}
+		}
+		return nil
+	}
 
 	f.Fly("machine run -a %s nginx", appName)
 	ml := f.MachinesList(appName)
@@ -86,19 +94,21 @@ func TestFlyMachineRun_standbyFor(t *testing.T) {
 	require.Empty(f, og.Config.Standbys)
 
 	// Run a another machine and set it as standby of first
+	t.Log("Run a another machine and set it as standby of first")
 	f.Fly("machine run -a %s nginx --standby-for=%s", appName, og.ID)
 	ml = f.MachinesList(appName)
 	require.Equal(f, 2, len(ml))
-
 	// Mahcine must be stopped and be standby for first machine ID
 	s1 := findNewMachine(ml, []string{og.ID})
-	require.Equal(f, "stopped", s1.State)
+	require.Contains(f, []string{"created", "stopped"}, s1.State)
 	require.Equal(f, []string{og.ID}, s1.Config.Standbys)
 
 	// Clear the standbys field
-	f.Fly("machine update -a %s %s --standby-for=''", appName, s1.ID)
+	f.Fly("machine update -a %s %s --standby-for='' -y", appName, s1.ID)
 	ml = f.MachinesList(appName)
+	s1 = findMachineByID(ml, s1.ID)
 	require.Equal(f, 2, len(ml))
+	// Updating a stopped machine doesn't start it
 	require.Equal(f, "started", s1.State)
 	require.Empty(f, s1.Config.Standbys)
 
@@ -107,12 +117,13 @@ func TestFlyMachineRun_standbyFor(t *testing.T) {
 	ml = f.MachinesList(appName)
 	require.Equal(f, 3, len(ml))
 	s2 := findNewMachine(ml, []string{og.ID, s1.ID})
-	require.Equal(f, "stopped", s2.State)
+	require.Contains(f, []string{"created", "stopped"}, s2.State)
 	require.Equal(f, []string{og.ID, s1.ID}, s2.Config.Standbys)
 
 	// Finally update the standby list to only one machine
-	f.Fly("machine update -a %s %s --standby-for=%s", appName, s2.ID, s1.ID)
+	f.Fly("machine update -a %s %s --standby-for=%s -y", appName, s2.ID, s1.ID)
 	ml = f.MachinesList(appName)
+	s2 = findMachineByID(ml, s2.ID)
 	require.Equal(f, "stopped", s2.State)
 	require.Equal(f, []string{s1.ID}, s2.Config.Standbys)
 }

--- a/test/preflight/fly_machine_test.go
+++ b/test/preflight/fly_machine_test.go
@@ -94,7 +94,6 @@ func TestFlyMachineRun_standbyFor(t *testing.T) {
 	require.Empty(f, og.Config.Standbys)
 
 	// Run a another machine and set it as standby of first
-	t.Log("Run a another machine and set it as standby of first")
 	f.Fly("machine run -a %s nginx --standby-for=%s", appName, og.ID)
 	ml = f.MachinesList(appName)
 	require.Equal(f, 2, len(ml))

--- a/test/preflight/testlib/test_env.go
+++ b/test/preflight/testlib/test_env.go
@@ -278,35 +278,42 @@ func (f *FlyctlTestEnv) Cleanup(cleanupFunc func()) {
 }
 
 func (f *FlyctlTestEnv) Error(args ...any) {
+	f.t.Helper()
 	f.DebugPrintHistory()
 	f.t.Error(args...)
 }
 
 func (f *FlyctlTestEnv) Errorf(format string, args ...any) {
+	f.t.Helper()
 	f.DebugPrintHistory()
 	f.t.Errorf(format, args...)
 }
 
 func (f *FlyctlTestEnv) Fail() {
+	f.t.Helper()
 	f.DebugPrintHistory()
 	f.t.Fail()
 }
 
 func (f *FlyctlTestEnv) FailNow() {
+	f.t.Helper()
 	f.DebugPrintHistory()
 	f.t.FailNow()
 }
 
 func (f *FlyctlTestEnv) Failed() bool {
+	f.t.Helper()
 	return f.t.Failed()
 }
 
 func (f *FlyctlTestEnv) Fatal(args ...any) {
+	f.t.Helper()
 	f.DebugPrintHistory()
 	f.t.Fatal(args...)
 }
 
 func (f *FlyctlTestEnv) Fatalf(format string, args ...any) {
+	f.t.Helper()
 	f.DebugPrintHistory()
 	f.t.Fatalf(format, args...)
 }
@@ -316,10 +323,12 @@ func (f *FlyctlTestEnv) Helper() {
 }
 
 func (f *FlyctlTestEnv) Log(args ...any) {
+	f.t.Helper()
 	f.t.Log(args...)
 }
 
 func (f *FlyctlTestEnv) Logf(format string, args ...any) {
+	f.t.Helper()
 	f.t.Logf(format, args...)
 }
 


### PR DESCRIPTION
Support Disabling the creation of spares machines on first deploy by passing `--ha=false` flag