### PR TITLE
Websocket metrics transport

### DIFF
--- a/internal/metrics/helpers.go
+++ b/internal/metrics/helpers.go
@@ -58,16 +58,15 @@ func Send[T any](ctx context.Context, metricSlug string, value T) {
 	if err != nil {
 		return
 	}
-	SendJson(ctx, metricSlug, string(valJson))
+	SendJson(ctx, metricSlug, valJson)
 }
 
 func SendNoData(ctx context.Context, metricSlug string) {
-
-	SendJson(ctx, metricSlug, "")
+	SendJson(ctx, metricSlug, nil)
 }
 
-func SendJson(ctx context.Context, metricSlug, jsonValue string) {
-	rawSend(ctx, metricSlug, jsonValue)
+func SendJson(ctx context.Context, metricSlug string, payload json.RawMessage) {
+	rawSend(ctx, metricSlug, payload)
 }
 
 func StartTiming(ctx context.Context, metricSlug string) func() {


### PR DESCRIPTION
Metrics are currently sent to the collector via HTTP requests. That part is just a detail, the important implication is that this forces us to wait for a response to every metric we send. Because there are some metrics that are sent right before flyctl exits (reporting command runtime, success, etc), this has the effect of adding an annoying delay before exit roughly about the round trip time to the metrics collector.

This PR reworks our instrumentation to stream metrics up to the collector over a websocket and without requiring server acknowledgement. We still block on the flush to socket to make sure that the metrics are actually sent, but once they've made it past the `write(2)` boundary flyctl no longer has to care about them.

I benchmarked this change with 30 trials of the command `time flyctl m list`. On my connection, the improvement is significant:

![image](https://user-images.githubusercontent.com/179065/235845224-38f94013-3e95-4c3f-b871-4f7f481636b9.png)

The mean runtime for this command is about 290ms faster using the WS transport compared to HTTP - this checks out, my mean RTT to ORD is about 240ms. There is also less variance in the timings when using the WS transport - fewer round trips mean less opportunity for a latency spike.