### PR TITLE
Substitute flyctl -> fly in readme code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,19 +62,19 @@ Download the appropriate version from the [Releases](https://github.com/superfly
 1. Sign into your fly account
 
 ```bash
-flyctl auth login
+fly auth login
 ```
 
 2. List your apps
 
 ```bash
-flyctl apps list
+fly apps list
 ```
 
 2. View app status
 
 ```bash
-flyctl status -a {app-name}
+fly status -a {app-name}
 ```
 
 ## App Settings


### PR DESCRIPTION
The inconsistency between some docs confused me when setting up `django-simple-deploy` during pycon 2023's sprints.

See:
- https://twitter.com/flydotio/status/1494376371975606274
- https://community.fly.io/t/whats-the-difference-between-fly-and-flyctl/1377