### PR TITLE
Remove broken limitedAccessTokens queries for now

### DIFF
--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -193,13 +193,6 @@ func (client *Client) GetApp(ctx context.Context, appName string) (*App, error) 
 				postgresAppRole: role {
 					name
 				}
-				limitedAccessTokens {
-				  nodes {
-					id
-					name
-					expiresAt
-				  }
-				}
 			}
 		}
 	`

--- a/api/resource_organizations.go
+++ b/api/resource_organizations.go
@@ -66,13 +66,6 @@ func (client *Client) GetOrganizationBySlug(ctx context.Context, slug string) (*
 				slug
 				name
 				type
-                limitedAccessTokens {
-					nodes {
-					    id
-					    name
-					    expiresAt
-					}
-                }
 			}
 		}
 	`

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -3,6 +3,7 @@ package tokens
 import (
 	"context"
 	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
@@ -58,6 +59,9 @@ func runList(ctx context.Context) (err error) {
 			return fmt.Errorf("failed retrieving app %s: %w", appName, err)
 		}
 
+		if app.LimitedAccessTokens == nil {
+			return fmt.Errorf("no access tokens")
+		}
 		for _, token := range app.LimitedAccessTokens.Nodes {
 			rows = append(rows, []string{token.Id, token.Name, token.ExpiresAt.String()})
 		}
@@ -68,6 +72,9 @@ func runList(ctx context.Context) (err error) {
 			return fmt.Errorf("failed retrieving org %w", err)
 		}
 
+		if org.LimitedAccessTokens == nil {
+			return fmt.Errorf("no access tokens")
+		}
 		for _, token := range org.LimitedAccessTokens.Nodes {
 			rows = append(rows, []string{token.Id, token.Name, token.ExpiresAt.String()})
 		}


### PR DESCRIPTION
The query fails sometimes. We'll need to fix this on the backend, then revert this change. This should unbreak flyctl for the non `fly tokens list` cases.

Related:
* https://github.com/superfly/flyctl/issues/2367
* https://community.fly.io/t/extend-volume-postgres-error-limitedaccesstokens/13195
* https://community.fly.io/t/cannot-create-an-app-on-fly-field-limitedaccesstokens-doesnt-exist-on-type-app/13201
* https://community.fly.io/t/failing-to-attach-a-postgres-db-to-an-app/13198
