### PR TITLE
`metrics`: ignore metrics in dev builds

### DIFF
--- a/internal/metrics/api.go
+++ b/internal/metrics/api.go
@@ -76,6 +76,11 @@ func handleErr(err error) {
 }
 
 func rawSend(parentCtx context.Context, metricSlug, jsonValue string) {
+
+	if buildinfo.IsDev() {
+		return
+	}
+
 	done.Add(1)
 	go func() {
 		defer done.Done()


### PR DESCRIPTION
sorry about the PR spam!

metrics on dev versions are useless garbage