### PR TITLE
Disable provisioning of new nomad apps

### DIFF
--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
+	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/deploy"
@@ -85,10 +86,10 @@ func run(ctx context.Context) (err error) {
 	client := client.FromContext(ctx).API()
 	workingDir := flag.GetString(ctx, "path")
 
-	deployArgs := deploy.DeployWithConfigArgs{
-		ForceNomad:    flag.GetBool(ctx, "force-nomad"),
-		ForceMachines: flag.GetBool(ctx, "force-machines"),
-		ForceYes:      flag.GetBool(ctx, "now"),
+	// Note: this also disables --force-nomad when launching into an existing nomad app.
+	// we're fast-tracking the removal of nomad support, so this should be fine.
+	if flag.GetBool(ctx, "force-nomad") && !buildinfo.IsDev() {
+		return fmt.Errorf("creating new apps on the nomad platform is no longer supported")
 	}
 
 	metrics.Started(ctx, "launch")
@@ -345,7 +346,7 @@ func run(ctx context.Context) (err error) {
 	}
 
 	if deployNow {
-		return deploy.DeployWithConfig(ctx, appConfig, deployArgs)
+		return deploy.DeployWithConfig(ctx, appConfig, flag.GetBool(ctx, "now"))
 	}
 
 	// Alternative deploy documentation if our standard deploy method is not correct
@@ -359,6 +360,7 @@ func run(ctx context.Context) (err error) {
 }
 
 func shouldAppUseMachinesPlatform(ctx context.Context, orgSlug, existingAppPlatform string) (bool, error) {
+
 	forceMachines := flag.GetBool(ctx, "force-machines")
 	forceNomad := flag.GetBool(ctx, "force-nomad")
 
@@ -382,13 +384,8 @@ func shouldAppUseMachinesPlatform(ctx context.Context, orgSlug, existingAppPlatf
 		return false, nil
 	}
 
-	// Query the organization looking for default platform version to use
-	apiClient := client.FromContext(ctx).API()
-	orgDefault, err := apiClient.GetAppsV2DefaultOnForOrg(ctx, orgSlug)
-	if err != nil {
-		return false, err
-	}
-	return orgDefault, nil
+	// Default to Apps v2
+	return true, nil
 }
 
 func appExists(ctx context.Context, cfg *appconfig.Config) (bool, *api.AppBasic, error) {

--- a/internal/command/turboku/turboku.go
+++ b/internal/command/turboku/turboku.go
@@ -252,10 +252,7 @@ func run(ctx context.Context) error {
 				return err
 			}
 		}
-		return deploy.DeployWithConfig(ctx, appConfig, deploy.DeployWithConfigArgs{
-			ForceNomad: true,
-			ForceYes:   deployNow,
-		})
+		return deploy.DeployWithConfig(ctx, appConfig, deployNow)
 	}
 
 	return nil


### PR DESCRIPTION
note: turboku is untested. it used to force nomad, and now it doesn't.

1. removes the `--machines` flag on `fly apps create`, hides the `--nomad` flag for `apps create` (and if it's specified, throws an error).
2. hides the `--force-nomad` and `--force-machines` flags for deploy/launch. they are now unused, but I didn't want to potentially break pipelines that use these flags. (and --force-nomad being specified can throw more helpful errors than just unknown flag)
3. deploy pulls which platform to use solely from the existing app (assumes machines if the platform version != "nomad")
4. fly launch always uses `machines` and throws an error if `--force-nomad` is specified.