### PR TITLE
Revert "Better key value handling"

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -211,7 +211,7 @@ func deployToMachines(ctx context.Context, appConfig *appconfig.Config, appCompa
 		AppCompact:            appCompact,
 		DeploymentImage:       img.Tag,
 		Strategy:              flag.GetString(ctx, "strategy"),
-		EnvFromFlags:          flag.GetStringArray(ctx, "env"),
+		EnvFromFlags:          flag.GetStringSlice(ctx, "env"),
 		PrimaryRegionFlag:     appConfig.PrimaryRegion,
 		SkipSmokeChecks:       flag.GetDetach(ctx) || !flag.GetBool(ctx, "smoke-checks"),
 		SkipHealthChecks:      flag.GetDetach(ctx),
@@ -322,7 +322,7 @@ func determineAppConfig(ctx context.Context) (cfg *appconfig.Config, err error) 
 		}
 	}
 
-	if env := flag.GetStringArray(ctx, "env"); len(env) > 0 {
+	if env := flag.GetStringSlice(ctx, "env"); len(env) > 0 {
 		parsedEnv, err := cmdutil.ParseKVStringsToMap(env)
 		if err != nil {
 			return nil, fmt.Errorf("failed parsing environment: %w", err)

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -97,7 +97,7 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgs
 		Buildpacks:      build.Buildpacks,
 	}
 
-	cliBuildSecrets, err := cmdutil.ParseKVStringsToMap(flag.GetStringArray(ctx, "build-secret"))
+	cliBuildSecrets, err := cmdutil.ParseKVStringsToMap(flag.GetStringSlice(ctx, "build-secret"))
 	if err != nil {
 		return
 	}
@@ -196,7 +196,7 @@ func mergeBuildArgs(ctx context.Context, args map[string]string) (map[string]str
 	}
 
 	// set additional Docker build args from the command line, overriding similar ones from the config
-	cliBuildArgs, err := cmdutil.ParseKVStringsToMap(flag.GetStringArray(ctx, "build-arg"))
+	cliBuildArgs, err := cmdutil.ParseKVStringsToMap(flag.GetStringSlice(ctx, "build-arg"))
 	if err != nil {
 		return nil, fmt.Errorf("invalid build args: %w", err)
 	}

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -186,7 +186,7 @@ func run(ctx context.Context) (err error) {
 	}
 
 	var envVars map[string]string = nil
-	envFlags := flag.GetStringArray(ctx, "env")
+	envFlags := flag.GetStringSlice(ctx, "env")
 	if len(envFlags) > 0 {
 		envVars, err = cmdutil.ParseKVStringsToMap(envFlags)
 		if err != nil {

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -55,7 +55,7 @@ var sharedFlags = flag.Set{
 		Name:        "memory",
 		Description: "Memory (in megabytes) to attribute to the machine",
 	},
-	flag.StringArray{
+	flag.StringSlice{
 		Name:        "env",
 		Shorthand:   "e",
 		Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
@@ -87,7 +87,7 @@ var sharedFlags = flag.Set{
 		Name:        "dockerfile",
 		Description: "Path to a Dockerfile. Defaults to the Dockerfile in the working directory.",
 	},
-	flag.StringArray{
+	flag.StringSlice{
 		Name:        "build-arg",
 		Description: "Set of build time variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
 		Hidden:      true,
@@ -107,11 +107,11 @@ var sharedFlags = flag.Set{
 		Description: "Do not use the cache when building the image",
 		Hidden:      true,
 	},
-	flag.StringArray{
+	flag.StringSlice{
 		Name:        "kernel-arg",
 		Description: "List of kernel arguments to be provided to the init. Can be specified multiple times.",
 	},
-	flag.StringArray{
+	flag.StringSlice{
 		Name:        "metadata",
 		Shorthand:   "m",
 		Description: "Metadata in the form of NAME=VALUE pairs. Can be specified multiple times.",
@@ -237,7 +237,7 @@ func runMachineRun(ctx context.Context) error {
 			CPUKind:    "shared",
 			CPUs:       1,
 			MemoryMB:   256,
-			KernelArgs: flag.GetStringArray(ctx, "kernel-arg"),
+			KernelArgs: flag.GetStringSlice(ctx, "kernel-arg"),
 		},
 		AutoDestroy: flag.GetBool(ctx, "rm"),
 		DNS: &api.DNSConfig{
@@ -372,7 +372,7 @@ func createApp(ctx context.Context, message, name string, client *api.Client) (*
 func parseKVFlag(ctx context.Context, flagName string, initialMap map[string]string) (parsed map[string]string, err error) {
 	parsed = initialMap
 
-	if value := flag.GetStringArray(ctx, flagName); len(value) > 0 {
+	if value := flag.GetStringSlice(ctx, flagName); len(value) > 0 {
 		parsed, err = cmdutil.ParseKVStringsToMap(value)
 		if err != nil {
 			return nil, fmt.Errorf("invalid key/value pairs specified for flag %s", flagName)
@@ -417,7 +417,7 @@ func determineImage(ctx context.Context, appName string, imageOrPath string) (im
 			opts.DockerfilePath = dockerfilePath
 		}
 
-		extraArgs, err := cmdutil.ParseKVStringsToMap(flag.GetStringArray(ctx, "build-arg"))
+		extraArgs, err := cmdutil.ParseKVStringsToMap(flag.GetStringSlice(ctx, "build-arg"))
 		if err != nil {
 			return nil, errors.Wrap(err, "invalid build-arg")
 		}
@@ -670,8 +670,8 @@ func determineMachineConfig(ctx context.Context, input *determineMachineConfigIn
 		return nil, fmt.Errorf("memory cannot be zero")
 	}
 
-	if len(flag.GetStringArray(ctx, "kernel-arg")) != 0 {
-		machineConf.Guest.KernelArgs = flag.GetStringArray(ctx, "kernel-arg")
+	if len(flag.GetStringSlice(ctx, "kernel-arg")) != 0 {
+		machineConf.Guest.KernelArgs = flag.GetStringSlice(ctx, "kernel-arg")
 	}
 
 	parsedEnv, err := parseKVFlag(ctx, "env", machineConf.Env)

--- a/internal/command/secrets/parser_test.go
+++ b/internal/command/secrets/parser_test.go
@@ -63,21 +63,3 @@ my only friend"""
 		"FIN":        "Here is the end,\nmy only friend",
 	}, secrets)
 }
-
-func Test_parse_with_comma(t *testing.T) {
-	reader := strings.NewReader("FOO=BAR,BAZ")
-	secrets, err := parseSecrets(reader)
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]string{
-		"FOO": "BAR,BAZ",
-	}, secrets)
-}
-
-func Test_parse_with_equal(t *testing.T) {
-	reader := strings.NewReader("FOO=BAR BAZ")
-	secrets, err := parseSecrets(reader)
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]string{
-		"FOO": "BAR BAZ",
-	}, secrets)
-}

--- a/internal/flag/context.go
+++ b/internal/flag/context.go
@@ -60,19 +60,7 @@ func GetInt(ctx context.Context, name string) int {
 	}
 }
 
-// GetStringArray returns the values of the named string flag ctx carries.
-// Preserves commas (unlike the following `GetStringSlice`): in `--flag x,y` the value is string[]{`x,y`}.
-// This is useful to pass key-value pairs like environment variables or build arguments.
-func GetStringArray(ctx context.Context, name string) []string {
-	if v, err := FromContext(ctx).GetStringArray(name); err != nil {
-		return []string{}
-	} else {
-		return v
-	}
-}
-
-// GetStringSlice returns the values of the named string flag ctx carries.
-// Can be comma separated or passed "by repeated flags": `--flag x,y` is equivalent to `--flag x --flag y`.
+// GetString returns the value of the named string flag ctx carries.
 func GetStringSlice(ctx context.Context, name string) []string {
 	if v, err := FromContext(ctx).GetStringSlice(name); err != nil {
 		return []string{}

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -164,30 +164,6 @@ func (ss StringSlice) addTo(cmd *cobra.Command) {
 	f.Hidden = ss.Hidden
 }
 
-// StringArray wraps the set of string array flags.
-type StringArray struct {
-	Name        string
-	Shorthand   string
-	Description string
-	Default     []string
-	ConfName    string
-	EnvName     string
-	Hidden      bool
-}
-
-func (ss StringArray) addTo(cmd *cobra.Command) {
-	flags := cmd.Flags()
-
-	if ss.Shorthand != "" {
-		_ = flags.StringArrayP(ss.Name, ss.Shorthand, ss.Default, ss.Description)
-	} else {
-		_ = flags.StringArray(ss.Name, ss.Default, ss.Description)
-	}
-
-	f := flags.Lookup(ss.Name)
-	f.Hidden = ss.Hidden
-}
-
 // Duration wraps the set of duration flags.
 type Duration struct {
 	Name        string
@@ -391,15 +367,15 @@ func NoCache() Bool {
 	}
 }
 
-func BuildSecret() StringArray {
-	return StringArray{
+func BuildSecret() StringSlice {
+	return StringSlice{
 		Name:        "build-secret",
 		Description: "Set of build secrets of NAME=VALUE pairs. Can be specified multiple times. See https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information",
 	}
 }
 
-func BuildArg() StringArray {
-	return StringArray{
+func BuildArg() StringSlice {
+	return StringSlice{
 		Name:        "build-arg",
 		Description: "Set of build time variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
 	}


### PR DESCRIPTION
Reverts superfly/flyctl#2265 which appears to have introduced a bug preventing command line key/values from being set.
See https://github.com/superfly/flyctl-actions/issues/45