### PR TITLE
Don't shadow wait error in `fly console`

### DIFF
--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -281,7 +281,7 @@ func makeEphemeralConsoleMachine(ctx context.Context, app *api.AppCompact, appCo
 	defer t.Stop()
 
 	for {
-		err := flapsClient.Wait(ctx, machine, api.MachineStateStarted, waitTimeout)
+		err = flapsClient.Wait(ctx, machine, api.MachineStateStarted, waitTimeout)
 		if err == nil {
 			return machine, true, nil
 		}


### PR DESCRIPTION
Otherwise we might return a `nil` error when we don't mean to do so.