### PR TITLE
migrate-to-v2: fix segfault if fly.toml is missing

### DIFF
--- a/internal/command/config/save.go
+++ b/internal/command/config/save.go
@@ -92,7 +92,7 @@ func keepPrevSections(ctx context.Context, currentCfg *appconfig.Config, configP
 	}
 
 	// Check if there's anything to actually copy over
-	if oldCfg.Build == nil {
+	if oldCfg != nil && oldCfg.Build == nil {
 		return nil
 	}
 


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0xff38d8]

goroutine 1 [running]:
github.com/superfly/flyctl/internal/command/config.keepPrevSections({0x1d8aca8, 0xc000e00c90}, 0xc0005cf680, {0xc000c3a690, 0x12})
	/home/ben/dev/flyctl/internal/command/config/save.go:96 +0x98
github.com/superfly/flyctl/internal/command/config.runSave({0x1d8aca8, 0xc000e00c00})
	/home/ben/dev/flyctl/internal/command/config/save.go:77 +0x2e7
github.com/superfly/flyctl/internal/command.newRunE.func1(0xc000de2780, {0xc0006b4900?, 0x2?, 0x2?})
	/home/ben/dev/flyctl/internal/command/command.go:118 +0x28c
github.com/spf13/cobra.(*Command).execute(0xc000de2780, {0xc0006b48e0, 0x2, 0x2})
	/home/ben/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0xc000605b80)
	/home/ben/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).ExecuteContextC(...)
	/home/ben/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:911
github.com/superfly/flyctl/internal/cli.Run({0x1d8b958?, 0xc000e9fac0?}, 0xc00020f7c0, {0xc00003e0b0, 0x4, 0x4})
	/home/ben/dev/flyctl/internal/cli/cli.go:44 +0x27c
main.run()
	/home/ben/dev/flyctl/main.go:45 +0x117
main.main()
	/home/ben/dev/flyctl/main.go:26 +0x1e

```