### PR TITLE
Experiment: add tab completion for `--app`, `--org`, and `--region`

### DIFF
--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -1,0 +1,81 @@
+package preparers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/httptracing"
+	"github.com/superfly/flyctl/internal/instrument"
+	"github.com/superfly/flyctl/internal/logger"
+	"github.com/superfly/flyctl/internal/state"
+)
+
+type Preparer func(context.Context) (context.Context, error)
+
+func LoadConfig(ctx context.Context) (context.Context, error) {
+	logger := logger.FromContext(ctx)
+
+	cfg := config.New()
+
+	// Apply config from the config file, if it exists
+	path := filepath.Join(state.ConfigDirectory(ctx), config.FileName)
+	if err := cfg.ApplyFile(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+
+	// Apply config from the environment, overriding anything from the file
+	cfg.ApplyEnv()
+
+	// Finally, apply command line options, overriding any previous setting
+	cfg.ApplyFlags(flagctx.FromContext(ctx))
+
+	logger.Debug("config initialized.")
+
+	return config.NewContext(ctx, cfg), nil
+}
+
+func InitClient(ctx context.Context) (context.Context, error) {
+	logger := logger.FromContext(ctx)
+	cfg := config.FromContext(ctx)
+
+	// TODO: refactor so that api package does NOT depend on global state
+	api.SetBaseURL(cfg.APIBaseURL)
+	api.SetErrorLog(cfg.LogGQLErrors)
+	api.SetInstrumenter(instrument.ApiAdapter)
+	api.SetTransport(httptracing.NewTransport(http.DefaultTransport))
+
+	c := client.FromToken(cfg.AccessToken)
+	logger.Debug("client initialized.")
+
+	return client.NewContext(ctx, c), nil
+}
+
+func DetermineConfigDir(ctx context.Context) (context.Context, error) {
+	dir := filepath.Join(state.UserHomeDirectory(ctx), ".fly")
+
+	logger.FromContext(ctx).
+		Debugf("determined config directory: %q", dir)
+
+	return state.WithConfigDirectory(ctx, dir), nil
+}
+
+func DetermineUserHomeDir(ctx context.Context) (context.Context, error) {
+	wd, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed determining user home directory: %w", err)
+	}
+
+	logger.FromContext(ctx).
+		Debugf("determined user home directory: %q", wd)
+
+	return state.WithUserHomeDirectory(ctx, wd), nil
+}

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/spf13/pflag"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/config"
@@ -78,4 +80,74 @@ func DetermineUserHomeDir(ctx context.Context) (context.Context, error) {
 		Debugf("determined user home directory: %q", wd)
 
 	return state.WithUserHomeDirectory(ctx, wd), nil
+}
+
+// ApplyAliases consolidates flags with aliases into a single source-of-truth flag.
+// After calling this, the main flags will have their values set as follows:
+//   - If the main flag was already set, it will keep its value.
+//   - If it was not set, but an alias was, it will take the value of the first specified alias flag.
+//     This will set flag.Changed to true, as if it were specified manually.
+//   - If none of the flags were set, the main flag will remain its default value.
+func ApplyAliases(ctx context.Context) (context.Context, error) {
+
+	var (
+		invalidFlagNames []string
+		invalidTypes     []string
+
+		flags = flagctx.FromContext(ctx)
+	)
+	flags.VisitAll(func(f *pflag.Flag) {
+		aliases, ok := f.Annotations["flyctl_alias"]
+		if !ok {
+			return
+		}
+
+		name := f.Name
+		gotValue := false
+		origFlag := flags.Lookup(name)
+
+		if origFlag == nil {
+			invalidFlagNames = append(invalidFlagNames, name)
+		} else {
+			gotValue = origFlag.Changed
+		}
+
+		for _, alias := range aliases {
+			aliasFlag := flags.Lookup(alias)
+			if aliasFlag == nil {
+				invalidFlagNames = append(invalidFlagNames, alias)
+				continue
+			}
+			if origFlag == nil {
+				continue // nothing left to do here if we have no root flag
+			}
+			if aliasFlag.Value.Type() != origFlag.Value.Type() {
+				invalidTypes = append(invalidTypes, fmt.Sprintf("%s (%s) and %s (%s)", name, origFlag.Value.Type(), alias, aliasFlag.Value.Type()))
+			}
+			if !gotValue && aliasFlag.Changed {
+				err := origFlag.Value.Set(aliasFlag.Value.String())
+				if err != nil {
+					panic(err)
+				}
+				origFlag.Changed = true
+			}
+		}
+	})
+
+	var err error
+	{
+		var errorMessages []string
+		if len(invalidFlagNames) > 0 {
+			errorMessages = append(errorMessages, fmt.Sprintf("flags '%v' are not valid flags", invalidFlagNames))
+		}
+		if len(invalidTypes) > 0 {
+			errorMessages = append(errorMessages, fmt.Sprintf("flags '%v' have different types", invalidTypes))
+		}
+		if len(errorMessages) > 1 {
+			err = fmt.Errorf("multiple errors occured:\n > %s\n", strings.Join(errorMessages, "\n > "))
+		} else if len(errorMessages) == 1 {
+			err = fmt.Errorf("%s", errorMessages[0])
+		}
+	}
+	return ctx, err
 }

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -21,6 +21,12 @@ import (
 	"github.com/superfly/flyctl/internal/state"
 )
 
