### PR TITLE
Remove probeTunnel's 5 seconds timeout

### DIFF
--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -300,9 +300,6 @@ func (s *server) probeTunnel(ctx context.Context, slug string) (err error) {
 
 	s.printf("probing %q ...", slug)
 
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
 	var results []net.IP
 	switch results, err = tunnel.LookupAAAA(ctx, "_api.internal"); {
 	case err != nil:


### PR DESCRIPTION
https://community.fly.io/t/error-tunnel-unavailable-failed-probing-personal-context-deadline-exceeded/7128 https://community.fly.io/t/error-tunnel-unavailable-failed-probing-personal-context-deadline-exceeded/13402