### PR TITLE
Match sentry release version with git tags

### DIFF
--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -26,7 +26,7 @@ func init() {
 		// TODO: maybe set Debug to buildinfo.IsDev?
 		// Debug:       true,
 		Environment: buildinfo.Environment(),
-		Release:     buildinfo.Version().String(),
+		Release:     "v" + buildinfo.Version().String(),
 		Transport: &sentry.HTTPSyncTransport{
 			Timeout: 3 * time.Second,
 		},


### PR DESCRIPTION
This should allow sentry to show the code from github by matching the release version string with the git tag