### PR TITLE
Monitor migrated machine

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -581,7 +581,7 @@ func (m *v2PlatformMigrator) Migrate(ctx context.Context) (err error) {
 		}
 	}
 
-	tb.Detail("Checking if app is responsive")
+	tb.Detail("Ensuring app is responsive")
 	err = m.checkAppResponsive()
 	if err != nil {
 		return err

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -927,7 +927,7 @@ func (m *v2PlatformMigrator) checkAppResponsive() error {
 	appName := m.appConfig.AppName
 	for _, svc := range httpServices {
 		// Make a request to the application and see if we get *any* response back
-		appUrl := fmt.Sprintf("%s://%s.fly.dev", svc.scheme, appName)
+		appUrl := fmt.Sprintf("%s://%s.fly.dev:%d", svc.scheme, appName, svc.port)
 		_, err := http.Get(appUrl)
 		if err != nil {
 			return errors.New("HTTP services are not responding")


### PR DESCRIPTION
WIP on ensuring an app has actually been successfully migrated. The first approach here only works for HTTP services and will attempt to make a request to the app via its `fly.dev` domain. The same strategy won't work for TCP and UDP. There, we might need to look at fly-proxy logs or something. Or potentially have a custom endpoint in the proxy that can tell us if there's connectivity (for TCP). For UDP, I have no idea.

There's some caveats here too. If an app requires downtime and nomad allocs are not scaled to zero, then this doesn't really meaningfully test anything.