### PR TITLE
canonicalize flags for memory and cpu to `--vm-[memory/cpu]`, add aliases

### DIFF
--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -39,16 +39,18 @@ func New() *cobra.Command {
 		flag.App(),
 		flag.AppConfig(),
 		flag.Int{
-			Name:        "cpus",
+			Name:        "vm-cpus",
 			Description: "How many (shared) CPUs to give the new machine",
+			Aliases:     []string{"cpus"},
 		},
 		flag.String{
 			Name:        "machine",
 			Description: "Run the console in the existing machine with the specified ID",
 		},
 		flag.Int{
-			Name:        "memory",
+			Name:        "vm-memory",
 			Description: "How much memory (in MB) to give the new machine",
+			Aliases:     []string{"memory"},
 		},
 		flag.Bool{
 			Name:        "select",
@@ -208,11 +210,11 @@ func promptForMachine(ctx context.Context, app *api.AppCompact, appConfig *appco
 }
 
 func getMachineByID(ctx context.Context) (*api.Machine, bool, error) {
-	if flag.IsSpecified(ctx, "cpus") {
-		return nil, false, errors.New("--cpus can't be used with --machine")
+	if flag.IsSpecified(ctx, "vm-cpus") {
+		return nil, false, errors.New("--vm-cpus can't be used with --machine")
 	}
-	if flag.IsSpecified(ctx, "memory") {
-		return nil, false, errors.New("--memory can't be used with --machine")
+	if flag.IsSpecified(ctx, "vm-memory") {
+		return nil, false, errors.New("--vm-memory can't be used with --machine")
 	}
 
 	flapsClient := flaps.FromContext(ctx)
@@ -318,8 +320,8 @@ func checkMachineDestruction(ctx context.Context, machine *api.Machine, firstErr
 func determineEphemeralConsoleMachineGuest(ctx context.Context) (*api.MachineGuest, error) {
 	desiredGuest := helpers.Clone(api.MachinePresets["shared-cpu-1x"])
 
-	if flag.IsSpecified(ctx, "cpus") {
-		cpus := flag.GetInt(ctx, "cpus")
+	if flag.IsSpecified(ctx, "vm-cpus") {
+		cpus := flag.GetInt(ctx, "vm-cpus")
 		if !lo.Contains([]int{1, 2, 4, 6, 8}, cpus) {
 			return nil, errors.New("invalid number of CPUs")
 		}
@@ -329,8 +331,8 @@ func determineEphemeralConsoleMachineGuest(ctx context.Context) (*api.MachineGue
 	minMemory := desiredGuest.CPUs * api.MIN_MEMORY_MB_PER_SHARED_CPU
 	maxMemory := desiredGuest.CPUs * api.MAX_MEMORY_MB_PER_SHARED_CPU
 
-	if flag.IsSpecified(ctx, "memory") {
-		memory := flag.GetInt(ctx, "memory")
+	if flag.IsSpecified(ctx, "vm-memory") {
+		memory := flag.GetInt(ctx, "vm-memory")
 		cpuS := lo.Ternary(desiredGuest.CPUs == 1, "", "s")
 		switch {
 		case memory < minMemory:

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -78,6 +78,7 @@ var CommonFlags = flag.Set{
 	flag.String{
 		Name:        "vm-size",
 		Description: `The VM size to use when deploying for the first time. See "fly platform vm-sizes" for valid values`,
+		Aliases:     []string{"size"},
 	},
 	flag.Bool{
 		Name:        "ha",
@@ -96,6 +97,7 @@ var CommonFlags = flag.Set{
 	flag.Int{
 		Name:        "vm-cpus",
 		Description: "Number of CPUs",
+		Aliases:     []string{"cpus"},
 	},
 	flag.String{
 		Name:        "vm-cpukind",
@@ -104,6 +106,7 @@ var CommonFlags = flag.Set{
 	flag.Int{
 		Name:        "vm-memory",
 		Description: "Memory (in megabytes) to attribute to the VM",
+		Aliases:     []string{"memory"},
 	},
 }
 
@@ -181,7 +184,13 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes
 		}
 	} else {
 		if flag.GetBool(ctx, "no-public-ips") {
-			return fmt.Errorf("The --no-public-ips flag can only be used for v2 apps")
+			return fmt.Errorf("the --no-public-ips flag can only be used for v2 apps")
+		}
+		if flag.IsSpecified(ctx, "vm-cpus") {
+			return fmt.Errorf("the --vm-cpus flag can only be used for v2 apps")
+		}
+		if flag.IsSpecified(ctx, "vm-memory") {
+			return fmt.Errorf("the --vm-memory flag can only be used for v2 apps")
 		}
 
 		err = deployToNomad(ctx, appConfig, appCompact, img)

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -46,17 +46,20 @@ var sharedFlags = flag.Set{
 	To remove a port mapping use '-' as handler, i.e.: --port 80/tcp:-`,
 	},
 	flag.String{
-		Name:        "size",
+		Name:        "vm-size",
 		Shorthand:   "s",
 		Description: "Preset guest cpu and memory for a machine, defaults to shared-cpu-1x",
+		Aliases:     []string{"size"},
 	},
 	flag.Int{
-		Name:        "cpus",
+		Name:        "vm-cpus",
 		Description: "Number of CPUs",
+		Aliases:     []string{"cpus"},
 	},
 	flag.Int{
-		Name:        "memory",
+		Name:        "vm-memory",
 		Description: "Memory (in megabytes) to attribute to the machine",
+		Aliases:     []string{"memory"},
 	},
 	flag.StringArray{
 		Name:        "env",
@@ -707,7 +710,7 @@ type determineMachineConfigInput struct {
 func determineMachineConfig(ctx context.Context, input *determineMachineConfigInput) (*api.MachineConfig, error) {
 	machineConf := mach.CloneConfig(&input.initialMachineConf)
 
-	if guestSize := flag.GetString(ctx, "size"); guestSize != "" {
+	if guestSize := flag.GetString(ctx, "vm-size"); guestSize != "" {
 		err := machineConf.Guest.SetSize(guestSize)
 		if err != nil {
 			return nil, err
@@ -715,15 +718,15 @@ func determineMachineConfig(ctx context.Context, input *determineMachineConfigIn
 	}
 
 	// Potential overrides for Guest
-	if cpus := flag.GetInt(ctx, "cpus"); cpus != 0 {
+	if cpus := flag.GetInt(ctx, "vm-cpus"); cpus != 0 {
 		machineConf.Guest.CPUs = cpus
-	} else if flag.IsSpecified(ctx, "cpus") {
+	} else if flag.IsSpecified(ctx, "vm-cpus") {
 		return nil, fmt.Errorf("cannot have zero cpus")
 	}
 
-	if memory := flag.GetInt(ctx, "memory"); memory != 0 {
+	if memory := flag.GetInt(ctx, "vm-memory"); memory != 0 {
 		machineConf.Guest.MemoryMB = memory
-	} else if flag.IsSpecified(ctx, "memory") {
+	} else if flag.IsSpecified(ctx, "vm-memory") {
 		return nil, fmt.Errorf("memory cannot be zero")
 	}
 

--- a/internal/command/scale/vm.go
+++ b/internal/command/scale/vm.go
@@ -33,7 +33,12 @@ For pricing, see https://fly.io/docs/about/pricing/`
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
-		flag.Int{Name: "memory", Description: "Memory in MB for the VM", Default: 0},
+		flag.Int{
+			Name:        "vm-memory",
+			Description: "Memory in MB for the VM",
+			Default:     0,
+			Aliases:     []string{"memory"},
+		},
 		flag.String{Name: "group", Description: "The process group to apply the VM size to"},
 	)
 	return cmd
@@ -41,7 +46,7 @@ For pricing, see https://fly.io/docs/about/pricing/`
 
 func runScaleVM(ctx context.Context) error {
 	sizeName := flag.FirstArg(ctx)
-	memoryMB := flag.GetInt(ctx, "memory")
+	memoryMB := flag.GetInt(ctx, "vm-memory")
 	group := flag.GetString(ctx, "group")
 	return scaleVertically(ctx, group, sizeName, memoryMB)
 }

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -3,6 +3,7 @@ package flag
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -52,6 +53,28 @@ const (
 	DetachName = "detach"
 )
 
+func makeAlias[T any](template T, name string) T {
+
+	var ret T
+	value := reflect.ValueOf(&ret).Elem()
+
+	descField := reflect.ValueOf(template).FieldByName("Description")
+	if descField.IsValid() {
+		value.FieldByName("Description").SetString(descField.String())
+	}
+
+	nameField := value.FieldByName("Name")
+	if nameField.IsValid() {
+		nameField.SetString(name)
+	}
+
+	hiddenField := value.FieldByName("Hidden")
+	if hiddenField.IsValid() {
+		hiddenField.SetBool(true)
+	}
+	return ret
+}
+
 // Flag wraps the set of flags.
 type Flag interface {
 	addTo(*cobra.Command)
@@ -79,6 +102,7 @@ type Bool struct {
 	Description string
 	Default     bool
 	Hidden      bool
+	Aliases     []string
 }
 
 func (b Bool) addTo(cmd *cobra.Command) {
@@ -92,6 +116,14 @@ func (b Bool) addTo(cmd *cobra.Command) {
 
 	f := flags.Lookup(b.Name)
 	f.Hidden = b.Hidden
+
+	for _, name := range b.Aliases {
+		makeAlias(b, name).addTo(cmd)
+	}
+	err := cmd.Flags().SetAnnotation(f.Name, "flyctl_alias", b.Aliases)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // String wraps the set of string flags.
@@ -103,6 +135,7 @@ type String struct {
 	ConfName    string
 	EnvName     string
 	Hidden      bool
+	Aliases     []string
 }
 
 func (s String) addTo(cmd *cobra.Command) {
@@ -116,6 +149,14 @@ func (s String) addTo(cmd *cobra.Command) {
 
 	f := flags.Lookup(s.Name)
 	f.Hidden = s.Hidden
+
+	for _, name := range s.Aliases {
+		makeAlias(s, name).addTo(cmd)
+	}
+	err := cmd.Flags().SetAnnotation(f.Name, "flyctl_alias", s.Aliases)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Int wraps the set of int flags.
@@ -125,6 +166,7 @@ type Int struct {
 	Description string
 	Default     int
 	Hidden      bool
+	Aliases     []string
 }
 
 func (i Int) addTo(cmd *cobra.Command) {
@@ -138,6 +180,14 @@ func (i Int) addTo(cmd *cobra.Command) {
 
 	f := flags.Lookup(i.Name)
 	f.Hidden = i.Hidden
+
+	for _, name := range i.Aliases {
+		makeAlias(i, name).addTo(cmd)
+	}
+	err := cmd.Flags().SetAnnotation(f.Name, "flyctl_alias", i.Aliases)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // StringSlice wraps the set of string slice flags.
@@ -149,6 +199,7 @@ type StringSlice struct {
 	ConfName    string
 	EnvName     string
 	Hidden      bool
+	Aliases     []string
 }
 
 func (ss StringSlice) addTo(cmd *cobra.Command) {
@@ -162,6 +213,14 @@ func (ss StringSlice) addTo(cmd *cobra.Command) {
 
 	f := flags.Lookup(ss.Name)
 	f.Hidden = ss.Hidden
+
+	for _, name := range ss.Aliases {
+		makeAlias(ss, name).addTo(cmd)
+	}
+	err := cmd.Flags().SetAnnotation(f.Name, "flyctl_alias", ss.Aliases)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // StringArray wraps the set of string array flags.
@@ -173,6 +232,7 @@ type StringArray struct {
 	ConfName    string
 	EnvName     string
 	Hidden      bool
+	Aliases     []string
 }
 
 func (ss StringArray) addTo(cmd *cobra.Command) {
@@ -186,6 +246,14 @@ func (ss StringArray) addTo(cmd *cobra.Command) {
 
 	f := flags.Lookup(ss.Name)
 	f.Hidden = ss.Hidden
+
+	for _, name := range ss.Aliases {
+		makeAlias(ss, name).addTo(cmd)
+	}
+	err := cmd.Flags().SetAnnotation(f.Name, "flyctl_alias", ss.Aliases)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Duration wraps the set of duration flags.
@@ -197,6 +265,7 @@ type Duration struct {
 	ConfName    string
 	EnvName     string
 	Hidden      bool
+	Aliases     []string
 }
 
 func (d Duration) addTo(cmd *cobra.Command) {
@@ -210,6 +279,14 @@ func (d Duration) addTo(cmd *cobra.Command) {
 
 	f := flags.Lookup(d.Name)
 	f.Hidden = d.Hidden
+
+	for _, name := range d.Aliases {
+		makeAlias(d, name).addTo(cmd)
+	}
+	err := cmd.Flags().SetAnnotation(f.Name, "flyctl_alias", d.Aliases)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Org returns an org string flag.


### PR DESCRIPTION
adds aliases from `--[memory/cpu]` to `--vm-[memory/cpu]`

Supersedes #2300 