### PR TITLE
Fix bad import caused by command port

### DIFF
--- a/internal/command/wireguard/others.go
+++ b/internal/command/wireguard/others.go
@@ -3,10 +3,10 @@ package wireguard
 import (
 	"context"
 	"fmt"
-	"html/template"
 	"io"
 	"net"
 	"os"
+	"text/template"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/superfly/flyctl/api"


### PR DESCRIPTION
Fixes bug introduced by https://github.com/superfly/flyctl/commit/f05edf51c096a8feadef9f3dd41d450719386d14

Reported by @lillianberryfly: 
> trying to create a wireguard config and there's html escaping in my private key
> i.e. "tGw/DQ*&#43;*c59....."

