### PR TITLE
poc: support running a minimum number of machines

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -441,6 +441,7 @@ type MachineService struct {
 	InternalPort             int                        `json:"internal_port,omitempty" toml:"internal_port,omitempty"`
 	Autostop                 *bool                      `json:"autostop,omitempty"`
 	Autostart                *bool                      `json:"autostart,omitempty"`
+	MinRunningMachines       *int                       `json:"min_running_machines,omitempty"`
 	Ports                    []MachinePort              `json:"ports,omitempty" toml:"ports,omitempty"`
 	Checks                   []MachineCheck             `json:"checks,omitempty" toml:"checks,omitempty"`
 	Concurrency              *MachineServiceConcurrency `json:"concurrency,omitempty" toml:"concurrency"`

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -113,8 +113,12 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 	// Services
 	mConfig.Services = nil
 	if services := c.AllServices(); len(services) > 0 {
-		mConfig.Services = lo.Map(services, func(s Service, _ int) api.MachineService {
-			return *s.toMachineService()
+		mConfig.Services = lo.Map(services, func(s Service, idx int) api.MachineService {
+			svc := *s.toMachineService()
+			if src != nil {
+				svc.Autostop = src.Services[idx].Autostop
+			}
+			return svc
 		})
 	}
 

--- a/internal/appconfig/service.go
+++ b/internal/appconfig/service.go
@@ -9,15 +9,16 @@ import (
 )
 
 type Service struct {
-	Protocol          string                         `json:"protocol,omitempty" toml:"protocol"`
-	InternalPort      int                            `json:"internal_port,omitempty" toml:"internal_port"`
-	AutoStopMachines  *bool                          `json:"auto_stop_machines,omitempty" toml:"auto_stop_machines,omitempty"`
-	AutoStartMachines *bool                          `json:"auto_start_machines,omitempty" toml:"auto_start_machines,omitempty"`
-	Ports             []api.MachinePort              `json:"ports,omitempty" toml:"ports"`
-	Concurrency       *api.MachineServiceConcurrency `json:"concurrency,omitempty" toml:"concurrency"`
-	TCPChecks         []*ServiceTCPCheck             `json:"tcp_checks,omitempty" toml:"tcp_checks,omitempty"`
-	HTTPChecks        []*ServiceHTTPCheck            `json:"http_checks,omitempty" toml:"http_checks,omitempty"`
-	Processes         []string                       `json:"processes,omitempty" toml:"processes,omitempty"`
+	Protocol           string                         `json:"protocol,omitempty" toml:"protocol"`
+	InternalPort       int                            `json:"internal_port,omitempty" toml:"internal_port"`
+	AutoStopMachines   *bool                          `json:"auto_stop_machines,omitempty" toml:"auto_stop_machines,omitempty"`
+	AutoStartMachines  *bool                          `json:"auto_start_machines,omitempty" toml:"auto_start_machines,omitempty"`
+	MinRunningMachines *int                           `json:"min_running_machines,omitempty" toml:"min_running_machines,omitempty"`
+	Ports              []api.MachinePort              `json:"ports,omitempty" toml:"ports"`
+	Concurrency        *api.MachineServiceConcurrency `json:"concurrency,omitempty" toml:"concurrency"`
+	TCPChecks          []*ServiceTCPCheck             `json:"tcp_checks,omitempty" toml:"tcp_checks,omitempty"`
+	HTTPChecks         []*ServiceHTTPCheck            `json:"http_checks,omitempty" toml:"http_checks,omitempty"`
+	Processes          []string                       `json:"processes,omitempty" toml:"processes,omitempty"`
 }
 
 type ServiceTCPCheck struct {
@@ -44,15 +45,16 @@ type ServiceHTTPCheck struct {
 }
 
 type HTTPService struct {
-	InternalPort      int                            `json:"internal_port,omitempty" toml:"internal_port,omitempty" validate:"required,numeric"`
-	ForceHTTPS        bool                           `toml:"force_https,omitempty" json:"force_https,omitempty"`
-	AutoStopMachines  *bool                          `json:"auto_stop_machines,omitempty" toml:"auto_stop_machines,omitempty"`
-	AutoStartMachines *bool                          `json:"auto_start_machines,omitempty" toml:"auto_start_machines,omitempty"`
-	Processes         []string                       `json:"processes,omitempty" toml:"processes,omitempty"`
-	Concurrency       *api.MachineServiceConcurrency `toml:"concurrency,omitempty" json:"concurrency,omitempty"`
-	TLSOptions        *api.TLSOptions                `json:"tls_options,omitempty" toml:"tls_options,omitempty"`
-	HTTPOptions       *api.HTTPOptions               `json:"http_options,omitempty" toml:"http_options,omitempty"`
-	ProxyProtoOptions *api.ProxyProtoOptions         `json:"proxy_proto_options,omitempty" toml:"proxy_proto_options,omitempty"`
+	InternalPort       int                            `json:"internal_port,omitempty" toml:"internal_port,omitempty" validate:"required,numeric"`
+	ForceHTTPS         bool                           `toml:"force_https,omitempty" json:"force_https,omitempty"`
+	AutoStopMachines   *bool                          `json:"auto_stop_machines,omitempty" toml:"auto_stop_machines,omitempty"`
+	AutoStartMachines  *bool                          `json:"auto_start_machines,omitempty" toml:"auto_start_machines,omitempty"`
+	MinRunningMachines *int                           `json:"min_running_machines,omitempty" toml:"min_running_machines,omitempty"`
+	Processes          []string                       `json:"processes,omitempty" toml:"processes,omitempty"`
+	Concurrency        *api.MachineServiceConcurrency `toml:"concurrency,omitempty" json:"concurrency,omitempty"`
+	TLSOptions         *api.TLSOptions                `json:"tls_options,omitempty" toml:"tls_options,omitempty"`
+	HTTPOptions        *api.HTTPOptions               `json:"http_options,omitempty" toml:"http_options,omitempty"`
+	ProxyProtoOptions  *api.ProxyProtoOptions         `json:"proxy_proto_options,omitempty" toml:"proxy_proto_options,omitempty"`
 }
 
 func (s *HTTPService) ToService() *Service {
@@ -76,6 +78,7 @@ func (s *HTTPService) ToService() *Service {
 		}},
 		AutoStopMachines:  s.AutoStopMachines,
 		AutoStartMachines: s.AutoStartMachines,
+		MinRunningMachines: s.MinRunningMachines,
 	}
 }
 
@@ -95,6 +98,7 @@ func (svc *Service) toMachineService() *api.MachineService {
 		Concurrency:  svc.Concurrency,
 		Autostop:     svc.AutoStopMachines,
 		Autostart:    svc.AutoStartMachines,
+		MinRunningMachines: svc.MinRunningMachines,
 	}
 
 	for _, tc := range svc.TCPChecks {


### PR DESCRIPTION
POC to support running a minimum number of machines. This absolutely does not work yet and the code is horrific (noob Gopher here) and there's some hardcoded values while I try test it locally but I'm keen to get some feedback. I think there's a bunch of plumbing I need to actually get it working.

1. A user sets a number of minimum machines to run in `fly.toml`
1. We restrict this to only work on the primary region. The minimum number of machines will all be run in the primary region.
    1. If the number of minimum machines is larger than the number of machines in the primary region, we issue a warning and all machines in the primary region are set to keep running
1. We set `autostop = false` on the number of machines specified by the user for the given process group.
