### PR TITLE
capture errors when performing migrations

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -117,6 +117,7 @@ func runMigrateToV2(ctx context.Context) (err error) {
 	}
 	err = migrator.Migrate(ctx)
 	if err != nil {
+		metrics.Send(ctx, "migrate_to_v2/errors", map[string]string{"app_name": appName, "error": err.Error()})
 		return err
 	}
 	return nil


### PR DESCRIPTION
Sends a metric to `flyctl-metrics` that captures any errors we see from migrations. Idea being that we can build some dashboards that surface (frequency of) errors relatively easily