### PR TITLE
`migrate-to-v2`: scale based on raw number of allocs, not filtered

### DIFF
--- a/helpers/clone_test.go
+++ b/helpers/clone_test.go
@@ -66,3 +66,19 @@ func TestClonePointer(t *testing.T) {
 
 	assert.NotEqualValues(t, c.Ch.S, clonedObj.Ch.S)
 }
+
+func TestCloneMap(t *testing.T) {
+	cloneMe := map[string]int{
+		"one": 1,
+		"two": 2,
+	}
+
+	cloned := Clone(cloneMe)
+
+	assert.EqualValues(t, cloneMe, cloned)
+
+	cloned["two"]++
+
+	assert.Equal(t, cloneMe["two"], 2)
+	assert.Equal(t, cloned["two"], 3)
+}

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -796,11 +796,11 @@ func (m *v2PlatformMigrator) createRelease(ctx context.Context) error {
 }
 
 func (m *v2PlatformMigrator) resolveProcessGroups(ctx context.Context) {
-	m.numMachinesToSpawn = map[string]int{}
+	m.rawNomadScaleMapping = map[string]int{}
 	for _, alloc := range m.oldAllocs {
-		m.numMachinesToSpawn[alloc.TaskName] += 1
+		m.rawNomadScaleMapping[alloc.TaskName] += 1
 	}
-	m.rawNomadScaleMapping = helpers.Clone(m.numMachinesToSpawn)
+	m.numMachinesToSpawn = helpers.Clone(m.rawNomadScaleMapping)
 }
 
 func (m *v2PlatformMigrator) filterAllocsWithExistingMachines(ctx context.Context) error {

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -20,6 +20,7 @@ import (
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/gql"
+	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
@@ -196,19 +197,25 @@ type v2PlatformMigrator struct {
 	oldAllocs               []*api.AllocationStatus
 	oldAttachedVolumes      []api.Volume
 	machineGuests           map[string]*api.MachineGuest
-	oldVmCounts             map[string]int
-	newMachinesInput        []*api.LaunchMachineInput
-	newMachines             machine.MachineSet
-	recovery                recoveryState
-	usesForkedVolumes       bool
-	createdVolumes          []*NewVolume
-	replacedVolumes         map[string]int
-	isPostgres              bool
-	pgConsulUrl             string
-	targetImg               string
-	backupMachines          map[string]int
-	verbose                 bool
-	machineWaitTimeout      time.Duration
+	// mapping from task/process group to number of allocs.
+	// filtered to include allocs without existing machines.
+	// for an unfiltered list, use rawNomadScaleMapping
+	numMachinesToSpawn map[string]int
+	// mapping from task/process group to number of allocs.
+	// you probably want numMachinesToSpawn, this is only used for nomad scale-down
+	rawNomadScaleMapping map[string]int
+	newMachinesInput     []*api.LaunchMachineInput
+	newMachines          machine.MachineSet
+	recovery             recoveryState
+	usesForkedVolumes    bool
+	createdVolumes       []*NewVolume
+	replacedVolumes      map[string]int
+	isPostgres           bool
+	pgConsulUrl          string
+	targetImg            string
+	backupMachines       map[string]int
+	verbose              bool
+	machineWaitTimeout   time.Duration
 }
 
 type recoveryState struct {
@@ -338,6 +345,7 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 	if err != nil {
 		return nil, err
 	}
+	migrator.resolveProcessGroups(ctx)
 	err = migrator.determinePrimaryRegion(ctx)
 	if err != nil {
 		return nil, err
@@ -354,7 +362,6 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 	if err != nil {
 		return nil, err
 	}
-	migrator.resolveProcessGroups(ctx)
 	return migrator, nil
 }
 
@@ -422,7 +429,7 @@ func (m *v2PlatformMigrator) rollback(ctx context.Context, tb *render.TextBlock)
 
 		input := gql.SetVMCountInput{
 			AppId: m.appConfig.AppName,
-			GroupCounts: lo.MapToSlice(m.oldVmCounts, func(name string, count int) gql.VMCountInput {
+			GroupCounts: lo.MapToSlice(m.rawNomadScaleMapping, func(name string, count int) gql.VMCountInput {
 				return gql.VMCountInput{Group: name, Count: count}
 			}),
 			LockId: lo.Ternary(m.recovery.appLocked, m.appLock, ""),
@@ -789,10 +796,11 @@ func (m *v2PlatformMigrator) createRelease(ctx context.Context) error {
 }
 
 func (m *v2PlatformMigrator) resolveProcessGroups(ctx context.Context) {
-	m.oldVmCounts = map[string]int{}
+	m.numMachinesToSpawn = map[string]int{}
 	for _, alloc := range m.oldAllocs {
-		m.oldVmCounts[alloc.TaskName] += 1
+		m.numMachinesToSpawn[alloc.TaskName] += 1
 	}
+	m.rawNomadScaleMapping = helpers.Clone(m.numMachinesToSpawn)
 }
 
 func (m *v2PlatformMigrator) filterAllocsWithExistingMachines(ctx context.Context) error {
@@ -812,7 +820,11 @@ func (m *v2PlatformMigrator) filterAllocsWithExistingMachines(ctx context.Contex
 	})
 
 	m.oldAllocs = lo.Filter(m.oldAllocs, func(alloc *api.AllocationStatus, _ int) bool {
-		return !slices.Contains(allocsWithMachines, alloc.ID)
+		filtered := slices.Contains(allocsWithMachines, alloc.ID)
+		if filtered {
+			m.numMachinesToSpawn[alloc.TaskName] -= 1
+		}
+		return !filtered
 	})
 
 	return nil
@@ -961,7 +973,7 @@ func (m *v2PlatformMigrator) ConfirmChanges(ctx context.Context) (bool, error) {
 	}
 
 	fmt.Fprintf(m.io.Out, " * Create machines, copying the configuration of each existing VM\n")
-	for name, count := range m.oldVmCounts {
+	for name, count := range m.numMachinesToSpawn {
 		s := "s"
 		if count == 1 {
 			s = ""

--- a/internal/command/migrate_to_v2/nomad.go
+++ b/internal/command/migrate_to_v2/nomad.go
@@ -59,7 +59,7 @@ func (m *v2PlatformMigrator) unlockApp(ctx context.Context) error {
 }
 
 func (m *v2PlatformMigrator) scaleNomadToZero(ctx context.Context) error {
-	err := scaleNomadToZero(ctx, m.appCompact, m.appLock, lo.Keys(m.oldVmCounts))
+	err := scaleNomadToZero(ctx, m.appCompact, m.appLock, lo.Keys(m.rawNomadScaleMapping))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
scale up/down based on the raw number of allocs, rather than the filtered data used for machine spawning that gets deduplicated.