### PR TITLE
Do not override machine image on fly m update

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -263,6 +263,11 @@ func runMachineRun(ctx context.Context) error {
 		return fmt.Errorf("the app %s uses an earlier version of the platform that does not support machines", app.Name)
 	}
 
+	imageOrPath := flag.FirstArg(ctx)
+	if imageOrPath == "" {
+		return fmt.Errorf("image argument can't be an empty string")
+	}
+
 	machineID := flag.GetString(ctx, "id")
 	if machineID != "" {
 		return fmt.Errorf("to update an existing machine, use 'flyctl machine update'")
@@ -271,7 +276,7 @@ func runMachineRun(ctx context.Context) error {
 	machineConf, err = determineMachineConfig(ctx, &determineMachineConfigInput{
 		initialMachineConf: *machineConf,
 		appName:            app.Name,
-		imageOrPath:        flag.FirstArg(ctx),
+		imageOrPath:        imageOrPath,
 		region:             input.Region,
 		updating:           false,
 	})

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -817,11 +817,13 @@ func determineMachineConfig(ctx context.Context, input *determineMachineConfigIn
 		return machineConf, err
 	}
 
-	img, err := determineImage(ctx, input.appName, input.imageOrPath)
-	if err != nil {
-		return machineConf, err
+	if input.imageOrPath != "" {
+		img, err := determineImage(ctx, input.appName, input.imageOrPath)
+		if err != nil {
+			return machineConf, err
+		}
+		machineConf.Image = img.Tag
 	}
-	machineConf.Image = img.Tag
 
 	// Service updates
 	for idx := range machineConf.Services {

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -83,17 +83,10 @@ func runUpdate(ctx context.Context) (err error) {
 	}
 
 	var imageOrPath string
-
 	if image != "" {
 		imageOrPath = image
 	} else if dockerfile != "" {
 		imageOrPath = "."
-	} else {
-		imageOrPath = machine.FullImageRef()
-	}
-
-	if imageOrPath == "" {
-		return fmt.Errorf("failed to resolve machine image")
 	}
 
 	// Identify configuration changes


### PR DESCRIPTION
Prevent `fly m update` to change the machine image when it is not meant to change like in:

<img width="1183" alt="image" src="https://github.com/superfly/flyctl/assets/37369/cc7ead5b-a742-4922-8362-634e0cfe66f5">
