### PR TITLE
The --attach-volume flag on machines clone now takes the mount path

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -163,6 +163,7 @@ func runMachineClone(ctx context.Context) (err error) {
 	var volID string
 	if volumeInfo := flag.GetString(ctx, "attach-volume"); volumeInfo != "" {
 		splitVolumeInfo := strings.Split(volumeInfo, ":")
+		volID = splitVolumeInfo[0]
 
 		if len(source.Config.Mounts) > 1 {
 			return fmt.Errorf("Can't use --attach-volume for machines with more than 1 volume.")
@@ -173,15 +174,13 @@ func runMachineClone(ctx context.Context) (err error) {
 		}
 
 		// patch the source config so the loop below attaches the volume on the passed mount path
+		// otherwise it will just reuse the existing mount path
 		if len(source.Config.Mounts) == 0 && len(splitVolumeInfo) == 2 {
-			volID = splitVolumeInfo[0]
 			source.Config.Mounts = []api.MachineMount{
 				{
 					Path: splitVolumeInfo[1],
 				},
 			}
-		} else {
-			volID = splitVolumeInfo[0]
 		}
 	}
 

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -160,16 +160,7 @@ func runMachineClone(ctx context.Context) (err error) {
 		fmt.Fprintf(io.Out, "Auto destroy enabled and will destroy machine on exit. Use --clear-auto-destroy to remove this setting.\n")
 	}
 
-	// clone machine w/o volume
-	// --attach-volume id -> error
-	// --attach-volume id:path -> works
-
-	// clone machine w/ volume
-	// --attach-volume id -> works
-	// --attach-volume id:path -> error
-
 	var volID string
-
 	if volumeInfo := flag.GetString(ctx, "attach-volume"); volumeInfo != "" {
 		splitVolumeInfo := strings.Split(volumeInfo, ":")
 
@@ -186,7 +177,7 @@ func runMachineClone(ctx context.Context) (err error) {
 			volID = splitVolumeInfo[0]
 			source.Config.Mounts = []api.MachineMount{
 				{
-					Path:   splitVolumeInfo[1],
+					Path: splitVolumeInfo[1],
 				},
 			}
 		} else {


### PR DESCRIPTION
When clonning a machine without volumes and trying to attatch an existing volume to it, we need a way to set the mount path.