### PR TITLE
Pre-fetch API requests

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -12,8 +12,6 @@ import (
 	"github.com/PuerkitoBio/rehttp"
 )
 
-var logMu sync.Mutex
-
 func NewHTTPClient(logger Logger, transport http.RoundTripper) (*http.Client, error) {
 	retryTransport := rehttp.NewTransport(
 		transport,
@@ -44,6 +42,7 @@ func NewHTTPClient(logger Logger, transport http.RoundTripper) (*http.Client, er
 type LoggingTransport struct {
 	InnerTransport http.RoundTripper
 	Logger         Logger
+	mu             sync.Mutex
 }
 
 type contextKey struct {
@@ -69,8 +68,8 @@ func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 func (t *LoggingTransport) logRequest(req *http.Request) {
-	logMu.Lock()
-	defer logMu.Unlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
 	t.Logger.Debugf("--> %s %s\n", req.Method, req.URL)
 
@@ -96,8 +95,8 @@ func (t *LoggingTransport) logRequest(req *http.Request) {
 }
 
 func (t *LoggingTransport) logResponse(resp *http.Response) {
-	logMu.Lock()
-	defer logMu.Unlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
 	ctx := resp.Request.Context()
 	defer func() { _ = resp.Body.Close() }()

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -69,6 +69,9 @@ func runMigrateToV2(ctx context.Context) (err error) {
 		apiClient = client.FromContext(ctx).API()
 	)
 
+	// pre-fetch platform regions for later use
+	prompt.PlatformRegions(ctx)
+
 	appCompact, err := apiClient.GetAppCompact(ctx, appName)
 	if err != nil {
 		return err

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -102,6 +102,9 @@ func run(ctx context.Context) (err error) {
 		colorize = io.ColorScheme()
 	)
 
+	// pre-fetch platform regions for later use
+	prompt.PlatformRegions(ctx)
+
 	if appName == "" {
 		if appName, err = prompt.SelectAppName(ctx); err != nil {
 			return

--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -87,6 +87,9 @@ func runImport(ctx context.Context) error {
 		imageRef  = flag.GetString(ctx, "image")
 	)
 
+	// pre-fetch platform regions for later use
+	prompt.PlatformRegions(ctx)
+
 	// Resolve target app
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {

--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -59,6 +59,9 @@ func newCreate() (cmd *cobra.Command) {
 func runCreate(ctx context.Context) (err error) {
 	io := iostreams.FromContext(ctx)
 
+	// pre-fetch platform regions for later use
+	prompt.PlatformRegions(ctx)
+
 	org, err := prompt.Org(ctx)
 	if err != nil {
 		return err

--- a/internal/command/volumes/create.go
+++ b/internal/command/volumes/create.go
@@ -77,6 +77,9 @@ func runCreate(ctx context.Context) error {
 		appName    = appconfig.NameFromContext(ctx)
 	)
 
+	// pre-fetch platform regions from API in background
+	prompt.PlatformRegions(ctx)
+
 	// fetch AppBasic in the background while we prompt for confirmation
 	appFuture := future.Spawn(func() (*api.AppBasic, error) {
 		return client.GetAppBasic(ctx, appName)

--- a/internal/future/future.go
+++ b/internal/future/future.go
@@ -1,0 +1,49 @@
+package future
+
+import (
+	"fmt"
+	"sync"
+)
+
+type Future[T any] struct {
+	mu  sync.RWMutex
+	val T
+	err error
+}
+
+func (fut *Future[T]) Get() (T, error) {
+	fut.mu.RLock()
+	defer fut.mu.RUnlock()
+
+	return fut.val, fut.err
+}
+
+// Spawns `fn` on a new goroutine and returns future which resolves on
+// completion.
+func Spawn[T any](fn func() (T, error)) *Future[T] {
+	// allocate future and lock it immediately, we pass implied ownership of
+	// this lock to the spawned goroutine
+	fut := new(Future[T])
+	fut.mu.Lock()
+
+	// spawn goroutine to call fn and update future when done
+	go func() {
+		defer func() {
+			// if we panicked, set future's error field and rethrow
+			if err := recover(); err != nil {
+				fut.err = fmt.Errorf("panic: %v", err)
+				panic(err)
+			}
+
+			fut.mu.Unlock()
+		}()
+
+		fut.val, fut.err = fn()
+	}()
+
+	return fut
+}
+
+func Ready[T any](val T) *Future[T] {
+	return &Future[T]{val: val}
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -254,23 +254,23 @@ var (
 	errRegionCodesRequired = NonInteractiveError("regions codes must be specified in a comma-separated when not running interactively")
 )
 
-type PlatformRegionInfo struct {
+type RegionInfo struct {
 	Regions       []api.Region
 	DefaultRegion *api.Region
 }
 
-var platformRegionsFutureOnce sync.Once
-var platformRegionsFuture *future.Future[PlatformRegionInfo]
+var regionsOnce sync.Once
+var regionsFuture *future.Future[RegionInfo]
 
 // Fetches all Fly regions and app's default region.
 // Only the first call to this function will issue an HTTP request using ctx.
 // Subsequent calls will return the same future as the first.
-func PlatformRegions(ctx context.Context) *future.Future[PlatformRegionInfo] {
-	platformRegionsFutureOnce.Do(func() {
-		platformRegionsFuture = future.Spawn(func() (PlatformRegionInfo, error) {
+func PlatformRegions(ctx context.Context) *future.Future[RegionInfo] {
+	regionsOnce.Do(func() {
+		regionsFuture = future.Spawn(func() (RegionInfo, error) {
 			client := client.FromContext(ctx).API()
 			regions, defaultRegion, err := client.PlatformRegions(ctx)
-			regionInfo := PlatformRegionInfo{
+			regionInfo := RegionInfo{
 				Regions:       regions,
 				DefaultRegion: defaultRegion,
 			}
@@ -278,7 +278,7 @@ func PlatformRegions(ctx context.Context) *future.Future[PlatformRegionInfo] {
 		})
 	})
 
-	return platformRegionsFuture
+	return regionsFuture
 }
 
 func sortedRegions(ctx context.Context, excludedRegionCodes []string) ([]api.Region, *api.Region, error) {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
@@ -17,6 +18,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/future"
 	"github.com/superfly/flyctl/internal/sort"
 )
 
@@ -252,13 +254,41 @@ var (
 	errRegionCodesRequired = NonInteractiveError("regions codes must be specified in a comma-separated when not running interactively")
 )
 
-func sortedRegions(ctx context.Context, excludedRegionCodes []string) ([]api.Region, *api.Region, error) {
-	client := client.FromContext(ctx).API()
+type PlatformRegionInfo struct {
+	Regions       []api.Region
+	DefaultRegion *api.Region
+}
 
-	regions, defaultRegion, err := client.PlatformRegions(ctx)
+var platformRegionsFutureOnce sync.Once
+var platformRegionsFuture *future.Future[PlatformRegionInfo]
+
+// Fetches all Fly regions and app's default region.
+// Only the first call to this function will issue an HTTP request using ctx.
+// Subsequent calls will return the same future as the first.
+func PlatformRegions(ctx context.Context) *future.Future[PlatformRegionInfo] {
+	platformRegionsFutureOnce.Do(func() {
+		platformRegionsFuture = future.Spawn(func() (PlatformRegionInfo, error) {
+			client := client.FromContext(ctx).API()
+			regions, defaultRegion, err := client.PlatformRegions(ctx)
+			regionInfo := PlatformRegionInfo{
+				Regions:       regions,
+				DefaultRegion: defaultRegion,
+			}
+			return regionInfo, err
+		})
+	})
+
+	return platformRegionsFuture
+}
+
+func sortedRegions(ctx context.Context, excludedRegionCodes []string) ([]api.Region, *api.Region, error) {
+	regionInfo, err := PlatformRegions(ctx).Get()
 	if err != nil {
 		return nil, nil, err
 	}
+
+	regions := regionInfo.Regions
+	defaultRegion := regionInfo.DefaultRegion
 
 	if len(excludedRegionCodes) > 0 {
 		regions = lo.Filter(regions, func(r api.Region, _ int) bool {


### PR DESCRIPTION
This PR makes some commands faster by pre-fetching API requests in the background before they are needed. The commands that this PR makes faster are: volumes create (2x RTT), postgres create and import (1x RTT), redis create (1x RTT), and migrate_to_v2 (1x RTT).

I've taken an interesting approach to achieve this without interrupting the existing control flow too much - there is now a new `Future` type under internal.

There are two ways to spawn a future: `future.Spawn(func() { ... })`, which spawns a new goroutine to call the passed function, which resolves the future on return; and `future.Ready(val)`, which creates a new future that is immediately resolved with the passed value.

There are two new uses of futures in this PR:

* `prompt.PlatformRegions()` - this new function fetches the list of regions from the API and returns a future. This function is memoised, so the HTTP request is only made on the first call, and subsequent calls reuse the same future.

  I added an extra call to this function at the beginning of execution for all commands that eventually call `prompt.Region`. This means that by the time the command calls `prompt.Region`, the list of regions has most likely already been fetched. If the request was slow and the future has not yet completed for some reason, `prompt.Region` will wait just like if it had made the request inline like previously.

* In the fly volumes create subcommand, fetching `AppBasic` in the background while waiting on the user to confirm the action. This one's pretty straight forward.

Would love to hear everyone's thoughts on this approach!! I think there's quite a bit of potential to make more parts of flyctl faster too, this PR is just where I've started off on this :)