### PR TITLE
`deploy`: allow setting cpu and memory

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -93,18 +93,6 @@ var CommonFlags = flag.Set{
 		Name:        "no-public-ips",
 		Description: "Do not allocate any new public IP addresses",
 	},
-	flag.Int{
-		Name:        "vm-cpus",
-		Description: "Number of CPUs",
-	},
-	flag.String{
-		Name:        "vm-cpukind",
-		Description: "The kind of CPU to use ('shared' or 'performance')",
-	},
-	flag.Int{
-		Name:        "vm-memory",
-		Description: "Memory (in megabytes) to attribute to the VM",
-	},
 }
 
 func New() (cmd *cobra.Command) {
@@ -217,9 +205,6 @@ func deployToMachines(ctx context.Context, appConfig *appconfig.Config, appCompa
 		WaitTimeout:           time.Duration(flag.GetInt(ctx, "wait-timeout")) * time.Second,
 		LeaseTimeout:          time.Duration(flag.GetInt(ctx, "lease-timeout")) * time.Second,
 		VMSize:                flag.GetString(ctx, "vm-size"),
-		VMCPUs:                flag.GetInt(ctx, "vm-cpus"),
-		VMMemory:              flag.GetInt(ctx, "vm-memory"),
-		VMCPUKind:             flag.GetString(ctx, "vm-cpukind"),
 		IncreasedAvailability: flag.GetBool(ctx, "ha"),
 		AllocPublicIP:         !flag.GetBool(ctx, "no-public-ips"),
 	})

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -103,6 +103,11 @@ var CommonFlags = flag.Set{
 		Name:        "vm-memory",
 		Description: "Memory (in megabytes) to give newly created machines",
 	},
+	flag.String{
+		Name:        "vm-cpukind",
+		Description: "The kind of CPU to use ('shared' or 'performance')",
+		Hidden:      true,
+	},
 	flag.Bool{
 		Name:        "ha",
 		Description: "Create spare machines that increases app availability",
@@ -181,9 +186,13 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes
 		if flag.IsSpecified(ctx, "vm-cpus", "cpus") {
 			machinesFlags = append(machinesFlags, "vm-cpus")
 		}
+		if flag.IsSpecified(ctx, "vm-cpukind") {
+			machinesFlags = append(machinesFlags, "vm-cpukind")
+		}
 		if len(machinesFlags) != 0 {
 			s := lo.Ternary(len(machinesFlags) == 1, "", "s")
-			return fmt.Errorf("the flag%s %s are only supported on Apps V2", s, strings.Join(machinesFlags, " and "))
+			isAre := lo.Ternary(len(machinesFlags) == 1, "is", "are")
+			return fmt.Errorf("the flag%s '%s' %s only supported on Apps V2", s, strings.Join(machinesFlags, ", "), isAre)
 		}
 	}
 
@@ -245,6 +254,7 @@ func deployToMachines(ctx context.Context, appConfig *appconfig.Config, appCompa
 		VMSize:                flag.GetFirstString(ctx, "vm-size", "size"),
 		CPUs:                  flag.GetFirstInt(ctx, "vm-cpus", "cpus"),
 		MemoryMB:              flag.GetFirstInt(ctx, "vm-memory", "memory"),
+		CPUKind:               flag.GetString(ctx, "vm-cpukind"),
 		IncreasedAvailability: flag.GetBool(ctx, "ha"),
 		AllocPublicIP:         !flag.GetBool(ctx, "no-public-ips"),
 	}

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -44,6 +44,7 @@ type MachineDeploymentArgs struct {
 	VMSize                string
 	CPUs                  int
 	MemoryMB              int
+	CPUKind               string
 	IncreasedAvailability bool
 	AllocPublicIP         bool
 }
