### PR TITLE
Sync docs on successful releases (except prereleases)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
   sync_docs:
     needs: release
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ !contains(github.ref, 'pre') }}
     steps:
       - name: Checkout flyctl
         uses: actions/checkout@v3


### PR DESCRIPTION
I think this isn't happening because releases are never run for pushes to `master`, only for tags. I updated the `if` condition to match the `aur-publish` job. Between requiring `release` and rejecting refs with `pre`, I *think* this should run only for non-prerelease releases.

Would appreciate double-checking from somebody with more experience with GitHub Actions!