### PR TITLE
win: use named pipes for agent <-> flyctl comms on older Windows

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -128,10 +128,6 @@ type Client struct {
 	dialer  net.Dialer
 }
 
-func (c *Client) dialContext(ctx context.Context) (conn net.Conn, err error) {
-	return c.dialer.DialContext(ctx, c.network, c.address)
-}
-
 var errDone = errors.New("done")
 
 func (c *Client) do(parent context.Context, fn func(net.Conn) error) (err error) {

--- a/agent/client_unix.go
+++ b/agent/client_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+// +build !windows
+
+package agent
+
+import (
+	"context"
+	"net"
+)
+
+func (c *Client) dialContext(ctx context.Context) (conn net.Conn, err error) {
+	return c.dialer.DialContext(ctx, c.network, c.address)
+}

--- a/agent/client_windows.go
+++ b/agent/client_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+// +build windows
+
+package agent
+
+import (
+	"context"
+	"net"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func (c *Client) dialContext(ctx context.Context) (conn net.Conn, err error) {
+	if UseUnixSockets() {
+		return c.dialer.DialContext(ctx, c.network, c.address)
+	}
+
+	pipe, err := PipeName()
+	if err != nil {
+		return nil, err
+	}
+
+	return winio.DialPipeContext(ctx, pipe)
+}

--- a/agent/cmd_windows.go
+++ b/agent/cmd_windows.go
@@ -4,7 +4,9 @@
 package agent
 
 import (
+	"fmt"
 	"os/exec"
+	"os/user"
 	"syscall"
 
 	"golang.org/x/sys/windows"
@@ -15,4 +17,24 @@ func setSysProcAttributes(cmd *exec.Cmd) {
 		HideWindow:    true,
 		CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP,
 	}
+}
+
+// Use UNIX sockets since 10.0.17063
+// https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
+func UseUnixSockets() bool {
+	maj, _, patch := windows.RtlGetNtVersionNumbers()
+	if maj > 10 || maj == 10 && patch >= 17063 {
+		return true
+	}
+
+	return false
+}
+
+func PipeName() (string, error) {
+	user, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("can't query current username: %w", err)
+	}
+
+	return `\\.\pipe\fly-agent-` + user.Username, nil
 }

--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -66,6 +66,15 @@ type bindError struct{ error }
 
 func (be bindError) Unwrap() error { return be.error }
 
+func bindUnixSocket(socket string) (net.Listener, error) {
+	l, err := net.Listen("unix", socket)
+	if err != nil {
+		return nil, fmt.Errorf("failed binding: %w", err)
+	}
+
+	return l, nil
+}
+
 func bind(socket string) (l net.Listener, err error) {
 	defer func() {
 		if err != nil {
@@ -79,11 +88,7 @@ func bind(socket string) (l net.Listener, err error) {
 		return
 	}
 
-	if l, err = net.Listen("unix", socket); err != nil {
-		err = fmt.Errorf("failed binding: %w", err)
-	}
-
-	return
+	return bindSocket(socket)
 }
 
 func latestChange(path string) (at time.Time, err error) {

--- a/agent/server/server_unix.go
+++ b/agent/server/server_unix.go
@@ -6,6 +6,7 @@ package server
 import (
 	"errors"
 	"io/fs"
+	"net"
 	"os"
 )
 
@@ -25,4 +26,8 @@ func removeSocket(path string) (err error) {
 	}
 
 	return
+}
+
+func bindSocket(socket string) (net.Listener, error) {
+	return bindUnixSocket(socket)
 }

--- a/agent/server/server_windows.go
+++ b/agent/server/server_windows.go
@@ -5,11 +5,20 @@ package server
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
+	"net"
 	"os"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/superfly/flyctl/agent"
 )
 
 func removeSocket(path string) (err error) {
+	if !agent.UseUnixSockets() {
+		return nil
+	}
+
 	switch _, err = os.Lstat(path); {
 	case errors.Is(err, fs.ErrNotExist):
 		err = nil
@@ -22,4 +31,26 @@ func removeSocket(path string) (err error) {
 	}
 
 	return
+}
+
+func bindSocket(socket string) (net.Listener, error) {
+	if agent.UseUnixSockets() {
+		return bindUnixSocket(socket)
+	}
+
+	pipe, err := agent.PipeName()
+	if err != nil {
+		return nil, err
+	}
+	// Default Named Pipe security policy grants full control to the LocalSystem
+	// account, administrators, and the creator owner. It also grants read
+	// access to members of the Everyone group and the anonymous account.
+	// Read allowed to everyone is Ok, because we need to write to pipe to actually
+	// establish a connection.
+	l, err := winio.ListenPipe(pipe, nil)
+	if err != nil {
+		err = fmt.Errorf("failed binding: %w", err)
+	}
+
+	return l, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
 	github.com/Masterminds/semver v1.5.0 // indirect
-	github.com/Microsoft/go-winio v0.5.2 // indirect
+	github.com/Microsoft/go-winio v0.5.2
 	github.com/Microsoft/hcsshim v0.8.25 // indirect
 	github.com/PuerkitoBio/rehttp v1.1.0
 	github.com/apex/log v1.9.0 // indirect


### PR DESCRIPTION
According to Sentry, we have a surprising number of users who still
use older Windows w/o UNIX socket support. They probably bail out
right after the first "fly deploy", because flyctl can't talk to
remote builder.

This patch implements Named Pipe support for older Windows and allows
to use remote builders on them.

`fly ssh console` still doesn't work though.
