### PR TITLE
migrate-to-v2: restore writes to PG primary

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -370,7 +370,7 @@ func (m *v2PlatformMigrator) rollback(ctx context.Context, tb *render.TextBlock)
 	}
 	if m.isPostgres {
 		tb.Detailf("Disabling readonly")
-		err := m.setNomadPgReadonly(ctx, true)
+		err := m.setNomadPgReadonly(ctx, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I haven't tested this or encountered this bug, but the code looks wrong
