### PR TITLE
Add `fly proxy balance` command

### DIFF
--- a/flyproxy/balance.go
+++ b/flyproxy/balance.go
@@ -1,9 +1,10 @@
 package flyproxy
 
 type BalanceResponse struct {
-	Total    uint                `json:"total"`
-	Chosen   *BalancedInstance   `json:"chosen"`
-	Rejected []*BalancedInstance `json:"rejected"`
+	Destination Destination         `json:"dest"`
+	Total       uint                `json:"total"`
+	Chosen      *BalancedInstance   `json:"chosen"`
+	Rejected    []*BalancedInstance `json:"rejected"`
 }
 
 type BalancedInstance struct {

--- a/flyproxy/balance.go
+++ b/flyproxy/balance.go
@@ -21,3 +21,7 @@ type BalanceRejection struct {
 	ID   string `json:"id"`
 	Desc string `json:"description"`
 }
+
+type BalanceOptions struct {
+	Destination string
+}

--- a/flyproxy/balance.go
+++ b/flyproxy/balance.go
@@ -1,0 +1,23 @@
+package flyproxy
+
+type BalanceResponse struct {
+	Total    uint                `json:"total"`
+	Chosen   *BalancedInstance   `json:"chosen"`
+	Rejected []*BalancedInstance `json:"rejected"`
+}
+
+type BalancedInstance struct {
+	ID          string            `json:"id"`
+	Region      string            `json:"region"`
+	State       string            `json:"state"`
+	Concurrency int               `json:"concurrency"`
+	Healthy     bool              `json:"healthy"`
+	NodeHealthy bool              `json:"node_healthy"`
+	NodeRttMs   float64           `json:"node_rtt_ms"`
+	Rejection   *BalanceRejection `json:"rejection"`
+}
+
+type BalanceRejection struct {
+	ID   string `json:"id"`
+	Desc string `json:"description"`
+}

--- a/flyproxy/client.go
+++ b/flyproxy/client.go
@@ -25,7 +25,6 @@ type Client struct {
 	baseUrl    *url.URL
 	httpClient *http.Client
 	userAgent  string
-	logger     api.Logger
 }
 
 func New(ctx context.Context, orgSlug string) (*Client, error) {

--- a/flyproxy/client.go
+++ b/flyproxy/client.go
@@ -1,0 +1,179 @@
+package flyproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/superfly/flyctl/agent"
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/buildinfo"
+	"github.com/superfly/flyctl/internal/logger"
+	"github.com/superfly/flyctl/terminal"
+)
+
+type Client struct {
+	baseUrl    *url.URL
+	httpClient *http.Client
+	userAgent  string
+	logger     api.Logger
+}
+
+func New(ctx context.Context, orgSlug string) (*Client, error) {
+	logger := logger.MaybeFromContext(ctx)
+
+	client := client.FromContext(ctx).API()
+	agentclient, err := agent.Establish(ctx, client)
+	if err != nil {
+		return nil, fmt.Errorf("error establishing agent: %w", err)
+	}
+
+	dialer, err := agentclient.Dialer(ctx, orgSlug)
+	if err != nil {
+		return nil, fmt.Errorf("fly-proxy: can't build tunnel for %s: %w", orgSlug, err)
+	}
+
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, addr)
+		},
+	}
+
+	httpClient, err := api.NewHTTPClient(logger, transport)
+	if err != nil {
+		return nil, fmt.Errorf("fly-proxy: can't setup HTTP client for %s: %w", orgSlug, err)
+	}
+
+	proxyBaseUrlString := fmt.Sprintf("http://[%s]:1729", resolvePeerIP(dialer.State().Peer.Peerip))
+	proxyBaseUrl, err := url.Parse(proxyBaseUrlString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse proxy url '%s' with error: %w", proxyBaseUrlString, err)
+	}
+
+	return &Client{
+		baseUrl:    proxyBaseUrl,
+		httpClient: httpClient,
+		userAgent:  strings.TrimSpace(fmt.Sprintf("fly-cli/%s", buildinfo.Version())),
+	}, nil
+}
+
+func (f *Client) Balance(ctx context.Context, appName string) (*BalanceResponse, error) {
+	out := new(BalanceResponse)
+
+	err := f.sendRequest(ctx, http.MethodGet, fmt.Sprintf("balance/%s", appName), nil, out, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get balance diagnostic for app %s: %w", appName, err)
+	}
+	return out, nil
+}
+
+func (f *Client) sendRequest(ctx context.Context, method, endpoint string, in, out interface{}, headers map[string][]string) error {
+	req, err := f.NewRequest(ctx, method, endpoint, in, headers)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", f.userAgent)
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			terminal.Debugf("error closing response body: %v\n", err)
+		}
+	}()
+
+	if resp.StatusCode > 299 {
+		responseBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			responseBody = make([]byte, 0)
+		}
+		return &Error{
+			OriginalError:      handleAPIError(resp.StatusCode, responseBody),
+			ResponseStatusCode: resp.StatusCode,
+			ResponseBody:       responseBody,
+		}
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *Client) urlFromBaseUrl(pathAndQueryString string) (*url.URL, error) {
+	newUrl := *f.baseUrl // this does a copy: https://github.com/golang/go/issues/38351#issue-597797864
+	newPath, err := url.Parse(pathAndQueryString)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing proxy path '%s' with error: %w", pathAndQueryString, err)
+	}
+	return newUrl.ResolveReference(&url.URL{Path: newPath.Path, RawQuery: newPath.RawQuery}), nil
+}
+
+func (f *Client) NewRequest(ctx context.Context, method, path string, in interface{}, headers map[string][]string) (*http.Request, error) {
+	var body io.Reader
+
+	if headers == nil {
+		headers = make(map[string][]string)
+	}
+
+	targetEndpoint, err := f.urlFromBaseUrl(fmt.Sprintf("/v1/%s", path))
+	if err != nil {
+		return nil, err
+	}
+
+	if in != nil {
+		b, err := json.Marshal(in)
+		if err != nil {
+			return nil, err
+		}
+		headers["Content-Type"] = []string{"application/json"}
+		body = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, targetEndpoint.String(), body)
+	if err != nil {
+		return nil, fmt.Errorf("could not create new request, %w", err)
+	}
+	req.Header = headers
+
+	return req, nil
+}
+
+func handleAPIError(statusCode int, responseBody []byte) error {
+	switch statusCode / 100 {
+	case 1, 3:
+		return fmt.Errorf("API returned unexpected status, %d", statusCode)
+	case 4, 5:
+		apiErr := struct {
+			Error string `json:"error"`
+		}{}
+		if err := json.Unmarshal(responseBody, &apiErr); err != nil {
+			return fmt.Errorf("request returned non-2xx status, %d", statusCode)
+		}
+		return errors.New(apiErr.Error)
+	default:
+		return errors.New("something went terribly wrong")
+	}
+}
+
+func resolvePeerIP(ip string) string {
+	peerIP := net.ParseIP(ip)
+	var natsIPBytes [16]byte
+	copy(natsIPBytes[0:], peerIP[0:6])
+	natsIPBytes[15] = 3
+
+	return net.IP(natsIPBytes[:]).String()
+}

