### PR TITLE
Improve migrate-to-v2 error msg when worker cannot fork volume

### DIFF
--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -75,7 +75,9 @@ func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 			Name:           nomadVolNameToV2VolName(vol.Name),
 			LockID:         m.appLock,
 		})
-		if err != nil {
+		if err != nil && strings.HasSuffix(err.Error(), " is not a valid candidate") {
+			return fmt.Errorf("unfortunately the worker hosting your volume %s (%s) does not have capacity for another volume to support the migration; some other options: 1) try again later and there might be more space on the worker, 2) run a manual migration https://community.fly.io/t/manual-migration-to-apps-v2/11870, or 3) wait until we support migrations across workers (we're working on it!)", vol.ID, vol.Name)
+		} else if err != nil {
 			return err
 		}
 

--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -76,7 +76,7 @@ func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 			LockID:         m.appLock,
 		})
 		if err != nil && strings.HasSuffix(err.Error(), " is not a valid candidate") {
-			return fmt.Errorf("unfortunately the worker hosting your volume %s (%s) does not have capacity for another volume to support the migration; some other options: 1) try again later and there might be more space on the worker, 2) run a manual migration https://community.fly.io/t/manual-migration-to-apps-v2/11870, or 3) wait until we support migrations across workers (we're working on it!)", vol.ID, vol.Name)
+			return fmt.Errorf("unfortunately the worker hosting your volume %s (%s) does not have capacity for another volume to support the migration; some other options: 1) try again later and there might be more space on the worker, 2) run a manual migration https://community.fly.io/t/manual-migration-to-apps-v2/11870, or 3) wait until we support volume migrations across workers (we're working on it!)", vol.ID, vol.Name)
 		} else if err != nil {
 			return err
 		}


### PR DESCRIPTION
This error is confusing:

> failed while migrating: Disk id 432 is not a valid candidate

It means the worker hosting the volume does not have capacity for the second volume that is created during the migration.

This change changes the error message to:

> failed while migrating: unfortunately the worker hosting your volume vol_8675309bob (the_vol_name) does not have capacity for another volume to support the migration; some other options: 1) try again later and there might be more space on the worker, 2) run a manual migration https://community.fly.io/t/manual-migration-to-apps-v2/11870, or 3) wait until we support volume migrations across workers (we're working on it!)

Which will hopefully be less confusing :-)
