### PR TITLE
Remove redundant health check from `m update`

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -202,12 +202,11 @@ func newRun() *cobra.Command {
 
 func runMachineRun(ctx context.Context) error {
 	var (
-		appName  = appconfig.NameFromContext(ctx)
-		client   = client.FromContext(ctx).API()
-		io       = iostreams.FromContext(ctx)
-		colorize = io.ColorScheme()
-		err      error
-		app      *api.AppCompact
+		appName = appconfig.NameFromContext(ctx)
+		client  = client.FromContext(ctx).API()
+		io      = iostreams.FromContext(ctx)
+		err     error
+		app     *api.AppCompact
 	)
 
 	if appName == "" {
@@ -321,8 +320,6 @@ func runMachineRun(ctx context.Context) error {
 	}
 
 	if !flag.GetDetach(ctx) {
-		fmt.Fprintln(io.Out, colorize.Green("==> "+"Monitoring health checks"))
-
 		if err := watch.MachinesChecks(ctx, []*api.Machine{machine}); err != nil {
 			return err
 		}


### PR DESCRIPTION
The `mach.Update` call already includes this, so there's no need to do it again.

Not yet sure what (if anything) to do about the fact that `--detach` and `--skip-health-checks` do the same thing. (Based on Git history, it looks like `--skip-health-checks` came first.)