### PR TITLE
Add "ls" alias to "list" commands

### DIFF
--- a/internal/command/checks/checks.go
+++ b/internal/command/checks/checks.go
@@ -14,6 +14,7 @@ func New() *cobra.Command {
 
 	// fly checks list
 	listCmd := command.New("list", "List health checks", "", runAppCheckList, command.RequireSession, command.RequireAppName)
+	listCmd.Aliases = []string{"ls"}
 	flag.Add(listCmd, commonFlags,
 		flag.String{Name: "check-name", Description: "Filter checks by name"},
 	)

--- a/internal/command/postgres/db.go
+++ b/internal/command/postgres/db.go
@@ -48,6 +48,8 @@ func newListDbs() *cobra.Command {
 		command.RequireAppName,
 	)
 
+	cmd.Aliases = []string{"ls"}
+
 	flag.Add(
 		cmd,
 		flag.App(),

--- a/internal/command/postgres/users.go
+++ b/internal/command/postgres/users.go
@@ -50,6 +50,8 @@ func newListUsers() *cobra.Command {
 		command.RequireAppName,
 	)
 
+	cmd.Aliases = []string{"ls"}
+
 	flag.Add(
 		cmd,
 		flag.App(),

--- a/internal/command/services/list.go
+++ b/internal/command/services/list.go
@@ -17,14 +17,16 @@ func newList() *cobra.Command {
 		short = "List services"
 	)
 
-	services := command.New("list", short, long, runList, command.RequireSession, command.RequireAppName)
+	cmd := command.New("list", short, long, runList, command.RequireSession, command.RequireAppName)
 
-	flag.Add(services,
+	cmd.Aliases = []string{"ls"}
+
+	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
 	)
 
-	return services
+	return cmd
 }
 
 func runList(ctx context.Context) error {

--- a/internal/command/volumes/snapshots/list.go
+++ b/internal/command/volumes/snapshots/list.go
@@ -29,6 +29,8 @@ func newList() *cobra.Command {
 		command.RequireSession,
 	)
 
+	cmd.Aliases = []string{"ls"}
+
 	cmd.Args = cobra.ExactArgs(1)
 
 	flag.Add(cmd, flag.JSONOutput())


### PR DESCRIPTION
While most of them are already added by #2178, there are still few
subcommands that could have "ls" alias.
    
This change is based on #1732. Thanks @kandros!