--- a/flyproxy/client.go
+++ b/flyproxy/client.go
@@ -66,10 +66,23 @@ func New(ctx context.Context, orgSlug string) (*Client, error) {
 	}, nil
 }
 
-func (f *Client) Balance(ctx context.Context, appName string) (*BalanceResponse, error) {
+func (f *Client) Balance(ctx context.Context, appName string, opts *BalanceOptions) (*BalanceResponse, error) {
 	out := new(BalanceResponse)
 
-	err := f.sendRequest(ctx, http.MethodGet, fmt.Sprintf("balance/%s", appName), nil, out, nil)
+	endpoint := fmt.Sprintf("balance/%s", appName)
+	query := []string{}
+
+	if opts != nil {
+		if opts.Destination != "" {
+			query = append(query, fmt.Sprintf("dest=%s", opts.Destination))
+		}
+	}
+
+	if len(query) > 0 {
+		endpoint = fmt.Sprintf("%s?%s", endpoint, strings.Join(query, "&"))
+	}
+
+	err := f.sendRequest(ctx, http.MethodGet, endpoint, nil, out, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get balance diagnostic for app %s: %w", appName, err)
 	}

--- a/flyproxy/error.go
+++ b/flyproxy/error.go
@@ -1,0 +1,23 @@
+package flyproxy
+
+type Error struct {
+	OriginalError      error
+	ResponseStatusCode int
+	ResponseBody       []byte
+	FlyRequestId       string
+}
+
+func (fe *Error) Error() string {
+	if fe.OriginalError == nil {
+		return ""
+	}
+	return fe.OriginalError.Error()
+}
+
+func (fe *Error) Unwrap() error {
+	return fe.OriginalError
+}
+
+func (fe *Error) ResponseBodyString() string {
+	return string(fe.ResponseBody)
+}

--- a/flyproxy/state.go
+++ b/flyproxy/state.go
@@ -1,0 +1,6 @@
+package flyproxy
+
+type Destination struct {
+	Proto string `json:"proto"`
+	Port  uint16 `json:"port"`
+}

--- a/internal/command/proxy/balance.go
+++ b/internal/command/proxy/balance.go
@@ -1,0 +1,148 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flyproxy"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/internal/render"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newBalance() *cobra.Command {
+	var (
+		long  = strings.Trim(`Runs the load balancing logic for an app through our proxy and shows how it might choose an instance to route to.`, "\n")
+		short = `Load balancing simulation for an app`
+		usage = "balance"
+	)
+
+	cmd := command.New(usage, short, long, runBalance,
+		command.RequireSession, command.LoadAppNameIfPresent)
+
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+		flag.Org(),
+	)
+
+	return cmd
+}
+
+func runBalance(ctx context.Context) (err error) {
+	apiClient := client.FromContext(ctx).API()
+	appName := appconfig.NameFromContext(ctx)
+	orgSlug := flag.GetString(ctx, "org")
+
+	if orgSlug != "" {
+		_, err := apiClient.GetOrganizationBySlug(ctx, orgSlug)
+		if err != nil {
+			return err
+		}
+	}
+
+	if appName == "" && orgSlug == "" {
+		org, err := prompt.Org(ctx)
+		if err != nil {
+			return err
+		}
+		orgSlug = org.Slug
+	}
+
+	if appName != "" {
+		app, err := apiClient.GetAppBasic(ctx, appName)
+		if err != nil {
+			return err
+		}
+		orgSlug = app.Organization.Slug
+	}
+
+	client, err := flyproxy.New(ctx, orgSlug)
+	if err != nil {
+		return err
+	}
+
+	io := iostreams.FromContext(ctx)
+	colorize := io.ColorScheme()
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	balanced, err := client.Balance(ctx, appName)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(io.Out, "%d instances were eligible for balancing %s.\n\n", balanced.Total, appName)
+
+	rows := [][]string{}
+
+	rejections := make(map[string]string)
+
+	if balanced.Chosen != nil {
+		rows = append(rows, generateRow(balanced.Chosen, true, rejections, colorize))
+	}
+
+	for _, instance := range balanced.Rejected {
+		rows = append(rows, generateRow(instance, false, rejections, colorize))
+	}
+
+	if len(rows) > 0 {
+		_ = render.Table(io.Out, fmt.Sprintf("Balancing response for %s", appName), rows, "✓", "ID", "State", "Region", "Healthy", "Load", "RTT", "Rejection")
+
+		if len(rejections) > 0 {
+			fmt.Fprintln(io.Out, "")
+			fmt.Fprintf(io.Out, "Rejection reasons descriptions:\n")
+			for id, desc := range rejections {
+				fmt.Fprintf(io.Out, "  - %s: %s\n", colorize.Bold(id), desc)
+			}
+		}
+	} else {
+		fmt.Fprintf(io.Out, "No instances found for balancing.\n")
+	}
+
+	return nil
+}
+
+func generateRow(instance *flyproxy.BalancedInstance, chosen bool, rejections map[string]string, colorize *iostreams.ColorScheme) []string {
+	healthy := "yes"
+	if !instance.NodeHealthy {
+		healthy = colorize.Yellow("no (host)")
+	}
+	if !instance.Healthy {
+		healthy = colorize.Red("no")
+	}
+	rejected := ""
+	if instance.Rejection != nil {
+		rejected = instance.Rejection.ID
+		rejections[instance.Rejection.ID] = instance.Rejection.Desc
+	}
+
+	chosenStr := ""
+	if chosen {
+		chosenStr = colorize.Green("✓")
+	} else {
+		chosenStr = colorize.Gray("✘")
+	}
+
+	rtt := fmt.Sprintf("%.2fms", instance.NodeRttMs)
+	if instance.NodeRttMs <= 60.0 {
+		rtt = colorize.Green(rtt)
+	} else if instance.NodeRttMs <= 120.0 {
+		rtt = colorize.Yellow(rtt)
+	} else {
+		rtt = colorize.Red(rtt)
+	}
+
+	return []string{
+		chosenStr, instance.ID, instance.State, instance.Region, healthy, strconv.Itoa(instance.Concurrency), rtt, rejected,
+	}
+}

--- a/internal/command/proxy/balance.go
+++ b/internal/command/proxy/balance.go
@@ -86,7 +86,7 @@ func runBalance(ctx context.Context) (err error) {
 		return err
 	}
 
-	fmt.Fprintf(io.Out, "%d instances were eligible for balancing %s.\n\n", balanced.Total, appName)
+	fmt.Fprintf(io.Out, "%d instances were eligible for balancing app: %s, destination: %s/%d.\n\n", balanced.Total, appName, balanced.Destination.Proto, balanced.Destination.Port)
 
 	rows := [][]string{}
 
@@ -101,7 +101,7 @@ func runBalance(ctx context.Context) (err error) {
 	}
 
 	if len(rows) > 0 {
-		_ = render.Table(io.Out, fmt.Sprintf("Balancing response for %s", appName), rows, "", "ID", "State", "Region", "Healthy", "Load", "RTT", "Rejection")
+		_ = render.Table(io.Out, fmt.Sprintf("Balancing response for %s (%s/%d)", appName, balanced.Destination.Proto, balanced.Destination.Port), rows, "", "ID", "State", "Region", "Healthy", "Load", "RTT", "Rejection")
 
 		if len(rejections) > 0 {
 			fmt.Fprintln(io.Out, "")

--- a/internal/command/proxy/balance.go
+++ b/internal/command/proxy/balance.go
@@ -32,6 +32,11 @@ func newBalance() *cobra.Command {
 		flag.App(),
 		flag.AppConfig(),
 		flag.Org(),
+		flag.String{
+			Name:        "dest",
+			Shorthand:   "d",
+			Description: "Destination to test for in the form of tcp/<port> or common protocol names (e.g. 'https', 'ssh')",
+		},
 	)
 
 	return cmd
@@ -75,7 +80,7 @@ func runBalance(ctx context.Context) (err error) {
 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	balanced, err := client.Balance(ctx, appName)
+	balanced, err := client.Balance(ctx, appName, &flyproxy.BalanceOptions{Destination: flag.GetString(ctx, "dest")})
 
 	if err != nil {
 		return err
@@ -96,7 +101,7 @@ func runBalance(ctx context.Context) (err error) {
 	}
 
 	if len(rows) > 0 {
-		_ = render.Table(io.Out, fmt.Sprintf("Balancing response for %s", appName), rows, "✓", "ID", "State", "Region", "Healthy", "Load", "RTT", "Rejection")
+		_ = render.Table(io.Out, fmt.Sprintf("Balancing response for %s", appName), rows, "", "ID", "State", "Region", "Healthy", "Load", "RTT", "Rejection")
 
 		if len(rejections) > 0 {
 			fmt.Fprintln(io.Out, "")

--- a/internal/command/proxy/forward.go
+++ b/internal/command/proxy/forward.go
@@ -16,14 +16,14 @@ import (
 	"github.com/superfly/flyctl/proxy"
 )
 
-func newStart() *cobra.Command {
+func newForward() *cobra.Command {
 	var (
 		long  = strings.Trim(`Proxies connections to a fly VM through a Wireguard tunnel The current application DNS is the default remote host`, "\n")
 		short = `Proxies connections to a fly VM`
-		usage = "start <local:remote> [remote_host]"
+		usage = "forward <local:remote> [remote_host]"
 	)
 
-	cmd := command.New(usage, short, long, runStart,
+	cmd := command.New(usage, short, long, runForward,
 		command.RequireSession, command.LoadAppNameIfPresent)
 
 	cmd.Args = cobra.RangeArgs(1, 2)
@@ -48,7 +48,7 @@ func newStart() *cobra.Command {
 	return cmd
 }
 
-func runStart(ctx context.Context) (err error) {
+func runForward(ctx context.Context) (err error) {
 	client := client.FromContext(ctx).API()
 	appName := appconfig.NameFromContext(ctx)
 	orgSlug := flag.GetString(ctx, "org")

--- a/internal/command/proxy/proxy.go
+++ b/internal/command/proxy/proxy.go
@@ -1,8 +1,13 @@
 package proxy
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/iostreams"
 )
 
 func New() *cobra.Command {
@@ -12,14 +17,49 @@ func New() *cobra.Command {
 		usage = "proxy <command>"
 	)
 
-	cmd := command.New(usage, short, long, nil)
-
-	cmd.Args = cobra.NoArgs
+	cmd := command.New(usage, short, long, runForwardWithDeprecationWarning)
 
 	cmd.AddCommand(
-		newStart(),
+		newForward(),
 		newBalance(),
 	)
 
+	// TODO: remove once we deprecate `fly proxy <local:remote> [remote_host]`
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+		flag.Org(),
+		flag.Bool{
+			Name:        "select",
+			Shorthand:   "s",
+			Default:     false,
+			Description: "Prompt to select from available instances from the current application",
+		},
+		flag.Bool{
+			Name:        "quiet",
+			Shorthand:   "q",
+			Description: "Don't print progress indicators for WireGuard",
+		},
+	)
+
 	return cmd
+}
+
+func runForwardWithDeprecationWarning(ctx context.Context) (err error) {
+	io := iostreams.FromContext(ctx)
+	colorize := io.ColorScheme()
+
+	fmt.Fprintln(io.Out, colorize.Yellow("`fly proxy <local:remote> [remote_host]` is deprecated in favor of `fly proxy forward <local:remote> [remote_host]`. Usage from `fly proxy` directly will be removed in a future version."))
+
+	ctx, err = command.RequireSession(ctx)
+	if err != nil {
+		return err
+	}
+
+	ctx, err = command.LoadAppNameIfPresent(ctx)
+	if err != nil {
+		return err
+	}
+
+	return runForward(ctx)
 }

--- a/internal/command/proxy/proxy.go
+++ b/internal/command/proxy/proxy.go
@@ -46,6 +46,12 @@ func New() *cobra.Command {
 }
 
 func runForwardWithDeprecationWarning(ctx context.Context) (err error) {
+	args := flag.Args(ctx)
+	if len(args) == 0 {
+		cmd := command.FromContext(ctx)
+		return cmd.Help()
+	}
+
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
 

--- a/internal/command/proxy/proxy.go
+++ b/internal/command/proxy/proxy.go
@@ -2,12 +2,11 @@ package proxy
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
-	"github.com/superfly/flyctl/iostreams"
+	"github.com/superfly/flyctl/internal/logger"
 )
 
 func New() *cobra.Command {
@@ -52,10 +51,8 @@ func runForwardWithDeprecationWarning(ctx context.Context) (err error) {
 		return cmd.Help()
 	}
 
-	io := iostreams.FromContext(ctx)
-	colorize := io.ColorScheme()
-
-	fmt.Fprintln(io.Out, colorize.Yellow("`fly proxy <local:remote> [remote_host]` is deprecated in favor of `fly proxy forward <local:remote> [remote_host]`. Usage from `fly proxy` directly will be removed in a future version."))
+	logger := logger.FromContext(ctx)
+	logger.Warn("`fly proxy <local:remote> [remote_host]` is deprecated in favor of `fly proxy forward <local:remote> [remote_host]`. Usage from `fly proxy` directly will be removed in a future version.")
 
 	ctx, err = command.RequireSession(ctx)
 	if err != nil {

--- a/internal/command/proxy/start.go
+++ b/internal/command/proxy/start.go
@@ -1,0 +1,119 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/agent"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/proxy"
+)
+
+func newStart() *cobra.Command {
+	var (
+		long  = strings.Trim(`Proxies connections to a fly VM through a Wireguard tunnel The current application DNS is the default remote host`, "\n")
+		short = `Proxies connections to a fly VM`
+		usage = "start <local:remote> [remote_host]"
+	)
+
+	cmd := command.New(usage, short, long, runStart,
+		command.RequireSession, command.LoadAppNameIfPresent)
+
+	cmd.Args = cobra.RangeArgs(1, 2)
+
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+		flag.Org(),
+		flag.Bool{
+			Name:        "select",
+			Shorthand:   "s",
+			Default:     false,
+			Description: "Prompt to select from available instances from the current application",
+		},
+		flag.Bool{
+			Name:        "quiet",
+			Shorthand:   "q",
+			Description: "Don't print progress indicators for WireGuard",
+		},
+	)
+
+	return cmd
+}
+
+func runStart(ctx context.Context) (err error) {
+	client := client.FromContext(ctx).API()
+	appName := appconfig.NameFromContext(ctx)
+	orgSlug := flag.GetString(ctx, "org")
+	args := flag.Args(ctx)
+	promptInstance := flag.GetBool(ctx, "select")
+
+	if promptInstance && appName == "" {
+		return errors.New("--app required when --select flag provided")
+	}
+
+	if orgSlug != "" {
+		_, err := client.GetOrganizationBySlug(ctx, orgSlug)
+		if err != nil {
+			return err
+		}
+	}
+
+	if appName == "" && orgSlug == "" {
+		org, err := prompt.Org(ctx)
+		if err != nil {
+			return err
+		}
+		orgSlug = org.Slug
+	}
+
+	// var app *api.App
+	if appName != "" {
+		app, err := client.GetAppBasic(ctx, appName)
+		if err != nil {
+			return err
+		}
+		orgSlug = app.Organization.Slug
+	}
+
+	agentclient, err := agent.Establish(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	// do this explicitly so we can get the DNS server address
+	_, err = agentclient.Establish(ctx, orgSlug)
+	if err != nil {
+		return err
+	}
+
+	dialer, err := agentclient.ConnectToTunnel(ctx, orgSlug)
+	if err != nil {
+		return err
+	}
+
+	ports := strings.Split(args[0], ":")
+
+	params := &proxy.ConnectParams{
+		Ports:            ports,
+		AppName:          appName,
+		OrganizationSlug: orgSlug,
+		Dialer:           dialer,
+		PromptInstance:   promptInstance,
+	}
+
+	if len(args) > 1 {
+		params.RemoteHost = args[1]
+	} else {
+		params.RemoteHost = fmt.Sprintf("%s.internal", appName)
+	}
+
+	return proxy.Connect(ctx, params)
+}


### PR DESCRIPTION
Changes:
- Adds a command `fly proxy balance` to run the load balancing logic on the wireguard gateway's proxy instance
- Moves the `fly proxy` command to `fly proxy forward` command
- Shows a deprecation warning if the `fly proxy` command is used without a subcommand

![image-redacted](https://user-images.githubusercontent.com/43325/236259906-5e0dbdf7-1a0b-49e2-b68d-3290df2c602e.png)
