### PR TITLE
Show price of Redis plans at creation time

### DIFF
--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -152,7 +152,7 @@ func Create(ctx context.Context, org *api.Organization, name string, region *api
 		var planOptions []string
 
 		for _, plan := range result.AddOnPlans.Nodes {
-			planOptions = append(planOptions, fmt.Sprintf("%s: %s Max Data Size", plan.DisplayName, plan.MaxDataSize))
+			planOptions = append(planOptions, fmt.Sprintf("%s: %s Max Data Size, ($%d / month)", plan.DisplayName, plan.MaxDataSize, plan.PricePerMonth))
 		}
 
 		err = prompt.Select(ctx, &planIndex, "Select an Upstash Redis plan", "", planOptions...)


### PR DESCRIPTION
```
? Optionally, choose one or more replica regions (can be changed later):
? Select an Upstash Redis plan  [Use arrows to move, type to filter]
> Free: 100 MB Max Data Size, ($0 / month)
  200M: 200 MB Max Data Size, ($10 / month)
  3G: 3 GB Max Data Size, ($90 / month)
```