### PR TITLE
Deploy took too long and the oldest leases have expired

### DIFF
--- a/internal/machine/machine_set.go
+++ b/internal/machine/machine_set.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -127,7 +128,7 @@ func (ms *machineSet) ReleaseLeases(ctx context.Context) error {
 	hadError := false
 	for err := range results {
 		contextTimedOutOrCanceled := errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
-		if err != nil && (!contextWasAlreadyCanceled || !contextTimedOutOrCanceled) {
+		if err != nil && (!contextWasAlreadyCanceled || !contextTimedOutOrCanceled || !strings.Contains(err.Error(), "lease not found")) {
 			hadError = true
 			terminal.Warnf("failed to release lease: %v\n", err)
 		}


### PR DESCRIPTION
```sh
....
  [34/34] Machine e784e22df29d38 [app] update finished: success
  Finished deploying
WARN failed to release lease for machine 91857706c09083: lease not found
WARN failed to release lease: lease not found
WARN failed to release lease for machine 4d891169c09987: lease not found
WARN WARN failed to release lease for machine 5683dd97cd618e: lease not found
WARN failed to release lease: lease not found
WARN failed to release lease: lease not found
failed to release lease for machine 3d8d91e6ce6528: lease not found
WARN failed to release lease for machine 3287004c636185: lease not found
WARN failed to release lease: lease not found
WARN failed to release lease: lease not found
```