+// Preparers are split between here and `command/command.go` because
+// tab-completion needs to run *some* of them, and importing the command package from there
+// would create a circular dependency. Likewise, if *all* the preparers were in this module,
+// that would also cause a circular dependency.
+// I don't like this, but it's shippable until someone else fixes it
+
 type Preparer func(context.Context) (context.Context, error)
 
 func LoadConfig(ctx context.Context) (context.Context, error) {

--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -33,7 +33,7 @@ from the Fly platform.
 		flag.Yes(),
 	)
 
-	destroy.ValidArgsFunction = completion.AdaptFn(completion.InitFlyApi(completion.CompleteApps))
+	destroy.ValidArgsFunction = completion.Adapt(completion.CompleteApps)
 
 	return destroy
 }

--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/flag/completion"
 
 	"github.com/superfly/flyctl/iostreams"
 
@@ -31,6 +32,8 @@ from the Fly platform.
 	flag.Add(destroy,
 		flag.Yes(),
 	)
+
+	destroy.ValidArgsFunction = completion.AdaptFn(completion.InitFlyApi(completion.CompleteApps))
 
 	return destroy
 }

--- a/internal/command/apps/list.go
+++ b/internal/command/apps/list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"github.com/superfly/flyctl/internal/format"
 	"github.com/superfly/flyctl/internal/render"
 )
@@ -87,7 +88,7 @@ func runList(ctx context.Context) (err error) {
 
 func getOrg(ctx context.Context) (*api.Organization, error) {
 	client := client.FromContext(ctx).API()
-	orgName := flag.GetString(ctx, flag.OrgName)
+	orgName := flag.GetString(ctx, flagnames.Org)
 
 	if orgName == "" {
 		return nil, nil

--- a/internal/command/apps/move.go
+++ b/internal/command/apps/move.go
@@ -42,7 +42,7 @@ organization the current user belongs to.
 		},
 	)
 
-	move.ValidArgsFunction = completion.AdaptFn(completion.InitFlyApi(completion.CompleteApps))
+	move.ValidArgsFunction = completion.Adapt(completion.CompleteApps)
 
 	return move
 }

--- a/internal/command/apps/move.go
+++ b/internal/command/apps/move.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/flag/completion"
 
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
@@ -40,6 +41,8 @@ organization the current user belongs to.
 			Default:     false,
 		},
 	)
+
+	move.ValidArgsFunction = completion.AdaptFn(completion.InitFlyApi(completion.CompleteApps))
 
 	return move
 }

