### PR TITLE
`migrate-to-v2`: use sentry for error logging

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -133,7 +133,17 @@ func runMigrateToV2(ctx context.Context) (err error) {
 	}
 	err = migrator.Migrate(ctx)
 	if err != nil {
-		metrics.Send(ctx, "migrate_to_v2/errors", map[string]string{"app_name": appName, "error": err.Error()})
+		sentry.CaptureException(err,
+			sentry.WithTag("feature", "migrate-to-v2"),
+			sentry.WithContexts(map[string]sentry.Context{
+				"app": {
+					"name": appName,
+				},
+				"organization": {
+					"name": appCompact.Organization.Slug,
+				},
+			}),
+		)
 		return err
 	}
 	return nil


### PR DESCRIPTION
because metrics is being flaky right now