### PR TITLE
Add 'tokens create litefs-cloud' command

### DIFF
--- a/internal/command/orgs/orgs.go
+++ b/internal/command/orgs/orgs.go
@@ -63,9 +63,9 @@ func emailFromSecondArgOrPrompt(ctx context.Context) (email string, err error) {
 
 var errSlugArgMustBeSpecified = prompt.NonInteractiveError("slug argument must be specified when not running interactively")
 
-func slugFromFirstArgOrSelect(ctx context.Context, filters ...api.OrganizationFilter) (slug string, err error) {
-	if slug = flag.FirstArg(ctx); slug != "" {
-		return
+func slugFromArgOrSelect(ctx context.Context, orgSlug string, filters ...api.OrganizationFilter) (slug string, err error) {
+	if orgSlug != "" {
+		return orgSlug, nil
 	}
 
 	io := iostreams.FromContext(ctx)
@@ -94,7 +94,16 @@ func slugFromFirstArgOrSelect(ctx context.Context, filters ...api.OrganizationFi
 }
 
 func OrgFromFirstArgOrSelect(ctx context.Context, filters ...api.OrganizationFilter) (*api.Organization, error) {
-	slug, err := slugFromFirstArgOrSelect(ctx, filters...)
+	slug, err := slugFromArgOrSelect(ctx, flag.FirstArg(ctx), filters...)
+	if err != nil {
+		return nil, err
+	}
+
+	return OrgFromSlug(ctx, slug)
+}
+
+func OrgFromFlagOrSelect(ctx context.Context, filters ...api.OrganizationFilter) (*api.Organization, error) {
+	slug, err := slugFromArgOrSelect(ctx, flag.GetOrg(ctx), filters...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/tokens/create.go
+++ b/internal/command/tokens/create.go
@@ -155,7 +155,7 @@ func runOrg(ctx context.Context) error {
 		expiry = expiryDuration.String()
 	}
 
-	org, err := orgs.OrgFromFirstArgOrSelect(ctx, api.AdminOnly)
+	org, err := orgs.OrgFromFirstArgOrSelect(ctx)
 	if err != nil {
 		return fmt.Errorf("failed retrieving org %w", err)
 	}

--- a/internal/command/tokens/create.go
+++ b/internal/command/tokens/create.go
@@ -31,6 +31,7 @@ func newCreate() *cobra.Command {
 	cmd.AddCommand(
 		newDeploy(),
 		newOrg(),
+		newLiteFSCloud(),
 	)
 
 	return cmd
@@ -87,6 +88,42 @@ func newDeploy() *cobra.Command {
 			Shorthand:   "x",
 			Description: "The duration that the token will be valid",
 			Default:     time.Hour * 24 * 365 * 20,
+		},
+	)
+
+	return cmd
+}
+
+func newLiteFSCloud() *cobra.Command {
+	const (
+		short = "Create LiteFS Cloud tokens"
+		long  = "Create an API token limited to a single LiteFS Cloud cluster."
+		usage = "litefs-cloud"
+	)
+
+	cmd := command.New(usage, short, long, runLiteFSCloud,
+		command.RequireSession,
+	)
+
+	flag.Add(cmd,
+		flag.JSONOutput(),
+		flag.Org(),
+		flag.String{
+			Name:        "name",
+			Shorthand:   "n",
+			Description: "Token name",
+			Default:     "LiteFS Cloud token",
+		},
+		flag.Duration{
+			Name:        "expiry",
+			Shorthand:   "x",
+			Description: "The duration that the token will be valid",
+			Default:     time.Hour * 24 * 365 * 20,
+		},
+		flag.String{
+			Name:        "cluster",
+			Shorthand:   "c",
+			Description: "Cluster name",
 		},
 	)
 
@@ -158,6 +195,44 @@ func runDeploy(ctx context.Context) (err error) {
 
 	resp, err := makeToken(ctx, apiClient, app.Organization.ID, expiry, "deploy", &gql.LimitedAccessTokenOptions{
 		"app_id": app.ID,
+	})
+	if err != nil {
+		return err
+	}
+
+	token = resp.CreateLimitedAccessToken.LimitedAccessToken.TokenHeader
+
+	io := iostreams.FromContext(ctx)
+	if config.FromContext(ctx).JSONOutput {
+		render.JSON(io.Out, map[string]string{"token": token})
+	} else {
+		fmt.Fprintln(io.Out, token)
+	}
+
+	return nil
+}
+
+func runLiteFSCloud(ctx context.Context) (err error) {
+	var token string
+	apiClient := client.FromContext(ctx).API()
+
+	expiry := ""
+	if expiryDuration := flag.GetDuration(ctx, "expiry"); expiryDuration != 0 {
+		expiry = expiryDuration.String()
+	}
+
+	cluster := flag.GetString(ctx, "cluster")
+	if cluster == "" {
+		return fmt.Errorf("cluster name is not provided")
+	}
+
+	org, err := orgs.OrgFromFlagOrSelect(ctx)
+	if err != nil {
+		return fmt.Errorf("failed retrieving org %w", err)
+	}
+
+	resp, err := makeToken(ctx, apiClient, org.ID, expiry, "litefs_cloud", &gql.LimitedAccessTokenOptions{
+		"cluster": cluster,
 	})
 	if err != nil {
 		return err

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -64,7 +63,7 @@ func runList(ctx context.Context) (err error) {
 		}
 
 	case "org":
-		org, err := orgs.OrgFromFirstArgOrSelect(ctx, api.AdminOnly)
+		org, err := orgs.OrgFromFirstArgOrSelect(ctx)
 		if err != nil {
 			return fmt.Errorf("failed retrieving org %w", err)
 		}


### PR DESCRIPTION
The command is used to issue RW tokes for a specific LiteFS Cloud
cluster.
