### PR TITLE
`deploy`: add `--release-command-timeout`, prompt change timeout on err

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	DefaultWaitTimeout = 120 * time.Second
-	DefaultLeaseTtl    = 13 * time.Second
-	DefaultVMSize      = "shared-cpu-1x"
+	DefaultWaitTimeout           = 2 * time.Minute
+	DefaultReleaseCommandTimeout = 5 * time.Minute
+	DefaultLeaseTtl              = 13 * time.Second
+	DefaultVMSize                = "shared-cpu-1x"
 )
 
 type MachineDeployment interface {
@@ -42,6 +43,7 @@ type MachineDeploymentArgs struct {
 	RestartOnly           bool
 	WaitTimeout           time.Duration
 	LeaseTimeout          time.Duration
+	ReleaseCmdTimeout     time.Duration
 	VMSize                string
 	VMCPUs                int
 	VMMemory              int
@@ -71,6 +73,7 @@ type machineDeployment struct {
 	waitTimeout           time.Duration
 	leaseTimeout          time.Duration
 	leaseDelayBetween     time.Duration
+	releaseCmdTimeout     time.Duration
 	isFirstDeploy         bool
 	machineGuest          *api.MachineGuest
 	increasedAvailability bool
@@ -139,6 +142,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		waitTimeout:           waitTimeout,
 		leaseTimeout:          leaseTimeout,
 		leaseDelayBetween:     leaseDelayBetween,
+		releaseCmdTimeout:     args.ReleaseCmdTimeout,
 		increasedAvailability: args.IncreasedAvailability,
 		listenAddressChecked:  make(map[string]struct{}),
 	}

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -320,7 +320,7 @@ func (lm *leasableMachine) WaitForHealthchecksToPass(ctx context.Context, timeou
 
 // waits for an eventType1 type event to show up after we see a eventType2 event, and returns it
 func (lm *leasableMachine) WaitForEventTypeAfterType(ctx context.Context, eventType1, eventType2 string, timeout time.Duration, allowInfinite bool) (*api.MachineEvent, error) {
-	waitCtx, cancel, timeout := resolveTimeoutContext(ctx, timeout, allowInfinite)
+	waitCtx, cancel, _ := resolveTimeoutContext(ctx, timeout, allowInfinite)
 	defer cancel()
 	b := &backoff.Backoff{
 		Min:    500 * time.Millisecond,


### PR DESCRIPTION
This adds a flag `--release-command-timeout`, so that the release command can have a separate timeout from the general purpose `wait-timeout` used on app machines. This timeout starts at five minutes, instead of two, and supports a `none` option to allow the release command to go on forever.

Release command failures (and normal wait failures) fail with this message when timing out now:
```
  Waiting for 4d891163a52087 to have state: destroyed
Error: release command failed - aborting deployment. error waiting for release_command machine 4d891163a52087 to finish running: timeout reached waiting for machine to destroyed failed to wait for VM 4d891163a52087 in destroyed state: Get "https://api.machines.dev/v1/apps/ali-process-dns-example/machines/4d891163a52087/wait?instance_id=01H1JV6NGZGGJK2N611XQXM8PE&state=destroyed&timeout=2": net/http: request canceled
note: you can change this timeout with the --release-command-timeout flag
```

(I'm not even sure if we *want* to post this on every wait failure, but it's a better status quo than now!)