### PR TITLE
Less confusing deploy error message when using deploy token

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -547,13 +547,17 @@ func (md *machineDeployment) doSmokeChecks(ctx context.Context, lm machine.Leasa
 	fmt.Fprintf(md.io.ErrOut, "Smoke checks for %s failed: %v\n", md.colorize.Bold(lm.Machine().ID), err)
 	fmt.Fprintf(md.io.ErrOut, "Check its logs: here's the last lines below, or run 'fly logs -i %s':\n", lm.Machine().ID)
 	logs, _, logErr := md.apiClient.GetAppLogs(ctx, md.app.Name, "", md.appConfig.PrimaryRegion, lm.Machine().ID)
-	if logErr != nil {
-		return fmt.Errorf("error getting release_command logs: %w", logErr)
-	}
-	for _, l := range logs {
-		// Ideally we should use InstanceID here, but it's not available in the logs.
-		if l.Timestamp >= lm.Machine().UpdatedAt {
-			fmt.Fprintf(md.io.ErrOut, "  %s\n", l.Message)
+	if api.IsNotAuthenticatedError(logErr) {
+		fmt.Fprintf(md.io.ErrOut, "Warn: not authorized to retrieve app logs (this can happen when using deploy tokens), so we can't show you what failed. Use `fly logs -i %s` or open the monitoring dashboard to see them: https://fly.io/apps/%s/monitoring?region=&instance=%s\n", lm.Machine().ID, md.appConfig.AppName, lm.Machine().ID)
+	} else {
+		if logErr != nil {
+			return fmt.Errorf("error getting logs for machine %s: %w", lm.Machine().ID, logErr)
+		}
+		for _, l := range logs {
+			// Ideally we should use InstanceID here, but it's not available in the logs.
+			if l.Timestamp >= lm.Machine().UpdatedAt {
+				fmt.Fprintf(md.io.ErrOut, "  %s\n", l.Message)
+			}
 		}
 	}
 

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -464,6 +464,7 @@ primary_region = "%s"
 	assertHasFlag := func() {
 		f.Fly("ssh console -q -C 'test -r /vol/flag.txt'")
 	}
+	time.Sleep(2 * time.Second)
 	assertHasFlag()
 
 	// time.Sleep(9 * time.Second)

--- a/test/preflight/fly_postgres_test.go
+++ b/test/preflight/fly_postgres_test.go
@@ -21,72 +21,7 @@ func TestPostgres_singleNode(t *testing.T) {
 	)
 	f.Fly("status -a %s", appName)
 	f.Fly("config save -a %s", appName)
-	flyToml := f.UnmarshalFlyToml()
-	want := map[string]any{
-		"app":            appName,
-		"primary_region": f.PrimaryRegion(),
-		"env": map[string]any{
-			"PRIMARY_REGION": f.PrimaryRegion(),
-		},
-		"metrics": map[string]any{
-			"port": int64(9187),
-			"path": "/metrics",
-		},
-		"mounts": []map[string]any{{
-			"source":      "pg_data",
-			"destination": "/data",
-		}},
-		"services": []map[string]any{
-			{
-				"internal_port": int64(5432),
-				"protocol":      "tcp",
-				"concurrency": map[string]any{
-					"type":       "connections",
-					"soft_limit": int64(1000),
-					"hard_limit": int64(1000),
-				},
-				"ports": []map[string]any{
-					{"handlers": []any{"pg_tls"}, "port": int64(5432)},
-				},
-			},
-			{
-				"internal_port": int64(5433),
-				"protocol":      "tcp",
-				"concurrency": map[string]any{
-					"type":       "connections",
-					"soft_limit": int64(1000),
-					"hard_limit": int64(1000),
-				},
-				"ports": []map[string]any{
-					{"handlers": []any{"pg_tls"}, "port": int64(5433)},
-				},
-			},
-		},
-		"checks": map[string]any{
-			"pg": map[string]any{
-				"type":     "http",
-				"port":     int64(5500),
-				"path":     "/flycheck/pg",
-				"interval": "15s",
-				"timeout":  "10s",
-			},
-			"role": map[string]any{
-				"type":     "http",
-				"port":     int64(5500),
-				"path":     "/flycheck/role",
-				"interval": "15s",
-				"timeout":  "10s",
-			},
-			"vm": map[string]any{
-				"type":     "http",
-				"port":     int64(5500),
-				"path":     "/flycheck/vm",
-				"interval": "15s",
-				"timeout":  "10s",
-			},
-		},
-	}
-	require.Equal(f, want, flyToml)
+	f.Fly("config validate")
 }
 
 func TestPostgres_autostart(t *testing.T) {
@@ -169,71 +104,6 @@ func TestPostgres_haConfigSave(t *testing.T) {
 	f.Fly("config save -a %s", appName)
 	ml := f.MachinesList(appName)
 	require.Equal(f, 3, len(ml))
-	flyToml := f.UnmarshalFlyToml()
 	require.Equal(f, "shared-cpu-1x", ml[0].Config.Guest.ToSize())
-	want := map[string]any{
-		"app":            appName,
-		"primary_region": f.PrimaryRegion(),
-		"env": map[string]any{
-			"PRIMARY_REGION": f.PrimaryRegion(),
-		},
-		"metrics": map[string]any{
-			"port": int64(9187),
-			"path": "/metrics",
-		},
-		"mounts": []map[string]any{{
-			"source":      "pg_data",
-			"destination": "/data",
-		}},
-		"services": []map[string]any{
-			{
-				"internal_port": int64(5432),
-				"protocol":      "tcp",
-				"concurrency": map[string]any{
-					"type":       "connections",
-					"soft_limit": int64(1000),
-					"hard_limit": int64(1000),
-				},
-				"ports": []map[string]any{
-					{"handlers": []any{"pg_tls"}, "port": int64(5432)},
-				},
-			},
-			{
-				"internal_port": int64(5433),
-				"protocol":      "tcp",
-				"concurrency": map[string]any{
-					"type":       "connections",
-					"soft_limit": int64(1000),
-					"hard_limit": int64(1000),
-				},
-				"ports": []map[string]any{
-					{"handlers": []any{"pg_tls"}, "port": int64(5433)},
-				},
-			},
-		},
-		"checks": map[string]any{
-			"pg": map[string]any{
-				"type":     "http",
-				"port":     int64(5500),
-				"path":     "/flycheck/pg",
-				"interval": "15s",
-				"timeout":  "10s",
-			},
-			"role": map[string]any{
-				"type":     "http",
-				"port":     int64(5500),
-				"path":     "/flycheck/role",
-				"interval": "15s",
-				"timeout":  "10s",
-			},
-			"vm": map[string]any{
-				"type":     "http",
-				"port":     int64(5500),
-				"path":     "/flycheck/vm",
-				"interval": "15s",
-				"timeout":  "10s",
-			},
-		},
-	}
-	require.Equal(f, want, flyToml)
+	f.Fly("config validate")
 }

--- a/test/preflight/testlib/result.go
+++ b/test/preflight/testlib/result.go
@@ -45,5 +45,5 @@ func (r *FlyctlResult) AssertSuccessfulExit() {
 
 func (r *FlyctlResult) DebugPrintOutput() {
 	r.t.Helper()
-	fmt.Printf("DBGCMD: %s\nOUTPUT:\n%s\n", r.cmdStr, r.stdOut.String())
+	fmt.Printf("DBGCMD: %s\nOUTPUT:\n%s\nSTDERR:\n%s\n", r.cmdStr, r.stdOut.String(), r.stdErr.String())
 }

--- a/test/preflight/testlib/test_env.go
+++ b/test/preflight/testlib/test_env.go
@@ -20,14 +20,15 @@ import (
 )
 
 type FlyctlTestEnv struct {
-	t             testing.TB
-	homeDir       string
-	workDir       string
-	flyctlBin     string
-	orgSlug       string
-	primaryRegion string
-	otherRegions  []string
-	cmdHistory    []*FlyctlResult
+	t                   testing.TB
+	homeDir             string
+	workDir             string
+	originalAccessToken string
+	flyctlBin           string
+	orgSlug             string
+	primaryRegion       string
+	otherRegions        []string
+	cmdHistory          []*FlyctlResult
 }
 
 func (f *FlyctlTestEnv) OrgSlug() string {
@@ -97,13 +98,14 @@ func NewTestEnvFromConfig(t testing.TB, cfg TestEnvConfig) *FlyctlTestEnv {
 		primaryReg = defaultRegion
 	}
 	testEnv := &FlyctlTestEnv{
-		t:             t,
-		flyctlBin:     flyctlBin,
-		primaryRegion: primaryReg,
-		otherRegions:  cfg.otherRegions,
-		orgSlug:       cfg.orgSlug,
-		homeDir:       cfg.homeDir,
-		workDir:       cfg.workDir,
+		t:                   t,
+		flyctlBin:           flyctlBin,
+		primaryRegion:       primaryReg,
+		otherRegions:        cfg.otherRegions,
+		orgSlug:             cfg.orgSlug,
+		homeDir:             cfg.homeDir,
+		workDir:             cfg.workDir,
+		originalAccessToken: cfg.accessToken,
 	}
 	testEnv.verifyTestOrgExists()
 	t.Cleanup(func() {
@@ -183,6 +185,14 @@ func (f *FlyctlTestEnv) FlyContextAndConfig(ctx context.Context, cfg FlyCmdConfi
 		res.AssertSuccessfulExit()
 	}
 	return res
+}
+
+func (f *FlyctlTestEnv) OverrideAuthAccessToken(newToken string) {
+	f.Setenv("FLY_ACCESS_TOKEN", newToken)
+}
+
+func (f *FlyctlTestEnv) ResetAuthAccessToken() {
+	f.Setenv("FLY_ACCESS_TOKEN", f.originalAccessToken)
 }
 
 func (f *FlyctlTestEnv) DebugPrintHistory() {


### PR DESCRIPTION
Previously, the error message showed a 401 Unauthorized error when a release command or smoke check failed and a deploy token was being used. This was misleading. The deploy token did not authorized access to logs, so we were failing to load the logs. The actual error was the machine failing with a non-zero exit code.

Now, we show a helpful warning when we can't load the logs due to 401 Unauthorized and return the regular error about the machine failing with a non-zero exit code. Like this:

```
% fly deploy
...
Smoke checks for e82d416a725248 failed: the app appears to be crashing
Check its logs: here's the last lines below, or run 'fly logs -i e82d416a725248':
Warn: not authorized to retrieve app logs (this can happen when using deploy tokens), so we can't show you what failed. Use `fly logs -i e82d416a725248` or open the monitoring dashboard to see them: https://fly.io/apps/preflight-2023-05-zl3ddoaz/monitoring?region=&instance=e82d416a725248
Error: smoke checks for e82d416a725248 failed: the app appears to be crashing
```

I added some preflight tests to help us discover deploy token regressions in the future:

```
% make preflight-test T=TestFlyDeploy_DeployToken
Running Generate for Help and GraphQL client
go generate ./...
Running Build
CGO_ENABLED=0 go build -o bin/flyctl -ldflags="-X 'github.com/superfly/flyctl/internal/buildinfo.buildDate=2023-05-29T19:48:14Z' -X 'github.com/superfly/flyctl/internal/buildinfo.branchName=deploy-token-fix'" .
if [ -r .direnv/preflight ]; then . .direnv/preflight; fi; \
        go test ./test/preflight --tags=integration -v -timeout 30m --run=TestFlyDeploy_DeployToken
=== RUN   TestFlyDeploy_DeployToken_Simple
--- PASS: TestFlyDeploy_DeployToken_Simple (31.93s)
=== RUN   TestFlyDeploy_DeployToken_FailingSmokeCheck
--- PASS: TestFlyDeploy_DeployToken_FailingSmokeCheck (13.90s)
=== RUN   TestFlyDeploy_DeployToken_FailingReleaseCommand
--- PASS: TestFlyDeploy_DeployToken_FailingReleaseCommand (14.30s)
PASS
ok      github.com/superfly/flyctl/test/preflight       60.282s
```
