### PR TITLE
Add additional detection to Deno scanner

### DIFF
--- a/scanner/deno.go
+++ b/scanner/deno.go
@@ -1,7 +1,7 @@
 package scanner
 
 func configureDeno(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
-	if !checksPass(sourceDir, dirContains("*.ts", "denopkg")) && !checksPass(sourceDir, dirContains("*.ts", "deno.land")) {
+	if !checksPass(sourceDir, dirContains("*.ts", "denopkg", "deno.land")) {
 		return nil, nil
 	}
 

--- a/scanner/deno.go
+++ b/scanner/deno.go
@@ -1,7 +1,7 @@
 package scanner
 
 func configureDeno(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
-	if !checksPass(sourceDir, dirContains("*.ts", "denopkg")) {
+	if !checksPass(sourceDir, dirContains("*.ts", "denopkg")) && !checksPass(sourceDir, dirContains("*.ts", "deno.land")) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
This change adds support for detecting "deno.land" detection in TypeScript files for determining if a directory is written in Deno.

<https://deno.land>, besides previously being the homepage of the Deno project and now redirecting to the new <https://deno.com> site, hosts the project's standard library at <https://deno.land/std> and many thousands of third-party packages at <https://deno.land/x/>.

As of right now, I **have** tested this some local code, but **have not** ran the preflight tests.

Disclaimers: first-time contributor, new to Fly, and haven't touched Go in a long time. :)

![image](https://user-images.githubusercontent.com/772507/235574613-161037ea-15a4-43cf-a06f-8786a62f173e.png)

![image](https://user-images.githubusercontent.com/772507/235574816-b20b40d3-694d-4715-93ae-6ef67ae975aa.png)
