### PR TITLE
Fix empty configFilePath regression in flyctl launch 

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -24,6 +24,7 @@ func NewConfig() *Config {
 	return &Config{
 		RawDefinition:    map[string]any{},
 		defaultGroupName: api.MachineProcessGroupApp,
+		configFilePath:   "--config path unset--",
 	}
 }
 

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -111,6 +111,10 @@ func (c *Config) ConfigFilePath() string {
 	return c.configFilePath
 }
 
+func (c *Config) SetConfigFilePath(configFilePath string) {
+	c.configFilePath = configFilePath
+}
+
 func (c *Config) HasNonHttpAndHttpsStandardServices() bool {
 	for _, service := range c.Services {
 		switch service.Protocol {

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -108,6 +108,7 @@ func TestFromDefinition(t *testing.T) {
 				},
 			},
 		},
+		configFilePath: "--config path unset--",
 		defaultGroupName: "app",
 		RawDefinition: map[string]any{
 			"env": map[string]any{},

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -271,6 +271,7 @@ func run(ctx context.Context) (err error) {
 	}
 
 	// Finally write application configuration to fly.toml
+	appConfig.SetConfigFilePath(configFilePath)
 	if err := appConfig.WriteToDisk(ctx, configFilePath); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR fixes a regression introduced in #2136 which reloads the app config after the user confirms deploy. The `appConfig` we generate for a fresh app has an empty `configFilePath`, which causes an error when we try to reload the config based on the value of this field.

This bug was encountered by a user over in https://community.fly.io/t/frustrating-time-with-elixir-tutorial/12404. I can reproduce this bug on Linux.

I tried a few various approaches to fixing this bug in a more robust way that would prevent it from being reintroduced in the future: eg. leveraging the type system by splitting out the `configFilePath` field into another struct that embeds `Config`. This started looking like a bit of a rabbit hole though, so considering the user-impacting nature of this bug, I've opted for the quick fix of setting this field where it's needed, as well as initialising `configFilePath` to a more obvious sentinel value in `NewConfig()` which should help root out similar bugs in future.

Longer term, I think a refactor of this part of the codebase would be helpful. `Config` is currently a mutable ball of state that's initialised in a variety of interesting ways. It isn't always loaded from disk or intended to be saved to disk, and so doesn't always have a valid file path set.