### PR TITLE
fix: get additional image details in app full gql call, skip calling GetImageInfo

### DIFF
--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -152,7 +152,10 @@ func (client *Client) GetApp(ctx context.Context, appName string) (*App, error) 
 					}
 				}
 				imageDetails {
+					registry
 					repository
+					tag
+					digest
 					version
 				}
 				volumes {

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -242,16 +242,13 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 	if err != nil {
 		return nil, err
 	}
-	imageInfo, err := apiClient.GetImageInfo(ctx, appName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get image info: %w", err)
-	}
+
 	var img string
 	switch {
-	case imageInfo.ImageDetails.Tag != "":
-		img = fmt.Sprintf("%s/%s:%s", imageInfo.ImageDetails.Registry, imageInfo.ImageDetails.Repository, imageInfo.ImageDetails.Tag)
-	case imageInfo.ImageDetails.Digest != "":
-		img = fmt.Sprintf("%s/%s@%s", imageInfo.ImageDetails.Registry, imageInfo.ImageDetails.Repository, imageInfo.ImageDetails.Digest)
+	case appFull.ImageDetails.Tag != "":
+		img = fmt.Sprintf("%s/%s:%s", appFull.ImageDetails.Registry, appFull.ImageDetails.Repository, appFull.ImageDetails.Tag)
+	case appFull.ImageDetails.Digest != "":
+		img = fmt.Sprintf("%s/%s@%s", appFull.ImageDetails.Registry, appFull.ImageDetails.Repository, appFull.ImageDetails.Digest)
 	default:
 		return nil, fmt.Errorf("failed to get image info: no tag or digest found")
 	}


### PR DESCRIPTION
The call to GetImageInfo includes a lot more fields than are needed for the migration and because we're already getting some of the image details when getting the app, it's easier to get the additional fields needed there.