### PR TITLE
Fix `fly version update` on Windows

### DIFF
--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -67,7 +67,14 @@ if (!(";$Path;".ToLower() -like "*;$BinDir;*".ToLower())) {
   $Env:Path += ";$BinDir"
 }
 
-if (!(Test-Path $FlyExe)) {
+if (!(Get-Item $FlyExe -ErrorAction SilentlyContinue).LinkTarget) {
+  # if fly.exe is not already a symlink, make it so.
+
+  # delete any existing file
+  Remove-Item $FlyExe -ErrorAction SilentlyContinue
+
+  # creating symlinks on windows requires administrator privileges by default,
+  # passing `-Verb runAs` means we'll pop up a UAC dialog here
   Start-Process -FilePath "$env:comspec" -ArgumentList "/c", "mklink", $FlyExe, $FlyctlExe -Verb runAs -WorkingDirectory "$env:windir"
 }
 

--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -68,7 +68,7 @@ if (!(";$Path;".ToLower() -like "*;$BinDir;*".ToLower())) {
 }
 
 if (!(Test-Path $FlyExe)) {
-  Start-Process -FilePath "$env:comspec" -ArgumentList "/c", "mklink", $FlyExe, $FlyctlExe -Verb runAs
+  Start-Process -FilePath "$env:comspec" -ArgumentList "/c", "mklink", $FlyExe, $FlyctlExe -Verb runAs -WorkingDirectory "$env:windir"
 }
 
 Write-Output "flyctl was installed successfully to $FlyctlExe"

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -209,13 +209,18 @@ func renameCurrentBinaries() error {
 }
 
 func currentWindowsBinaries() ([]string, error) {
-	binaryPath, err := os.Executable()
+	execPath, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+
+	canonicalPath, err := filepath.EvalSymlinks(execPath)
 	if err != nil {
 		return nil, err
 	}
 
 	return []string{
-		binaryPath,
-		filepath.Join(filepath.Dir(binaryPath), "wintun.dll"),
+		canonicalPath,
+		filepath.Join(filepath.Dir(canonicalPath), "wintun.dll"),
 	}, nil
 }


### PR DESCRIPTION
flyctl on Windows can currently only be updated when invoked as `flyctl version update`, not `fly version update`.

There's a quirk of Windows where running programs lock their .exe file preventing it from being overwritten, but not renamed. Our self-update code works around this by first renaming `flyctl.exe` to `flyctl.exe.old`, and then dropping the new .exe in place.

The problem is that when flyctl is invoked as `fly`, Go's `os.Executable()` func returns the path to the `fly.exe` _symlink_, and not the actual `flyctl.exe` executable. This causes our self-update code to rename the symlink instead of the actual executable, which then results in an error when we try to drop the new `flyctl.exe` in place, because we're trying to overwrite a running program's executable:

![flyctl-pr-2](https://github.com/superfly/flyctl/assets/179065/6027a430-89c5-47b5-8a1c-4d433321d4e3)

We can see that the symlink itself has been renamed:

![flyctl-pr-1](https://github.com/superfly/flyctl/assets/179065/c082f169-b061-4598-97c2-93295432be68)

This PR fixes this by calling `filepath.EvalSymlinks` to get the canonical path to the `flyctl.exe` executable.

There's a bonus fix I've thrown in here too: the `install.ps1` script would throw an error if invoked from a drive other than the `C:` drive. I encountered this because my Fly workspace is mounted via virtiofs as the `Z:` drive in my Windows VM, but this could also cause problems for users who primarily work from a network drive. I'm unclear on the detailed specifics of why this error occurs, but it seems to only happen when spawning `cmd.exe` with elevated privileges from a drive other than the `C:` drive. Nevertheless, explicitly setting `cmd.exe`'s working directory to `%WINDIR%` (usually `C:\WINDOWS`) fixes things.