### PR TITLE
Fix Debugf

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -123,3 +123,11 @@ linters-settings:
     # path to a file containing a list of functions to exclude from checking
     # see https://github.com/kisielk/errcheck#excluding-functions for details
     #exclude: /path/to/file.txt
+  govet:
+    settings:
+      printf:
+        funcs:
+          - github.com/superfly/flyctl/terminal.Debugf
+          - github.com/superfly/flyctl/terminal.Infof
+          - github.com/superfly/flyctl/terminal.Warnf
+          - github.com/superfly/flyctl/terminal.Errorf

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -192,7 +192,7 @@ func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 	}
 
 	buildkitEnabled, err := buildkitEnabled(docker)
-	terminal.Debugf("buildkitEnabled", buildkitEnabled)
+	terminal.Debugf("buildkitEnabled %v", buildkitEnabled)
 	if err != nil {
 		if dockerFactory.IsRemote() {
 			metrics.SendNoData(ctx, "remote_builder_failure")

--- a/internal/build/imgsrc/local_image_resolver.go
+++ b/internal/build/imgsrc/local_image_resolver.go
@@ -48,7 +48,7 @@ func (*localImageResolver) Run(ctx context.Context, dockerFactory *dockerClientF
 		terminal.Debug("error fetching docker server info:", err)
 	} else {
 		buildkitEnabled, err := buildkitEnabled(docker)
-		terminal.Debugf("buildkitEnabled", buildkitEnabled)
+		terminal.Debugf("buildkitEnabled %v", buildkitEnabled)
 		if err == nil {
 			build.SetBuilderMetaPart2(buildkitEnabled, serverInfo.ServerVersion, fmt.Sprintf("%s/%s/%s", serverInfo.OSType, serverInfo.Architecture, serverInfo.OSVersion))
 		}

--- a/internal/command/ssh/connect.go
+++ b/internal/command/ssh/connect.go
@@ -91,7 +91,7 @@ func Connect(p *ConnectParams, addr string) (*ssh.Client, error) {
 		return nil, errors.Wrap(err, "error connecting to SSH server")
 	}
 
-	terminal.Debugf("Connection completed.\n", addr)
+	terminal.Debugf("Connection %s completed.\n", addr)
 
 	if !p.DisableSpinner {
 		endSpin()

--- a/internal/command/ssh/ssh_terminal.go
+++ b/internal/command/ssh/ssh_terminal.go
@@ -96,7 +96,7 @@ func SSHConnect(p *SSHParams, addr string) error {
 	}
 	defer sshClient.Close()
 
-	terminal.Debugf("Connection completed.\n", addr)
+	terminal.Debugf("Connection %s completed.\n", addr)
 
 	if !p.DisableSpinner {
 		endSpin()


### PR DESCRIPTION
The first commit adds golangci-lint check to detect problematic Debugf calls. The second commit fixes them.