@@ -52,6 +53,7 @@ type requestedGuest struct {
 	RealizedGuest *api.MachineGuest
 	MemoryMB      int
 	CPUs          int
+	CPUKind       string
 }
 
 type machineDeployment struct {
@@ -149,7 +151,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	if err := md.setStrategy(); err != nil {
 		return nil, err
 	}
-	if err := md.setMachineGuest(args.VMSize, args.CPUs, args.MemoryMB); err != nil {
+	if err := md.setMachineGuest(args.VMSize, args.CPUs, args.MemoryMB, args.CPUKind); err != nil {
 		return nil, err
 	}
 	if err := md.setMachinesForDeployment(ctx); err != nil {
@@ -391,7 +393,7 @@ func (md *machineDeployment) latestImage(ctx context.Context) (string, error) {
 	return resp.App.CurrentReleaseUnprocessed.ImageRef, nil
 }
 
-func (md *machineDeployment) setMachineGuest(vmSize string, cpus int, memoryMB int) error {
+func (md *machineDeployment) setMachineGuest(vmSize string, cpus int, memoryMB int, cpuKind string) error {
 	if vmSize != "" {
 		fullGuest := &api.MachineGuest{}
 		err := fullGuest.SetSize(vmSize)
@@ -402,6 +404,7 @@ func (md *machineDeployment) setMachineGuest(vmSize string, cpus int, memoryMB i
 	}
 	md.machineGuest.CPUs = cpus
 	md.machineGuest.MemoryMB = memoryMB
+	md.machineGuest.CPUKind = cpuKind
 	return nil
 }
 

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -24,7 +24,6 @@ import (
 const (
 	DefaultWaitTimeout = 120 * time.Second
 	DefaultLeaseTtl    = 13 * time.Second
-	DefaultVMSize      = "shared-cpu-1x"
 )
 
 type MachineDeployment interface {
@@ -43,9 +42,6 @@ type MachineDeploymentArgs struct {
 	WaitTimeout           time.Duration
 	LeaseTimeout          time.Duration
 	VMSize                string
-	VMCPUs                int
-	VMMemory              int
-	VMCPUKind             string
 	IncreasedAvailability bool
 	AllocPublicIP         bool
 }
@@ -145,7 +141,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	if err := md.setStrategy(); err != nil {
 		return nil, err
 	}
-	if err := md.setMachineGuest(args.VMSize, args.VMCPUKind, args.VMCPUs, args.VMMemory); err != nil {
+	if err := md.setMachineGuest(args.VMSize); err != nil {
 		return nil, err
 	}
 	if err := md.setMachinesForDeployment(ctx); err != nil {
@@ -387,24 +383,12 @@ func (md *machineDeployment) latestImage(ctx context.Context) (string, error) {
 	return resp.App.CurrentReleaseUnprocessed.ImageRef, nil
 }
 
-func (md *machineDeployment) setMachineGuest(vmSize string, vmCPUKind string, vmCPUs int, vmMem int) error {
-	md.machineGuest = &api.MachineGuest{}
+func (md *machineDeployment) setMachineGuest(vmSize string) error {
 	if vmSize == "" {
-		vmSize = DefaultVMSize
+		return nil
 	}
-	if err := md.machineGuest.SetSize(vmSize); err != nil {
-		return err
-	}
-	if vmCPUKind != "" {
-		md.machineGuest.CPUKind = vmCPUKind
-	}
-	if vmCPUs > 0 {
-		md.machineGuest.CPUs = vmCPUs
-	}
-	if vmMem > 0 {
-		md.machineGuest.MemoryMB = vmMem
-	}
-	return nil
+	md.machineGuest = &api.MachineGuest{}
+	return md.machineGuest.SetSize(vmSize)
 }
 
 func (md *machineDeployment) setStrategy() error {

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -311,12 +311,9 @@ type metadata struct {
 	value string
 }
 
-func (md *machineDeployment) guestForMachine(mach *api.Machine, group string) *api.MachineGuest {
+func (md *machineDeployment) guestForGroup(group string) *api.MachineGuest {
 
 	var guest *api.MachineGuest
-	if mach != nil && mach.Config != nil && mach.Config.Guest != nil {
-		guest = helpers.Clone(mach.Config.Guest)
-	}
 	if md.machineGuest.RealizedGuest != nil {
 		guest = helpers.Clone(md.machineGuest.RealizedGuest)
 	}
@@ -349,7 +346,7 @@ func (md *machineDeployment) guestForMachine(mach *api.Machine, group string) *a
 }
 
 func (md *machineDeployment) spawnMachineInGroup(ctx context.Context, groupName string, i, total int, standbyFor []string, meta ...metadata) (machine.LeasableMachine, error) {
-	launchInput, err := md.launchInputForLaunch(groupName, md.guestForMachine(nil, groupName), standbyFor)
+	launchInput, err := md.launchInputForLaunch(groupName, md.guestForGroup(groupName), standbyFor)
 	if err != nil {
 		return nil, fmt.Errorf("error creating machine configuration: %w", err)
 	}

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -330,7 +330,7 @@ func (md *machineDeployment) guestForGroup(group string) *api.MachineGuest {
 		}
 	}
 	if guest == nil {
-		if md.machineGuest.CPUs == 0 && md.machineGuest.MemoryMB == 0 {
+		if md.machineGuest.CPUs == 0 && md.machineGuest.MemoryMB == 0 && md.machineGuest.CPUKind == "" {
 			return nil
 		}
 		guest = helpers.Clone(api.MachinePresets["shared-cpu-1x"])
@@ -341,6 +341,9 @@ func (md *machineDeployment) guestForGroup(group string) *api.MachineGuest {
 	}
 	if md.machineGuest.CPUs != 0 {
 		guest.CPUs = md.machineGuest.CPUs
+	}
+	if md.machineGuest.CPUKind != "" {
+		guest.CPUKind = md.machineGuest.CPUKind
 	}
 	return guest
 }

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -126,6 +126,9 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 		mConfig.Standbys = nil
 	}
 
+	// Potentially update the VM guest
+	mConfig.Guest = md.guestForMachine(origMachineRaw, processGroup)
+
 	return &api.LaunchMachineInput{
 		ID:         mID,
 		Region:     origMachineRaw.Region,

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -126,9 +126,6 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 		mConfig.Standbys = nil
 	}
 
-	// Potentially update the VM guest
-	mConfig.Guest = md.guestForMachine(origMachineRaw, processGroup)
-
 	return &api.LaunchMachineInput{
 		ID:         mID,
 		Region:     origMachineRaw.Region,

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -47,6 +47,11 @@ var sharedFlags = flag.Set{
 	},
 	flag.String{
 		Name:        "size",
+		Description: "Preset guest cpu and memory for a machine, defaults to shared-cpu-1x",
+		Hidden:      true,
+	},
+	flag.String{
+		Name:        "vm-size",
 		Shorthand:   "s",
 		Description: "Preset guest cpu and memory for a machine, defaults to shared-cpu-1x",
 	},
@@ -717,7 +722,7 @@ type determineMachineConfigInput struct {
 func determineMachineConfig(ctx context.Context, input *determineMachineConfigInput) (*api.MachineConfig, error) {
 	machineConf := mach.CloneConfig(&input.initialMachineConf)
 
-	if guestSize := flag.GetString(ctx, "size"); guestSize != "" {
+	if guestSize := flag.GetFirstString(ctx, "vm-size", "size"); guestSize != "" {
 		err := machineConf.Guest.SetSize(guestSize)
 		if err != nil {
 			return nil, err

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -53,9 +53,19 @@ var sharedFlags = flag.Set{
 	flag.Int{
 		Name:        "cpus",
 		Description: "Number of CPUs",
+		Hidden:      true,
+	},
+	flag.Int{
+		Name:        "vm-cpus",
+		Description: "Number of CPUs",
 	},
 	flag.Int{
 		Name:        "memory",
+		Description: "Memory (in megabytes) to attribute to the machine",
+		Hidden:      true,
+	},
+	flag.Int{
+		Name:        "vm-memory",
 		Description: "Memory (in megabytes) to attribute to the machine",
 	},
 	flag.StringArray{
@@ -715,15 +725,15 @@ func determineMachineConfig(ctx context.Context, input *determineMachineConfigIn
 	}
 
 	// Potential overrides for Guest
-	if cpus := flag.GetInt(ctx, "cpus"); cpus != 0 {
+	if cpus := flag.GetFirstInt(ctx, "vm-cpus", "cpus"); cpus != 0 {
 		machineConf.Guest.CPUs = cpus
-	} else if flag.IsSpecified(ctx, "cpus") {
+	} else if flag.IsSpecified(ctx, "vm-cpus", "cpus") {
 		return nil, fmt.Errorf("cannot have zero cpus")
 	}
 
-	if memory := flag.GetInt(ctx, "memory"); memory != 0 {
+	if memory := flag.GetFirstInt(ctx, "vm-memory", "memory"); memory != 0 {
 		machineConf.Guest.MemoryMB = memory
-	} else if flag.IsSpecified(ctx, "memory") {
+	} else if flag.IsSpecified(ctx, "vm-memory", "memory") {
 		return nil, fmt.Errorf("memory cannot be zero")
 	}
 

--- a/internal/command/scale/vm.go
+++ b/internal/command/scale/vm.go
@@ -33,7 +33,8 @@ For pricing, see https://fly.io/docs/about/pricing/`
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
-		flag.Int{Name: "memory", Description: "Memory in MB for the VM", Default: 0},
+		flag.Int{Name: "memory", Description: "Memory in MB for the VM", Hidden: true},
+		flag.Int{Name: "vm-memory", Description: "Memory in MB for the VM", Default: 0},
 		flag.String{Name: "group", Description: "The process group to apply the VM size to"},
 	)
 	return cmd
@@ -41,7 +42,7 @@ For pricing, see https://fly.io/docs/about/pricing/`
 
 func runScaleVM(ctx context.Context) error {
 	sizeName := flag.FirstArg(ctx)
-	memoryMB := flag.GetInt(ctx, "memory")
+	memoryMB := flag.GetFirstInt(ctx, "vm-memory", "memory")
 	group := flag.GetString(ctx, "group")
 	return scaleVertically(ctx, group, sizeName, memoryMB)
 }

--- a/internal/machine/query.go
+++ b/internal/machine/query.go
@@ -6,6 +6,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/flaps"
+	"golang.org/x/exp/slices"
 )
 
 func ListActive(ctx context.Context) ([]*api.Machine, error) {
@@ -21,4 +22,33 @@ func ListActive(ctx context.Context) ([]*api.Machine, error) {
 	})
 
 	return machines, nil
+}
+
+// GetMedianGuest returns the median guest of a list of machines, or nil if no machines are provided.
+// Calculated by sorting the machines by CPU count, taking the all machines with the median CPU count,
+// and then sorting those by memory count and taking the median of those.
+func GetMedianGuest(machines []*api.Machine) *api.MachineGuest {
+	guests := lo.FilterMap(machines, func(m *api.Machine, _ int) (*api.MachineGuest, bool) {
+		if m.Config == nil || m.Config.Guest == nil {
+			return nil, false
+		}
+		return m.Config.Guest, true
+	})
+	if len(guests) == 0 {
+		return nil
+	}
+
+	cpuCounts := lo.Map(guests, func(g *api.MachineGuest, _ int) int {
+		return g.CPUs
+	})
+	slices.Sort(cpuCounts)
+	medianCPUCount := cpuCounts[len(cpuCounts)/2]
+
+	guests = lo.Filter(guests, func(g *api.MachineGuest, _ int) bool {
+		return g.CPUs == medianCPUCount
+	})
+	slices.SortFunc(guests, func(a, b *api.MachineGuest) bool {
+		return a.MemoryMB < b.MemoryMB
+	})
+	return guests[len(guests)/2]
 }

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -799,3 +799,18 @@ func TestNoPublicIPDeployMachines(t *testing.T) {
 	// There should be no ips allocated
 	require.Equal(f, "[]\n", result.StdOut().String())
 }
+
+func TestLaunchCpusMem(t *testing.T) {
+	var (
+		f       = testlib.NewTestEnvFromEnv(t)
+		appName = f.CreateRandomAppName()
+	)
+
+	f.Fly("launch --org %s --name %s --region %s --now --internal-port 80 --image nginx --auto-confirm --vm-size performance-2x --vm-cpus 4 --vm-memory 8192", f.OrgSlug(), appName, f.PrimaryRegion())
+	machines := f.MachinesList(appName)
+	firstMachineGuest := machines[0].Config.Guest
+
+	require.Equal(f, 4, firstMachineGuest.CPUs)
+	require.Equal(f, 8192, firstMachineGuest.MemoryMB)
+	require.Equal(f, "performance", firstMachineGuest.CPUKind)
+}

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -806,7 +806,7 @@ func TestLaunchCpusMem(t *testing.T) {
 		appName = f.CreateRandomAppName()
 	)
 
-	f.Fly("launch --org %s --name %s --region %s --now --internal-port 80 --image nginx --auto-confirm --vm-size performance-2x --vm-cpus 4 --vm-memory 8192", f.OrgSlug(), appName, f.PrimaryRegion())
+	f.Fly("launch --org %s --name %s --region %s --now --internal-port 80 --image nginx --auto-confirm --vm-size shared-cpu-2x --vm-cpukind performance --vm-cpus 4 --vm-memory 8192", f.OrgSlug(), appName, f.PrimaryRegion())
 	machines := f.MachinesList(appName)
 	firstMachineGuest := machines[0].Config.Guest
 

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -393,6 +393,7 @@ func TestPGFlexFailover(t *testing.T) {
 	fmt.Println(newLeaderMachineID)
 	fmt.Println(leaderMachineID)
 	require.NotEqual(t, newLeaderMachineID, leaderMachineID, "Failover failed! PG Leader didn't change!")
+
 }
 
 func TestAppsV2_PostgresNoMachines(t *testing.T) {
@@ -797,19 +798,4 @@ func TestNoPublicIPDeployMachines(t *testing.T) {
 	result = f.Fly("ips list --json")
 	// There should be no ips allocated
 	require.Equal(f, "[]\n", result.StdOut().String())
-}
-
-func TestLaunchCpusMem(t *testing.T) {
-	var (
-		f       = testlib.NewTestEnvFromEnv(t)
-		appName = f.CreateRandomAppName()
-	)
-
-	f.Fly("launch --org %s --name %s --region %s --now --internal-port 80 --image nginx --auto-confirm --vm-cpus 4 --vm-memory 8192 --vm-cpukind performance", f.OrgSlug(), appName, f.PrimaryRegion())
-	machines := f.MachinesList(appName)
-	firstMachineGuest := machines[0].Config.Guest
-
-	require.Equal(f, 4, firstMachineGuest.CPUs)
-	require.Equal(f, 8192, firstMachineGuest.MemoryMB)
-	require.Equal(f, "performance", firstMachineGuest.CPUKind)
 }


### PR DESCRIPTION
Adds `--vm-memory` and `--vm-cpus` to `fly deploy`.

This introduces quite a bit of complexity, so let's talk about the side effects:

- `--memory` and `--cpus` flags have been canonicalized to `--vm-[memory/cpus]` throughout flyctl. Aliases exist for the old parameters, so that existing scripts and docs still work.
- `flag` got support for grabbing from multiple named parameters. This allows aliasing parameter names for graceful deprecation.

The way deploy determines an appropriate guest for a machine got a little bit more robust:
1. if the machine already exists (deploying over an existing app), we reuse the existing guest.
2. if the user passes `--vm-size` to deploy, that takes precedence.
3. if there's still no guest, but there *are* existing machines (so, new machine in existing process group),
        we take the median machine size and use that. (find the median CPU size for the process group, out of all machines that size in the group, take the median memory, and use that guest)
4. if `--vm-cpus` or `--vm-memory` is specified, and there is still no guest (so, not an existing machine, no `--vm-size`, and the process group doesn't exist, we use `shared-cpu-1x`.
        * If we didn't specify either of those parameters, and there's still no guest, we provide a nil guest.
5. finally, with the resulting guest, apply `--vm-cpus` or `--vm-memory`.

Currently, most preflight tests pass, and the ones that don't pass also don't pass on master, so maybe that's not an issue?