### PR TITLE
Machine guest memory can be lower than preset size

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -893,11 +893,14 @@ func determineVmSpecs(vmSize api.VMSize) (*api.MachineGuest, error) {
 	}
 
 	guest := &api.MachineGuest{}
-	err := guest.SetSize(preset)
-	if err != nil {
+	if err := guest.SetSize(preset); err != nil {
 		return nil, fmt.Errorf("nomad VM definition incompatible with machines API: %w", err)
 	}
-	guest.MemoryMB = vmSize.MemoryMB
+
+	// Can't set less memory than the preset
+	if vmSize.MemoryMB > guest.MemoryMB {
+		guest.MemoryMB = vmSize.MemoryMB
+	}
 
 	// minimum memory for a machine is 256MB, micro-1x on V1 allowed 128MB
 	if guest.MemoryMB < 256 {


### PR DESCRIPTION
Fixes error with `cpu1mem1` nomad allocs that attempt to set less memory than the mapped preset

```
failed while migrating: failed creating a machine in region lax: failed to launch VM: invalid config.guest.memory_mb, minimum required 2048 MiB
```