### PR TITLE
Re-apply "Instrument calls to GraphQL API and Flaps" with fixes

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -17,8 +17,9 @@ import (
 )
 
 var (
-	baseURL  string
-	errorLog bool
+	baseURL      string
+	errorLog     bool
+	instrumenter InstrumentationService
 )
 
 // SetBaseURL - Sets the base URL for the API
@@ -29,6 +30,15 @@ func SetBaseURL(url string) {
 // SetErrorLog - Sets whether errors should be loddes
 func SetErrorLog(log bool) {
 	errorLog = log
+}
+
+func SetInstrumenter(i InstrumentationService) {
+	instrumenter = i
+}
+
+type InstrumentationService interface {
+	Begin()
+	End()
 }
 
 // Client - API client encapsulating the http and GraphQL clients
@@ -108,6 +118,9 @@ func (c *Client) Logger() Logger { return c.logger }
 
 // RunWithContext - Runs a GraphQL request within a Go context
 func (c *Client) RunWithContext(ctx context.Context, req *graphql.Request) (Query, error) {
+	instrumenter.Begin()
+	defer instrumenter.End()
+
 	var resp Query
 	err := c.client.Run(ctx, req, &resp)
 

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -17,14 +17,15 @@ import (
 
 	"github.com/google/go-querystring/query"
 	"github.com/samber/lo"
-	"github.com/superfly/flyctl/internal/metrics"
 
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/buildinfo"
+	"github.com/superfly/flyctl/internal/instrument"
 	"github.com/superfly/flyctl/internal/logger"
+	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/terminal"
 )
 
@@ -464,6 +465,9 @@ func (f *Client) Exec(ctx context.Context, machineID string, in *api.MachineExec
 }
 
 func (f *Client) sendRequest(ctx context.Context, method, endpoint string, in, out interface{}, headers map[string][]string) error {
+	timing := instrument.Flaps.Begin()
+	defer timing.End()
+
 	req, err := f.NewRequest(ctx, method, endpoint, in, headers)
 	if err != nil {
 		return err

--- a/flyctl/flyctl.go
+++ b/flyctl/flyctl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/helpers"
+	"github.com/superfly/flyctl/internal/instrument"
 	"github.com/superfly/flyctl/terminal"
 	"gopkg.in/yaml.v2"
 )
@@ -83,6 +84,7 @@ func initViper() {
 
 	api.SetBaseURL(viper.GetString(ConfigAPIBaseURL))
 	api.SetErrorLog(viper.GetBool(ConfigGQLErrorLogging))
+	api.SetInstrumenter(instrument.ApiAdapter)
 }
 
 func loadConfig() error {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -25,6 +25,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/instrument"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/internal/state"
@@ -288,6 +289,7 @@ func initClient(ctx context.Context) (context.Context, error) {
 	// TODO: refactor so that api package does NOT depend on global state
 	api.SetBaseURL(cfg.APIBaseURL)
 	api.SetErrorLog(cfg.LogGQLErrors)
+	api.SetInstrumenter(instrument.ApiAdapter)
 	c := client.FromToken(cfg.AccessToken)
 	logger.Debug("client initialized.")
 

--- a/internal/instrument/call.go
+++ b/internal/instrument/call.go
@@ -1,0 +1,71 @@
+package instrument
+
+import (
+	"sync"
+	"time"
+)
+
+var (
+	mu         sync.Mutex
+	GraphQL    CallInstrumenter
+	Flaps      CallInstrumenter
+	ApiAdapter = &ApiInstrumenter{Instrumenter: &GraphQL}
+)
+
+type CallInstrumenter struct {
+	metrics CallMetrics
+}
+
+type CallMetrics struct {
+	Calls    int
+	Duration float64
+}
+
+type CallTimer struct {
+	start   time.Time
+	metrics *CallMetrics
+}
+
+func (i *CallInstrumenter) Begin() CallTimer {
+	return CallTimer{
+		start:   time.Now(),
+		metrics: &i.metrics,
+	}
+}
+
+func (i *CallInstrumenter) Get() CallMetrics {
+	mu.Lock()
+	defer mu.Unlock()
+
+	return i.metrics
+}
+
+func (t *CallTimer) End() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	duration := time.Since(t.start).Seconds()
+
+	t.metrics.Calls += 1
+	t.metrics.Duration += duration
+}
+
+// adapter for the api package's instrumentation facade
+type ApiInstrumenter struct {
+	Instrumenter *CallInstrumenter
+	current      *CallTimer
+}
+
+func (s *ApiInstrumenter) Begin() {
+	if s.current != nil {
+		panic("nested instrument span!")
+	}
+
+	timing := s.Instrumenter.Begin()
+	s.current = &timing
+}
+
+func (s *ApiInstrumenter) End() {
+	s.current.End()
+	s.current = nil
+}

--- a/internal/metrics/command.go
+++ b/internal/metrics/command.go
@@ -2,21 +2,32 @@ package metrics
 
 import (
 	"context"
-	"github.com/spf13/cobra"
+	"sync"
 	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/instrument"
 )
 
 var (
 	processStartTime = time.Now()
 	commandContext   context.Context
+	mu               sync.Mutex
 )
 
-type commandTimingData struct {
-	Duration float64 `json:"duration_seconds"`
-	Command  string  `json:"command"`
+type commandStats struct {
+	Command         string  `json:"c"`
+	Duration        float64 `json:"d"`
+	GraphQLCalls    int     `json:"gc"`
+	GraphQLDuration float64 `json:"gd"`
+	FlapsCalls      int     `json:"fc"`
+	FlapsDuration   float64 `json:"fd"`
 }
 
 func RecordCommandContext(ctx context.Context) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	if commandContext != nil {
 		panic("called metrics.RecordCommandContext twice")
 	}
@@ -25,14 +36,22 @@ func RecordCommandContext(ctx context.Context) {
 }
 
 func RecordCommandFinish(cmd *cobra.Command) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	duration := time.Since(processStartTime)
 
-	data := commandTimingData{
-		Duration: duration.Seconds(),
-		Command:  cmd.CommandPath(),
-	}
+	graphql := instrument.GraphQL.Get()
+	flaps := instrument.Flaps.Get()
 
 	if commandContext != nil {
-		Send(commandContext, "command/duration", data)
+		Send(commandContext, "command/stats", commandStats{
+			Command:         cmd.CommandPath(),
+			Duration:        duration.Seconds(),
+			GraphQLCalls:    graphql.Calls,
+			GraphQLDuration: graphql.Duration,
+			FlapsCalls:      flaps.Calls,
+			FlapsDuration:   flaps.Duration,
+		})
 	}
 }


### PR DESCRIPTION
Sorry about the interruption @jsierles, I'm pretty sure the bug that was causing that error was a concurrency bug.

I've replaced the begin-end method pair in `api.InstrumentationService`, which relied on mutable state, with a single method to report a `time.Duration` directly. See this PR's second commit for the fix.

ref #2234 #2233