### PR TITLE
Use builtin go buildinfo for git version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,4 @@
 NOW_RFC3339 = $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-GIT_SHA = $(shell git rev-parse HEAD 2>/dev/null || no_git)
-GIT_BRANCH = $(shell git symbolic-ref --short HEAD 2>/dev/null ||:)
-ifneq ($(GIT_BRANCH),)
-GIT_COMMIT = $(GIT_SHA) ($(GIT_BRANCH))
-else
-GIT_COMMIT = $(GIT_SHA)
-endif
 
 all: build cmddocs
 
@@ -15,7 +8,7 @@ generate:
 
 build: generate
 	@echo Running Build
-	go build -o bin/flyctl -ldflags="-X 'github.com/superfly/flyctl/internal/buildinfo.buildDate=$(NOW_RFC3339)' -X 'github.com/superfly/flyctl/internal/buildinfo.commit=$(GIT_COMMIT)'" .
+	go build -o bin/flyctl -ldflags="-X 'github.com/superfly/flyctl/internal/buildinfo.buildDate=$(NOW_RFC3339)'" .
 
 test: FORCE
 	go test ./... -ldflags="-X 'github.com/superfly/flyctl/internal/buildinfo.buildDate=$(NOW_RFC3339)'" --run=$(T)

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"time"
+	"runtime/debug"
 
 	"github.com/blang/semver"
 	"github.com/superfly/flyctl/terminal"
@@ -13,7 +14,6 @@ import (
 var (
 	buildDate = "<date>"
 	version   = "<version>"
-	commit    = "<commit>"
 )
 
 var (
@@ -66,7 +66,22 @@ func loadMeta() {
 }
 
 func Commit() string {
-	return commit
+	info, _ := debug.ReadBuildInfo();
+	var rev string = "<none>";
+	var dirty string = "";
+	for _, v := range info.Settings {
+		if v.Key == "vcs.revision" {
+			rev = v.Value;
+		}
+		if v.Key == "vcs.modified" {
+			if v.Value == "true" {
+				dirty = "-dirty"
+			} else {
+				dirty = "";
+			}
+		}
+	}
+	return rev + dirty;
 }
 
 func Version() semver.Version {

--- a/internal/buildinfo/version_test.go
+++ b/internal/buildinfo/version_test.go
@@ -12,22 +12,18 @@ func TestProdMeta(t *testing.T) {
 	environment = "production"
 	version = "1.2.3"
 	buildDate = "2020-06-05T13:32:23Z"
-	commit = "c8f7b8f"
 
 	loadMeta()
 
 	assert.Equal(t, "1.2.3", Version().String())
 	assert.Equal(t, "2020-06-05T13:32:23Z", BuildDate().Format(time.RFC3339))
-	assert.Equal(t, "c8f7b8f", Commit())
 }
 
 func TestDevMeta(t *testing.T) {
 	environment = "development"
 	version = "<version>"
-	commit = "<commit>"
 
 	loadMeta()
 
 	assert.Equal(t, fmt.Sprintf("0.0.0-%d+dev", BuildDate().Unix()), Version().String())
-	assert.Equal(t, "<commit>", Commit())
 }


### PR DESCRIPTION
This makes things more workable with offbeat build procedures eg package managers that might not fetch the repo from git, golang autoembeds this info when available & fails gracefully when not, or when manually requested with `-buildinfo=false` or `-buildvcs=false` (this is what gentoo does)