### PR TITLE
Add -c/--config flags to several commands that have -a/--app flags

### DIFF
--- a/internal/command/autoscale/root.go
+++ b/internal/command/autoscale/root.go
@@ -44,6 +44,7 @@ func newAutoscaleDisable() *cobra.Command {
 	)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.JSONOutput(),
 	)
 	cmd.Args = cobra.MaximumNArgs(2)
@@ -64,6 +65,7 @@ max=int - maximum number of instances to be allocated globally.`
 	)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.JSONOutput(),
 	)
 	cmd.Args = cobra.MaximumNArgs(2)
@@ -81,6 +83,7 @@ func newAutoscaleShow() *cobra.Command {
 	)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.JSONOutput(),
 	)
 	cmd.Args = cobra.NoArgs

--- a/internal/command/certificates/root.go
+++ b/internal/command/certificates/root.go
@@ -51,6 +51,7 @@ func newCertificatesList() *cobra.Command {
 	)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.JSONOutput(),
 	)
 	cmd.Args = cobra.NoArgs
@@ -69,6 +70,7 @@ as a parameter for the certificate.`
 	)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.JSONOutput(),
 	)
 	cmd.Args = cobra.ExactArgs(1)
@@ -88,6 +90,7 @@ as a parameter to locate the certificate.`
 	)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.Yes(),
 	)
 	cmd.Args = cobra.ExactArgs(1)
@@ -107,6 +110,7 @@ Takes hostname as a parameter to locate the certificate.`
 	)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.JSONOutput(),
 	)
 	cmd.Args = cobra.ExactArgs(1)
@@ -125,6 +129,7 @@ Displays results in the same format as the SHOW command.`
 	)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.JSONOutput(),
 	)
 	cmd.Args = cobra.ExactArgs(1)

--- a/internal/command/dashboard/root.go
+++ b/internal/command/dashboard/root.go
@@ -26,6 +26,7 @@ func New() *cobra.Command {
 	)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 	)
 	cmd.Aliases = []string{"dash"}
 	return cmd
@@ -42,6 +43,7 @@ func newDashboardMetrics() *cobra.Command {
 	)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 	)
 	return cmd
 }

--- a/internal/command/postgres/barman.go
+++ b/internal/command/postgres/barman.go
@@ -275,6 +275,7 @@ func newCheckBarman() *cobra.Command {
 
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 	)
 
 	return cmd
@@ -291,6 +292,7 @@ func newBarmanListBackup() *cobra.Command {
 
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 	)
 
 	return cmd
@@ -309,6 +311,7 @@ func newBarmanShowBackup() *cobra.Command {
 
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 	)
 
 	return cmd
@@ -325,6 +328,7 @@ func newBarmanBackup() *cobra.Command {
 
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 	)
 
 	return cmd
@@ -341,6 +345,7 @@ func newBarmanSwitchWal() *cobra.Command {
 
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 	)
 
 	return cmd
@@ -359,6 +364,7 @@ func newBarmanRecover() *cobra.Command {
 
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.String{
 			Name:        "backup-id",
 			Shorthand:   "b",

--- a/internal/command/regions/root.go
+++ b/internal/command/regions/root.go
@@ -39,6 +39,7 @@ func newRegionsAdd() *cobra.Command {
 	cmd.Args = cobra.MinimumNArgs(1)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.Yes(),
 		flag.JSONOutput(),
 		flag.String{Name: "group", Description: "The process group to add the region to"},
@@ -58,6 +59,7 @@ func newRegionsRemove() *cobra.Command {
 	cmd.Args = cobra.MinimumNArgs(1)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.Yes(),
 		flag.JSONOutput(),
 		flag.String{Name: "group", Description: "The process group to add the region to"},
@@ -77,6 +79,7 @@ func newRegionsSet() *cobra.Command {
 	cmd.Args = cobra.MinimumNArgs(1)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.Yes(),
 		flag.JSONOutput(),
 		flag.String{Name: "group", Description: "The process group to add the region to"},
@@ -96,6 +99,7 @@ func newRegionsBackup() *cobra.Command {
 	cmd.Args = cobra.MinimumNArgs(1)
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.Yes(),
 		flag.JSONOutput(),
 	)
@@ -114,6 +118,7 @@ func newRegionsList() *cobra.Command {
 	cmd.Args = cobra.NoArgs
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.JSONOutput(),
 	)
 	return cmd

--- a/internal/command/tokens/create.go
+++ b/internal/command/tokens/create.go
@@ -3,6 +3,8 @@ package tokens
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/gql"
@@ -11,7 +13,6 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
-	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/command"
@@ -73,6 +74,7 @@ func newDeploy() *cobra.Command {
 
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.JSONOutput(),
 		flag.String{
 			Name:        "name",

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -3,6 +3,7 @@ package tokens
 import (
 	"context"
 	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
@@ -28,6 +29,7 @@ func newList() *cobra.Command {
 
 	flag.Add(cmd,
 		flag.App(),
+		flag.AppConfig(),
 		flag.JSONOutput(),
 		flag.String{
 			Name:        "scope",


### PR DESCRIPTION
Found these using:

```
$ diff <(git grep -n --no-color -c 'flag.App()')  <(git grep -n --no-color -c 'flag.AppConfig()')
4,5d3
< internal/command/autoscale/root.go:3
< internal/command/certificates/root.go:5
14d11
< internal/command/dashboard/root.go:2
19d15
< internal/command/domains/root.go:1
43a40
> internal/command/migrate_to_v2/migrate_to_v2.go:1
48c45
< internal/command/postgres/barman.go:7
---
> internal/command/postgres/barman.go:1
61d57
< internal/command/regions/root.go:5
72,73d67
< internal/command/tokens/create.go:1
< internal/command/tokens/list.go:1
```
