### PR TITLE
`scale show`: re-add --json, add json support for v2

### DIFF
--- a/internal/command/scale/show.go
+++ b/internal/command/scale/show.go
@@ -28,6 +28,7 @@ func newScaleShow() *cobra.Command {
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 	)
 	return cmd
 }

--- a/internal/command/scale/show_machines.go
+++ b/internal/command/scale/show_machines.go
@@ -53,8 +53,8 @@ func runMachinesScaleShow(ctx context.Context) error {
 		type groupData struct {
 			Process string
 			Count   int
-			CpuKind string
-			Cpus    int
+			CPUKind string
+			CPUs    int
 			Memory  int
 			Regions map[string]int
 		}
@@ -68,8 +68,8 @@ func runMachinesScaleShow(ctx context.Context) error {
 			return groupData{
 				Process: name,
 				Count:   len(machines),
-				CpuKind: guest.CPUKind,
-				Cpus:    guest.CPUs,
+				CPUKind: guest.CPUKind,
+				CPUs:    guest.CPUs,
 				Memory:  guest.MemoryMB,
 				Regions: lo.CountValues(lo.Map(machines, func(m *api.Machine, _ int) string {
 					return m.Region


### PR DESCRIPTION
Would fix #2188 

V2 output looks like
```
❯ ~/Work/flyctl/bin/flyctl scale show --json
[
    {
        "Process": "app",
        "Count": 2,
        "CpuKind": "shared",
        "Cpus": 1,
        "Memory": 256,
        "Regions": {
            "ord": 2
        }
    }
]
```