### PR TITLE
Set `console_command` for Laravel apps

### DIFF
--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -48,7 +48,8 @@ func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 				},
 			},
 		},
-		SkipDatabase: true,
+		SkipDatabase:   true,
+		ConsoleCommand: "php /var/www/html/artisan tinker",
 	}
 
 	phpVersion, err := extractPhpVersion()


### PR DESCRIPTION
This is the command that @fideloper suggested for the `fly console` [Fresh Produce post](https://community.fly.io/t/easily-run-a-console-in-a-new-machine-with-fly-console/12773).