### PR TITLE
Add "Paid Plan Only" column to `fly platform regions` table

### DIFF
--- a/internal/command/platform/regions.go
+++ b/internal/command/platform/regions.go
@@ -54,13 +54,17 @@ func runRegions(ctx context.Context) error {
 		if region.GatewayAvailable {
 			gateway = "✓"
 		}
-
+		paidPlan := ""
+		if region.RequiresPaidPlan {
+			paidPlan = "✓"
+		}
 		rows = append(rows, []string{
 			region.Code,
 			region.Name,
 			gateway,
+			paidPlan,
 		})
 	}
 
-	return render.Table(out, "", rows, "Code", "Name", "Gateway")
+	return render.Table(out, "", rows, "Code", "Name", "Gateway", "Paid Plan Only")
 }


### PR DESCRIPTION
This PR adds the "paid plan only" column to `fly platform regions` for consistency with both the `--json` output and the list of regions here - https://fly.io/docs/reference/regions/#fly-io-regions
```
./scripts/dfly platform regions
CODE	NAME                        	GATEWAY	PAID PLAN ONLY
ams 	Amsterdam, Netherlands      	✓      	              	
arn 	Stockholm, Sweden           	       	              	
atl 	Atlanta, Georgia (US)       	       	              	
bog 	Bogotá, Colombia            	       	              	
bom 	Mumbai, India               	       	✓             	
bos 	Boston, Massachusetts (US)  	       	              	
cdg 	Paris, France               	✓      	              	
den 	Denver, Colorado (US)       	       	              	
dfw 	Dallas, Texas (US)          	✓      	              	
ewr 	Secaucus, NJ (US)           	       	              	
eze 	Ezeiza, Argentina           	       	              	
fra 	Frankfurt, Germany          	✓      	✓             	
gdl 	Guadalajara, Mexico         	       	              	
gig 	Rio de Janeiro, Brazil      	       	              	
gru 	Sao Paulo, Brazil           	       	              	
hkg 	Hong Kong, Hong Kong        	✓      	              	
iad 	Ashburn, Virginia (US)      	✓      	              	
jnb 	Johannesburg, South Africa  	       	              	
lax 	Los Angeles, California (US)	✓      	              	
lhr 	London, United Kingdom      	✓      	              	
maa 	Chennai (Madras), India     	✓      	✓             	
mad 	Madrid, Spain               	       	              	
mia 	Miami, Florida (US)         	       	              	
nrt 	Tokyo, Japan                	✓      	              	
ord 	Chicago, Illinois (US)      	✓      	              	
otp 	Bucharest, Romania          	       	              	
phx 	Phoenix, Arizona (US)       	       	              	
qro 	Querétaro, Mexico           	       	              	
scl 	Santiago, Chile             	✓      	              	
sea 	Seattle, Washington (US)    	✓      	              	
sin 	Singapore, Singapore        	✓      	              	
sjc 	San Jose, California (US)   	✓      	              	
syd 	Sydney, Australia           	✓      	              	
waw 	Warsaw, Poland              	       	              	
yul 	Montreal, Canada            	       	              	
yyz 	Toronto, Canada             	✓     
```

The `--json` output for reference - 

```
./scripts/dfly platform regions --json | head -n 9
[
    {
        "Code": "ams",
        "Name": "Amsterdam, Netherlands",
        "Latitude": 52.374344,
        "Longitude": 4.895439,
        "GatewayAvailable": true,
        "RequiresPaidPlan": false
    },
```