### PR TITLE
Fixes for autostart/autostop-related config fields

### DIFF
--- a/internal/appconfig/service.go
+++ b/internal/appconfig/service.go
@@ -11,8 +11,8 @@ import (
 type Service struct {
 	Protocol           string                         `json:"protocol,omitempty" toml:"protocol"`
 	InternalPort       int                            `json:"internal_port,omitempty" toml:"internal_port"`
-	AutoStopMachines   *bool                          `json:"auto_stop_machines,omitempty" toml:"auto_stop_machines,omitempty"`
-	AutoStartMachines  *bool                          `json:"auto_start_machines,omitempty" toml:"auto_start_machines,omitempty"`
+	AutoStopMachines   *bool                          `json:"auto_stop_machines,omitempty" toml:"auto_stop_machines"`
+	AutoStartMachines  *bool                          `json:"auto_start_machines,omitempty" toml:"auto_start_machines"`
 	MinMachinesRunning *int                           `json:"min_machines_running,omitempty" toml:"min_machines_running,omitempty"`
 	Ports              []api.MachinePort              `json:"ports,omitempty" toml:"ports"`
 	Concurrency        *api.MachineServiceConcurrency `json:"concurrency,omitempty" toml:"concurrency"`
@@ -47,8 +47,8 @@ type ServiceHTTPCheck struct {
 type HTTPService struct {
 	InternalPort       int                            `json:"internal_port,omitempty" toml:"internal_port,omitempty" validate:"required,numeric"`
 	ForceHTTPS         bool                           `toml:"force_https,omitempty" json:"force_https,omitempty"`
-	AutoStopMachines   *bool                          `json:"auto_stop_machines,omitempty" toml:"auto_stop_machines,omitempty"`
-	AutoStartMachines  *bool                          `json:"auto_start_machines,omitempty" toml:"auto_start_machines,omitempty"`
+	AutoStopMachines   *bool                          `json:"auto_stop_machines,omitempty" toml:"auto_stop_machines"`
+	AutoStartMachines  *bool                          `json:"auto_start_machines,omitempty" toml:"auto_start_machines"`
 	MinMachinesRunning *int                           `json:"min_machines_running,omitempty" toml:"min_machines_running,omitempty"`
 	Processes          []string                       `json:"processes,omitempty" toml:"processes,omitempty"`
 	Concurrency        *api.MachineServiceConcurrency `toml:"concurrency,omitempty" json:"concurrency,omitempty"`

--- a/internal/appconfig/service.go
+++ b/internal/appconfig/service.go
@@ -160,13 +160,16 @@ func serviceFromMachineService(ms api.MachineService, processes []string) *Servi
 		}
 	}
 	return &Service{
-		Protocol:     ms.Protocol,
-		InternalPort: ms.InternalPort,
-		Ports:        ms.Ports,
-		Concurrency:  ms.Concurrency,
-		TCPChecks:    tcpChecks,
-		HTTPChecks:   httpChecks,
-		Processes:    processes,
+		Protocol:           ms.Protocol,
+		InternalPort:       ms.InternalPort,
+		AutoStopMachines:   ms.Autostop,
+		AutoStartMachines:  ms.Autostart,
+		MinMachinesRunning: ms.MinMachinesRunning,
+		Ports:              ms.Ports,
+		Concurrency:        ms.Concurrency,
+		TCPChecks:          tcpChecks,
+		HTTPChecks:         httpChecks,
+		Processes:          processes,
 	}
 }
 


### PR DESCRIPTION
1. When generating an app config from machines, copy the `autostart`, `autostop`, and `min_machines_running` fields.
2. Don't use `omitempty` for TOML serialization of `auto_start_machines` and `auto_stop_machines`. The encoder always omits `nil` values since they can't be represented in TOML. `omitempty` actually omits non-`nil` `false` values as well.

The motivation for this is to make sure that using `fly config save` and then `fly deploy` doesn't inadvertently change the configuration (especially for [Postgres](https://community.fly.io/t/how-to-turn-off-postgres-scaling-to-zero-after-1-hour/12522/2)).