### PR TITLE
[django] Auto set django console command

### DIFF
--- a/scanner/django.go
+++ b/scanner/django.go
@@ -39,7 +39,7 @@ func configureDjango(sourceDir string, config *ScannerConfig) (*SourceInfo, erro
 				UrlPrefix: "/static/",
 			},
 		},
-		SkipDeploy: true,
+		SkipDeploy:     true,
 		ConsoleCommand: "/code/manage.py shell",
 	}
 

--- a/scanner/django.go
+++ b/scanner/django.go
@@ -40,6 +40,7 @@ func configureDjango(sourceDir string, config *ScannerConfig) (*SourceInfo, erro
 			},
 		},
 		SkipDeploy: true,
+		ConsoleCommand: "/code/manage.py shell",
 	}
 
 	vars := make(map[string]interface{})


### PR DESCRIPTION
Auto set `console_command` on fly.toml for Django apps on `fly launch`:

```
console_command = "/code/manage.py shell"
```

Reference: https://community.fly.io/t/easily-run-a-console-in-a-new-machine-with-fly-console/12773