### PR TITLE
Add `Dockerfile` to build context regardless of path

### DIFF
--- a/internal/build/imgsrc/archive_test.go
+++ b/internal/build/imgsrc/archive_test.go
@@ -159,17 +159,39 @@ func TestArchiverNoCompressionWithAdditions(t *testing.T) {
 }
 
 func TestParseDockerignore(t *testing.T) {
-	cases := map[string][]string{
-		"node_modules\n*.jpg":                {"node_modules", "*.jpg"},
-		"node_modules\n*.jpg\nDockerfile":    {"node_modules", "*.jpg", "Dockerfile", "![Dd]ockerfile"},
-		"node_modules\n*.jpg\ndockerfile":    {"node_modules", "*.jpg", "dockerfile", "![Dd]ockerfile"},
-		"node_modules\n*.jpg\n.dockerignore": {"node_modules", "*.jpg", ".dockerignore", "!.dockerignore"},
+	type testCase struct {
+		input      string
+		dockerfile string
+		expected   []string
+	}
+	cases := []testCase{
+		{
+			input:    "node_modules\n*.jpg",
+			expected: []string{"node_modules", "*.jpg"},
+		},
+		{
+			input:    "node_modules\n*.jpg\nDockerfile",
+			expected: []string{"node_modules", "*.jpg", "Dockerfile", "![Dd]ockerfile"},
+		},
+		{
+			input:    "node_modules\n*.jpg\ndockerfile",
+			expected: []string{"node_modules", "*.jpg", "dockerfile", "![Dd]ockerfile"},
+		},
+		{
+			input:    "node_modules\n*.jpg\n.dockerignore",
+			expected: []string{"node_modules", "*.jpg", ".dockerignore", "!.dockerignore"},
+		},
+		{
+			input:      "node_modules\n*.jpg\nDockerfile\nbuild/Dockerfile",
+			dockerfile: "build/Dockerfile",
+			expected:   []string{"node_modules", "*.jpg", "Dockerfile", "build/Dockerfile", "!build/Dockerfile"},
+		},
 	}
 
-	for input, expected := range cases {
-		excludes, err := parseDockerignore(strings.NewReader(input))
+	for _, c := range cases {
+		excludes, err := parseDockerignore(strings.NewReader(c.input), c.dockerfile)
 		assert.NoError(t, err)
-		assert.Equal(t, expected, excludes, input)
+		assert.Equal(t, c.expected, excludes, c.input)
 	}
 }
 

--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -72,7 +72,7 @@ func (*buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 	cmdfmt.PrintDone(streams.ErrOut, msg)
 
 	build.ContextBuildStart()
-	excludes, err := readDockerignore(opts.WorkingDir, opts.IgnorefilePath)
+	excludes, err := readDockerignore(opts.WorkingDir, opts.IgnorefilePath, "")
 	if err != nil {
 		build.ContextBuildFinish()
 		build.BuildFinish()

--- a/internal/build/imgsrc/builtin_builder.go
+++ b/internal/build/imgsrc/builtin_builder.go
@@ -65,7 +65,7 @@ func (*builtinBuilder) Run(ctx context.Context, dockerFactory *dockerClientFacto
 		compressed: dockerFactory.IsRemote(),
 	}
 
-	excludes, err := readDockerignore(opts.WorkingDir, opts.IgnorefilePath)
+	excludes, err := readDockerignore(opts.WorkingDir, opts.IgnorefilePath, "")
 	if err != nil {
 		build.BuildFinish()
 		return nil, "", errors.Wrap(err, "error reading .dockerignore")

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -108,14 +108,6 @@ func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 		compressed: dockerFactory.IsRemote(),
 	}
 
-	excludes, err := readDockerignore(opts.WorkingDir, opts.IgnorefilePath)
-	if err != nil {
-		build.BuildFinish()
-		build.ContextBuildFinish()
-		return nil, "", errors.Wrap(err, "error reading .dockerignore")
-	}
-	archiveOpts.exclusions = excludes
-
 	var relativedockerfilePath string
 
 	// copy dockerfile into the archive if it's outside the context dir
@@ -141,6 +133,14 @@ func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 		// run in a Linux VM at the end.
 		relativedockerfilePath = filepath.ToSlash(p)
 	}
+
+	excludes, err := readDockerignore(opts.WorkingDir, opts.IgnorefilePath, relativedockerfilePath)
+	if err != nil {
+		build.BuildFinish()
+		build.ContextBuildFinish()
+		return nil, "", errors.Wrap(err, "error reading .dockerignore")
+	}
+	archiveOpts.exclusions = excludes
 
 	// Start tracking this build
 


### PR DESCRIPTION
The `Dockerfile` must always be in the build context sent to the Docker daemon, even if it's covered by `.dockerignore`. See issue #2245. (For reference, `docker build` ensures that the `Dockerfile` is sent to the daemon [here](https://github.com/docker/cli/blob/bc3f905a2aa9e7ea84591851860b820bb31caa07/cli/command/image/build/dockerignore.go#L28), and the daemon itself removes the `Dockerfile` if it's in `.dockerignore` [here](https://github.com/moby/moby/blob/f70d9933d160b12b8d6247c77e721c94fae9eefe/builder/remotecontext/detect.go#L117), I think.)

Right now we make sure that `/Dockerfile` and `/dockerfile` are added to the build context even if they're excluded by the `.dockerignore`. However, if the `Dockerfile` is located elsewhere, we should add an override for *that* path instead. Otherwise, it isn't sent to the daemon and it results in an error like the one shown in #2245.

Admittedly, this might cause strange behavior if the `Dockerfile` path has any characters with special meaning for `.dockerignore` matching rules (e.g. `*` and `?`). However, `docker build` itself [doesn't](https://github.com/docker/cli/blob/bc3f905a2aa9e7ea84591851860b820bb31caa07/cli/command/image/build/dockerignore.go#L39) seem to worry about this, so I think it'll be fine.

PR #1213 (now closed) was in part a WIP fix for this, and I arrived at more or less the same thing. So thanks to jacobgreenleaf for taking the first look at this!