### PR TITLE
Support different port for service checks

### DIFF
--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -360,6 +360,7 @@ func TestToDefinition(t *testing.T) {
 				},
 				"tcp_checks": []any{
 					map[string]any{
+						"port":         int64(1001),
 						"interval":     "21s",
 						"timeout":      "4s",
 						"grace_period": "1s",
@@ -367,6 +368,7 @@ func TestToDefinition(t *testing.T) {
 				},
 				"http_checks": []any{
 					map[string]any{
+						"port":            int64(2020),
 						"interval":        "1m21s",
 						"timeout":         "7s",
 						"grace_period":    "2s",

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -675,6 +675,17 @@ func TestToMachineConfig_services(t *testing.T) {
 			InternalPort: 1004,
 			Autostart:    nil,
 			Autostop:     nil,
+			Checks: []fly.MachineCheck{
+				{
+					Port: fly.Pointer(9090),
+					Type: fly.Pointer("tcp"),
+				}, {
+					Port:       fly.Pointer(2020),
+					Type:       fly.Pointer("http"),
+					HTTPMethod: fly.Pointer("GET"),
+					HTTPPath:   fly.Pointer("/"),
+				},
+			},
 		},
 	}
 

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -567,6 +567,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 
 				TCPChecks: []*ServiceTCPCheck{
 					{
+						Port:        fly.Pointer(1001),
 						Interval:    fly.MustParseDuration("21s"),
 						Timeout:     fly.MustParseDuration("4s"),
 						GracePeriod: fly.MustParseDuration("1s"),
@@ -575,6 +576,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 
 				HTTPChecks: []*ServiceHTTPCheck{
 					{
+						Port:              fly.Pointer(2020),
 						Interval:          fly.MustParseDuration("81s"),
 						Timeout:           fly.MustParseDuration("7s"),
 						GracePeriod:       fly.MustParseDuration("2s"),

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -197,11 +197,13 @@ host_dedication_id = "06031957"
       idle_timeout = 600
 
   [[services.tcp_checks]]
+    port = 1001
     interval = "21s"
     timeout = "4s"
     grace_period = "1s"
 
   [[services.http_checks]]
+    port = 2020
     interval = "1m21s"
     timeout = "7s"
     grace_period = "2s"

--- a/internal/appconfig/testdata/tomachine-services.toml
+++ b/internal/appconfig/testdata/tomachine-services.toml
@@ -32,3 +32,11 @@ primary_region = "scl"
 [[services]]
   protocol = "tcp"
   internal_port = 1004
+
+  [[services.tcp_checks]]
+    port = 9090
+
+  [[services.http_checks]]
+    port = 2020
+    method = "GET"
+    path = "/"


### PR DESCRIPTION
Support monitoring TCP services on a different port. By closing the alternate port, fly-proxy can declare the machine service as unhealthy and will stop sending traffic to it while the ongoing connections are drained.