### PR TITLE
`migrate-to-v2`: filter out volumes for already migrated allocs

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -280,17 +280,6 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 		return false
 	})
 
-	attachedVolumes := lo.Filter(appFull.Volumes.Nodes, func(v api.Volume, _ int) bool {
-		if v.AttachedAllocation != nil {
-			for _, a := range allocs {
-				if a.ID == v.AttachedAllocation.ID {
-					return true
-				}
-			}
-		}
-		return false
-	})
-
 	vmSize, _, groups, err := apiClient.AppVMResources(ctx, appName)
 	if err != nil {
 		return nil, err
@@ -316,7 +305,6 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 		formattedProcessConfigs: formattedProcessConfigs,
 		img:                     img,
 		oldAllocs:               allocs,
-		oldAttachedVolumes:      attachedVolumes,
 		machineGuests:           machineGuests,
 		isPostgres:              appCompact.IsPostgresApp(),
 		replacedVolumes:         map[string]int{},
@@ -346,6 +334,7 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 	if err != nil {
 		return nil, err
 	}
+	migrator.resolveOldVolumes()
 	err = migrator.prepMachinesToCreate(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -124,6 +124,21 @@ func (m *v2PlatformMigrator) nomadVolPath(v *api.Volume, group string) string {
 	return ""
 }
 
+// Must run *after* allocs are filtered
+func (m *v2PlatformMigrator) resolveOldVolumes() {
+
+	m.oldAttachedVolumes = lo.Filter(m.appFull.Volumes.Nodes, func(v api.Volume, _ int) bool {
+		if v.AttachedAllocation != nil {
+			for _, a := range m.oldAllocs {
+				if a.ID == v.AttachedAllocation.ID {
+					return true
+				}
+			}
+		}
+		return false
+	})
+}
+
 func (m *v2PlatformMigrator) printReplacedVolumes() {
 	if len(m.replacedVolumes) == 0 {
 		return


### PR DESCRIPTION
prevent re-migrating volumes when there's already a machine for the given alloc