### PR TITLE
The context here may not have Fly-specific keys

### DIFF
--- a/internal/build/imgsrc/auth.go
+++ b/internal/build/imgsrc/auth.go
@@ -1,0 +1,48 @@
+package imgsrc
+
+import (
+	"os"
+
+	"github.com/docker/docker/api/types"
+	"github.com/spf13/viper"
+	"github.com/superfly/flyctl/flyctl"
+)
+
+func getAPIToken() string {
+	// Are either env vars set?
+	// check Access token
+	accessToken, lookup := os.LookupEnv("FLY_ACCESS_TOKEN")
+
+	if lookup {
+		return accessToken
+	}
+
+	// check API token
+	apiToken, lookup := os.LookupEnv("FLY_API_TOKEN")
+
+	if lookup {
+		return apiToken
+	}
+
+	viperAuth := viper.GetString(flyctl.ConfigAPIToken)
+
+	return viperAuth
+}
+
+func authConfigFromToken(token string) map[string]types.AuthConfig {
+	authConfigs := map[string]types.AuthConfig{}
+
+	authConfigs["registry.fly.io"] = registryAuth(token)
+
+	dockerhubUsername := os.Getenv("DOCKER_HUB_USERNAME")
+	dockerhubPassword := os.Getenv("DOCKER_HUB_PASSWORD")
+	if dockerhubUsername != "" && dockerhubPassword != "" {
+		cfg := types.AuthConfig{
+			Username:      dockerhubUsername,
+			Password:      dockerhubPassword,
+			ServerAddress: "index.docker.io",
+		}
+		authConfigs["https://index.docker.io/v1/"] = cfg
+	}
+	return authConfigs
+}

--- a/internal/build/imgsrc/auth.go
+++ b/internal/build/imgsrc/auth.go
@@ -4,30 +4,7 @@ import (
 	"os"
 
 	"github.com/docker/docker/api/types"
-	"github.com/spf13/viper"
-	"github.com/superfly/flyctl/flyctl"
 )
-
-func getAPIToken() string {
-	// Are either env vars set?
-	// check Access token
-	accessToken, lookup := os.LookupEnv("FLY_ACCESS_TOKEN")
-
-	if lookup {
-		return accessToken
-	}
-
-	// check API token
-	apiToken, lookup := os.LookupEnv("FLY_API_TOKEN")
-
-	if lookup {
-		return apiToken
-	}
-
-	viperAuth := viper.GetString(flyctl.ConfigAPIToken)
-
-	return viperAuth
-}
 
 func authConfigFromToken(token string) map[string]types.AuthConfig {
 	authConfigs := map[string]types.AuthConfig{}

--- a/internal/build/imgsrc/buildkit.go
+++ b/internal/build/imgsrc/buildkit.go
@@ -148,7 +148,8 @@ func (ap *buildkitAuthProvider) Register(server *grpc.Server) {
 }
 
 func (ap *buildkitAuthProvider) Credentials(ctx context.Context, req *auth.CredentialsRequest) (*auth.CredentialsResponse, error) {
-	auths := authConfigs(ctx)
+	// The `ctx` here wouldn't have Fly-specific keys, including auth/authz information.
+	auths := authConfigFromToken(getAPIToken())
 	res := &auth.CredentialsResponse{}
 	if a, ok := auths[req.Host]; ok {
 		res.Username = a.Username

--- a/internal/build/imgsrc/buildkit.go
+++ b/internal/build/imgsrc/buildkit.go
@@ -137,19 +137,21 @@ func (t *tracer) write(msg jsonmessage.JSONMessage) {
 	t.displayCh <- &s
 }
 
-func newBuildkitAuthProvider() session.Attachable {
-	return &buildkitAuthProvider{}
+func newBuildkitAuthProvider(token string) session.Attachable {
+	return &buildkitAuthProvider{ token: token }
 }
 
-type buildkitAuthProvider struct{}
+type buildkitAuthProvider struct{
+	token string
+}
 
 func (ap *buildkitAuthProvider) Register(server *grpc.Server) {
 	auth.RegisterAuthServer(server, ap)
 }
 
 func (ap *buildkitAuthProvider) Credentials(ctx context.Context, req *auth.CredentialsRequest) (*auth.CredentialsResponse, error) {
-	// The `ctx` here wouldn't have Fly-specific keys, including auth/authz information.
-	auths := authConfigFromToken(getAPIToken())
+	// Note that `ctx` here won't have Fly-specific keys.
+	auths := authConfigFromToken(ap.token)
 	res := &auth.CredentialsResponse{}
 	if a, ok := auths[req.Host]; ok {
 		res.Username = a.Username

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/cmdfmt"
+	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -303,7 +304,9 @@ func runBuildKitBuild(ctx context.Context, streams *iostreams.IOStreams, docker 
 	if err != nil {
 		panic(err)
 	}
-	s.Allow(newBuildkitAuthProvider())
+
+	token := config.FromContext(ctx).AccessToken
+	s.Allow(newBuildkitAuthProvider(token))
 
 	if s == nil {
 		panic("buildkit not supported")


### PR DESCRIPTION
Fixing the panic below.

```
panic: interface conversion: interface {} is nil, not *config.Config

goroutine 68 [running]:
github.com/superfly/flyctl/internal/config.FromContext(...)
/home/runner/work/flyctl/flyctl/internal/config/context.go:15
github.com/superfly/flyctl/internal/build/imgsrc.authConfigs({0x1d5c6a8, 0xc000dfff80})
/home/runner/work/flyctl/flyctl/internal/build/imgsrc/docker.go:428 +0x276
github.com/superfly/flyctl/internal/build/imgsrc.(*buildkitAuthProvider).Credentials(0x16?, {0x1d5c6a8?, 0xc000dfff80?}, 0xc000dfb2f0)
/home/runner/work/flyctl/flyctl/internal/build/imgsrc/buildkit.go:151 +0x4c
```