### PR TITLE
Revert "WIP(Use Viper's setDefault method to make websockets enabled by default)"

### DIFF
--- a/flyctl/flyctl.go
+++ b/flyctl/flyctl.go
@@ -69,7 +69,6 @@ func initViper() {
 	viper.SetDefault(ConfigAPIBaseURL, "https://api.fly.io")
 	viper.SetDefault(ConfigFlapsBaseUrl, "https://api.machines.dev")
 	viper.SetDefault(ConfigRegistryHost, "registry.fly.io")
-	viper.SetDefault(ConfigWireGuardWebsockets, true)
 
 	viper.BindEnv(ConfigVerboseOutput, "VERBOSE")
 	viper.BindEnv(ConfigGQLErrorLogging, "GQLErrorLogging")


### PR DESCRIPTION
Reverts superfly/flyctl#2408

This broke things when the `wire_guard_websockets` key was missing from ~/.fly.config.yml. Reverting for now. We can figure out the actual fix later.

```
% grep -c wire_guard_websockets ~/.fly/config.yml
0
% fly ssh console -a my-app
Connecting to tunnel 🌍Error: tunnel unavailable: failed probing "my-org": context deadline exceeded

% fly wg websockets disable
% grep wire_guard_websockets ~/.fly/config.yml
wire_guard_websockets: false
% fly ssh console -a my-app
Connecting to fdaa:0:... complete
root@host:/usr/src/app#
```
