### PR TITLE
Do not touch machine's DNSConfig if there is nothing to set

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -757,10 +757,11 @@ func determineMachineConfig(ctx context.Context, input *determineMachineConfigIn
 		machineConf.Init.Cmd = flag.Args(ctx)[1:]
 	}
 
-	if machineConf.DNS == nil {
-		machineConf.DNS = &api.DNSConfig{
-			SkipRegistration: flag.GetBool(ctx, "skip-dns-registration"),
+	if flag.IsSpecified(ctx, "skip-dns-registration") {
+		if machineConf.DNS == nil {
+			machineConf.DNS = &api.DNSConfig{}
 		}
+		machineConf.DNS.SkipRegistration = flag.GetBool(ctx, "skip-dns-registration")
 	}
 
 	// Metadata


### PR DESCRIPTION
A small tweak to prevent the empty `dns: {}` in diffs 

<img width="700" alt="image" src="https://github.com/superfly/flyctl/assets/37369/d2bc4060-3680-4ee2-8d9d-0f1f89abc9ee">
