### PR TITLE
Mention individual tests in Slack

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -35,6 +35,7 @@ jobs:
           echo "FLY_PREFLIGHT_TEST_APP_PREFIX=pf-gha-$(openssl rand -hex 4)" >> "$GITHUB_ENV"
           make
       - name: Run preflight tests
+        id: preflight
         env:
           FLY_PREFLIGHT_TEST_ACCESS_TOKEN: ${{ secrets.FLYCTL_PREFLIGHT_CI_FLY_API_TOKEN }}
           FLY_PREFLIGHT_TEST_FLY_ORG: flyctl-ci-preflight
@@ -42,7 +43,9 @@ jobs:
           FLY_PREFLIGHT_TEST_NO_PRINT_HISTORY_ON_FAIL: "true"
           FLY_FORCE_TRACE: "true"
         run: |
-          PATH=$PWD/bin:$PATH ./scripts/preflight.sh -r "${{ github.ref }}" -t "${{ matrix.parallelism }}" -i "${{ matrix.index }}"
+          export PATH=$PWD/bin:$PATH
+          echo -n failed= >> $GITHUB_OUTPUT
+          ./scripts/preflight.sh -r "${{ github.ref }}" -t "${{ matrix.parallelism }}" -i "${{ matrix.index }}" -o $GITHUB_OUTPUT
       - name: Post failure to slack
         if: ${{ github.ref == 'refs/heads/master' && failure() }}
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
@@ -57,7 +60,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":sob: preflight tests failed: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": ":sob: preflight tests failed: ${{ steps.preflight.outputs.failed }} ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 ref=
 total=
 index=
+out=
 
-while getopts r:t:i: name
+while getopts r:t:i:o: name
 do
     case "$name" in
         r)
@@ -17,8 +18,11 @@ do
         i)
 	    index="$OPTARG"
 	    ;;
+        o)
+	    out="$OPTARG"
+	    ;;
         ?)
-	    printf "Usage: %s: [-r REF] [-t TOTAL] [-i INDEX]\n" $0
+	    printf "Usage: %s: [-r REF] [-t TOTAL] [-i INDEX] [-o FILE]\n" $0
             exit 2
 	    ;;
     esac
@@ -31,8 +35,26 @@ if [[ "$ref" != "refs/heads/master" ]]; then
     test_opts=-short
 fi
 
+test_log="$(mktemp)"
+function finish {
+  rm "$test_log"
+}
+trap finish EXIT
+
+set +e
+
 gotesplit \
     -total "$total" \
     -index "$index" \
     github.com/superfly/flyctl/test/preflight/... \
-    -- --tags=integration -v -timeout=60m $test_opts
+    -- --tags=integration -v -timeout=60m $test_opts | tee "$test_log"
+test_status=$?
+
+set -e
+
+if [[ -n "$out" ]]; then
+    awk '/^--- FAIL:/{ printf("%s ", $3) }' "$test_log" >> "$out"
+    echo >> "$out"
+fi
+
+exit $test_status


### PR DESCRIPTION
Our preflight tests are currently not stable. To avoid the broken window
situation, this commit changes the tests' Slack message to mention
individual failing tests.