### PR TITLE
Fix `Dockerfile` typo in error message.

### DIFF
--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -163,7 +163,7 @@ func RailsCallback(appName string, srcInfo *SourceInfo, options map[string]bool)
 		cmd.Stderr = os.Stderr
 
 		if err := cmd.Run(); err != nil {
-			return errors.Wrap(err, "Failed to generate Dockefile")
+			return errors.Wrap(err, "Failed to generate Dockerfile")
 		}
 	} else {
 		if options["postgresql"] && !strings.Contains(string(gemfile), "pg") {


### PR DESCRIPTION
## Description

I was trying to deploy a Rails app and noticed this typo. 

## Screenshot

<img width="959" alt="Screen Shot 2023-06-04 at 7 03 32 AM" src="https://github.com/superfly/flyctl/assets/17516559/9d98d601-7a1d-46bb-8641-0b494edfd475">
