### PR TITLE
Send metrics from dev builds if metrics base URL is overridden

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,6 +158,10 @@ func (cfg *Config) ApplyFlags(fs *pflag.FlagSet) {
 	})
 }
 
+func (cfg *Config) MetricsBaseURLIsProduction() bool {
+	return cfg.MetricsBaseURL == defaultMetricsBaseURL
+}
+
 func applyStringFlags(fs *pflag.FlagSet, flags map[string]*string) {
 	for name, dst := range flags {
 		if !fs.Changed(name) {


### PR DESCRIPTION
This allows for running a dev flyctl alongside a dev metrics collector