### PR TITLE
Only migrate used volumes

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -245,10 +245,16 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 		return alloc.Status == "running" && alloc.LatestVersion
 	})
 
-	var attachedVolumes []api.Volume
-	for _, a := range allocs {
-		attachedVolumes = append(attachedVolumes, a.AttachedVolumes.Nodes...)
-	}
+	attachedVolumes := lo.Filter(appFull.Volumes.Nodes, func(v api.Volume, _ int) bool {
+		if v.AttachedAllocation != nil {
+			for _, a := range allocs {
+				if a.ID == v.AttachedAllocation.ID {
+					return true
+				}
+			}
+		}
+		return false
+	})
 
 	vmSize, _, groups, err := apiClient.AppVMResources(ctx, appName)
 	if err != nil {

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -170,6 +170,7 @@ type v2PlatformMigrator struct {
 	releaseId               string
 	releaseVersion          int
 	oldAllocs               []*api.AllocationStatus
+	oldAttachedVolumes      []api.Volume
 	machineGuests           map[string]*api.MachineGuest
 	oldVmCounts             map[string]int
 	newMachinesInput        []*api.LaunchMachineInput
@@ -243,6 +244,12 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 	allocs = lo.Filter(allocs, func(alloc *api.AllocationStatus, _ int) bool {
 		return alloc.Status == "running" && alloc.LatestVersion
 	})
+
+	var attachedVolumes []api.Volume
+	for _, a := range allocs {
+		attachedVolumes = append(attachedVolumes, a.AttachedVolumes.Nodes...)
+	}
+
 	vmSize, _, groups, err := apiClient.AppVMResources(ctx, appName)
 	if err != nil {
 		return nil, err
@@ -268,6 +275,7 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 		formattedProcessConfigs: formattedProcessConfigs,
 		img:                     img,
 		oldAllocs:               allocs,
+		oldAttachedVolumes:      attachedVolumes,
 		machineGuests:           machineGuests,
 		isPostgres:              appCompact.IsPostgresApp(),
 		replacedVolumes:         map[string]int{},

--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -20,7 +20,7 @@ func (m *v2PlatformMigrator) validateVolumes(ctx context.Context) error {
 		return nil
 	}
 	numMounts := len(m.appConfig.Mounts)
-	m.usesForkedVolumes = numMounts != 0
+	m.usesForkedVolumes = numMounts != 0 && len(m.oldAttachedVolumes) > 0
 
 	volsPerProcess := map[string]int{}
 	for _, mount := range m.appConfig.Mounts {
@@ -65,9 +65,7 @@ func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 		return v
 	}))
 
-	for _, vol := range m.appFull.Volumes.Nodes {
-		// TODO(ali): Should we migrate _all_ volumes, or just the ones used currently?
-
+	for _, vol := range m.oldAttachedVolumes {
 		newVol, err := m.apiClient.ForkVolume(ctx, api.ForkVolumeInput{
 			AppID:          m.appFull.ID,
 			SourceVolumeID: vol.ID,


### PR DESCRIPTION
```
$ make preflight-test T=MigrateToV2_Volumes
Running Generate for Help and GraphQL client
go generate ./...
Running Build
CGO_ENABLED=0 go build -o bin/flyctl -ldflags="-X 'github.com/superfly/flyctl/internal/buildinfo.buildDate=2023-05-25T22:12:49Z' -X 'github.com/superfly/flyctl/internal/buildinfo.branchName=fix/only-migrate-used-volumes'" .
if [ -r .direnv/preflight ]; then . .direnv/preflight; fi; \
go test ./test/preflight --tags=integration -v -timeout 30m --run=MigrateToV2_Volumes
=== RUN   TestAppsV2MigrateToV2_Volumes
--- PASS: TestAppsV2MigrateToV2_Volumes (137.65s)
PASS
ok      github.com/superfly/flyctl/test/preflight       137.659s
```