### PR TITLE
auto set rails console command

### DIFF
--- a/internal/appconfig/setters.go
+++ b/internal/appconfig/setters.go
@@ -153,6 +153,11 @@ func (c *Config) v1SetDockerCommand(cmd string) {
 	}
 }
 
+func (c *Config) SetConsoleCommand(cmd string) {
+	// no V1 compatibility for this feature
+	c.ConsoleCommand = cmd
+}
+
 func (c *Config) SetKillSignal(signal string) {
 	c.RawDefinition["kill_signal"] = signal
 	if signal != "" {

--- a/internal/command/launch/srcinfo.go
+++ b/internal/command/launch/srcinfo.go
@@ -276,6 +276,10 @@ func setAppconfigFromSrcinfo(ctx context.Context, srcInfo *scanner.SourceInfo, a
 		appConfig.SetDockerCommand(srcInfo.DockerCommand)
 	}
 
+	if srcInfo.ConsoleCommand != "" {
+		appConfig.SetConsoleCommand(srcInfo.ConsoleCommand)
+	}
+
 	if srcInfo.DockerEntrypoint != "" {
 		appConfig.SetDockerEntrypoint(srcInfo.DockerEntrypoint)
 	}

--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -26,8 +26,9 @@ func configureRails(sourceDir string, config *ScannerConfig) (*SourceInfo, error
 	}
 
 	s := &SourceInfo{
-		Family:   "Rails",
-		Callback: RailsCallback,
+		Family:         "Rails",
+		Callback:       RailsCallback,
+		ConsoleCommand: "/rails/bin/rails console",
 	}
 
 	// master.key comes with Rails apps from v5.2 onwards, but may not be present

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -56,6 +56,7 @@ type SourceInfo struct {
 	Concurrency                  map[string]int
 	Callback                     func(srcInfo *SourceInfo, options map[string]bool) error
 	HttpCheckPath                string
+	ConsoleCommand               string
 }
 
 type SourceFile struct {


### PR DESCRIPTION
Add console_command to fly.toml for Rails applications.