### PR TITLE
Do not print history for preflight test failures

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -39,6 +39,7 @@ jobs:
           FLY_PREFLIGHT_TEST_ACCESS_TOKEN: ${{ secrets.FLYCTL_PREFLIGHT_CI_FLY_API_TOKEN }}
           FLY_PREFLIGHT_TEST_FLY_ORG: flyctl-ci-preflight
           FLY_PREFLIGHT_TEST_FLY_REGIONS: iad syd
+          FLY_PREFLIGHT_TEST_NO_PRINT_HISTORY_ON_FAIL: "true"
         run: |
           PATH=$PWD/bin:$PATH ./scripts/preflight.sh -r "${{ github.ref }}" -t "${{ matrix.parallelism }}" -i "${{ matrix.index }}"
       - name: Post failure to slack


### PR DESCRIPTION
There is often db creds and stuff like that in the history. We do have a script that deletes all apps at the end of each run, so we can think of this as defense in depth (yay buzzwords!).

Plus, this encourages folks to run the test locally when reproducing and that is a good thing.
