### PR TITLE
`migrate-to-v2`: lookup alloc by ID

### DIFF
--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -83,6 +83,12 @@ func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 		path := ""
 		if alloc := vol.AttachedAllocation; alloc != nil {
 			allocId = alloc.ID
+			alloc, ok := lo.Find(m.oldAllocs, func(a *api.AllocationStatus) bool {
+				return a.ID == allocId
+			})
+			if !ok {
+				return fmt.Errorf("volume %s[%s] is attached to alloc %s, but that alloc is not running", vol.Name, vol.ID, allocId)
+			}
 			path = m.nomadVolPath(&vol, alloc.TaskName)
 			if path == "" {
 				return fmt.Errorf("volume %s[%s] is mounted on alloc %s, but has no mountpoint", vol.Name, vol.ID, allocId)


### PR DESCRIPTION
`GetApp` only retrieves the IDs of `AttachedAllocation` on vols, even though you get an instance of the whole Allocation structure. We were trying to lookup volume info based on `taskName`, and because of this, it was an empty string.

