### PR TITLE
Replace `apps.BuildContext` in a few places

### DIFF
--- a/internal/command/config/save.go
+++ b/internal/command/config/save.go
@@ -2,13 +2,11 @@ package config
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
-	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/state"
@@ -37,17 +35,15 @@ func runSave(ctx context.Context) error {
 	var (
 		err         error
 		appName     = appconfig.NameFromContext(ctx)
-		apiClient   = client.FromContext(ctx).API()
 		autoConfirm = flag.GetBool(ctx, "yes")
 	)
-	appCompact, err := apiClient.GetAppCompact(ctx, appName)
-	if err != nil {
-		return fmt.Errorf("error getting app with name %s: %w", appName, err)
-	}
-	ctx, err = apps.BuildContext(ctx, appCompact)
+
+	flapsClient, err := flaps.NewFromAppName(ctx, appName)
 	if err != nil {
 		return err
 	}
+	ctx = flaps.NewContext(ctx, flapsClient)
+
 	cfg, err := appconfig.FromRemoteApp(ctx, appName)
 	if err != nil {
 		return err

--- a/internal/command/config/show.go
+++ b/internal/command/config/show.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
-	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -33,17 +32,12 @@ in JSON format. The configuration data is retrieved from the Fly service.`
 func runShow(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
 
-	appCompact, err := apiClient.GetAppCompact(ctx, appName)
-	if err != nil {
-		return fmt.Errorf("error getting app with name %s: %w", appName, err)
-	}
-
-	ctx, err = apps.BuildContext(ctx, appCompact)
+	flapsClient, err := flaps.NewFromAppName(ctx, appName)
 	if err != nil {
 		return err
 	}
+	ctx = flaps.NewContext(ctx, flapsClient)
 
 	cfg, err := appconfig.FromRemoteApp(ctx, appName)
 	if err != nil {

--- a/internal/command/services/machines.go
+++ b/internal/command/services/machines.go
@@ -7,8 +7,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
-	"github.com/superfly/flyctl/client"
-	"github.com/superfly/flyctl/internal/command/apps"
+	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/render"
@@ -20,7 +19,6 @@ import (
 func ShowMachineServiceInfo(ctx context.Context, app *api.AppInfo) error {
 	var (
 		io        = iostreams.FromContext(ctx)
-		client    = client.FromContext(ctx).API()
 		jsonOuput = flag.GetBool(ctx, "json")
 	)
 
@@ -28,15 +26,11 @@ func ShowMachineServiceInfo(ctx context.Context, app *api.AppInfo) error {
 		return fmt.Errorf("outputting to json is not yet supported")
 	}
 
-	appCompact, err := client.GetAppCompact(ctx, app.Name)
+	flapsClient, err := flaps.NewFromAppName(ctx, app.Name)
 	if err != nil {
 		return err
 	}
-
-	ctx, err = apps.BuildContext(ctx, appCompact)
-	if err != nil {
-		return err
-	}
+	ctx = flaps.NewContext(ctx, flapsClient)
 
 	machines, err := machine.ListActive(ctx)
 	if err != nil {


### PR DESCRIPTION
Noticed this today when `config show` failed in my local dev setup (no Wireguard). This PR reduces the number of round-trips to the API for these and eliminates the whole start-an-agent-for-Wireguard process when not necessary.

(There are a bunch more commands that use `BuildContext` and perhaps might be candidates for this treatment someday. These are just three that I thought I could quickly verify don't break.)