### PR TITLE
`migrate-to-v2`: filter out failed nomad allocs

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -236,6 +236,9 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 	if err != nil {
 		return nil, err
 	}
+	allocs = lo.Filter(allocs, func(alloc *api.AllocationStatus, _ int) bool {
+		return !alloc.Failed && alloc.LatestVersion
+	})
 	vmSize, _, groups, err := apiClient.AppVMResources(ctx, appName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Preflight passes, but I'd really appreciate if someone who knows nomad better that I do could double-check that filtering by `!alloc.Failed && alloc.LatestVersion` shouldn't introduce weird side effects
