### PR TITLE
Perform sanity checks after Apps V2 deploy

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -81,6 +81,11 @@ var CommonFlags = flag.Set{
 		Description: "Create spare machines that increases app availability",
 		Default:     true,
 	},
+	flag.Bool{
+		Name:        "sanity-checks",
+		Description: "Perform sanity checks during deployment",
+		Default:     true,
+	},
 }
 
 func New() (cmd *cobra.Command) {
@@ -198,6 +203,7 @@ func deployToMachines(ctx context.Context, appConfig *appconfig.Config, appCompa
 		Strategy:              flag.GetString(ctx, "strategy"),
 		EnvFromFlags:          flag.GetStringSlice(ctx, "env"),
 		PrimaryRegionFlag:     appConfig.PrimaryRegion,
+		SkipSanityChecks:      flag.GetDetach(ctx) || !flag.GetBool(ctx, "sanity-checks"),
 		SkipHealthChecks:      flag.GetDetach(ctx),
 		WaitTimeout:           time.Duration(flag.GetInt(ctx, "wait-timeout")) * time.Second,
 		LeaseTimeout:          time.Duration(flag.GetInt(ctx, "lease-timeout")) * time.Second,

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -36,6 +36,7 @@ type MachineDeploymentArgs struct {
 	Strategy              string
 	EnvFromFlags          []string
 	PrimaryRegionFlag     string
+	SkipSanityChecks      bool
 	SkipHealthChecks      bool
 	RestartOnly           bool
 	WaitTimeout           time.Duration
@@ -59,6 +60,7 @@ type machineDeployment struct {
 	strategy              string
 	releaseId             string
 	releaseVersion        int
+	skipSanityChecks      bool
 	skipHealthChecks      bool
 	restartOnly           bool
 	waitTimeout           time.Duration
@@ -120,6 +122,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		app:                   args.AppCompact,
 		appConfig:             appConfig,
 		img:                   args.DeploymentImage,
+		skipSanityChecks:      args.SkipSanityChecks,
 		skipHealthChecks:      args.SkipHealthChecks,
 		restartOnly:           args.RestartOnly,
 		waitTimeout:           waitTimeout,


### PR DESCRIPTION
Now that the healthchecks are disabled by default, it's very easy
to rollout a broken version on every machine in the app.

This PR introduces a "sanity check" step during the rollout. We are
gonna wait for up to 10 seconds to ensure that the newly deployed
machine is up and running and not restarting with non-zero exit code.
This won't catch all errors, but should prevent the most obvious ones
like OOMs right after deploy, missing configuration, etc.