--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -42,7 +42,7 @@ func newRestart() *cobra.Command {
 		},
 	)
 
-	cmd.ValidArgsFunction = completion.AdaptFn(completion.InitFlyApi(completion.CompleteApps))
+	cmd.ValidArgsFunction = completion.Adapt(completion.CompleteApps)
 
 	return cmd
 }

--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/flag/completion"
 
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
@@ -40,6 +41,8 @@ func newRestart() *cobra.Command {
 			Default:     false,
 		},
 	)
+
+	cmd.ValidArgsFunction = completion.AdaptFn(completion.InitFlyApi(completion.CompleteApps))
 
 	return cmd
 }

--- a/internal/command/apps/resume.go
+++ b/internal/command/apps/resume.go
@@ -35,7 +35,7 @@ the number of configured instances.
 	resume.Hidden = true
 	resume.Args = cobra.ExactArgs(1)
 
-	resume.ValidArgsFunction = completion.AdaptFn(completion.InitFlyApi(completion.CompleteApps))
+	resume.ValidArgsFunction = completion.Adapt(completion.CompleteApps)
 
 	return resume
 }

--- a/internal/command/apps/resume.go
+++ b/internal/command/apps/resume.go
@@ -8,6 +8,7 @@ import (
 	"github.com/azazeal/pause"
 	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/flag/completion"
 
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/iostreams"
@@ -33,6 +34,8 @@ the number of configured instances.
 
 	resume.Hidden = true
 	resume.Args = cobra.ExactArgs(1)
+
+	resume.ValidArgsFunction = completion.AdaptFn(completion.InitFlyApi(completion.CompleteApps))
 
 	return resume
 }

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -10,14 +10,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/blang/semver"
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/iostreams"
 
@@ -48,7 +45,7 @@ func New(usage, short, long string, fn Runner, p ...preparers.Preparer) *cobra.C
 }
 
 var commonPreparers = []preparers.Preparer{
-	applyAliases,
+	preparers.ApplyAliases,
 	determineHostname,
 	determineWorkingDir,
 	preparers.DetermineUserHomeDir,
@@ -143,76 +140,6 @@ func finalize(ctx context.Context) {
 				Warnf("failed saving cache to %s: %v", path, err)
 		}
 	}
-}
-
-// applyAliases consolidates flags with aliases into a single source-of-truth flag.
-// After calling this, the main flags will have their values set as follows:
-//   - If the main flag was already set, it will keep its value.
-//   - If it was not set, but an alias was, it will take the value of the first specified alias flag.
-//     This will set flag.Changed to true, as if it were specified manually.
-//   - If none of the flags were set, the main flag will remain its default value.
-func applyAliases(ctx context.Context) (context.Context, error) {
-
-	var (
-		invalidFlagNames []string
-		invalidTypes     []string
-
-		flags = flag.FromContext(ctx)
-	)
-	flags.VisitAll(func(f *pflag.Flag) {
-		aliases, ok := f.Annotations["flyctl_alias"]
-		if !ok {
-			return
-		}
-
-		name := f.Name
-		gotValue := false
-		origFlag := flags.Lookup(name)
-
-		if origFlag == nil {
-			invalidFlagNames = append(invalidFlagNames, name)
-		} else {
-			gotValue = origFlag.Changed
-		}
-
-		for _, alias := range aliases {
-			aliasFlag := flags.Lookup(alias)
-			if aliasFlag == nil {
-				invalidFlagNames = append(invalidFlagNames, alias)
-				continue
-			}
-			if origFlag == nil {
-				continue // nothing left to do here if we have no root flag
-			}
-			if aliasFlag.Value.Type() != origFlag.Value.Type() {
-				invalidTypes = append(invalidTypes, fmt.Sprintf("%s (%s) and %s (%s)", name, origFlag.Value.Type(), alias, aliasFlag.Value.Type()))
-			}
-			if !gotValue && aliasFlag.Changed {
-				err := origFlag.Value.Set(aliasFlag.Value.String())
-				if err != nil {
-					panic(err)
-				}
-				origFlag.Changed = true
-			}
-		}
-	})
-
-	var err error
-	{
-		var errorMessages []string
-		if len(invalidFlagNames) > 0 {
-			errorMessages = append(errorMessages, fmt.Sprintf("flags '%v' are not valid flags", invalidFlagNames))
-		}
-		if len(invalidTypes) > 0 {
-			errorMessages = append(errorMessages, fmt.Sprintf("flags '%v' have different types", invalidTypes))
-		}
-		if len(errorMessages) > 1 {
-			err = fmt.Errorf("multiple errors occured:\n > %s\n", strings.Join(errorMessages, "\n > "))
-		} else if len(errorMessages) == 1 {
-			err = fmt.Errorf("%s", errorMessages[0])
-		}
-	}
-	return ctx, err
 }
 
 func determineHostname(ctx context.Context) (context.Context, error) {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -44,6 +44,11 @@ func New(usage, short, long string, fn Runner, p ...preparers.Preparer) *cobra.C
 	}
 }
 
