### PR TITLE
Move lock files to ~/.fly to fix multi-user flyctl

### DIFF
--- a/agent/start.go
+++ b/agent/start.go
@@ -97,10 +97,18 @@ func (alreadyStartingError) Error() string {
 	return "another process is already starting the agent"
 }
 
-var lockPath = filepath.Join(os.TempDir(), "flyctl.agent.start.lock")
+var internalLockPath string
+
+func lockPath() string {
+	if internalLockPath == "" {
+		internalLockPath = filepath.Join(flyctl.ConfigDir(), "flyctl.agent.start.lock")
+	}
+
+	return internalLockPath
+}
 
 func lock(ctx context.Context) (unlock filemu.UnlockFunc, err error) {
-	switch unlock, err = filemu.Lock(ctx, lockPath); {
+	switch unlock, err = filemu.Lock(ctx, lockPath()); {
 	case err == nil:
 		break // all done
 	case ctx.Err() != nil:

--- a/agent/start.go
+++ b/agent/start.go
@@ -97,14 +97,8 @@ func (alreadyStartingError) Error() string {
 	return "another process is already starting the agent"
 }
 
-var internalLockPath string
-
 func lockPath() string {
-	if internalLockPath == "" {
-		internalLockPath = filepath.Join(flyctl.ConfigDir(), "flyctl.agent.start.lock")
-	}
-
-	return internalLockPath
+	return filepath.Join(flyctl.ConfigDir(), "flyctl.agent.start.lock")
 }
 
 func lock(ctx context.Context) (unlock filemu.UnlockFunc, err error) {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -142,14 +142,8 @@ type wrapper struct {
 	LatestRelease *update.Release `yaml:"latest_release,omitempty"`
 }
 
-var internalLockPath string
-
 func lockPath() string {
-	if internalLockPath == "" {
-		internalLockPath = filepath.Join(flyctl.ConfigDir(), "flyctl.cache.lock")
-	}
-
-	return internalLockPath
+	return filepath.Join(flyctl.ConfigDir(), "flyctl.cache.lock")
 }
 
 // Save writes the YAML-encoded representation of c to the named file path via

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -12,6 +12,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/filemu"
 	"github.com/superfly/flyctl/internal/update"
 )
@@ -141,7 +142,15 @@ type wrapper struct {
 	LatestRelease *update.Release `yaml:"latest_release,omitempty"`
 }
 
-var lockPath = filepath.Join(os.TempDir(), "flyctl.cache.lock")
+var internalLockPath string
+
+func lockPath() string {
+	if internalLockPath == "" {
+		internalLockPath = filepath.Join(flyctl.ConfigDir(), "flyctl.cache.lock")
+	}
+
+	return internalLockPath
+}
 
 // Save writes the YAML-encoded representation of c to the named file path via
 // os.WriteFile.
@@ -162,7 +171,7 @@ func (c *cache) Save(path string) (err error) {
 	}
 
 	var unlock filemu.UnlockFunc
-	if unlock, err = filemu.Lock(context.Background(), lockPath); err != nil {
+	if unlock, err = filemu.Lock(context.Background(), lockPath()); err != nil {
 		return
 	}
 	defer func() {
@@ -180,7 +189,7 @@ func (c *cache) Save(path string) (err error) {
 // Load loads the YAML-encoded cache file at the given path.
 func Load(path string) (c Cache, err error) {
 	var unlock filemu.UnlockFunc
-	if unlock, err = filemu.RLock(context.Background(), lockPath); err != nil {
+	if unlock, err = filemu.RLock(context.Background(), lockPath()); err != nil {
 		return
 	}
 	defer func() {

--- a/internal/command/agent/run.go
+++ b/internal/command/agent/run.go
@@ -107,14 +107,8 @@ func (*dupInstanceError) Description() string {
 
 var errDupInstance = new(dupInstanceError)
 
-var internalLockPath string
-
 func lockPath() string {
-	if internalLockPath == "" {
-		internalLockPath = filepath.Join(flyctl.ConfigDir(), "flyctl.agent.lock")
-	}
-
-	return internalLockPath
+	return filepath.Join(flyctl.ConfigDir(), "flyctl.agent.lock")
 }
 
 func lock(ctx context.Context, logger *log.Logger) (unlock filemu.UnlockFunc, err error) {

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -55,14 +55,8 @@ func set(path string, vals map[string]interface{}) error {
 	return marshal(path, m)
 }
 
-var internalLockPath string
-
 func lockPath() string {
-	if internalLockPath == "" {
-		internalLockPath = filepath.Join(flyctl.ConfigDir(), "flyctl.config.lock")
-	}
-
-	return internalLockPath
+	return filepath.Join(flyctl.ConfigDir(), "flyctl.config.lock")
 }
 
 func unmarshal(path string, v interface{}) (err error) {

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -8,6 +8,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/filemu"
 )
 
@@ -54,11 +55,19 @@ func set(path string, vals map[string]interface{}) error {
 	return marshal(path, m)
 }
 
-var lockPath = filepath.Join(os.TempDir(), "flyctl.config.lock")
+var internalLockPath string
+
+func lockPath() string {
+	if internalLockPath == "" {
+		internalLockPath = filepath.Join(flyctl.ConfigDir(), "flyctl.config.lock")
+	}
+
+	return internalLockPath
+}
 
 func unmarshal(path string, v interface{}) (err error) {
 	var unlock filemu.UnlockFunc
-	if unlock, err = filemu.RLock(context.Background(), lockPath); err != nil {
+	if unlock, err = filemu.RLock(context.Background(), lockPath()); err != nil {
 		return
 	}
 	defer func() {
@@ -90,7 +99,7 @@ func unmarshalUnlocked(path string, v interface{}) (err error) {
 
 func marshal(path string, v interface{}) (err error) {
 	var unlock filemu.UnlockFunc
-	if unlock, err = filemu.Lock(context.Background(), lockPath); err != nil {
+	if unlock, err = filemu.Lock(context.Background(), lockPath()); err != nil {
 		return
 	}
 	defer func() {


### PR DESCRIPTION
Right now, when running flyctl in a multi-user environment, you run into
permission issues with the shared lock files in /tmp:

* `flyctl.cache.lock`
* `flyctl.config.lock`
* `flyctl.agent.lock`
* `flyctl.agent.start.lock`

So, I've moved them all to `~/.fly`. In `~/.fly` we already have
`config.yml` and `fly-agent.sock`, so it makes sense that the lock files
are also not shared.

Closes #977
