### PR TITLE
Fix "Ignoring Dockerfile due to config" warning

### DIFF
--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -20,6 +20,30 @@ import (
 	"github.com/superfly/flyctl/terminal"
 )
 
+func multipleDockerfile(ctx context.Context, appConfig *appconfig.Config) error {
+	if len(appConfig.BuildStrategies()) == 0 {
+		// fly.toml doesn't know anything about building this image.
+		return nil
+	}
+
+	found := imgsrc.ResolveDockerfile(state.WorkingDirectory(ctx))
+	if found == "" {
+		// No Dockerfile in the directory.
+		return nil
+	}
+
+	config, _ := resolveDockerfilePath(ctx, appConfig)
+	if config == "" {
+		// No Dockerfile in fly.toml.
+		return nil
+	}
+
+	if found != config {
+		return fmt.Errorf("Use %s (in fly.toml) instead of %s", config, found)
+	}
+	return nil
+}
+
 // determineImage picks the deployment strategy, builds the image and returns a
 // DeploymentImage struct
 func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgsrc.DeploymentImage, err error) {
@@ -29,12 +53,8 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgs
 	client := client.FromContext(ctx).API()
 	io := iostreams.FromContext(ctx)
 
-	if len(appConfig.BuildStrategies()) > 0 {
-		foundDF := imgsrc.ResolveDockerfile(state.WorkingDirectory(ctx))
-		configDF, _ := resolveDockerfilePath(ctx, appConfig)
-		if foundDF != "" && foundDF != configDF {
-			terminal.Warnf("Ignoring %s due to config\n", foundDF)
-		}
+	if err := multipleDockerfile(ctx, appConfig); err != nil {
+		terminal.Warnf("%s\n", err.Error())
 	}
 
 	resolver := imgsrc.NewResolver(daemonType, client, appConfig.AppName, io)

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -39,7 +39,7 @@ func multipleDockerfile(ctx context.Context, appConfig *appconfig.Config) error 
 	}
 
 	if found != config {
-		return fmt.Errorf("Use %s (in fly.toml) instead of %s", config, found)
+		return fmt.Errorf("Ignoring %s, and using %s (from fly.toml).", found, config)
 	}
 	return nil
 }

--- a/internal/command/deploy/deploy_build_test.go
+++ b/internal/command/deploy/deploy_build_test.go
@@ -1,0 +1,34 @@
+package deploy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultipleDockerfile(t *testing.T) {
+	dir := t.TempDir()
+
+	f, err := os.Create(filepath.Join(dir, "Dockerfile"))
+	require.NoError(t, err)
+	defer f.Close() // skipcq: GO-S2307
+
+	ctx := state.WithWorkingDirectory(context.Background(), dir)
+	err = multipleDockerfile(ctx, &appconfig.Config{})
+	assert.NoError(t, err)
+
+	err = multipleDockerfile(
+		ctx,
+		&appconfig.Config{
+			Build: &appconfig.Build{
+				Dockerfile: "Dockerfile.from-fly-toml",
+			},
+		},
+	)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
If `[build]` is in fly.toml, appConfig.Build.Dockerfile will be "", but it shouldn't trigger "Ignoring ..." warning.

https://community.fly.io/t/deploy-warning/12424