### PR TITLE
Port services.ports.http_options to v2 apps

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -360,7 +360,7 @@ type MachinePort struct {
 	StartPort   *int         `json:"start_port,omitempty" toml:"start_port,omitempty"`
 	EndPort     *int         `json:"end_port,omitempty" toml:"end_port,omitempty"`
 	Handlers    []string     `json:"handlers,omitempty" toml:"handlers,omitempty"`
-	ForceHttps  bool         `json:"force_https,omitempty" toml:"force_https,omitempty"`
+	ForceHTTPS  bool         `json:"force_https,omitempty" toml:"force_https,omitempty"`
 	TLSOptions  *TLSOptions  `json:"tls_options,omitempty" toml:"tls_options,omitempty"`
 	HTTPOptions *HTTPOptions `json:"http_options,omitempty" toml:"tls_options,omitempty"`
 }

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -424,7 +424,7 @@ type HTTPOptions struct {
 }
 
 type HTTPResponseOptions struct {
-	Headers map[string]string `json:"headers,omitempty" toml:"headers,omitempty"`
+	Headers map[string]any `json:"headers,omitempty" toml:"headers,omitempty"`
 }
 
 type MachineService struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -356,12 +356,13 @@ type MachineCheckStatus struct {
 }
 
 type MachinePort struct {
-	Port       *int        `json:"port,omitempty" toml:"port,omitempty"`
-	StartPort  *int        `json:"start_port,omitempty" toml:"start_port,omitempty"`
-	EndPort    *int        `json:"end_port,omitempty" toml:"end_port,omitempty"`
-	Handlers   []string    `json:"handlers,omitempty" toml:"handlers,omitempty"`
-	ForceHttps bool        `json:"force_https,omitempty" toml:"force_https,omitempty"`
-	TlsOptions *TlsOptions `json:"tls_options,omitempty" toml:"tls_options,omitempty"`
+	Port        *int         `json:"port,omitempty" toml:"port,omitempty"`
+	StartPort   *int         `json:"start_port,omitempty" toml:"start_port,omitempty"`
+	EndPort     *int         `json:"end_port,omitempty" toml:"end_port,omitempty"`
+	Handlers    []string     `json:"handlers,omitempty" toml:"handlers,omitempty"`
+	ForceHttps  bool         `json:"force_https,omitempty" toml:"force_https,omitempty"`
+	TlsOptions  *TlsOptions  `json:"tls_options,omitempty" toml:"tls_options,omitempty"`
+	HTTPOptions *HTTPOptions `json:"http_options,omitempty" toml:"tls_options,omitempty"`
 }
 
 func (mp *MachinePort) ContainsPort(port int) bool {
@@ -415,6 +416,15 @@ func (mp *MachinePort) HasNonHttpPorts() bool {
 type TlsOptions struct {
 	Alpn     []string `json:"alpn,omitempty" toml:"alpn,omitempty"`
 	Versions []string `json:"versions,omitempty" toml:"version,omitempty"`
+}
+
+type HTTPOptions struct {
+	Compress *bool                `json:"compress,omitempty" toml:"compress,omitempty"`
+	Response *HTTPResponseOptions `json:"response,omitempty" toml:"response,omitempty"`
+}
+
+type HTTPResponseOptions struct {
+	Headers map[string]string `json:"headers,omitempty" toml:"headers,omitempty"`
 }
 
 type MachineService struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -361,7 +361,7 @@ type MachinePort struct {
 	EndPort     *int         `json:"end_port,omitempty" toml:"end_port,omitempty"`
 	Handlers    []string     `json:"handlers,omitempty" toml:"handlers,omitempty"`
 	ForceHttps  bool         `json:"force_https,omitempty" toml:"force_https,omitempty"`
-	TlsOptions  *TlsOptions  `json:"tls_options,omitempty" toml:"tls_options,omitempty"`
+	TLSOptions  *TLSOptions  `json:"tls_options,omitempty" toml:"tls_options,omitempty"`
 	HTTPOptions *HTTPOptions `json:"http_options,omitempty" toml:"tls_options,omitempty"`
 }
 
@@ -413,7 +413,7 @@ func (mp *MachinePort) HasNonHttpPorts() bool {
 	return false
 }
 
-type TlsOptions struct {
+type TLSOptions struct {
 	Alpn     []string `json:"alpn,omitempty" toml:"alpn,omitempty"`
 	Versions []string `json:"versions,omitempty" toml:"version,omitempty"`
 }

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -90,7 +90,7 @@ func TestFromDefinition(t *testing.T) {
 					{
 						Port:       api.Pointer(80),
 						Handlers:   []string{"http"},
-						ForceHttps: true,
+						ForceHTTPS: true,
 					},
 					{
 						Port:     api.Pointer(443),
@@ -108,7 +108,7 @@ func TestFromDefinition(t *testing.T) {
 				},
 			},
 		},
-		configFilePath: "--config path unset--",
+		configFilePath:   "--config path unset--",
 		defaultGroupName: "app",
 		RawDefinition: map[string]any{
 			"env": map[string]any{},

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -19,8 +19,8 @@ func TestToMachineConfig(t *testing.T) {
 				Protocol:     "tcp",
 				InternalPort: 8080,
 				Ports: []api.MachinePort{
-					{Port: api.Pointer(80), Handlers: []string{"http"}, ForceHttps: true},
-					{Port: api.Pointer(443), Handlers: []string{"http", "tls"}, ForceHttps: false},
+					{Port: api.Pointer(80), Handlers: []string{"http"}, ForceHTTPS: true},
+					{Port: api.Pointer(443), Handlers: []string{"http", "tls"}, ForceHTTPS: false},
 				},
 			},
 		},
@@ -79,8 +79,8 @@ func TestToMachineConfig_nullifyManagedFields(t *testing.T) {
 				Protocol:     "tcp",
 				InternalPort: 8080,
 				Ports: []api.MachinePort{
-					{Port: api.Pointer(80), Handlers: []string{"http"}, ForceHttps: true},
-					{Port: api.Pointer(443), Handlers: []string{"http", "tls"}, ForceHttps: false},
+					{Port: api.Pointer(80), Handlers: []string{"http"}, ForceHTTPS: true},
+					{Port: api.Pointer(443), Handlers: []string{"http", "tls"}, ForceHTTPS: false},
 				},
 			},
 		},
@@ -207,8 +207,8 @@ func TestToMachineConfig_defaultV2flytoml(t *testing.T) {
 				Protocol:     "tcp",
 				InternalPort: 8080,
 				Ports: []api.MachinePort{
-					{Port: api.Pointer(80), Handlers: []string{"http"}, ForceHttps: true},
-					{Port: api.Pointer(443), Handlers: []string{"http", "tls"}, ForceHttps: false},
+					{Port: api.Pointer(80), Handlers: []string{"http"}, ForceHTTPS: true},
+					{Port: api.Pointer(443), Handlers: []string{"http", "tls"}, ForceHTTPS: false},
 				},
 			},
 		},
@@ -267,8 +267,8 @@ func TestToMachineConfig_services(t *testing.T) {
 			Autostart:    api.Pointer(true),
 			Autostop:     api.Pointer(true),
 			Ports: []api.MachinePort{
-				{Port: api.Pointer(80), Handlers: []string{"http"}, ForceHttps: true},
-				{Port: api.Pointer(443), Handlers: []string{"http", "tls"}, ForceHttps: false},
+				{Port: api.Pointer(80), Handlers: []string{"http"}, ForceHTTPS: true},
+				{Port: api.Pointer(443), Handlers: []string{"http", "tls"}, ForceHTTPS: false},
 			},
 		},
 		{

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -68,6 +68,7 @@ func TestLoadTOMLAppConfigServicePorts(t *testing.T) {
 		Ports: []api.MachinePort{{
 			Port: api.Pointer(80),
 			HTTPOptions: &api.HTTPOptions{
+				Compress: api.Pointer(true),
 				Response: &api.HTTPResponseOptions{
 					Headers: map[string]any{
 						"fly-request-id": false,

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -67,7 +67,7 @@ func TestLoadTOMLAppConfigServicePorts(t *testing.T) {
 		InternalPort: 8080,
 		Ports: []api.MachinePort{{
 			Port: api.Pointer(80),
-			TlsOptions: &api.TlsOptions{
+			TLSOptions: &api.TLSOptions{
 				Alpn:     []string{"h2", "http/1.1"},
 				Versions: []string{"TLSv1.2", "TLSv1.3"},
 			},
@@ -434,7 +434,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 						StartPort:  api.Pointer(100),
 						EndPort:    api.Pointer(200),
 						Handlers:   []string{"https"},
-						ForceHttps: true,
+						ForceHTTPS: true,
 					},
 				},
 

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -67,6 +67,10 @@ func TestLoadTOMLAppConfigServicePorts(t *testing.T) {
 		InternalPort: 8080,
 		Ports: []api.MachinePort{{
 			Port: api.Pointer(80),
+			TlsOptions: &api.TlsOptions{
+				Alpn:     []string{"h2", "http/1.1"},
+				Versions: []string{"TLSv1.2", "TLSv1.3"},
+			},
 			HTTPOptions: &api.HTTPOptions{
 				Compress: api.Pointer(true),
 				Response: &api.HTTPResponseOptions{

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -57,6 +57,31 @@ func TestLoadTOMLAppConfigWithEmptyService(t *testing.T) {
 	assert.Nil(t, p.Services)
 }
 
+func TestLoadTOMLAppConfigServicePorts(t *testing.T) {
+	const path = "./testdata/services-ports.toml"
+
+	p, err := LoadConfig(path)
+	require.NoError(t, err)
+	want := []Service{{
+		Protocol:     "tcp",
+		InternalPort: 8080,
+		Ports: []api.MachinePort{{
+			Port: api.Pointer(80),
+			HTTPOptions: &api.HTTPOptions{
+				Response: &api.HTTPResponseOptions{
+					Headers: map[string]any{
+						"fly-request-id": false,
+						"fly-wasnt-here": "yes, it was",
+						"multi-valued":   []any{"value1", "value2"},
+					},
+				},
+			},
+		}},
+	}}
+
+	assert.Equal(t, want, p.Services)
+}
+
 func TestLoadTOMLAppConfigInvalidV2(t *testing.T) {
 	const path = "./testdata/always-invalid-v2.toml"
 	cfg, err := LoadConfig(path)

--- a/internal/appconfig/service.go
+++ b/internal/appconfig/service.go
@@ -61,7 +61,7 @@ func (s *HTTPService) ToService() *Service {
 		Ports: []api.MachinePort{{
 			Port:       api.IntPointer(80),
 			Handlers:   []string{"http"},
-			ForceHttps: s.ForceHTTPS,
+			ForceHTTPS: s.ForceHTTPS,
 		}, {
 			Port:     api.IntPointer(443),
 			Handlers: []string{"http", "tls"},

--- a/internal/appconfig/testdata/services-ports.toml
+++ b/internal/appconfig/testdata/services-ports.toml
@@ -1,0 +1,14 @@
+app = "foo"
+
+[[services]]
+  internal_port = 8080
+  protocol = "tcp"
+
+  [[services.ports]]
+    port = 80
+
+  # https://community.fly.io/t/new-feature-basic-http-response-header-modification/3594
+  [services.ports.http_options.response.headers]
+    fly-request-id = false
+    fly-wasnt-here = "yes, it was"
+    multi-valued = ["value1", "value2"]

--- a/internal/appconfig/testdata/services-ports.toml
+++ b/internal/appconfig/testdata/services-ports.toml
@@ -7,6 +7,10 @@ app = "foo"
   [[services.ports]]
     port = 80
 
+  [services.ports.tls_options]
+  alpn = ["h2", "http/1.1"]
+  versions = ["TLSv1.2", "TLSv1.3"]
+
   # https://community.fly.io/t/new-feature-basic-http-response-header-modification/3594
   [services.ports.http_options]
     compress = true

--- a/internal/appconfig/testdata/services-ports.toml
+++ b/internal/appconfig/testdata/services-ports.toml
@@ -8,6 +8,9 @@ app = "foo"
     port = 80
 
   # https://community.fly.io/t/new-feature-basic-http-response-header-modification/3594
+  [services.ports.http_options]
+    compress = true
+
   [services.ports.http_options.response.headers]
     fly-request-id = false
     fly-wasnt-here = "yes, it was"


### PR DESCRIPTION
V1 apps supported configuring some proxy options we lost in the transition to v2
https://community.fly.io/t/how-to-remove-headers-from-fly-io-proxy-response/12465
