### PR TITLE
Detect python app by setup.py and setup.cfg

### DIFF
--- a/scanner/python.go
+++ b/scanner/python.go
@@ -2,7 +2,7 @@ package scanner
 
 func configurePython(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
 	// using 'poetry.lock' as an indicator instead of 'pyproject.toml', as Paketo doesn't support PEP-517 implementations
-	if !checksPass(sourceDir, fileExists("requirements.txt", "environment.yml", "poetry.lock", "Pipfile")) {
+	if !checksPass(sourceDir, fileExists("requirements.txt", "environment.yml", "poetry.lock", "Pipfile", "setup.py", "setup.cfg")) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
These are pretty standard indicators for python apps. In particular in cases where the authors introduce a separate "build" step.