### PR TITLE
Add "platform" to high level `fly help`

### DIFF
--- a/internal/command/help/help.go
+++ b/internal/command/help/help.go
@@ -112,6 +112,11 @@ Monitoring and managing things:
 		listCommands([]string{"logs", "status", "dashboard", "dig", "ping", "ssh", "sftp"})
 
 		fmt.Printf(`
+Platform overview:
+`)
+		listCommands([]string{"platform"})
+
+		fmt.Printf(`
 Access control:
 `)
 		listCommands([]string{"orgs", "auth", "move"})


### PR DESCRIPTION
I am _always_ forgetting how to retrieve the list of available regions - `fly platform regions`

I find myself exploring `fly help`, see a reference to regions then immediately try `fly regions` (which is the wrong command). 

We don't actually have `fly platform` listed if we run `fly help` and is only discoverable via `fly help commands`.

This PR adds a high level entry for `platform` under the list of available commands in `fly help` - 

```
Platform overview:
  platform        Fly platform information
```

----

```
./scripts/dfly help

Deploying apps and machines:
  apps            Manage apps
  machine         Commands that manage machines
  launch          Create and configure a new app from source code or a Docker image.
  deploy          Deploy Fly applications
  destroy         Permanently destroys an app
  open            Open browser to current deployed application

Scaling and configuring:
  scale           Scale app resources
  regions         V1 APPS ONLY: Manage regions
  secrets         Manage application secrets with the set and unset commands.

Provisioning storage:
  volumes         Volume management commands
  postgres        Manage Postgres clusters.
  redis           Launch and manage Redis databases managed by Upstash.com
  consul          Enable and manage Consul clusters

Networking configuration:
  ips             Manage IP addresses for apps
  wireguard       Commands that manage WireGuard peer connections
  proxy           Proxies connections to a fly VM
  certs           Manage certificates

Monitoring and managing things:
  logs            View app logs
  status          Show app status
  dashboard       Open web browser on Fly Web UI for this app
  dig             Make DNS requests against Fly.io's internal DNS server
  ping            Test connectivity with ICMP ping messages
  ssh             Use SSH to login to or run commands on VMs
  sftp            Get or put files from a remote VM.

Platform overview:
  platform        Fly platform information

Access control:
  orgs            Commands for managing Fly organizations
  auth            Manage authentication
  move            Move an app to another organization

More help:
  docs            View Fly documentation
  doctor          The DOCTOR command allows you to debug your Fly environment
  help commands   A complete list of commands (there are a bunch more)
```

----

Even though this does not explicitly call attention to `fly platform regions` directly it should at least be a reminder that `fly platform` exists.

