### PR TITLE
Disallow `experimental` features in V2 configs

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -102,12 +102,13 @@ type Build struct {
 }
 
 type Experimental struct {
-	Cmd          []string `toml:"cmd,omitempty" json:"cmd,omitempty"`
-	Entrypoint   []string `toml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
-	Exec         []string `toml:"exec,omitempty" json:"exec,omitempty"`
-	AutoRollback bool     `toml:"auto_rollback,omitempty" json:"auto_rollback,omitempty"`
-	EnableConsul bool     `toml:"enable_consul,omitempty" json:"enable_consul,omitempty"`
-	EnableEtcd   bool     `toml:"enable_etcd,omitempty" json:"enable_etcd,omitempty"`
+	Cmd                []string `toml:"cmd,omitempty" json:"cmd,omitempty"`
+	Entrypoint         []string `toml:"entrypoint,omitempty" json:"entrypoint,omitempty"`
+	Exec               []string `toml:"exec,omitempty" json:"exec,omitempty"`
+	AutoRollback       bool     `toml:"auto_rollback,omitempty" json:"auto_rollback,omitempty"`
+	EnableConsul       bool     `toml:"enable_consul,omitempty" json:"enable_consul,omitempty"`
+	EnableEtcd         bool     `toml:"enable_etcd,omitempty" json:"enable_etcd,omitempty"`
+	AllowedPublicPorts []int    `toml:"allowed_public_ports,omitempty" json:"allowed_public_ports,omitempty"`
 }
 
 func (c *Config) ConfigFilePath() string {

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -125,25 +125,8 @@ func (cfg *Config) validateNoExperimental() (extraInfo string, err error) {
 		return
 	}
 
-	if len(cfg.Experimental.Cmd) != 0 {
-		extraInfo += "Experimental.cmd is not supported in Apps V2\n"
-		err = ValidationError
-	}
-	if len(cfg.Experimental.Entrypoint) != 0 {
-		extraInfo += "Experimental.entrypoint is not supported in Apps V2\n"
-		err = ValidationError
-	}
-	if len(cfg.Experimental.Exec) != 0 {
-		extraInfo += "Experimental.exec is not supported in Apps V2\n"
-		err = ValidationError
-	}
-	// Ignore Experimental.AutoRollback
-	if cfg.Experimental.EnableConsul {
-		extraInfo += "Experimental.enable_consul is not supported in Apps V2\n"
-		err = ValidationError
-	}
-	if cfg.Experimental.EnableEtcd {
-		extraInfo += "Experimental.enable_etcd is not supported in Apps V2\n"
+	if len(cfg.Experimental.AllowedPublicPorts) != 0 {
+		extraInfo += "experimental.allowed_public_ports is not supported in Apps V2\n"
 		err = ValidationError
 	}
 	return

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -96,6 +96,7 @@ func (cfg *Config) ValidateForMachinesPlatform(ctx context.Context) (err error, 
 		cfg.validateProcessesSection,
 		cfg.validateMachineConversion,
 		cfg.validateConsoleCommand,
+		cfg.validateNoExperimental,
 	}
 
 	for _, vFunc := range validators {
@@ -117,6 +118,35 @@ func (cfg *Config) ValidateForMachinesPlatform(ctx context.Context) (err error, 
 
 	extra_info += fmt.Sprintf("%s Configuration is valid\n", aurora.Green("✓"))
 	return nil, extra_info
+}
+
+func (cfg *Config) validateNoExperimental() (extraInfo string, err error) {
+	if cfg.Experimental == nil {
+		return
+	}
+
+	if len(cfg.Experimental.Cmd) != 0 {
+		extraInfo += "Experimental.cmd is not supported in Apps V2\n"
+		err = ValidationError
+	}
+	if len(cfg.Experimental.Entrypoint) != 0 {
+		extraInfo += "Experimental.entrypoint is not supported in Apps V2\n"
+		err = ValidationError
+	}
+	if len(cfg.Experimental.Exec) != 0 {
+		extraInfo += "Experimental.exec is not supported in Apps V2\n"
+		err = ValidationError
+	}
+	// Ignore Experimental.AutoRollback
+	if cfg.Experimental.EnableConsul {
+		extraInfo += "Experimental.enable_consul is not supported in Apps V2\n"
+		err = ValidationError
+	}
+	if cfg.Experimental.EnableEtcd {
+		extraInfo += "Experimental.enable_etcd is not supported in Apps V2\n"
+		err = ValidationError
+	}
+	return
 }
 
 func (cfg *Config) validateBuildStrategies() (extraInfo string, err error) {

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -230,6 +230,10 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 			return nil, err
 		}
 		migrator.pgConsulUrl = consul.ConsulURL
+		if migrator.appConfig.Experimental != nil {
+			// Required to pass config validation for v2 because we don't support experimental features.
+			migrator.appConfig.Experimental.EnableConsul = false
+		}
 	}
 	err = migrator.validate(ctx)
 	if err != nil {

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -230,10 +230,6 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 			return nil, err
 		}
 		migrator.pgConsulUrl = consul.ConsulURL
-		if migrator.appConfig.Experimental != nil {
-			// Required to pass config validation for v2 because we don't support experimental features.
-			migrator.appConfig.Experimental.EnableConsul = false
-		}
 	}
 	err = migrator.validate(ctx)
 	if err != nil {


### PR DESCRIPTION
People are getting burned by failed migrations because the migrator doesn't warn them that `experimental` config sections are unsupported for Apps V2.

There's room for improvement and making this more user friendly (such as linking to docs and suggesting solutions for specific fields) but this is a good first step.