### PR TITLE
`migrate-to-v2`: better filtering for nomad allocs

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -237,7 +237,7 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 		return nil, err
 	}
 	allocs = lo.Filter(allocs, func(alloc *api.AllocationStatus, _ int) bool {
-		return !alloc.Failed && alloc.LatestVersion
+		return alloc.Status == "running" && alloc.LatestVersion
 	})
 	vmSize, _, groups, err := apiClient.AppVMResources(ctx, appName)
 	if err != nil {


### PR DESCRIPTION
based on dangra's research