### PR TITLE
Add helpers to encourage migration

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -252,3 +252,7 @@ func (cfg *Config) URL() *url.URL {
 		return nil
 	}
 }
+
+func (cfg *Config) PlatformVersion() string {
+	return cfg.platformVersion
+}

--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -72,8 +72,13 @@ func runRestart(ctx context.Context) error {
 }
 
 func runNomadRestart(ctx context.Context, app *api.AppCompact) error {
-	command.PromptToMigrate(ctx)
 	client := client.FromContext(ctx).API()
+
+	appName := flag.FirstArg(ctx)
+	app, err := client.GetAppCompact(ctx, appName)
+	if err != nil {
+		command.PromptToMigrate(ctx, app)
+	}
 
 	if _, err := client.RestartApp(ctx, app.Name); err != nil {
 		return fmt.Errorf("failed restarting app: %w", err)

--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -3,6 +3,7 @@ package apps
 import (
 	"context"
 	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/flaps"
 
@@ -71,6 +72,7 @@ func runRestart(ctx context.Context) error {
 }
 
 func runNomadRestart(ctx context.Context, app *api.AppCompact) error {
+	command.PromptToMigrate(ctx)
 	client := client.FromContext(ctx).API()
 
 	if _, err := client.RestartApp(ctx, app.Name); err != nil {

--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -74,11 +74,7 @@ func runRestart(ctx context.Context) error {
 func runNomadRestart(ctx context.Context, app *api.AppCompact) error {
 	client := client.FromContext(ctx).API()
 
-	appName := flag.FirstArg(ctx)
-	app, err := client.GetAppCompact(ctx, appName)
-	if err != nil {
-		command.PromptToMigrate(ctx, app)
-	}
+	command.PromptToMigrate(ctx, app)
 
 	if _, err := client.RestartApp(ctx, app.Name); err != nil {
 		return fmt.Errorf("failed restarting app: %w", err)

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/api"
@@ -423,6 +424,16 @@ func promptToUpdate(ctx context.Context) (context.Context, error) {
 	fmt.Fprintln(io.ErrOut, colorize.Yellow(msg))
 
 	return ctx, nil
+}
+
+func PromptToMigrate(ctx context.Context) {
+	config := appconfig.ConfigFromContext(ctx)
+	if config != nil {
+		if config.PlatformVersion() == "nomad" {
+			io := iostreams.FromContext(ctx)
+			fmt.Fprintf(io.ErrOut, "%s Apps v1 Platform is deprecated. We recommend migrating your app with:\nfly migrate-to-v2 -c %s", aurora.Yellow("WARN"), config.ConfigFilePath())
+		}
+	}
 }
 
 func killOldAgent(ctx context.Context) (context.Context, error) {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -426,10 +426,10 @@ func promptToUpdate(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }
 
-func PromptToMigrate(ctx context.Context) {
-	config := appconfig.ConfigFromContext(ctx)
-	if config != nil {
-		if config.PlatformVersion() == "nomad" {
+func PromptToMigrate(ctx context.Context, app *api.AppCompact) {
+	if app.PlatformVersion == "nomad" {
+		config := appconfig.ConfigFromContext(ctx)
+		if config != nil {
 			io := iostreams.FromContext(ctx)
 			fmt.Fprintf(io.ErrOut, "%s Apps v1 Platform is deprecated. We recommend migrating your app with:\nfly migrate-to-v2 -c %s", aurora.Yellow("WARN"), config.ConfigFilePath())
 		}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -251,7 +251,7 @@ func deployToNomad(ctx context.Context, appConfig *appconfig.Config, appCompact 
 
 	// Give a warning about nomad deprecation every 5 releases
 	if release.Version%5 == 0 {
-		command.PromptToMigrate(ctx)
+		command.PromptToMigrate(ctx, appCompact)
 	}
 
 	if flag.GetDetach(ctx) {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/iostreams"
@@ -252,8 +251,7 @@ func deployToNomad(ctx context.Context, appConfig *appconfig.Config, appCompact 
 
 	// Give a warning about nomad deprecation every 5 releases
 	if release.Version%5 == 0 {
-		io := iostreams.FromContext(ctx)
-		fmt.Fprintf(io.ErrOut, "%s Apps v1 Platform is deprecated. We recommend migrating your app with `fly migrate-to-v2`", aurora.Yellow("WARN"))
+		command.PromptToMigrate(ctx)
 	}
 
 	if flag.GetDetach(ctx) {

--- a/internal/command/secrets/set.go
+++ b/internal/command/secrets/set.go
@@ -34,13 +34,14 @@ func newSet() (cmd *cobra.Command) {
 }
 
 func runSet(ctx context.Context) (err error) {
-	command.PromptToMigrate(ctx)
 	client := client.FromContext(ctx).API()
 	appName := appconfig.NameFromContext(ctx)
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
 		return err
 	}
+
+	command.PromptToMigrate(ctx, app)
 
 	secrets, err := cmdutil.ParseKVStringsToMap(flag.Args(ctx))
 	if err != nil {

--- a/internal/command/secrets/set.go
+++ b/internal/command/secrets/set.go
@@ -34,6 +34,7 @@ func newSet() (cmd *cobra.Command) {
 }
 
 func runSet(ctx context.Context) (err error) {
+	command.PromptToMigrate(ctx)
 	client := client.FromContext(ctx).API()
 	appName := appconfig.NameFromContext(ctx)
 	app, err := client.GetAppCompact(ctx, appName)

--- a/internal/command/status/status.go
+++ b/internal/command/status/status.go
@@ -109,7 +109,7 @@ func once(ctx context.Context, out io.Writer) (err error) {
 		err = renderMachineStatus(ctx, app, out)
 		return
 	} else {
-		command.PromptToMigrate(ctx)
+		command.PromptToMigrate(ctx, app)
 	}
 
 	var status *api.AppStatus

--- a/internal/command/status/status.go
+++ b/internal/command/status/status.go
@@ -108,6 +108,8 @@ func once(ctx context.Context, out io.Writer) (err error) {
 	if platformVersion == "machines" {
 		err = renderMachineStatus(ctx, app, out)
 		return
+	} else {
+		command.PromptToMigrate(ctx)
 	}
 
 	var status *api.AppStatus


### PR DESCRIPTION
I extracted the messaging from `fly deploy` to a separate function so we can a) call it from more places and b) change how assertive/aggressive it gets over time (E.g. maybe we eventually offer to run the migration automatically on interactive terminals prior to forcing it.)

I also called this function from `fly status`. I don't have any Nomad apps to test with but I inverted the check to make sure it worked, and it seemed to. I think I uninverted the invert but definitely check since I'm unfortunately out of coffee today so who knows what my brain is doing to get back at me for that.