### PR TITLE
Fix `LoadAppNameIfPresent` by using correct error in `RequireAppName`

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -548,7 +548,7 @@ func appConfigFilePaths(ctx context.Context) (paths []string) {
 	return
 }
 
-var errRequireAppName = fmt.Errorf("we couldn't find a fly.toml nor an app specified by the -a flag. If you want to launch a new app, use '%s launch'", buildinfo.Name())
+var errRequireAppName = fmt.Errorf("the config for your app is missing an app name, add an app_name field to the fly.toml file or specify with the -a flag`")
 
 // RequireAppName is a Preparer which makes sure the user has selected an
 // application name via command line arguments, the environment or an application
@@ -571,8 +571,7 @@ func RequireAppName(ctx context.Context) (context.Context, error) {
 	}
 
 	if name == "" {
-		err := fmt.Errorf("the config for your app is missing an app name, add an app_name field to the fly.toml file or specify with the -a flag`")
-		return nil, err
+		return nil, errRequireAppName
 	}
 
 	return appconfig.WithName(ctx, name), nil


### PR DESCRIPTION
`LoadAppNameIfPresent` expects the error returned from `RequireAppName` to be `errRequireAppName` so that it can ignore it. (It looks like we recently improved the error message, but did so by replacing `errRequireAppName` instead of updating its message.)

See the [community forum](https://community.fly.io/t/fly-v0-0-540-fly-cli-proxy-new-a-argument/12469).