### PR TITLE
Change error to say app instead of app_name

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -575,7 +575,7 @@ func appConfigFilePaths(ctx context.Context) (paths []string) {
 	return
 }
 
-var errRequireAppName = fmt.Errorf("the config for your app is missing an app name, add an app_name field to the fly.toml file or specify with the -a flag`")
+var errRequireAppName = fmt.Errorf("the config for your app is missing an app name, add an app field to the fly.toml file or specify with the -a flag`")
 
 // RequireAppName is a Preparer which makes sure the user has selected an
 // application name via command line arguments, the environment or an application


### PR DESCRIPTION
The error said you need to add an `app_name` field to fly.toml, but it's just `app`. 

Community post with some confusion around this error: https://community.fly.io/t/unable-to-deploy-from-a-repo-in-github/12937/2

Note:: this error came up in the following scenario: no`-a`  flag, no `FLY_APP` env variable, and not only no `app` field in fly.toml, but no `fly.toml` present at all. 