### PR TITLE
fix: make stop_config.signal a string pointer type

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -508,7 +508,7 @@ type DNSConfig struct {
 
 type StopConfig struct {
 	Timeout *Duration `json:"timeout,omitempty"`
-	Signal  *Signal   `json:"signal,omitempty"`
+	Signal  *string   `json:"signal,omitempty"`
 }
 
 type MachineLease struct {


### PR DESCRIPTION
After attempting to utilize the new field, it became clear the custom `Signal` type is not easy to work with across platforms.