### PR TITLE
Ignore HTTP_PROXY for tunneled remote builder connections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/docker/cli v20.10.7+incompatible // indirect
 	github.com/docker/distribution v2.8.0+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/docker/libnetwork v0.8.0-dev.2.0.20200917202933-d0951081b35f // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect


### PR DESCRIPTION
If host-wide HTTP_PROXY is set, `flyctl` fails to connect to the
remote builder because Docker client tries to connect to the daemon
via proxy.
We can't really proxy request to remote builder, as the proxy knows
nothing about the tunnel established by `fly agent`.

So, use a custom HTTP client for Docker that ignores proxy settings
from environment.
