### PR TITLE
Add an alias to `version update`: `upgrade`

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -353,14 +353,14 @@ func startQueryingForNewRelease(ctx context.Context) (context.Context, error) {
 }
 
 // shouldIgnore allows a preparer to disable itself for specific commands
-// E.g. `shouldIgnore([][]string{{"version", "update"}, {"machine", "status"}})`
-// would return true for "fly version update" and "fly machine status"
+// E.g. `shouldIgnore([][]string{{"version", "upgrade"}, {"machine", "status"}})`
+// would return true for "fly version upgrade" and "fly machine status"
 func shouldIgnore(ctx context.Context, cmds [][]string) bool {
 	cmd := FromContext(ctx)
 	for _, ignoredCmd := range cmds {
 		match := true
 		currentCmd := cmd
-		// The shape of the ignoredCmd slice is something like ["version", "update"],
+		// The shape of the ignoredCmd slice is something like ["version", "upgrade"],
 		// but we're walking up the tree from the end, so we have to iterate that in reverse
 		for i := len(ignoredCmd) - 1; i >= 0; i-- {
 			if !currentCmd.HasParent() || currentCmd.Use != ignoredCmd[i] {
@@ -382,7 +382,7 @@ func shouldIgnore(ctx context.Context, cmds [][]string) bool {
 func promptToUpdate(ctx context.Context) (context.Context, error) {
 	cfg := config.FromContext(ctx)
 	if cfg.JSONOutput || shouldIgnore(ctx, [][]string{
-		{"version", "update"},
+		{"version", "upgrade"},
 	}) {
 		return ctx, nil
 	}
@@ -414,10 +414,10 @@ func promptToUpdate(ctx context.Context) (context.Context, error) {
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
 
-	msg := fmt.Sprintf("Update available %s -> %s.\nRun \"%s\" to upgrade.",
+	msg := fmt.Sprintf("Upgrade available %s -> %s.\nRun \"%s\" to upgrade.",
 		current,
 		r.Version,
-		colorize.Bold(buildinfo.Name()+" version update"),
+		colorize.Bold(buildinfo.Name()+" version upgrade"),
 	)
 
 	fmt.Fprintln(io.ErrOut, colorize.Yellow(msg))

--- a/internal/command/version/update.go
+++ b/internal/command/version/update.go
@@ -30,9 +30,9 @@ command to update the application.`
 	)
 
 	cmd := command.New("update", short, long, runUpdate)
-	
+
 	cmd.Aliases = []string{"upgrade"}
-	
+
 	return cmd
 }
 

--- a/internal/command/version/update.go
+++ b/internal/command/version/update.go
@@ -29,7 +29,11 @@ func newUpdate() *cobra.Command {
 command to update the application.`
 	)
 
-	return command.New("update", short, long, runUpdate)
+	cmd := command.New("update", short, long, runUpdate)
+	
+	cmd.Aliases = []string{"upgrade"}
+	
+	return cmd
 }
 
 func runUpdate(ctx context.Context) error {

--- a/internal/command/version/upgrade.go
+++ b/internal/command/version/upgrade.go
@@ -21,22 +21,22 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 )
 
-func newUpdate() *cobra.Command {
+func newUpgrade() *cobra.Command {
 	const (
-		short = "Checks for available updates and automatically updates"
+		short = "Checks for available upgrades and automatically upgrades"
 
-		long = `Checks for update and if one is available, runs the appropriate
-command to update the application.`
+		long = `Checks for an upgrade and if one is available, runs the appropriate
+command to upgrade the application.`
 	)
 
-	cmd := command.New("update", short, long, runUpdate)
+	cmd := command.New("upgrade", short, long, runUpgrade)
 
-	cmd.Aliases = []string{"upgrade"}
+	cmd.Aliases = []string{"update"}
 
 	return cmd
 }
 
-func runUpdate(ctx context.Context) error {
+func runUpgrade(ctx context.Context) error {
 	release, err := update.LatestRelease(ctx, cache.FromContext(ctx).Channel())
 	switch {
 	case err != nil:
@@ -52,7 +52,7 @@ func runUpdate(ctx context.Context) error {
 	}
 
 	if buildinfo.Version().GTE(latest) {
-		return errors.New("no available update")
+		return errors.New("no available upgrade")
 	}
 
 	io := iostreams.FromContext(ctx)
@@ -63,15 +63,15 @@ func runUpdate(ctx context.Context) error {
 		return err
 	}
 
-	err = printVersionUpdate(ctx, buildinfo.Version(), homebrew)
+	err = printVersionUpgrade(ctx, buildinfo.Version(), homebrew)
 	if err != nil {
-		terminal.Debugf("Error printing version update: %v", err)
+		terminal.Debugf("Error printing version upgrade: %v", err)
 	}
 	return nil
 }
 
-// printVersionUpdate prints "Updated flyctl [oldVersion] -> [newVersion]"
-func printVersionUpdate(ctx context.Context, oldVersion semver.Version, homebrew bool) error {
+// printVersionUpgrade prints "Upgraded flyctl [oldVersion] -> [newVersion]"
+func printVersionUpgrade(ctx context.Context, oldVersion semver.Version, homebrew bool) error {
 
 	var (
 		io         = iostreams.FromContext(ctx)
@@ -101,12 +101,12 @@ func printVersionUpdate(ctx context.Context, oldVersion semver.Version, homebrew
 		} else {
 			source = fmt.Sprintf("'%s'", os.Args[0])
 		}
-		fmt.Fprintf(io.ErrOut, "Flyctl was updated, but the flyctl pointed to by %s is still version %s.\n", source, currentVer.String())
+		fmt.Fprintf(io.ErrOut, "Flyctl was upgraded, but the flyctl pointed to by %s is still version %s.\n", source, currentVer.String())
 		fmt.Fprintf(io.ErrOut, "Please ensure that your PATH is set correctly!")
 		return nil
 	}
 
-	fmt.Fprintf(io.Out, "Updated flyctl v%s -> v%s\n", oldVersion.String(), currentVer.String())
+	fmt.Fprintf(io.Out, "Upgraded flyctl v%s -> v%s\n", oldVersion.String(), currentVer.String())
 	return nil
 }
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -135,7 +135,7 @@ func IsUnderHomebrew() bool {
 	return strings.HasPrefix(flyBinary, brewBinPrefix)
 }
 
-func updateCommand(prerelease bool) string {
+func upgradeCommand(prerelease bool) string {
 	if IsUnderHomebrew() {
 		return "brew upgrade flyctl"
 	}
@@ -180,9 +180,9 @@ func UpgradeInPlace(ctx context.Context, io *iostreams.IOStreams, prelease bool)
 	}
 	fmt.Println(shellToUse, switchToUse)
 
-	command := updateCommand(prelease)
+	command := upgradeCommand(prelease)
 
-	fmt.Fprintf(io.ErrOut, "Running automatic update [%s]\n", command)
+	fmt.Fprintf(io.ErrOut, "Running automatic upgrade [%s]\n", command)
 
 	cmd := exec.Command(shellToUse, switchToUse, command)
 	cmd.Stdout = io.Out


### PR DESCRIPTION
Hello,

Every time I want to upgrade flyctl, I write `fly version upgrade` instead of `fly version update`. I guess I'm used to other CLI tools where `upgrade` is used for full version updates/upgrades.

Unless I'm the only one, this would be a nice addition. :D