### PR TITLE
fix: Add error if machine size < image size 

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -177,10 +177,10 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, args Dep
 		return err
 	}
 	if machines[0].Config.Guest.MemoryMB < imgSize {
-		showMachineSize := fmt.Sprintf("%d MB\n", machines[0].Config.Guest.MemoryMB)
-		fmt.Fprintf(io.Out, "Machine Memory: ")
-		fmt.Fprintln(io.Out, colorize.Red(showMachineSize))
-		return fmt.Errorf("the current machine size is too small for the image, consider scaling up your app with fly scale memory [memoryMB]")
+		sizeDiff := imgSize - machines[0].Config.Guest.MemoryMB
+		fmt.Fprintf(io.Out, "%s: %d MB ", "Machine Memory", machines[0].Config.Guest.MemoryMB)
+		fmt.Fprintln(io.Out, colorize.Red(fmt.Sprintf("(%d MB smaller than image)", sizeDiff)))
+		return fmt.Errorf("the current machine size is too small for the image, consider scaling up your app with `fly scale memory [memoryMB]`")
 	}
 
 	fmt.Fprintf(io.Out, "\nWatch your app at https://fly.io/apps/%s/monitoring\n\n", appName)


### PR DESCRIPTION
Right now, a deploy fails if the machine is not big enough for an image and an OOM automatically occurs. This is frustrating since it may not be immediately apparent that the machine cannot accommodate the image. 

![Screenshot 2023-05-02 at 12 29 11 PM](https://user-images.githubusercontent.com/3229484/235740564-855077df-1d87-468b-9049-bcbe5226c210.png)
