### PR TITLE
fly proxy: fix FD leak

### DIFF
--- a/proxy/server.go
+++ b/proxy/server.go
@@ -44,11 +44,11 @@ func (srv *Server) ProxyServer(ctx context.Context) error {
 				}
 				terminal.Debug("Error accepting connection: ", err)
 			}
-			defer source.Close()
-
 			terminal.Debug("accepted new connection from: ", source.RemoteAddr())
 
 			go func() {
+				defer source.Close()
+
 				target, err := srv.Dial(ctx, "tcp", srv.Addr)
 				if err != nil {
 					terminal.Debug("failed to connect to target: ", err)


### PR DESCRIPTION
`defer` is not called until the function returns, so `fly proxy`
has been leaking one socket per connection.
