### PR TITLE
fly consul attach|detach

### DIFF
--- a/internal/command/consul/attach.go
+++ b/internal/command/consul/attach.go
@@ -1,0 +1,60 @@
+package consul
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/command/secrets"
+	"github.com/superfly/flyctl/internal/flag"
+)
+
+const (
+	consulUrlDefaultVariableName = "FLY_CONSUL_URL"
+)
+
+func newAttach() *cobra.Command {
+	const (
+		short = "Attach Consul cluster to an app"
+		long  = "Attach Consul cluster to an app, and setting the " + consulUrlDefaultVariableName + " secret"
+		usage = "attach"
+	)
+	cmd := command.New(usage, short, long, runAttach,
+		command.RequireSession,
+		command.RequireAppName,
+	)
+	cmd.Args = cobra.NoArgs
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+		flag.String{
+			Name:        "variable-name",
+			Default:     consulUrlDefaultVariableName,
+			Description: "The environment variable name that will be added to the consuming app.",
+		},
+	)
+	return cmd
+}
+
+func runAttach(ctx context.Context) error {
+	var (
+		apiClient  = client.FromContext(ctx).API()
+		appName    = appconfig.NameFromContext(ctx)
+		secretName = flag.GetString(ctx, "variable-name")
+	)
+	appCompact, err := apiClient.GetAppCompact(ctx, appName)
+	if err != nil {
+		return err
+	}
+	consulPayload, err := apiClient.EnablePostgresConsul(ctx, appName)
+	if err != nil {
+		return nil
+	}
+	secretsToSet := map[string]string{
+		secretName: consulPayload.ConsulURL,
+	}
+	err = secrets.SetSecretsAndDeploy(ctx, appCompact, secretsToSet, false, false)
+	return err
+}

--- a/internal/command/consul/consul.go
+++ b/internal/command/consul/consul.go
@@ -1,0 +1,19 @@
+package consul
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/command"
+)
+
+func New() *cobra.Command {
+	const (
+		short = "Enable and manage Consul clusters"
+		long  = "Enable and manage Consul clusters"
+	)
+	cmd := command.New("consul", short, long, nil)
+	cmd.AddCommand(
+		newAttach(),
+		newDetach(),
+	)
+	return cmd
+}

--- a/internal/command/consul/detach.go
+++ b/internal/command/consul/detach.go
@@ -1,0 +1,50 @@
+package consul
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/command/secrets"
+	"github.com/superfly/flyctl/internal/flag"
+)
+
+func newDetach() *cobra.Command {
+	const (
+		short = "Detach Consul cluster from an app"
+		long  = "Detach Consul cluster from an app, and unsetting the " + consulUrlDefaultVariableName + " secret"
+		usage = "detach"
+	)
+	cmd := command.New(usage, short, long, runDetach,
+		command.RequireSession,
+		command.RequireAppName,
+	)
+	cmd.Args = cobra.NoArgs
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+		flag.String{
+			Name:        "variable-name",
+			Default:     consulUrlDefaultVariableName,
+			Description: "The secret name that will be removed from the app.",
+		},
+	)
+	return cmd
+}
+
+func runDetach(ctx context.Context) error {
+	var (
+		apiClient  = client.FromContext(ctx).API()
+		appName    = appconfig.NameFromContext(ctx)
+		secretName = flag.GetString(ctx, "variable-name")
+	)
+	appCompact, err := apiClient.GetAppCompact(ctx, appName)
+	if err != nil {
+		return err
+	}
+	secretsToUnset := []string{secretName}
+	err = secrets.UnsetSecretsAndDeploy(ctx, appCompact, secretsToUnset, false, false)
+	return err
+}

--- a/internal/command/help/help.go
+++ b/internal/command/help/help.go
@@ -99,7 +99,7 @@ Scaling and configuring:
 		fmt.Printf(`
 Provisioning storage:
 `)
-		listCommands([]string{"volumes", "postgres", "redis"})
+		listCommands([]string{"volumes", "postgres", "redis", "consul"})
 
 		fmt.Printf(`
 Networking configuration:

--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/auth"
 	"github.com/superfly/flyctl/internal/command/checks"
 	"github.com/superfly/flyctl/internal/command/config"
+	"github.com/superfly/flyctl/internal/command/consul"
 	"github.com/superfly/flyctl/internal/command/create"
 	"github.com/superfly/flyctl/internal/command/curl"
 	"github.com/superfly/flyctl/internal/command/deploy"
@@ -174,6 +175,7 @@ func New() *cobra.Command {
 		migrate_to_v2.New(),
 		tokens.New(),
 		extensions.New(),
+		consul.New(),
 	}
 
 	// if os.Getenv("DEV") != "" {


### PR DESCRIPTION
Add a new command for attaching and detaching a Consul cluster to an app. We borrow the postgres launcher functionality for provisioning a Consul cluster, and set FLY_CONSUL_URL with the cluster url.

Detach will unset the secret with the cluster url.

This works for any app. Going forward the `fly consul attach` command should be used instead of the fly.toml experimental `enable_consul` configuration field.
