### PR TITLE
Exclude fly auth token from metrics

### DIFF
--- a/internal/command/auth/token.go
+++ b/internal/command/auth/token.go
@@ -24,7 +24,9 @@ independent of flyctl.
 	)
 
 	cmd := command.New("token", short, long, runAuthToken,
-		command.RequireSession)
+		command.ExcludeFromMetrics,
+		command.RequireSession,
+	)
 
 	flag.Add(cmd, flag.JSONOutput())
 	return cmd

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -480,6 +480,11 @@ func recordMetricsCommandContext(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }
 
+func ExcludeFromMetrics(ctx context.Context) (context.Context, error) {
+	metrics.Enabled = false
+	return ctx, nil
+}
+
 // RequireSession is a Preparer which makes sure a session exists.
 func RequireSession(ctx context.Context) (context.Context, error) {
 	if !client.FromContext(ctx).Authenticated() {

--- a/internal/metrics/api.go
+++ b/internal/metrics/api.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/net/websocket"
 )
 
+var Enabled = true
 var websocketConn *websocket.Conn
 var websocketMu sync.Mutex
 var done sync.WaitGroup
@@ -119,6 +120,10 @@ func rawSend(parentCtx context.Context, metricSlug string, payload json.RawMessa
 }
 
 func shouldSendMetrics(ctx context.Context) bool {
+	if !Enabled {
+		return false
+	}
+
 	cfg := config.FromContext(ctx)
 
 	// never send metrics to the production collector from dev builds


### PR DESCRIPTION
This command is so fast that the metrics WebSocket hasn't even had a chance to connect by the time it's ready to exit, leading to an annoying delay after printing the auth token on every invocation.

It does no RPC and no other network I/O, it just spits out a value from config on disk, so metrics are pretty low value for this subcommand anyway. Let's just skip metrics so the command can be instant.