### PR TITLE
Check that app is listening on the correct address during deployment

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -581,3 +581,21 @@ type MachineExecResponse struct {
 	StdOut   string `json:"stdout,omitempty"`
 	StdErr   string `json:"stderr,omitempty"`
 }
+
+type MachinePsResponse []ProcessStat
+
+type ProcessStat struct {
+	Pid           int32          `json:"pid"`
+	Stime         uint64         `json:"stime"`
+	Rtime         uint64         `json:"rtime"`
+	Command       string         `json:"command"`
+	Directory     string         `json:"directory"`
+	Cpu           uint64         `json:"cpu"`
+	Rss           uint64         `json:"rss"`
+	ListenSockets []ListenSocket `json:"listen_sockets"`
+}
+
+type ListenSocket struct {
+	Proto   string `json:"proto"`
+	Address string `json:"address"`
+}

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -464,6 +464,19 @@ func (f *Client) Exec(ctx context.Context, machineID string, in *api.MachineExec
 	return out, nil
 }
 
+func (f *Client) GetProcesses(ctx context.Context, machineID string) (api.MachinePsResponse, error) {
+	endpoint := fmt.Sprintf("/%s/ps", machineID)
+
+	var out api.MachinePsResponse
+
+	err := f.sendRequest(ctx, http.MethodGet, endpoint, nil, &out, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get processes from VM %s: %w", machineID, err)
+	}
+
+	return out, nil
+}
+
 func (f *Client) sendRequest(ctx context.Context, method, endpoint string, in, out interface{}, headers map[string][]string) error {
 	timing := instrument.Flaps.Begin()
 	defer timing.End()

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -70,6 +70,7 @@ type machineDeployment struct {
 	isFirstDeploy         bool
 	machineGuest          *api.MachineGuest
 	increasedAvailability bool
+	listenAddressChecked  map[string]struct{}
 }
 
 func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (MachineDeployment, error) {
@@ -130,6 +131,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		leaseTimeout:          leaseTimeout,
 		leaseDelayBetween:     leaseDelayBetween,
 		increasedAvailability: args.IncreasedAvailability,
+		listenAddressChecked:  make(map[string]struct{}),
 	}
 	if err := md.setStrategy(args.Strategy); err != nil {
 		return nil, err


### PR DESCRIPTION
The PR adds an additional check during Apps V2 deploy. flyctl now verifies that 
an app is listening on the correct address (0.0.0.0) and internal_port for each
service defined in fly.toml. If that's not the case, a warning is shown for
the first machine in each process group:

```
Watch your app at https://fly.io/apps/pbor-test/monitoring

Updating existing machines in 'pbor-test' with rolling strategy
  [1/2] Machine 4d89169ef66698 [app] update finished: success

WARNING The app is listening on the incorrect address and will not be reachable by fly-proxy.
Make sure your app is listening on the following addresses:
  - 0.0.0.0:8080
Found these processes inside the machine with open listening sockets:
  PROCESS        | ADDRESSES                             
-----------------*---------------------------------------
  /app           | 127.0.0.1:8080                        
  /.fly/hallpass | [fdaa:1:d615:a7b:13b:3d2c:8f58:2]:22

  [2/2] Machine 9185793eb11048 [app] update finished: success
  Finished deploying
```
