### PR TITLE
Add support for exporting HAR trace of HTTP requests

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -18,9 +18,10 @@ import (
 )
 
 var (
-	baseURL      string
-	errorLog     bool
-	instrumenter InstrumentationService
+	baseURL          string
+	errorLog         bool
+	instrumenter     InstrumentationService
+	defaultTransport http.RoundTripper = http.DefaultTransport
 )
 
 // SetBaseURL - Sets the base URL for the API
@@ -35,6 +36,10 @@ func SetErrorLog(log bool) {
 
 func SetInstrumenter(i InstrumentationService) {
 	instrumenter = i
+}
+
+func SetTransport(t http.RoundTripper) {
+	defaultTransport = t
 }
 
 type InstrumentationService interface {
@@ -73,7 +78,7 @@ type ClientOptions struct {
 
 func (t *Transport) setDefaults(opts ClientOptions) {
 	if t.UnderlyingTransport == nil {
-		t.UnderlyingTransport = http.DefaultTransport
+		t.UnderlyingTransport = defaultTransport
 	}
 	if t.Token == "" {
 		t.Token = opts.AccessToken

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -23,6 +23,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/buildinfo"
+	"github.com/superfly/flyctl/internal/httptracing"
 	"github.com/superfly/flyctl/internal/instrument"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/metrics"
@@ -85,7 +86,7 @@ func NewWithOptions(ctx context.Context, opts NewClientOpts) (*Client, error) {
 	if opts.Logger != nil {
 		logger = opts.Logger
 	}
-	httpClient, err := api.NewHTTPClient(logger, http.DefaultTransport)
+	httpClient, err := api.NewHTTPClient(logger, httptracing.NewTransport(http.DefaultTransport))
 	if err != nil {
 		return nil, fmt.Errorf("flaps: can't setup HTTP client to %s: %w", flapsUrl.String(), err)
 	}
@@ -140,7 +141,7 @@ func newWithUsermodeWireguard(ctx context.Context, params wireguardConnectionPar
 		},
 	}
 
-	httpClient, err := api.NewHTTPClient(logger, transport)
+	httpClient, err := api.NewHTTPClient(logger, httptracing.NewTransport(transport))
 	if err != nil {
 		return nil, fmt.Errorf("flaps: can't setup HTTP client for %s: %w", params.orgSlug, err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/gofrs/flock v0.8.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/haileys/go-harlog v0.0.0-20230517070437-0f99204b5a57
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.3.0
 	github.com/heroku/heroku-go/v5 v5.4.0
@@ -76,6 +77,7 @@ require (
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/tools v0.2.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.sum
+++ b/go.sum
@@ -782,6 +782,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
+github.com/haileys/go-harlog v0.0.0-20230517070437-0f99204b5a57 h1:m7J0Y9Bqry85LVC3uboOp9sDUnH29o85FB5ZoSa3fTg=
+github.com/haileys/go-harlog v0.0.0-20230517070437-0f99204b5a57/go.mod h1:feJwxrNkN8pzC59AtacOExfyTP4Z5Z44hlgNYEG+KKM=
 github.com/hanwen/go-fuse v1.0.0/go.mod h1:unqXarDXqzAk0rt98O2tVndEPIpUgLD9+rwFisZH3Ok=
 github.com/hanwen/go-fuse/v2 v2.0.3/go.mod h1:0EQM6aH2ctVpvZ6a+onrQ/vaykxh2GH7hy3e13vzTUY=
 github.com/hanwen/go-fuse/v2 v2.1.0/go.mod h1:oRyA5eK+pvJyv5otpO/DgccS8y/RvYMaO00GgRLGryc=
@@ -1514,6 +1516,7 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRu
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -1809,6 +1812,7 @@ golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20190910044552-dd2b5c81c578/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190930201159-7c411dea38b0/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superfly/graphql"
 
 	"github.com/superfly/flyctl/internal/flyerr"
+	"github.com/superfly/flyctl/internal/httptracing"
 	"github.com/superfly/flyctl/internal/logger"
 
 	"github.com/superfly/flyctl/internal/command/root"
@@ -26,6 +27,9 @@ import (
 func Run(ctx context.Context, io *iostreams.IOStreams, args ...string) int {
 	ctx = iostreams.NewContext(ctx, io)
 	ctx = logger.NewContext(ctx, logger.FromEnv(io.ErrOut))
+
+	httptracing.Init()
+	defer httptracing.Finish()
 
 	cmd := root.New()
 	cmd.SetOut(io.Out)

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -25,6 +26,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/httptracing"
 	"github.com/superfly/flyctl/internal/instrument"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/metrics"
@@ -290,6 +292,8 @@ func initClient(ctx context.Context) (context.Context, error) {
 	api.SetBaseURL(cfg.APIBaseURL)
 	api.SetErrorLog(cfg.LogGQLErrors)
 	api.SetInstrumenter(instrument.ApiAdapter)
+	api.SetTransport(httptracing.NewTransport(http.DefaultTransport))
+
 	c := client.FromToken(cfg.AccessToken)
 	logger.Debug("client initialized.")
 

--- a/internal/command/platform/status.go
+++ b/internal/command/platform/status.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/httptracing"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -56,7 +57,7 @@ func runStatus(ctx context.Context) error {
 	}
 
 	if cfg.JSONOutput {
-		httpClient, err := api.NewHTTPClient(logger.MaybeFromContext(ctx), http.DefaultTransport)
+		httpClient, err := api.NewHTTPClient(logger.MaybeFromContext(ctx), httptracing.NewTransport(http.DefaultTransport))
 		if err != nil {
 			return err
 		}

--- a/internal/httptracing/har.go
+++ b/internal/httptracing/har.go
@@ -1,0 +1,53 @@
+package httptracing
+
+import (
+	"encoding/json"
+	"github.com/haileys/go-harlog"
+	"github.com/superfly/flyctl/terminal"
+	"net/http"
+	"os"
+)
+
+type harOpt struct {
+	Path      string
+	Container *harlog.HARContainer
+}
+
+var har *harOpt
+
+func Init() {
+	if path := os.Getenv("FLY_OUTPUT_HAR"); path != "" {
+		har = &harOpt{
+			Path:      path,
+			Container: harlog.NewHARContainer(),
+		}
+	}
+}
+
+func Finish() {
+	if har == nil {
+		return
+	}
+
+	harJson, err := json.MarshalIndent(har.Container, "", "    ")
+	if err != nil {
+		terminal.Warnf("error serializing HAR: %v\n", err)
+		return
+	}
+
+	err = os.WriteFile(har.Path, harJson, 0644)
+	if err != nil {
+		terminal.Warnf("error writing HAR: %v\n", err)
+	}
+}
+
+func NewTransport(transport http.RoundTripper) http.RoundTripper {
+	if har == nil {
+		return transport
+	}
+
+	return &harlog.Transport{
+		Transport: transport,
+		Container: har.Container,
+	}
+}

--- a/internal/httptracing/har.go
+++ b/internal/httptracing/har.go
@@ -16,7 +16,7 @@ type harOpt struct {
 var har *harOpt
 
 func Init() {
-	if path := os.Getenv("FLY_OUTPUT_HAR"); path != "" {
+	if path := os.Getenv("FLYCTL_OUTPUT_HAR"); path != "" {
 		har = &harOpt{
 			Path:      path,
 			Container: harlog.NewHARContainer(),


### PR DESCRIPTION
This PR adds a new env var `FLYCTL_OUTPUT_HAR` which when set to a filename, enables HTTP request tracing and outputs a [HAR file](https://en.wikipedia.org/wiki/HAR_(file_format)) containing detailed performance data of all HTTP requests issued by flyctl.

The HAR can then be opened in Chrome devtools and we get a nice little waterfall chart of all our HTTP requests!

Here's `fly ssh console`:

![image](https://github.com/superfly/flyctl/assets/179065/97544b73-7175-47c5-aa7f-f4e8110e1519)

You can mouse over each request in the "waterfall" column and get detailed timing stats of that particular request:

![image](https://github.com/superfly/flyctl/assets/179065/f28e90cc-32fd-41ce-b00f-39d577547eb6)
