### PR TITLE
Deprecate creating new apps v1 apps

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -64,8 +64,9 @@ var CommonFlags = flag.Set{
 	},
 	flag.Bool{
 		Name:        "force-nomad",
-		Description: "Use the Apps v1 platform built with Nomad",
+		Description: "(Deprecated) Use the Apps v1 platform built with Nomad",
 		Default:     false,
+		Hidden:      true,
 	},
 	flag.Bool{
 		Name:        "force-machines",

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/iostreams"
@@ -248,6 +249,12 @@ func deployToNomad(ctx context.Context, appConfig *appconfig.Config, appCompact 
 	release, releaseCommand, err := createRelease(ctx, appConfig, img)
 	if err != nil {
 		return err
+	}
+
+	// Give a warning about nomad deprecation every 5 releases
+	if release.Version%5 == 0 {
+		io := iostreams.FromContext(ctx)
+		fmt.Fprintf(io.ErrOut, "%s Apps v1 Platform is deprecated. We recommend migrating your app with `fly migrate-to-v2`", aurora.Yellow("WARN"))
 	}
 
 	if flag.GetDetach(ctx) {

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -401,7 +401,7 @@ func (md *machineDeployment) setStrategy(passedInStrategy string) error {
 }
 
 func MachineSupportedStrategy(strategy string) bool {
-	return strategy == "rolling" || strategy == "immediate"
+	return strategy == "rolling" || strategy == "immediate" || strategy == ""
 }
 
 func (md *machineDeployment) createReleaseInBackend(ctx context.Context) error {

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -394,10 +394,14 @@ func (md *machineDeployment) setStrategy(passedInStrategy string) error {
 	} else {
 		md.strategy = "rolling"
 	}
-	if md.strategy != "rolling" && md.strategy != "immediate" {
+	if !MachineSupportedStrategy(md.strategy) {
 		return fmt.Errorf("error unsupported deployment strategy '%s'; fly deploy for machines supports rolling and immediate strategies", md.strategy)
 	}
 	return nil
+}
+
+func MachineSupportedStrategy(strategy string) bool {
+	return strategy == "rolling" || strategy == "immediate"
 }
 
 func (md *machineDeployment) createReleaseInBackend(ctx context.Context) error {

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -180,8 +180,9 @@ func run(ctx context.Context) (err error) {
 		return err
 	}
 
-	if !shouldUseMachines {
-		fmt.Fprintf(io.ErrOut, "%s Apps v1 Platform is deprecated. Please use the --force-machines flag", aurora.Yellow("WARN"))
+	using_appsv1_only_feature := !deploy.MachineSupportedStrategy(flag.GetString(ctx, "strategy"))
+	if !shouldUseMachines && !using_appsv1_only_feature {
+		fmt.Fprintf(io.ErrOut, "%s Apps v1 Platform is deprecated. We recommend using the --force-machines flag", aurora.Yellow("WARN"))
 	}
 
 	var envVars map[string]string = nil

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
@@ -172,11 +173,15 @@ func run(ctx context.Context) (err error) {
 	}
 	// Do not change PrimaryRegion after this line
 	appConfig.PrimaryRegion = region.Code
-	fmt.Fprintf(io.Out, "App will use '%s' region as primary\n", appConfig.PrimaryRegion)
+	fmt.Fprintf(io.Out, "App will use '%s' region as primary\n\n", appConfig.PrimaryRegion)
 
 	shouldUseMachines, err := shouldAppUseMachinesPlatform(ctx, org.Slug, existingAppPlatform)
 	if err != nil {
 		return err
+	}
+
+	if !shouldUseMachines {
+		fmt.Fprintf(io.ErrOut, "%s Apps v1 Platform is deprecated. Please use the --force-machines flag", aurora.Yellow("WARN"))
 	}
 
 	var envVars map[string]string = nil

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -182,7 +182,7 @@ func run(ctx context.Context) (err error) {
 
 	using_appsv1_only_feature := !deploy.MachineSupportedStrategy(flag.GetString(ctx, "strategy"))
 	if !shouldUseMachines && !using_appsv1_only_feature {
-		fmt.Fprintf(io.ErrOut, "%s Apps v1 Platform is deprecated. We recommend using the --force-machines flag\n", aurora.Yellow("WARN"))
+		fmt.Fprintf(io.ErrOut, "%s Apps v1 Platform is deprecated. We recommend using the --force-machines flag, or setting\nyour organization's default for new apps to Apps v2 with 'fly orgs apps-v2 default-on <org-name>'\n", aurora.Yellow("WARN"))
 	}
 
 	var envVars map[string]string = nil

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -182,7 +182,7 @@ func run(ctx context.Context) (err error) {
 
 	using_appsv1_only_feature := !deploy.MachineSupportedStrategy(flag.GetString(ctx, "strategy"))
 	if !shouldUseMachines && !using_appsv1_only_feature {
-		fmt.Fprintf(io.ErrOut, "%s Apps v1 Platform is deprecated. We recommend using the --force-machines flag", aurora.Yellow("WARN"))
+		fmt.Fprintf(io.ErrOut, "%s Apps v1 Platform is deprecated. We recommend using the --force-machines flag\n", aurora.Yellow("WARN"))
 	}
 
 	var envVars map[string]string = nil


### PR DESCRIPTION
Should this be expanded to all actions that touch apps v1?

Edit: It's been decided that for now, we'll just give warnings on deploys.