### PR TITLE
Remove unused fields from API requests

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -547,16 +547,15 @@ type MachineStartResponse struct {
 }
 
 type LaunchMachineInput struct {
-	AppID      string         `json:"appId,omitempty"`
-	ID         string         `json:"id,omitempty"`
-	Name       string         `json:"name,omitempty"`
-	OrgSlug    string         `json:"organizationId,omitempty"`
-	Region     string         `json:"region,omitempty"`
 	Config     *MachineConfig `json:"config,omitempty"`
+	Region     string         `json:"region,omitempty"`
+	Name       string         `json:"name,omitempty"`
 	SkipLaunch bool           `json:"skip_launch,omitempty"`
 	LeaseTTL   int            `json:"lease_ttl,omitempty"`
+
 	// Client side only
-	SkipHealthChecks bool
+	ID               string `json:"-"`
+	SkipHealthChecks bool   `json:"-"`
 }
 
 type MachineProcess struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -223,10 +223,8 @@ type MachineIP struct {
 }
 
 type RemoveMachineInput struct {
-	AppID string `json:"appId,omitempty"`
-	ID    string `json:"id,omitempty"`
-
-	Kill bool `json:"kill,omitempty"`
+	ID   string `json:"id,omitempty"`
+	Kill bool   `json:"kill,omitempty"`
 }
 
 type MachineRestartPolicy string

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -154,13 +154,6 @@ func (f *Client) CreateApp(ctx context.Context, name string, org string) (err er
 }
 
 func (f *Client) Launch(ctx context.Context, builder api.LaunchMachineInput) (out *api.Machine, err error) {
-	var endpoint string
-	if builder.ID != "" {
-		endpoint = fmt.Sprintf("/%s", builder.ID)
-	}
-
-	out = new(api.Machine)
-
 	metrics.Started(ctx, "machine_launch")
 	sendUpdateMetrics := metrics.StartTiming(ctx, "machine_launch/duration")
 	defer func() {
@@ -170,7 +163,8 @@ func (f *Client) Launch(ctx context.Context, builder api.LaunchMachineInput) (ou
 		}
 	}()
 
-	if err := f.sendRequest(ctx, http.MethodPost, endpoint, builder, out, nil); err != nil {
+	out = new(api.Machine)
+	if err := f.sendRequest(ctx, http.MethodPost, "", builder, out, nil); err != nil {
 		return nil, fmt.Errorf("failed to launch VM: %w", err)
 	}
 

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -212,10 +212,8 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 		machineConf.DisableMachineAutostart = api.Pointer(!config.Autostart)
 
 		launchInput := api.LaunchMachineInput{
-			AppID:   app.ID,
-			OrgSlug: config.Organization.ID,
-			Region:  config.Region,
-			Config:  machineConf,
+			Region: config.Region,
+			Config: machineConf,
 		}
 
 		machine, err := flapsClient.Launch(ctx, launchInput)
@@ -288,7 +286,7 @@ func (l *Launcher) getPostgresConfig(config *CreateClusterInput) *api.MachineCon
 	}
 
 	if config.ScaleToZero {
-		//TODO make this configurable
+		// TODO make this configurable
 		machineConfig.Env["FLY_SCALE_TO_ZERO"] = "1h"
 	}
 

--- a/internal/command/apps/move.go
+++ b/internal/command/apps/move.go
@@ -127,11 +127,8 @@ func runMoveAppOnMachines(ctx context.Context, app *api.AppCompact, targetOrg *a
 
 	for _, machine := range machines {
 		input := &api.LaunchMachineInput{
-			AppID:            app.ID,
-			ID:               machine.ID,
 			Name:             machine.Name,
 			Region:           machine.Region,
-			OrgSlug:          targetOrg.ID,
 			Config:           machine.Config,
 			SkipHealthChecks: skipHealthChecks,
 		}

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -15,11 +15,9 @@ func (md *machineDeployment) launchInputForRestart(origMachineRaw *api.Machine) 
 	md.setMachineReleaseData(Config)
 
 	return &api.LaunchMachineInput{
-		ID:      origMachineRaw.ID,
-		AppID:   md.app.Name,
-		OrgSlug: md.app.Organization.ID,
-		Config:  Config,
-		Region:  origMachineRaw.Region,
+		ID:     origMachineRaw.ID,
+		Config: Config,
+		Region: origMachineRaw.Region,
 	}
 }
 
@@ -49,8 +47,6 @@ func (md *machineDeployment) launchInputForLaunch(processGroup string, guest *ap
 	}
 
 	return &api.LaunchMachineInput{
-		AppID:      md.app.Name,
-		OrgSlug:    md.app.Organization.ID,
 		Region:     region,
 		Config:     mConfig,
 		SkipLaunch: len(standbyFor) > 0,
@@ -126,8 +122,6 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 
 	return &api.LaunchMachineInput{
 		ID:         mID,
-		AppID:      md.app.Name,
-		OrgSlug:    md.app.Organization.ID,
 		Region:     origMachineRaw.Region,
 		Config:     mConfig,
 		SkipLaunch: len(mConfig.Standbys) > 0,

--- a/internal/command/deploy/machines_launchinput_test.go
+++ b/internal/command/deploy/machines_launchinput_test.go
@@ -25,8 +25,7 @@ func Test_launchInputFor_Basic(t *testing.T) {
 
 	// Launch a new machine
 	want := &api.LaunchMachineInput{
-		OrgSlug: "my-dangling-org",
-		Region:  "scl",
+		Region: "scl",
 		Config: &api.MachineConfig{
 			Env: map[string]string{
 				"PRIMARY_REGION":    "scl",

--- a/internal/command/deploy/machines_releasecommand.go
+++ b/internal/command/deploy/machines_releasecommand.go
@@ -117,11 +117,8 @@ func (md *machineDeployment) launchInputForReleaseCommand(origMachineRaw *api.Ma
 	md.setMachineReleaseData(mConfig)
 
 	return &api.LaunchMachineInput{
-		ID:      origMachineRaw.ID,
-		AppID:   md.app.Name,
-		OrgSlug: md.app.Organization.ID,
-		Config:  mConfig,
-		Region:  origMachineRaw.Region,
+		Config: mConfig,
+		Region: origMachineRaw.Region,
 	}
 }
 

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -37,7 +37,6 @@ func Test_resolveUpdatedMachineConfig_Basic(t *testing.T) {
 	li, err := md.launchInputForLaunch("", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, &api.LaunchMachineInput{
-		OrgSlug: "my-dangling-org",
 		Config: &api.MachineConfig{
 			Env: map[string]string{
 				"PRIMARY_REGION":    "scl",
@@ -100,7 +99,6 @@ func Test_resolveUpdatedMachineConfig_ReleaseCommand(t *testing.T) {
 	li, err := md.launchInputForLaunch("", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, &api.LaunchMachineInput{
-		OrgSlug: "my-dangling-org",
 		Config: &api.MachineConfig{
 			Env: map[string]string{
 				"PRIMARY_REGION":    "scl",
@@ -142,7 +140,6 @@ func Test_resolveUpdatedMachineConfig_ReleaseCommand(t *testing.T) {
 
 	// New release command machine
 	assert.Equal(t, &api.LaunchMachineInput{
-		OrgSlug: "my-dangling-org",
 		Config: &api.MachineConfig{
 			Init: api.MachineInit{
 				Cmd: []string{"touch", "sky"},
@@ -187,7 +184,6 @@ func Test_resolveUpdatedMachineConfig_ReleaseCommand(t *testing.T) {
 		},
 	}
 	assert.Equal(t, &api.LaunchMachineInput{
-		OrgSlug: "my-dangling-org",
 		Config: &api.MachineConfig{
 			Env: map[string]string{
 				"PRIMARY_REGION":    "scl",
@@ -234,7 +230,6 @@ func Test_resolveUpdatedMachineConfig_Mounts(t *testing.T) {
 	li, err := md.launchInputForLaunch("", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, &api.LaunchMachineInput{
-		OrgSlug: "my-dangling-org",
 		Config: &api.MachineConfig{
 			Image: "super/balloon",
 			Metadata: map[string]string{
@@ -267,7 +262,6 @@ func Test_resolveUpdatedMachineConfig_Mounts(t *testing.T) {
 	li, err = md.launchInputForUpdate(origMachine)
 	require.NoError(t, err)
 	assert.Equal(t, &api.LaunchMachineInput{
-		OrgSlug: "my-dangling-org",
 		Config: &api.MachineConfig{
 			Image: "super/balloon",
 			Metadata: map[string]string{
@@ -309,8 +303,7 @@ func Test_resolveUpdatedMachineConfig_restartOnly(t *testing.T) {
 	}
 
 	assert.Equal(t, &api.LaunchMachineInput{
-		ID:      "OrigID",
-		OrgSlug: "my-dangling-org",
+		ID: "OrigID",
 		Config: &api.MachineConfig{
 			Image: "instead-use/the-redmoon",
 			Metadata: map[string]string{
@@ -353,8 +346,7 @@ func Test_resolveUpdatedMachineConfig_restartOnlyProcessGroup(t *testing.T) {
 	}
 
 	assert.Equal(t, &api.LaunchMachineInput{
-		ID:      "OrigID",
-		OrgSlug: "my-dangling-org",
+		ID: "OrigID",
 		Config: &api.MachineConfig{
 			Image: "instead-use/the-redmoon",
 			Metadata: map[string]string{

--- a/internal/command/image/update_machines.go
+++ b/internal/command/image/update_machines.go
@@ -58,9 +58,6 @@ func updateImageForMachines(ctx context.Context, app *api.AppCompact) error {
 
 	for machine, machineConf := range eligible {
 		input := &api.LaunchMachineInput{
-			ID:               machine.ID,
-			AppID:            app.Name,
-			OrgSlug:          app.Organization.Slug,
 			Region:           machine.Region,
 			Config:           &machineConf,
 			SkipHealthChecks: skipHealthChecks,
@@ -167,11 +164,8 @@ func updatePostgresOnMachines(ctx context.Context, app *api.AppCompact) (err err
 	for _, member := range members["replica"] {
 		machine := member.Machine
 		input := &api.LaunchMachineInput{
-			ID:      machine.ID,
-			AppID:   app.Name,
-			OrgSlug: app.Organization.Slug,
-			Region:  machine.Region,
-			Config:  &member.TargetConfig,
+			Region: machine.Region,
+			Config: &member.TargetConfig,
 		}
 		if err := mach.Update(ctx, machine, input); err != nil {
 			return err
@@ -184,18 +178,14 @@ func updatePostgresOnMachines(ctx context.Context, app *api.AppCompact) (err err
 			machine := primary.Machine
 
 			input := &api.LaunchMachineInput{
-				ID:      machine.ID,
-				AppID:   app.Name,
-				OrgSlug: app.Organization.Slug,
-				Region:  machine.Region,
-				Config:  &primary.TargetConfig,
+				Region: machine.Region,
+				Config: &primary.TargetConfig,
 			}
 			if err := mach.Update(ctx, machine, input); err != nil {
 				return err
 			}
 		}
 	} else {
-
 		if len(members["leader"]) > 0 {
 			leader := members["leader"][0]
 			machine := leader.Machine
@@ -222,11 +212,8 @@ func updatePostgresOnMachines(ctx context.Context, app *api.AppCompact) (err err
 
 			// Update leader
 			input := &api.LaunchMachineInput{
-				ID:      machine.ID,
-				AppID:   app.Name,
-				OrgSlug: app.Organization.Slug,
-				Region:  machine.Region,
-				Config:  &leader.TargetConfig,
+				Region: machine.Region,
+				Config: &leader.TargetConfig,
 			}
 			if err := mach.Update(ctx, machine, input); err != nil {
 				return err

--- a/internal/command/logs/ship.go
+++ b/internal/command/logs/ship.go
@@ -18,7 +18,6 @@ import (
 )
 
 func newShip() (cmd *cobra.Command) {
-
 	const (
 		short = "Ship application logs to Logtail"
 		long  = short + "\n"
@@ -44,7 +43,6 @@ func runSetup(ctx context.Context) (err error) {
 
 	// Fetch the target organization from the app
 	appNameResponse, err := gql.GetApp(ctx, client, appName)
-
 	if err != nil {
 		return err
 	}
@@ -58,7 +56,7 @@ func runSetup(ctx context.Context) (err error) {
 
 	// Fetch or create the Logtail integration for the app
 
-	var addOnName = appName + "-log-shipper"
+	addOnName := appName + "-log-shipper"
 	getAddOnResponse, err := gql.GetAddOn(ctx, client, addOnName)
 
 	if err != nil {
@@ -71,7 +69,6 @@ func runSetup(ctx context.Context) (err error) {
 		}
 
 		createAddOnResponse, err := gql.CreateAddOn(ctx, client, input)
-
 		if err != nil {
 			return err
 		}
@@ -85,13 +82,11 @@ func runSetup(ctx context.Context) (err error) {
 	tokenResponse, err := gql.CreateLimitedAccessToken(ctx, client, appName+"-logs", targetOrg.Id, "read_organization_apps", &gql.LimitedAccessTokenOptions{
 		"app_ids": []string{targetApp.Name},
 	}, "")
-
 	if err != nil {
 		return
 	}
 
 	flapsClient, machine, err := EnsureShipperMachine(ctx, targetOrg)
-
 	if err != nil {
 		return
 	}
@@ -105,7 +100,6 @@ func runSetup(ctx context.Context) (err error) {
 
 	flapsClient.Wait(ctx, machine, "started", time.Second*5)
 	response, err := flapsClient.Exec(ctx, machine.ID, request)
-
 	if err != nil {
 		fmt.Fprintf(io.ErrOut, response.StdErr)
 		return err
@@ -114,12 +108,10 @@ func runSetup(ctx context.Context) (err error) {
 }
 
 func EnsureShipperMachine(ctx context.Context, targetOrg gql.AppDataOrganization) (flapsClient *flaps.Client, machine *api.Machine, err error) {
-
 	client := client.FromContext(ctx).API().GenqClient
 	io := iostreams.FromContext(ctx)
 
 	appsResult, err := gql.GetAppsByRole(ctx, client, "log-shipper", targetOrg.Id)
-
 	if err != nil {
 		return nil, nil, err
 	}
@@ -136,7 +128,6 @@ func EnsureShipperMachine(ctx context.Context, targetOrg gql.AppDataOrganization
 		input.Name = targetOrg.RawSlug + "-log-shipper"
 
 		createdAppResult, err := gql.CreateApp(ctx, client, input)
-
 		if err != nil {
 			return nil, nil, err
 		}
@@ -155,14 +146,12 @@ func EnsureShipperMachine(ctx context.Context, targetOrg gql.AppDataOrganization
 	}
 
 	machines, err := flapsClient.List(ctx, "")
-
 	if err != nil {
 		return nil, nil, err
 	}
 
 	if len(machines) > 0 {
 		machine = machines[0]
-
 	} else {
 
 		machineConf := &api.MachineConfig{
@@ -175,13 +164,11 @@ func EnsureShipperMachine(ctx context.Context, targetOrg gql.AppDataOrganization
 		}
 
 		launchInput := api.LaunchMachineInput{
-			AppID:  shipperApp.Name,
 			Name:   "log-shipper",
 			Config: machineConf,
 		}
 
 		regionResponse, err := gql.GetNearestRegion(ctx, client)
-
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -257,7 +257,6 @@ func runMachineClone(ctx context.Context) (err error) {
 	}
 
 	input := api.LaunchMachineInput{
-		AppID:      app.Name,
 		Name:       flag.GetString(ctx, "name"),
 		Region:     region,
 		Config:     targetConfig,

--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -82,12 +82,10 @@ func Destroy(ctx context.Context, app *api.AppCompact, machine *api.Machine, for
 	var (
 		out         = iostreams.FromContext(ctx).Out
 		flapsClient = flaps.FromContext(ctx)
-		appName     = app.Name
 
 		input = api.RemoveMachineInput{
-			AppID: appName,
-			ID:    machine.ID,
-			Kill:  force,
+			ID:   machine.ID,
+			Kill: force,
 		}
 	)
 

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -246,7 +246,6 @@ func runMachineRun(ctx context.Context) error {
 	}
 
 	input := api.LaunchMachineInput{
-		AppID:  app.Name,
 		Name:   flag.GetString(ctx, "name"),
 		Region: flag.GetString(ctx, "region"),
 	}

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -129,13 +129,11 @@ func runUpdate(ctx context.Context) (err error) {
 
 	// Perform update
 	input := &api.LaunchMachineInput{
-		ID:               machine.ID,
-		AppID:            appName,
 		Name:             machine.Name,
 		Region:           machine.Region,
 		Config:           machineConf,
-		SkipHealthChecks: skipHealthChecks,
 		SkipLaunch:       len(machineConf.Standbys) > 0,
+		SkipHealthChecks: skipHealthChecks,
 	}
 	if err := mach.Update(ctx, machine, input); err != nil {
 		return err

--- a/internal/command/migrate_to_v2/machines.go
+++ b/internal/command/migrate_to_v2/machines.go
@@ -30,10 +30,8 @@ func (m *v2PlatformMigrator) resolveMachineFromAlloc(alloc *api.AllocationStatus
 	}
 
 	launchInput := &api.LaunchMachineInput{
-		AppID:   m.appFull.Name,
-		OrgSlug: m.appFull.Organization.ID,
-		Region:  alloc.Region,
-		Config:  mConfig,
+		Region: alloc.Region,
+		Config: mConfig,
 	}
 
 	return launchInput, nil

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -275,9 +275,8 @@ func (m *v2PlatformMigrator) rollback(ctx context.Context, tb *render.TextBlock)
 		for _, mach := range m.recovery.machinesCreated {
 
 			input := api.RemoveMachineInput{
-				AppID: m.appFull.Name,
-				ID:    mach.ID,
-				Kill:  true,
+				ID:   mach.ID,
+				Kill: true,
 			}
 			err := m.flapsClient.Destroy(ctx, input, mach.LeaseNonce)
 			if err != nil {

--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -202,7 +202,7 @@ func runImport(ctx context.Context) error {
 
 	// Destroy machine
 	fmt.Fprintf(io.Out, "%s has been destroyed\n", machine.ID)
-	if err := flapsClient.Destroy(ctx, api.RemoveMachineInput{ID: machine.ID, AppID: app.ID}, machine.LeaseNonce); err != nil {
+	if err := flapsClient.Destroy(ctx, api.RemoveMachineInput{ID: machine.ID}, machine.LeaseNonce); err != nil {
 		return fmt.Errorf("failed to destroy machine %s: %s", machine.ID, err)
 	}
 

--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -157,10 +157,8 @@ func runImport(ctx context.Context) error {
 	machineConfig.Image = imageRef
 
 	launchInput := api.LaunchMachineInput{
-		AppID:   app.ID,
-		OrgSlug: app.Organization.ID,
-		Region:  region.Code,
-		Config:  machineConfig,
+		Region: region.Code,
+		Config: machineConfig,
 	}
 
 	// Create emphemeral machine

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -144,15 +144,11 @@ func launchMachine(ctx context.Context, action *planItem) (*api.Machine, error) 
 }
 
 func destroyMachine(ctx context.Context, machine *api.Machine) error {
-	appName := appconfig.NameFromContext(ctx)
 	flapsClient := flaps.FromContext(ctx)
-
 	input := api.RemoveMachineInput{
-		AppID: appName,
-		ID:    machine.ID,
-		Kill:  true,
+		ID:   machine.ID,
+		Kill: true,
 	}
-
 	return flapsClient.Destroy(ctx, input, machine.LeaseNonce)
 }
 

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -134,21 +134,13 @@ func runMachinesScaleCount(ctx context.Context, appName string, expectedGroupCou
 }
 
 func launchMachine(ctx context.Context, action *planItem) (*api.Machine, error) {
-	appName := appconfig.NameFromContext(ctx)
 	flapsClient := flaps.FromContext(ctx)
 
 	input := api.LaunchMachineInput{
-		AppID:  appName,
 		Region: action.Region,
 		Config: action.MachineConfig,
 	}
-
-	m, err := flapsClient.Launch(ctx, input)
-	if err != nil {
-		return nil, fmt.Errorf("could not launch machine: %w", err)
-	}
-
-	return m, nil
+	return flapsClient.Launch(ctx, input)
 }
 
 func destroyMachine(ctx context.Context, machine *api.Machine) error {

--- a/internal/command/scale/machines.go
+++ b/internal/command/scale/machines.go
@@ -57,12 +57,9 @@ func v2ScaleVM(ctx context.Context, appName, group, sizeName string, memoryMB in
 		}
 
 		input := &api.LaunchMachineInput{
-			ID:               machine.ID,
-			AppID:            appName,
-			Name:             machine.Name,
-			Region:           machine.Region,
-			Config:           machine.Config,
-			SkipHealthChecks: false,
+			Name:   machine.Name,
+			Region: machine.Region,
+			Config: machine.Config,
 		}
 		if err := mach.Update(ctx, machine, input); err != nil {
 			return nil, err

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -59,6 +59,7 @@ func (lm *leasableMachine) Update(ctx context.Context, input api.LaunchMachineIn
 	if !lm.HasLease() {
 		return fmt.Errorf("no current lease for machine %s", lm.machine.ID)
 	}
+	input.ID = lm.machine.ID
 	updateMachine, err := lm.flapsClient.Update(ctx, input, lm.leaseNonce)
 	if err != nil {
 		return err

--- a/internal/machine/update.go
+++ b/internal/machine/update.go
@@ -84,7 +84,7 @@ func Update(ctx context.Context, m *api.Machine, input *api.LaunchMachineInput) 
 	input.ID = m.ID
 	updatedMachine, err = flapsClient.Update(ctx, *input, m.LeaseNonce)
 	if err != nil {
-		return fmt.Errorf("could not stop machine %s: %w", input.ID, err)
+		return fmt.Errorf("could not update machine %s: %w", m.ID, err)
 	}
 
 	waitForAction := "start"


### PR DESCRIPTION
Friday broom day 🧹 

```
 make preflight-test
Running Generate for Help and GraphQL client
go generate ./...
generating cli help
Running Build
go build -o bin/flyctl -ldflags="-X 'github.com/superfly/flyctl/internal/buildinfo.buildDate=2023-04-28T20:22:34Z' -X 'github.com/superfly/flyctl/internal/buildinfo.commit=988cf9d2e36bbacfccc26db74705a2753a9ae528 (chore/update-createmachinerequest)'" .
if [ -r .direnv/preflight ]; then . .direnv/preflight; fi; \
go test ./test/preflight --tags=integration -v -timeout 30m --run=
=== RUN   TestAppsV2Example
--- PASS: TestAppsV2Example (120.48s)
=== RUN   TestAppsV2ConfigChanges
--- PASS: TestAppsV2ConfigChanges (57.47s)
=== RUN   TestAppsV2ConfigSave_ProcessGroups
--- PASS: TestAppsV2ConfigSave_ProcessGroups (23.41s)
=== RUN   TestAppsV2ConfigSave_OneMachineNoAppConfig
--- PASS: TestAppsV2ConfigSave_OneMachineNoAppConfig (10.28s)
=== RUN   TestAppsV2ConfigSave_PostgresSingleNode
--- PASS: TestAppsV2ConfigSave_PostgresSingleNode (49.58s)
=== RUN   TestAppsV2_PostgresAutostart
--- PASS: TestAppsV2_PostgresAutostart (79.98s)
=== RUN   TestAppsV2_PostgresNoMachines
--- PASS: TestAppsV2_PostgresNoMachines (52.62s)
=== RUN   TestAppsV2ConfigSave_PostgresHA
--- PASS: TestAppsV2ConfigSave_PostgresHA (84.14s)
=== RUN   TestAppsV2Config_ParseExperimental
--- PASS: TestAppsV2Config_ParseExperimental (10.21s)
=== RUN   TestAppsV2Config_ProcessGroups
--- PASS: TestAppsV2Config_ProcessGroups (88.86s)
=== RUN   TestAppsV2MigrateToV2
--- PASS: TestAppsV2MigrateToV2 (125.84s)
=== RUN   TestAppsV2MigrateToV2_Volumes
--- FAIL: TestAppsV2MigrateToV2_Volumes (16.20s)
=== RUN   TestFlyDeploy_case01
--- PASS: TestFlyDeploy_case01 (68.27s)
=== RUN   TestFlyLaunch_case01
--- PASS: TestFlyLaunch_case01 (5.44s)
=== RUN   TestFlyLaunch_case02
--- PASS: TestFlyLaunch_case02 (6.93s)
=== RUN   TestFlyLaunch_case03
--- PASS: TestFlyLaunch_case03 (4.65s)
=== RUN   TestFlyLaunch_case04
--- PASS: TestFlyLaunch_case04 (2.34s)
=== RUN   TestFlyLaunch_case05a
--- PASS: TestFlyLaunch_case05a (2.55s)
=== RUN   TestFlyLaunch_case05b
--- PASS: TestFlyLaunch_case05b (15.96s) 
=== RUN   TestFlyLaunch_case06
--- PASS: TestFlyLaunch_case06 (10.92s)
=== RUN   TestFlyLaunch_case07
--- PASS: TestFlyLaunch_case07 (40.98s)
=== RUN   TestFlyLaunch_case08
--- PASS: TestFlyLaunch_case08 (12.11s)
=== RUN   TestFlyLaunch_case09
--- PASS: TestFlyLaunch_case09 (39.81s)
=== RUN   TestFlyLaunch_case10
--- PASS: TestFlyLaunch_case10 (39.00s)
=== RUN   TestFlyMachineRun_autoStartStop
--- PASS: TestFlyMachineRun_autoStartStop (26.35s)
=== RUN   TestFlyMachineRun_standbyFor
--- PASS: TestFlyMachineRun_standbyFor (25.01s)
FAIL
FAIL    github.com/superfly/flyctl/test/preflight       1020.423s
```

`TestAppsV2MigrateToV2_Volumes` fails but that is a known issue @alichay was looking at.