### PR TITLE
Remove sleep in redis connect

### DIFF
--- a/proxy/connect.go
+++ b/proxy/connect.go
@@ -23,6 +23,8 @@ type ConnectParams struct {
 	DisableSpinner   bool
 }
 
+// Binds to a local port and runs a proxy to a remote address over Wireguard.
+// Blocks until context is cancelled.
 func Connect(ctx context.Context, p *ConnectParams) (err error) {
 	server, err := NewServer(ctx, p)
 	if err != nil {
@@ -30,6 +32,22 @@ func Connect(ctx context.Context, p *ConnectParams) (err error) {
 	}
 
 	return server.ProxyServer(ctx)
+}
+
+// Binds to a local port and then starts a goroutine to run a proxy to a remote
+// address over Wireguard. Proxy runs until context is cancelled.
+// Blocks only until local listener is bound and ready to accept connections.
+func Start(ctx context.Context, p *ConnectParams) error {
+	server, err := NewServer(ctx, p)
+	if err != nil {
+		return err
+	}
+
+	// currently ignores any error returned by ProxyServer
+	// TODO return a channel to caller for async error notification
+	go server.ProxyServer(ctx)
+
+	return nil
 }
 
 func NewServer(ctx context.Context, p *ConnectParams) (*Server, error) {


### PR DESCRIPTION
The `fly redis connect` command currently sleeps for 3 seconds after spawning a `proxy.Connect` goroutine to wait for the proxy socket to start up.

This PR introduces a new function `proxy.Start`, which binds a local listener synchronously before spawning a goroutine to run the proxy asynchronously. This means that we can rely on the local listener being ready to accept connections as soon as `proxy.Start` returns and no further synchronisation is required.

I put together a small expect script to measure the total time taken to connect a Redis session and issue a ping command:

```expect
spawn bin/flyctl redis connect

expect "Select a database to connect to"
send -- "\n"

expect "127.0.0.1:16379>"
send -- "ping\n"

expect "127.0.0.1:16379>"
send -- "exit\n"
```

On my machine this change results in an improvement from about 4.7 seconds to 2 seconds. The reason it shaves off 2.7 seconds and not 3 seconds is that both `proxy.Connect` and `proxy.Start` make a synchronous call to the API to update the list of wireguard peers. This is about a 300ms round trip on my connection.

There are two remaining calls to `proxy.Connect` - these are both proxy commands (`machine api-proxy` and `proxy`) and don't exhibit the same requirement for synchronisation as `redis connect`.