### PR TITLE
Skip GetAppCompact in machines list

### DIFF
--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -57,18 +57,14 @@ type newClientOpts struct {
 
 func newWithOptions(ctx context.Context, opts newClientOpts) (*Client, error) {
 	app := opts.AppCompact
-	appName := opts.AppName
-	if app != nil {
-		appName = app.Name
-	}
 	// FIXME: do this once we setup config for `fly config ...` commands, and then use cfg.FlapsBaseURL below
 	// cfg := config.FromContext(ctx)
 	var err error
 	flapsBaseURL := os.Getenv("FLY_FLAPS_BASE_URL")
 	if strings.TrimSpace(strings.ToLower(flapsBaseURL)) == "peer" {
-		app, err = resolveApp(ctx, app, appName)
+		app, err = resolveApp(ctx, app, opts.AppName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get app '%s': %w", appName, err)
+			return nil, fmt.Errorf("failed to get app '%s': %w", opts.AppName, err)
 		}
 		return newWithUsermodeWireguard(ctx, wireguardConnectionParams{
 			appName: opts.AppName,
@@ -90,7 +86,7 @@ func newWithOptions(ctx context.Context, opts newClientOpts) (*Client, error) {
 		return nil, fmt.Errorf("flaps: can't setup HTTP client to %s: %w", flapsUrl.String(), err)
 	}
 	return &Client{
-		appName:    appName,
+		appName:    opts.AppName,
 		baseUrl:    flapsUrl,
 		authToken:  flyctl.GetAPIToken(),
 		httpClient: httpClient,

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -51,13 +51,13 @@ func NewFromAppName(ctx context.Context, appName string) (*Client, error) {
 
 type newClientOpts struct {
 	// required:
-	AppName    string
+	AppName string
 
 	// optional, avoids API roundtrip when connecting to flaps by wireguard:
 	AppCompact *api.AppCompact
 
 	// optional:
-	Logger     api.Logger
+	Logger api.Logger
 }
 
 func newWithOptions(ctx context.Context, opts newClientOpts) (*Client, error) {

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -42,14 +42,14 @@ type Client struct {
 }
 
 func New(ctx context.Context, app *api.AppCompact) (*Client, error) {
-	return newWithOptions(ctx, newClientOpts{AppCompact: app, AppName: app.Name})
+	return NewWithOptions(ctx, NewClientOpts{AppCompact: app, AppName: app.Name})
 }
 
 func NewFromAppName(ctx context.Context, appName string) (*Client, error) {
-	return newWithOptions(ctx, newClientOpts{AppName: appName})
+	return NewWithOptions(ctx, NewClientOpts{AppName: appName})
 }
 
-type newClientOpts struct {
+type NewClientOpts struct {
 	// required:
 	AppName string
 
@@ -60,7 +60,7 @@ type newClientOpts struct {
 	Logger api.Logger
 }
 
-func newWithOptions(ctx context.Context, opts newClientOpts) (*Client, error) {
+func NewWithOptions(ctx context.Context, opts NewClientOpts) (*Client, error) {
 	// FIXME: do this once we setup config for `fly config ...` commands, and then use cfg.FlapsBaseURL below
 	// cfg := config.FromContext(ctx)
 	var err error

--- a/internal/command/machine/list.go
+++ b/internal/command/machine/list.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
-	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -50,26 +49,12 @@ func newList() *cobra.Command {
 func runMachineList(ctx context.Context) (err error) {
 	var (
 		appName = appconfig.NameFromContext(ctx)
-		client  = client.FromContext(ctx).API()
 		io      = iostreams.FromContext(ctx)
 		silence = flag.GetBool(ctx, "quiet")
 		cfg     = config.FromContext(ctx)
 	)
 
-	app, err := client.GetAppCompact(ctx, appName)
-	if err != nil {
-		help := newList().Help()
-
-		if help != nil {
-			fmt.Println(help)
-
-		}
-
-		fmt.Println()
-
-		return err
-	}
-	flapsClient, err := flaps.New(ctx, app)
+	flapsClient, err := flaps.NewFromAppName(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("list of machines could not be retrieved: %w", err)
 	}


### PR DESCRIPTION
The Flaps client actually doesn't need `AppCompact` in the happy-path case. Only in the case that the user has set `FLY_FLAPS_BASE_URL=peer` indicating that we should hit Flaps over Wireguard rather than `https://api.machines.dev/` do we need the app organization slug, and so we can defer calling `GetAppCompact` until then.