### PR TITLE
`migrate to v2`: keep build section in config

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -812,12 +812,21 @@ func (m *v2PlatformMigrator) ConfirmChanges(ctx context.Context) (bool, error) {
 
 func determineAppConfigForMachines(ctx context.Context) (*appconfig.Config, error) {
 	appNameFromContext := appconfig.NameFromContext(ctx)
+
+	// We're pulling the remote config because we don't want to inadvertently trigger a new deployment -
+	// people will expect this to migrate what's _currently_ live.
+	// That said, we need to reference the local config to get the build config, because it's
+	// sanitized out before being sent to the API.
+	localAppConfig := appconfig.ConfigFromContext(ctx)
 	cfg, err := appconfig.FromRemoteApp(ctx, appNameFromContext)
 	if err != nil {
 		return nil, err
 	}
 	if appNameFromContext != "" {
 		cfg.AppName = appNameFromContext
+	}
+	if localAppConfig != nil {
+		cfg.Build = localAppConfig.Build
 	}
 	return cfg, nil
 }

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -52,7 +52,6 @@ func newMigrateToV2() *cobra.Command {
 	cmd.Args = cobra.NoArgs
 	flag.Add(cmd,
 		flag.Yes(),
-		flag.App(),
 		flag.AppConfig(),
 		flag.String{
 			Name:        "primary-region",


### PR DESCRIPTION
This does three things, because I snuck a couple drive-by fixes in here while I did this:
 * Removes -a/--app flag. Closes #2027 
    * You can still specify a `-c/--config`, or it will load the cwd's `fly.toml`
 * Cleans up error handling if saving the final config fails. Now it still prints the volume changelog, and the error handling happens inline, slimming down the rollback code a bit.
 * And finally, the star of the show: the `build` section is pulled from the local config, and inserted into the config obtained remotely. This fixes a [bug report from the forum thread](https://community.fly.io/t/fly-migrate-to-v2-automatic-migration-to-apps-v2/11984/23?u=allison).