### PR TITLE
Assign volume considering machine region

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -233,14 +233,19 @@ func (md *machineDeployment) setVolumes(ctx context.Context) error {
 	return nil
 }
 
-func (md *machineDeployment) popVolumeFor(name string) *api.Volume {
+func (md *machineDeployment) popVolumeFor(name, region string) *api.Volume {
 	volumes, ok := md.volumes[name]
 	if !ok {
 		return nil
 	}
-	var vol api.Volume
-	vol, md.volumes[name] = volumes[0], volumes[1:]
-	return &vol
+	for idx, v := range volumes {
+		if region != "" && v.Region != region {
+			continue
+		}
+		md.volumes[name] = append(volumes[:idx], volumes[idx+1:]...)
+		return &v
+	}
+	return nil
 }
 
 func (md *machineDeployment) validateVolumeConfig() error {


### PR DESCRIPTION
Volume assignment could fail when its region doesn't match the region of the machine been updated.

```
            [1/2] Replacing 148ee2ec379e89 [app] by new machine
        Error: failed to launch VM: Mounts source volume "vol_jn924okpd12v03lq" is in the wrong region ("ord" != "mia")
```