### PR TITLE
Better no-machines error for `machines` with `--select`

### DIFF
--- a/internal/command/machine/select.go
+++ b/internal/command/machine/select.go
@@ -154,6 +154,8 @@ func promptForOneMachine(ctx context.Context) (*api.Machine, error) {
 	machines, err := flaps.FromContext(ctx).List(ctx, "")
 	if err != nil {
 		return nil, fmt.Errorf("could not get a list of machines: %w", err)
+	} else if len(machines) == 0 {
+		return nil, fmt.Errorf("the app %s has no machines", appconfig.NameFromContext(ctx))
 	}
 
 	options := sortAndBuildOptions(machines)
@@ -168,6 +170,8 @@ func promptForManyMachines(ctx context.Context) ([]*api.Machine, error) {
 	machines, err := flaps.FromContext(ctx).List(ctx, "")
 	if err != nil {
 		return nil, fmt.Errorf("could not get a list of machines: %w", err)
+	} else if len(machines) == 0 {
+		return nil, fmt.Errorf("the app %s has no machines", appconfig.NameFromContext(ctx))
 	}
 
 	options := sortAndBuildOptions(machines)


### PR DESCRIPTION
Currently, the error is from trying to create a prompt with no options, which is not helpful:

```
Error: could not prompt for machines: please provide options to select from
```