### PR TITLE
migrate-to-v2: troubleshoot shouldn't assume automated migration

### DIFF
--- a/internal/command/migrate_to_v2/troubleshoot.go
+++ b/internal/command/migrate_to_v2/troubleshoot.go
@@ -163,8 +163,6 @@ func (t *troubleshooter) refreshAllocs(ctx context.Context) error {
 }
 
 func (t *troubleshooter) hasMigrated(ctx context.Context) bool {
-	client := client.FromContext(ctx).API()
-
 	if t.app.PlatformVersion == appconfig.DetachedPlatform {
 		return true
 	}
@@ -183,20 +181,7 @@ func (t *troubleshooter) hasMigrated(ctx context.Context) bool {
 		}
 	}
 
-	// Look for a release created by admin-bot@fly.io
-	releases, err := client.GetAppReleasesMachines(ctx, t.app.Name, "", 25)
-	if err != nil {
-		return false
-	}
-	for _, release := range releases {
-		// Technically, I don't think this is the only time we could use admin-bot@fly.io,
-		// but we use it infrequently and soon we'll be done dealing with this,
-		// so it's probably an acceptable way to determine this for now.
-		if release.User.Email == "admin-bot@fly.io" {
-			return true
-		}
-	}
-	return false
+	return true
 }
 
 func (t *troubleshooter) run(ctx context.Context) error {

--- a/internal/command/migrate_to_v2/troubleshoot.go
+++ b/internal/command/migrate_to_v2/troubleshoot.go
@@ -163,25 +163,7 @@ func (t *troubleshooter) refreshAllocs(ctx context.Context) error {
 }
 
 func (t *troubleshooter) hasMigrated(ctx context.Context) bool {
-	if t.app.PlatformVersion == appconfig.DetachedPlatform {
-		return true
-	}
-
-	// Check that the app is not currently on nomad
-	if t.app.PlatformVersion == appconfig.NomadPlatform {
-		return false
-	}
-
-	// Look for a machine tied to a previous alloc
-	for _, machine := range t.machines {
-		if machine.Config != nil && machine.Config.Metadata != nil {
-			if _, ok := machine.Config.Metadata[api.MachineConfigMetadataKeyFlyPreviousAlloc]; ok {
-				return true
-			}
-		}
-	}
-
-	return true
+	return t.app.PlatformVersion != appconfig.NomadPlatform
 }
 
 func (t *troubleshooter) run(ctx context.Context) error {


### PR DESCRIPTION
Migrations done by users themselves (locally) don't have admin-bot@fly.io releases. This was probably affecting https://community.fly.io/t/error-creating-a-new-machine-in-group-app-requires-an-unattached-data-volume-create-it-with-fly-volume-create-data/13403/10

This also applies to apps that have always been on v2 from the start