### PR TITLE
Clear `Standbys` if services are added

### DIFF
--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -120,6 +120,12 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 		mID = "" // Forces machine replacement
 	}
 
+	// If this is a standby machine that now has a service, then clear
+	// the standbys list.
+	if len(mConfig.Services) > 0 && len(mConfig.Standbys) > 0 {
+		mConfig.Standbys = nil
+	}
+
 	return &api.LaunchMachineInput{
 		ID:         mID,
 		Region:     origMachineRaw.Region,

--- a/internal/command/deploy/machines_launchinput_test.go
+++ b/internal/command/deploy/machines_launchinput_test.go
@@ -213,3 +213,27 @@ func Test_launchInputForUpdate_keepUnmanagedFields(t *testing.T) {
 	assert.Equal(t, &api.DNSConfig{SkipRegistration: true}, li.Config.DNS)
 	assert.Equal(t, []api.MachineProcess{{CmdOverride: []string{"foo"}}}, li.Config.Processes)
 }
+
+// Check that standby machines with services have their standbys list
+// cleared.
+func Test_launchInputForUpdate_clearStandbysWithServices(t *testing.T) {
+	md, err := stabMachineDeployment(&appconfig.Config{
+		AppName:       "my-cool-app",
+		PrimaryRegion: "scl",
+		HTTPService: &appconfig.HTTPService{
+			InternalPort: 8080,
+		},
+	})
+	require.NoError(t, err)
+
+	li, err := md.launchInputForUpdate(&api.Machine{
+		ID:     "ab1234567890",
+		Region: "scl",
+		Config: &api.MachineConfig{
+			Standbys: []string{"xy0987654321"},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, len(li.Config.Standbys))
+}


### PR DESCRIPTION
This makes `fly deploy` clear `Standbys` from machines if services are added, per #2162.