### PR TITLE
Fix 'flyctl turboku' command

### DIFF
--- a/internal/command/turboku/turboku.go
+++ b/internal/command/turboku/turboku.go
@@ -33,8 +33,6 @@ func New() (cmd *cobra.Command) {
 
 	flag.Add(cmd,
 		flag.Org(),
-		flag.Region(),
-		flag.Now(),
 		flag.NoDeploy(),
 
 		flag.Bool{
@@ -46,6 +44,7 @@ func New() (cmd *cobra.Command) {
 			Name:        "name",
 			Description: "the name of the new app",
 		},
+		deploy.CommonFlags,
 	)
 	cmd.Args = cobra.ExactArgs(2)
 	return cmd


### PR DESCRIPTION
Since forcing all deploys to go to machines, we now need a lot more
flags defined for 'turboku', as they are accessed directly in
deployToMachines() function.

Otherwise 'flyctl dies with "flag accessed but not defined"
