### PR TITLE
Fix build_target option in fly.toml

### DIFF
--- a/flyctl/app_config.go
+++ b/flyctl/app_config.go
@@ -182,7 +182,7 @@ func (ac *AppConfig) unmarshalNativeMap(data map[string]interface{}) error {
 			case "dockerfile":
 				b.Dockerfile = fmt.Sprint(v)
 				insection = true
-			case "build_target":
+			case "build_target", "build-target":
 				b.DockerBuildTarget = fmt.Sprint(v)
 				insection = true
 			default:
@@ -191,7 +191,7 @@ func (ac *AppConfig) unmarshalNativeMap(data map[string]interface{}) error {
 				}
 			}
 		}
-		if b.Builder != "" || b.Builtin != "" || b.Image != "" || b.Dockerfile != "" || len(b.Args) > 0 {
+		if b.Builder != "" || b.Builtin != "" || b.Image != "" || b.Dockerfile != "" || b.DockerBuildTarget != "" || len(b.Args) > 0 {
 			ac.Build = &b
 		}
 	}

--- a/flyctl/app_config_test.go
+++ b/flyctl/app_config_test.go
@@ -22,6 +22,13 @@ func TestLoadTOMLAppConfigWithBuilderName(t *testing.T) {
 	assert.Equal(t, p.Build.Builder, "builder/name")
 }
 
+func TestLoadTOMLAppConfigWithBuildTarget(t *testing.T) {
+	path := "./testdata/build-target.toml"
+	p, err := LoadAppConfig(path)
+	assert.NoError(t, err)
+	assert.Equal(t, p.Build.DockerBuildTarget, "target")
+}
+
 func TestLoadTOMLAppConfigWithImage(t *testing.T) {
 	path := "./testdata/image.toml"
 	p, err := LoadAppConfig(path)

--- a/flyctl/testdata/build-target.toml
+++ b/flyctl/testdata/build-target.toml
@@ -1,0 +1,4 @@
+app = "build-target"
+
+[build]
+    build_target = "target"


### PR DESCRIPTION
The `build_target` build option in `fly.toml` was broken and didn't have a config test, this PR fixes the option and adds a test.