### PR TITLE
Show link to app monitoring page when deploying

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -157,6 +157,7 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, args Dep
 		return nil
 	}
 
+	fmt.Fprintf(io.Out, "\nWatch your app at https://fly.io/apps/%s/monitoring\n\n", appName)
 	switch isV2App, err := useMachines(ctx, appConfig, appCompact, args, apiClient); {
 	case err != nil:
 		return err


### PR DESCRIPTION
An updated version of https://github.com/superfly/flyctl/pull/1504

```
$ fly launch --ha=false --image nginx --name dangra-t4 -r scl -o personal --internal-port 80 --now
Creating app in /home/daniel/src/flyctl
An existing fly.toml file was found for app dangra-t4
? Would you like to copy its configuration to the new app? No
Using image nginx
? App dangra-t4 already exists, do you want to launch into that app? Yes
App will use 'scl' region as primary
Admin URL: https://fly.io/apps/dangra-t4
Hostname: dangra-t4.fly.dev
Wrote config file fly.toml
Validating /home/daniel/src/flyctl/fly.toml
Platform: machines
✓ Configuration is valid
==> Building image
Searching for image 'nginx' remotely...
image found: img_3xdk4x0kg574go0e

Watch your app at https://fly.io/apps/dangra-t4/monitoring

Updating existing machines in 'dangra-t4' with rolling strategy
  [1/1] Machine d5683d09b4028e [app] update finished: success
  Finished deploying

Visit your newly deployed app at https://dangra-t4.fly.dev/
```