### PR TITLE
`migrate-to-v2`: better prompt if no config is found

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -49,7 +49,14 @@ func newMigrateToV2() *cobra.Command {
 	)
 	cmd := command.New(
 		usage, short, long, runMigrateToV2,
-		command.RequireSession, command.RequireAppName,
+		command.RequireSession,
+		func(ctx context.Context) (context.Context, error) {
+			if cfg := appconfig.ConfigFromContext(ctx); cfg == nil {
+				return nil, fmt.Errorf("no config found, please ensure there is a fly.toml in the current directory or pass one with '-c <path>'")
+			}
+			return ctx, nil
+		},
+		command.RequireAppName,
 	)
 	cmd.Args = cobra.NoArgs
 	flag.Add(cmd,

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -50,8 +50,13 @@ func newMigrateToV2() *cobra.Command {
 	cmd := command.New(
 		usage, short, long, runMigrateToV2,
 		command.RequireSession,
+		command.LoadAppConfigIfPresent,
 		func(ctx context.Context) (context.Context, error) {
-			if cfg := appconfig.ConfigFromContext(ctx); cfg == nil {
+			if cfg := appconfig.ConfigFromContext(ctx); cfg != nil {
+				if cfg.AppName == "" {
+					return nil, fmt.Errorf("your fly.toml is missing an app name, please ensure the 'app' field is set")
+				}
+			} else {
 				return nil, fmt.Errorf("no config found, please ensure there is a fly.toml in the current directory or pass one with '-c <path>'")
 			}
 			return ctx, nil


### PR DESCRIPTION
Instead of the confusing *and incorrect* prompt 
```
Error: the config for your app is missing an app name, add an app field to the fly.toml file or specify with the -a flag`
```
we now display
```
Error: no config found, please ensure there is a fly.toml in the current directory or pass one with '-c <path>'
```