### PR TITLE
Multiple fixes to "fly machine update --port"

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -39,9 +39,11 @@ var sharedFlags = flag.Set{
 	flag.AppConfig(),
 	flag.Detach(),
 	flag.StringSlice{
-		Name:        "port",
-		Shorthand:   "p",
-		Description: "Exposed port mappings (format: (edgePort|startPort-endPort)[:machinePort]/[protocol[:handler]])",
+		Name:      "port",
+		Shorthand: "p",
+		Description: `Publish ports, format: port[:machinePort][/protocol[:handler[:handler...]]])
+	i.e.: --port 80/tcp --port 443:80/tcp:http:tls --port 5432/tcp:pg_tls
+	To remove a port mapping use '-' as handler, i.e.: --port 80/tcp:-`,
 	},
 	flag.String{
 		Name:        "size",

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -590,7 +590,7 @@ func determineServices(ctx context.Context, services []api.MachineService) ([]ap
 
 	// Remove any service without exposed ports
 	services = lo.FilterMap(servicesRef, func(s *api.MachineService, _ int) (api.MachineService, bool) {
-		if s != nil && len(s.Ports) >= 0 {
+		if s != nil && len(s.Ports) > 0 {
 			return *s, true
 		}
 		return api.MachineService{}, false


### PR DESCRIPTION
Motivated by a support request to expose a postgres machine (from a cluster) I found that the following would remove service concurrency settings among other service flags.

```
fly m update MACHINEID --port 5444:5433/tcp:pg_tls
```

With the changes in this PR a few things changed:
1. It always update existing services or append to current service list if not exists
2. It is possible to remove a service completely by passing a dash `-` as handler. i.e.: `--port 5432/tcp:-`
3. Now `--port 80` is the same as `--port 80/tcp` and `--port 80:80/tcp`. Before it was using port 0 as internal port which is invalid.

