### PR TITLE
`migrate-to-v2`: respect process group VMSize

### DIFF
--- a/internal/command/migrate_to_v2/machines.go
+++ b/internal/command/migrate_to_v2/machines.go
@@ -18,8 +18,13 @@ func (m *v2PlatformMigrator) resolveMachineFromAlloc(alloc *api.AllocationStatus
 		return nil, err
 	}
 
+	guest, ok := m.machineGuests[mConfig.ProcessGroup()]
+	if !ok {
+		return nil, fmt.Errorf("no guest found for process '%s'", mConfig.ProcessGroup())
+	}
+
 	mConfig.Mounts = nil
-	mConfig.Guest = m.machineGuest
+	mConfig.Guest = guest
 	mConfig.Image = m.img
 	mConfig.Metadata[api.MachineConfigMetadataKeyFlyReleaseId] = m.releaseId
 	mConfig.Metadata[api.MachineConfigMetadataKeyFlyReleaseVersion] = strconv.Itoa(m.releaseVersion)


### PR DESCRIPTION
```
❯ fly scale show
VM Resources for ali-nomad-multi-pg
          Count: a=1 b=1
 Max Per Region: a=0 b=0

Process group a
        VM Size: shared-cpu-1x
      VM Memory: 256 MB
 Max Per Region: 0

Process group b
        VM Size: dedicated-cpu-4x
      VM Memory: 8 GB
 Max Per Region: 0

❯ ~/Work/flyctl/bin/flyctl migrate-to-v2
<snip>

❯ fly scale show
VM Resources for app: ali-nomad-multi-pg

Groups
NAME	COUNT	KIND       	CPUS	MEMORY 	REGIONS
a   	1    	shared     	1   	256 MB 	iad
b   	1    	performance	4   	8192 MB	iad