+// Preparers are split between here and the preparers package because
+// tab-completion needs to run *some* of them, and importing this package from there
+// would create a circular dependency. Likewise, if *all* the preparers were in the preparers module,
+// that would also create a circular dependency.
+// I don't like this, but it's shippable until someone else fixes it
 var commonPreparers = []preparers.Preparer{
 	preparers.ApplyAliases,
 	determineHostname,

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -43,10 +43,7 @@ func newClone() *cobra.Command {
 		flag.App(),
 		flag.AppConfig(),
 		selectFlag,
-		flag.String{
-			Name:        "region",
-			Description: "Target region for the new machine",
-		},
+		flag.Region(),
 		flag.String{
 			Name:        "name",
 			Description: "Optional name for the new machine",

--- a/internal/command/migrate_to_v2/troubleshoot.go
+++ b/internal/command/migrate_to_v2/troubleshoot.go
@@ -22,6 +22,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/machine"
 	"github.com/superfly/flyctl/internal/command/status"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"github.com/superfly/flyctl/internal/format"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -572,10 +573,10 @@ func (t *troubleshooter) deployMachines(ctx context.Context) (err error) {
 	newDeployCmd := deploy.New()
 	fakeFlagCtx := flag.NewContext(ctx, newDeployCmd.Flags())
 
-	if err := flag.SetString(fakeFlagCtx, flag.AppConfigFilePathName, flag.GetAppConfigFilePath(ctx)); err != nil {
+	if err := flag.SetString(fakeFlagCtx, flagnames.AppConfigFilePath, flag.GetAppConfigFilePath(ctx)); err != nil {
 		return err
 	}
-	if err := flag.SetString(fakeFlagCtx, flag.AppName, flag.GetApp(ctx)); err != nil {
+	if err := flag.SetString(fakeFlagCtx, flagnames.App, flag.GetApp(ctx)); err != nil {
 		return err
 	}
 

--- a/internal/command/postgres/events.go
+++ b/internal/command/postgres/events.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flag/flagnames"
 	mach "github.com/superfly/flyctl/internal/machine"
 )
 
@@ -119,8 +120,8 @@ func runListEvents(ctx context.Context) error {
 		return fmt.Errorf("this feature is not compatible with this postgres service ")
 	}
 
-	ignoreFlags := []string{flag.AccessTokenName, flag.AppName, flag.AppConfigFilePathName,
-		flag.VerboseName, "help"}
+	ignoreFlags := []string{flagnames.AccessToken, flagnames.App, flagnames.AppConfigFilePath,
+		flagnames.Verbose, "help"}
 
 	flagsName := flag.GetFlagsName(ctx, ignoreFlags)
 

--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -62,7 +62,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/vm"
 	"github.com/superfly/flyctl/internal/command/volumes"
 	"github.com/superfly/flyctl/internal/command/wireguard"
-	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flag/flagnames"
 )
 
 // New initializes and returns a reference to a new root command.
@@ -91,8 +91,8 @@ To read more, use the docs command to view Fly's help on the web.
 	}
 
 	fs := root.PersistentFlags()
-	_ = fs.StringP(flag.AccessTokenName, "t", "", "Fly API Access Token")
-	_ = fs.BoolP(flag.VerboseName, "", false, "Verbose output")
+	_ = fs.StringP(flagnames.AccessToken, "t", "", "Fly API Access Token")
+	_ = fs.BoolP(flagnames.Verbose, "", false, "Verbose output")
 
 	flyctl.InitConfig()
 

--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -45,11 +45,7 @@ func stdArgsSSH(cmd *cobra.Command) {
 			Default:     false,
 			Description: "select available instances",
 		},
-		flag.String{
-			Name:        "region",
-			Shorthand:   "r",
-			Description: "Region to create WireGuard connection in",
-		},
+		flag.Region(),
 		flag.Bool{
 			Name:        "quiet",
 			Shorthand:   "q",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/superfly/flyctl/internal/env"
-	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flag/flagnames"
 )
 
 const (
@@ -153,15 +153,15 @@ func (cfg *Config) ApplyFlags(fs *pflag.FlagSet) {
 	defer cfg.mu.Unlock()
 
 	applyStringFlags(fs, map[string]*string{
-		flag.AccessTokenName: &cfg.AccessToken,
-		flag.OrgName:         &cfg.Organization,
-		flag.RegionName:      &cfg.Region,
+		flagnames.AccessToken: &cfg.AccessToken,
+		flagnames.Org:         &cfg.Organization,
+		flagnames.Region:      &cfg.Region,
 	})
 
 	applyBoolFlags(fs, map[string]*bool{
-		flag.VerboseName:    &cfg.VerboseOutput,
-		flag.JSONOutputName: &cfg.JSONOutput,
-		flag.LocalOnlyName:  &cfg.LocalOnly,
+		flagnames.Verbose:    &cfg.VerboseOutput,
+		flagnames.JSONOutput: &cfg.JSONOutput,
+		flagnames.LocalOnly:  &cfg.LocalOnly,
 	})
 }
 

--- a/internal/flag/completion/completion_preparers.go
+++ b/internal/flag/completion/completion_preparers.go
@@ -2,6 +2,7 @@ package completion
 
 import (
 	"context"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/cmdutil/preparers"
@@ -56,6 +57,9 @@ func Adapt(
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
+
+		ctx, cancelFn := context.WithTimeout(ctx, 5*time.Second)
+		defer cancelFn()
 
 		ctx, err = preparers.InitClient(ctx)
 		if err != nil {

--- a/internal/flag/completion/completion_preparers.go
+++ b/internal/flag/completion/completion_preparers.go
@@ -1,0 +1,73 @@
+package completion
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/cmdutil/preparers"
+	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/logger"
+	"github.com/superfly/flyctl/iostreams"
+	"github.com/superfly/flyctl/terminal"
+)
+
+func prepareInitialCtx(cmd *cobra.Command) (context.Context, error) {
+
+	io := iostreams.System()
+	ctx := cmd.Context()
+	ctx = flagctx.NewContext(ctx, cmd.Flags())
+	ctx, err := preparers.DetermineUserHomeDir(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ctx, err = preparers.DetermineConfigDir(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ctx = iostreams.NewContext(ctx, io)
+	ctx = logger.NewContext(ctx, logger.FromEnv(io.ErrOut))
+	ctx, err = preparers.LoadConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return ctx, nil
+}
+
+func AdaptFn(
+	fn func(ctx context.Context, cmd *cobra.Command, args []string, partial string) ([]string, error),
+) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, partial string) (ideas []string, code cobra.ShellCompDirective) {
+		terminal.Debugf("\n---\nDOING COMPLETION FOR %s\n---\n", cmd.Name())
+
+		var err error
+		defer func() {
+			if code == cobra.ShellCompDirectiveError {
+				terminal.Debugf("completion error: %v\n", err)
+			}
+		}()
+
+		ctx, err := prepareInitialCtx(cmd)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		res, err := fn(ctx, cmd, args, partial)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		} else {
+			return res, cobra.ShellCompDirectiveNoFileComp
+		}
+	}
+}
+
+func InitFlyApi(
+	fn func(ctx context.Context, cmd *cobra.Command, args []string, partial string) ([]string, error),
+) func(ctx context.Context, cmd *cobra.Command, args []string, partial string) ([]string, error) {
+	return func(ctx context.Context, cmd *cobra.Command, args []string, partial string) ([]string, error) {
+		ctx, err := preparers.InitClient(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return fn(ctx, cmd, args, partial)
+	}
+}

--- a/internal/flag/completion/completion_preparers.go
+++ b/internal/flag/completion/completion_preparers.go
@@ -16,7 +16,11 @@ func prepareInitialCtx(cmd *cobra.Command) (context.Context, error) {
 	io := iostreams.System()
 	ctx := cmd.Context()
 	ctx = flagctx.NewContext(ctx, cmd.Flags())
-	ctx, err := preparers.DetermineUserHomeDir(ctx)
+	ctx, err := preparers.ApplyAliases(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ctx, err = preparers.DetermineUserHomeDir(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/flag/completion/completions.go
+++ b/internal/flag/completion/completions.go
@@ -1,0 +1,109 @@
+package completion
+
+import (
+	"context"
+	"strings"
+
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/client"
+	"golang.org/x/exp/slices"
+)
+
+func CompleteApps(
+	ctx context.Context,
+	cmd *cobra.Command,
+	args []string,
+	partial string,
+) ([]string, error) {
+
+	var (
+		client    = client.FromContext(ctx)
+		clientApi = client.API()
+
+		apps []api.App
+		err  error
+	)
+
+	// We can't use `flag.*` here because of import cycles. *sigh*
+	orgFlag := cmd.Flag("org")
+	if orgFlag != nil && orgFlag.Changed {
+		var org *api.Organization
+		org, err = clientApi.GetOrganizationBySlug(ctx, orgFlag.Value.String())
+		if err != nil {
+			return nil, err
+		}
+		apps, err = clientApi.GetAppsForOrganization(ctx, org.ID)
+	} else {
+		apps, err = clientApi.GetApps(ctx, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	ret := lo.FilterMap(apps, func(app api.App, _ int) (string, bool) {
+		if strings.HasPrefix(app.Name, partial) {
+			return app.Name, true
+		}
+		return "", false
+	})
+	slices.Sort(ret)
+	return ret, nil
+}
+
+func CompleteOrgs(
+	ctx context.Context,
+	cmd *cobra.Command,
+	args []string,
+	partial string,
+) ([]string, error) {
+
+	clientApi := client.FromContext(ctx).API()
+
+	personal, others, err := clientApi.GetCurrentOrganizations(ctx)
+	if err != nil {
+		return nil, err
+	}
+	names := []string{personal.Slug}
+	for _, org := range others {
+		names = append(names, org.Slug)
+	}
+	ret := lo.Filter(names, func(name string, _ int) bool {
+		return strings.HasPrefix(name, partial)
+	})
+	slices.Sort(ret)
+	return ret, nil
+}
+
+func CompleteRegions(
+	ctx context.Context,
+	cmd *cobra.Command,
+	args []string,
+	partial string,
+) ([]string, error) {
+
+	clientApi := client.FromContext(ctx).API()
+
+	// TODO(ali): Do we need to worry about which ones are marked as "gateway"?
+	regions, reqRegion, err := clientApi.PlatformRegions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	regionNames := lo.FilterMap(regions, func(region api.Region, _ int) (string, bool) {
+		if strings.HasPrefix(region.Code, partial) {
+			return region.Code, true
+		}
+		return "", false
+	})
+	slices.Sort(regionNames)
+	// If the region we're closest to is in the list, put it at the top
+	if reqRegion != nil && strings.HasPrefix(reqRegion.Code, partial) {
+		idx := slices.Index(regionNames, reqRegion.Code)
+		// Should always be true because of the check above, but just to be safe...
+		if idx >= 0 {
+			regionNames = append([]string{regionNames[idx]}, append(regionNames[:idx], regionNames[idx+1:]...)...)
+		}
+	}
+	return regionNames, nil
+}

--- a/internal/flag/completion/completions.go
+++ b/internal/flag/completion/completions.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"golang.org/x/exp/slices"
 )
 
@@ -27,7 +28,7 @@ func CompleteApps(
 	)
 
 	// We can't use `flag.*` here because of import cycles. *sigh*
-	orgFlag := cmd.Flag("org")
+	orgFlag := cmd.Flag(flagnames.Org)
 	if orgFlag != nil && orgFlag.Changed {
 		var org *api.Organization
 		org, err = clientApi.GetOrganizationBySlug(ctx, orgFlag.Value.String())

--- a/internal/flag/context.go
+++ b/internal/flag/context.go
@@ -5,20 +5,20 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"golang.org/x/exp/slices"
 )
 
-type contextKey struct{}
-
 // NewContext derives a context that carries fs from ctx.
 func NewContext(ctx context.Context, fs *pflag.FlagSet) context.Context {
-	return context.WithValue(ctx, contextKey{}, fs)
+	return flagctx.NewContext(ctx, fs)
 }
 
 // FromContext returns the FlagSet ctx carries. It panics in case ctx carries
 // no FlagSet.
 func FromContext(ctx context.Context) *pflag.FlagSet {
-	return ctx.Value(contextKey{}).(*pflag.FlagSet)
+	return flagctx.FromContext(ctx)
 }
 
 // Args is shorthand for FromContext(ctx).Args().
@@ -106,29 +106,29 @@ func IsSpecified(ctx context.Context, name string) bool {
 	return flag != nil && flag.Changed
 }
 
-// GetOrg is shorthand for GetString(ctx, OrgName).
+// GetOrg is shorthand for GetString(ctx, Org).
 func GetOrg(ctx context.Context) string {
-	return GetString(ctx, OrgName)
+	return GetString(ctx, flagnames.Org)
 }
 
-// GetRegion is shorthand for GetString(ctx, RegionName).
+// GetRegion is shorthand for GetString(ctx, Region).
 func GetRegion(ctx context.Context) string {
-	return GetString(ctx, RegionName)
+	return GetString(ctx, flagnames.Region)
 }
 
-// GetYes is shorthand for GetBool(ctx, YesName).
+// GetYes is shorthand for GetBool(ctx, Yes).
 func GetYes(ctx context.Context) bool {
-	return GetBool(ctx, YesName)
+	return GetBool(ctx, flagnames.Yes)
 }
 
-// GetApp is shorthand for GetString(ctx, AppName).
+// GetApp is shorthand for GetString(ctx, App).
 func GetApp(ctx context.Context) string {
-	return GetString(ctx, AppName)
+	return GetString(ctx, flagnames.App)
 }
 
-// GetAppConfigFilePath is shorthand for GetString(ctx, AppConfigFilePathName).
+// GetAppConfigFilePath is shorthand for GetString(ctx, AppConfigFilePath).
 func GetAppConfigFilePath(ctx context.Context) string {
-	if path, err := FromContext(ctx).GetString(AppConfigFilePathName); err != nil {
+	if path, err := FromContext(ctx).GetString(flagnames.AppConfigFilePath); err != nil {
 		return ""
 	} else {
 		return path

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -121,7 +121,7 @@ func (s String) addTo(cmd *cobra.Command) {
 
 	// Completion
 	if s.CompletionFn != nil {
-		err := cmd.RegisterFlagCompletionFunc(s.Name, completion.AdaptFn(s.CompletionFn))
+		err := cmd.RegisterFlagCompletionFunc(s.Name, completion.Adapt(s.CompletionFn))
 		if err != nil {
 			panic(err)
 		}
@@ -268,7 +268,7 @@ func Org() String {
 		Name:         flagnames.Org,
 		Description:  "The target Fly organization",
 		Shorthand:    "o",
-		CompletionFn: completion.InitFlyApi(completion.CompleteOrgs),
+		CompletionFn: completion.CompleteOrgs,
 	}
 }
 
@@ -278,7 +278,7 @@ func Region() String {
 		Name:         flagnames.Region,
 		Description:  "The target region (see 'flyctl platform regions')",
 		Shorthand:    "r",
-		CompletionFn: completion.InitFlyApi(completion.CompleteRegions),
+		CompletionFn: completion.CompleteRegions,
 	}
 }
 
@@ -297,7 +297,7 @@ func App() String {
 		Name:         flagnames.App,
 		Shorthand:    "a",
 		Description:  "Application name",
-		CompletionFn: completion.InitFlyApi(completion.CompleteApps),
+		CompletionFn: completion.CompleteApps,
 	}
 }
 

--- a/internal/flag/flagctx/helpers.go
+++ b/internal/flag/flagctx/helpers.go
@@ -1,0 +1,23 @@
+package flagctx
+
+import (
+	"context"
+
+	"github.com/spf13/pflag"
+)
+
+// This is a hack to allow constructing a flag context from within completion,
+// a dependency of flag.
+
+type contextKey struct{}
+
+// NewContext derives a context that carries fs from ctx.
+func NewContext(ctx context.Context, fs *pflag.FlagSet) context.Context {
+	return context.WithValue(ctx, contextKey{}, fs)
+}
+
+// FromContext returns the FlagSet ctx carries. It panics in case ctx carries
+// no FlagSet.
+func FromContext(ctx context.Context) *pflag.FlagSet {
+	return ctx.Value(contextKey{}).(*pflag.FlagSet)
+}

--- a/internal/flag/flagnames/constants.go
+++ b/internal/flag/flagnames/constants.go
@@ -1,0 +1,45 @@
+package flagnames
+
+const (
+	// AccessToken denotes the name of the access token flag.
+	AccessToken = "access-token"
+
+	// Verbose denotes the name of the verbose flag.
+	Verbose = "verbose"
+
+	// JSONOutput denotes the name of the json output flag.
+	JSONOutput = "json"
+
+	// LocalOnly denotes the name of the local-only flag.
+	LocalOnly = "local-only"
+
+	// Org denotes the name of the org flag.
+	Org = "org"
+
+	// Region denotes the name of the region flag.
+	Region = "region"
+
+	// Yes denotes the name of the yes flag.
+	Yes = "yes"
+
+	// App denotes the name of the app flag.
+	App = "app"
+
+	// AppConfigFilePath denotes the name of the app config file path flag.
+	AppConfigFilePath = "config"
+
+	// Image denotes the name of the image flag.
+	Image = "image"
+
+	// Now denotes the name of the now flag.
+	Now = "now"
+
+	// NoDeploy denotes the name of the no deploy flag.
+	NoDeploy = "no-deploy"
+
+	// GenerateName denotes the name of the generate name flag.
+	GenerateNameFlag = "generate-name"
+
+	// DetachName denotes the name of the detach flag.
+	Detach = "detach"
+)


### PR DESCRIPTION
I had to do some ugly reshuffling to get this to build without circular dependencies (hello, `flagnames` package!), but the end result is _really_ slick.

https://github.com/superfly/flyctl/assets/13626644/6a188fdc-50d1-442f-8481-261c403f62eb

