### PR TITLE
fly regions add (2nd attempt)

### DIFF
--- a/internal/appsv2/scale_count_test.go
+++ b/internal/appsv2/scale_count_test.go
@@ -1,4 +1,4 @@
-package scale
+package appsv2
 
 import (
 	"testing"

--- a/internal/appsv2/scale_defaults.go
+++ b/internal/appsv2/scale_defaults.go
@@ -1,4 +1,4 @@
-package scale
+package appsv2
 
 import (
 	"github.com/superfly/flyctl/api"

--- a/internal/command/regions/machines.go
+++ b/internal/command/regions/machines.go
@@ -5,11 +5,16 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/samber/lo"
+	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/appsv2"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
+	"golang.org/x/exp/slices"
 )
 
 func v2RunRegionsList(ctx context.Context) error {
@@ -75,4 +80,65 @@ func printApssV2Regions(ctx context.Context, machineRegions map[string][]string)
 	for group, regionlist := range machineRegions {
 		fmt.Fprintf(io.Out, "Regions [%s]: %s\n", colorize.Bold(group), strings.Join(regionlist, ", "))
 	}
+}
+
+func v2RunRegionsAdd(ctx context.Context) error {
+	io := iostreams.FromContext(ctx)
+	appName := appconfig.NameFromContext(ctx)
+	appConfig := appconfig.ConfigFromContext(ctx)
+
+	// Compute current regions with machines
+	flapsClient, err := flaps.NewFromAppName(ctx, appName)
+	if err != nil {
+		return err
+	}
+	ctx = flaps.NewContext(ctx, flapsClient)
+
+	// Process group to add
+	groupName := ""
+	processNames := appConfig.ProcessNames()
+	if !slices.Contains(processNames, api.MachineProcessGroupApp) {
+		// No app group found, so we require the process-group flag
+		groupName = flag.GetString(ctx, "group")
+		if groupName == "" {
+			return fmt.Errorf("--group flag is required when no group named 'app' is defined")
+		}
+	}
+	if groupName == "" {
+		groupName = appConfig.DefaultProcessName()
+	}
+
+	// Compute regions missing machines
+	machines, _, err := flapsClient.ListFlyAppsMachines(ctx)
+	if err != nil {
+		return err
+	}
+
+	currentRegions := lo.CountValues(lo.Map(machines,
+		func(m *api.Machine, _ int) string { return m.Region }),
+	)
+	missingRegions := lo.Uniq(lo.Filter(flag.Args(ctx),
+		func(rn string, _ int) bool { return currentRegions[rn] == 0 }),
+	)
+
+	if len(missingRegions) == 0 {
+		fmt.Fprintf(io.Out, "App already present in all requested regions\n")
+		return nil
+	}
+
+	// Add one machine per region to the same process group
+	groupCounts := map[string]int{
+		groupName: len(missingRegions),
+	}
+
+	input := appsv2.ScaleCountInput{
+		AppName:             appName,
+		AppConfig:           appConfig,
+		ExpectedGroupCounts: groupCounts,
+		Regions:             missingRegions,
+		AutoConfirm:         flag.GetYes(ctx),
+		MaxPerRegion:        -1,
+	}
+
+	return appsv2.ScaleCount(ctx, input)
 }

--- a/internal/command/regions/nomad.go
+++ b/internal/command/regions/nomad.go
@@ -15,7 +15,7 @@ import (
 	"github.com/superfly/flyctl/api"
 )
 
-func runRegionsAdd(ctx context.Context) error {
+func v1RunRegionsAdd(ctx context.Context) error {
 	appName := appconfig.NameFromContext(ctx)
 	apiClient := client.FromContext(ctx).API()
 

--- a/internal/command/scale/count.go
+++ b/internal/command/scale/count.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/appsv2"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/iostreams"
@@ -141,4 +142,23 @@ func runNomadScaleCount(ctx context.Context, appName string, groups map[string]i
 
 	fmt.Fprintf(io.Out, "Count changed to %s\n", countMessage(counts))
 	return nil
+}
+
+func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appconfig.Config, expectedGroupCounts map[string]int, maxPerRegion int) error {
+	var regions []string
+	if v := flag.GetRegion(ctx); v != "" {
+		regions = strings.Split(v, ",")
+	}
+	if len(regions) == 0 {
+		regions = []string{appConfig.PrimaryRegion}
+	}
+
+	return appsv2.ScaleCount(ctx, appsv2.ScaleCountInput{
+		AppName:             appName,
+		AppConfig:           appConfig,
+		Regions:             regions,
+		MaxPerRegion:        maxPerRegion,
+		ExpectedGroupCounts: expectedGroupCounts,
+		AutoConfirm:         flag.GetYes(ctx),
+	})
 }


### PR DESCRIPTION
**WIP** needs rebasing and porting changes since May 10th.

Adds `fly regions add` support for v2 apps while attempting to reuse logic from `fly scale count`