### PR TITLE
Always use remote config in `fly scale count`

### DIFF
--- a/internal/command/scale/count.go
+++ b/internal/command/scale/count.go
@@ -40,8 +40,11 @@ For pricing, see https://fly.io/docs/about/pricing/`
 }
 
 func runScaleCount(ctx context.Context) error {
-	appConfig := appconfig.ConfigFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
+	appConfig, err := appconfig.FromRemoteApp(ctx, appName)
+	if err != nil {
+		return err
+	}
 
 	args := flag.Args(ctx)
 
@@ -73,7 +76,7 @@ func runScaleCount(ctx context.Context) error {
 		return err
 	}
 	if isV2 {
-		return runMachinesScaleCount(ctx, appName, groups, maxPerRegion)
+		return runMachinesScaleCount(ctx, appName, appConfig, groups, maxPerRegion)
 	}
 	return runNomadScaleCount(ctx, appName, groups, maxPerRegion)
 }

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-func runMachinesScaleCount(ctx context.Context, appName string, expectedGroupCounts map[string]int, maxPerRegion int) error {
+func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appconfig.Config, expectedGroupCounts map[string]int, maxPerRegion int) error {
 	io := iostreams.FromContext(ctx)
 
 	flapsClient, err := flaps.NewFromAppName(ctx, appName)
@@ -27,10 +27,6 @@ func runMachinesScaleCount(ctx context.Context, appName string, expectedGroupCou
 	}
 	ctx = flaps.NewContext(ctx, flapsClient)
 
-	appConfig, err := appconfig.FromRemoteApp(ctx, appName)
-	if err != nil {
-		return err
-	}
 	ctx = appconfig.WithConfig(ctx, appConfig)
 
 	machines, _, err := flapsClient.ListFlyAppsMachines(ctx)


### PR DESCRIPTION
In response to #2164, where reading from a local `fly.toml` (for a different app!) caused unexpected behavior with the `-a` flag.