### PR TITLE
fix: sort allocs by version and filter by running and highest version

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -251,8 +251,19 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 	if err != nil {
 		return nil, err
 	}
+
+	// sort allocs by version descending
+	slices.SortFunc(allocs, func(i, j *api.AllocationStatus) bool {
+		return i.Version > j.Version
+	})
+
+	var highestVersion int
 	allocs = lo.Filter(allocs, func(alloc *api.AllocationStatus, _ int) bool {
-		return alloc.Status == "running" && alloc.LatestVersion
+		if alloc.Status == "running" && alloc.Version >= highestVersion {
+			highestVersion = alloc.Version
+			return true
+		}
+		return false
 	})
 
 	attachedVolumes := lo.Filter(appFull.Volumes.Nodes, func(v api.Volume, _ int) bool {


### PR DESCRIPTION
It's possible for all of the running allocs to not be the `LatestVersion` which results in no machines getting created and the call to stop the allocs to do nothing. With these changes, we now filter the allocs based on whether or not it's running and only the highest version.