### PR TITLE
add processes=app in by default

### DIFF
--- a/internal/command/launch/freshconfigs.go
+++ b/internal/command/launch/freshconfigs.go
@@ -16,6 +16,7 @@ func freshV2Config(appName string, srcCfg *appconfig.Config) (*appconfig.Config,
 		AutoStartMachines:  api.Pointer(true),
 		AutoStopMachines:   api.Pointer(true),
 		MinMachinesRunning: api.Pointer(0),
+		Processes:          []string{"app"},
 	}
 	if err := newCfg.SetMachinesPlatform(); err != nil {
 		return nil, err

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -43,6 +43,7 @@ func TestFlyLaunch_case01(t *testing.T) {
 			"auto_stop_machines":   true,
 			"auto_start_machines":  true,
 			"min_machines_running": int64(0),
+			"processes":            []string{"app"},
 		},
 	}
 	require.EqualValues(f, want, toml)

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -43,7 +43,7 @@ func TestFlyLaunch_case01(t *testing.T) {
 			"auto_stop_machines":   true,
 			"auto_start_machines":  true,
 			"min_machines_running": int64(0),
-			"processes":            append(make([]interface{}, 0), "app"),
+			"processes":            []any{"app"},
 		},
 	}
 	require.EqualValues(f, want, toml)

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -43,7 +43,7 @@ func TestFlyLaunch_case01(t *testing.T) {
 			"auto_stop_machines":   true,
 			"auto_start_machines":  true,
 			"min_machines_running": int64(0),
-			"processes":            []string{"app"},
+			"processes":            []string{"app"}[:],
 		},
 	}
 	require.EqualValues(f, want, toml)

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -43,7 +43,7 @@ func TestFlyLaunch_case01(t *testing.T) {
 			"auto_stop_machines":   true,
 			"auto_start_machines":  true,
 			"min_machines_running": int64(0),
-			"processes":            []string{"app"}[:],
+			"processes":            append(make([]interface{}, 0), "app"),
 		},
 	}
 	require.EqualValues(f, want, toml)


### PR DESCRIPTION
Adds the default process (`app`) to the fresh config that's created  by `fly launch`. This is in an effort to make it more transparent to the user.