### PR TITLE
`deploy`: batch deploys >= 6 into batches of five machines at a time

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -117,8 +117,9 @@ var CommonFlags = flag.Set{
 	flag.Bool{
 		Name: "strategy-batch",
 		Description: fmt.Sprintf(
-			"For \"rolling\" and \"canary\": batch Machine updates into groups of %d when updating more than %d.",
-			BATCHING_GROUP_SIZE, BATCHING_CUTOFF,
+			"For \"rolling\" and \"canary\": batch Machine updates into %d groups when updating more than %d.",
+			batchingGroupCount,
+			batchingCutoff,
 		),
 		Default: true,
 	},

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -114,6 +114,14 @@ var CommonFlags = flag.Set{
 		Description: "Memory (in megabytes) to attribute to the VM",
 		Aliases:     []string{"memory"},
 	},
+	flag.Bool{
+		Name: "strategy-batch",
+		Description: fmt.Sprintf(
+			"For \"rolling\" and \"canary\": batch Machine updates into groups of %d when updating more than %d.",
+			BATCHING_GROUP_SIZE, BATCHING_CUTOFF,
+		),
+		Default: true,
+	},
 }
 
 func New() (cmd *cobra.Command) {
@@ -241,6 +249,7 @@ func deployToMachines(ctx context.Context, appConfig *appconfig.Config, appCompa
 		AppCompact:            appCompact,
 		DeploymentImage:       img.Tag,
 		Strategy:              flag.GetString(ctx, "strategy"),
+		BatchMachineWaits:     flag.GetBool(ctx, "strategy-batch"),
 		EnvFromFlags:          flag.GetStringArray(ctx, "env"),
 		PrimaryRegionFlag:     appConfig.PrimaryRegion,
 		SkipSmokeChecks:       flag.GetDetach(ctx) || !flag.GetBool(ctx, "smoke-checks"),

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -36,6 +36,7 @@ type MachineDeploymentArgs struct {
 	AppCompact            *api.AppCompact
 	DeploymentImage       string
 	Strategy              string
+	BatchMachineWaits     bool
 	EnvFromFlags          []string
 	PrimaryRegionFlag     string
 	SkipSmokeChecks       bool
@@ -65,6 +66,7 @@ type machineDeployment struct {
 	releaseCommandMachine machine.MachineSet
 	volumes               map[string][]api.Volume
 	strategy              string
+	batchMachineWaits     bool
 	releaseId             string
 	releaseVersion        int
 	skipSmokeChecks       bool
@@ -136,6 +138,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		app:                   args.AppCompact,
 		appConfig:             appConfig,
 		img:                   args.DeploymentImage,
+		batchMachineWaits:     args.BatchMachineWaits,
 		skipSmokeChecks:       args.SkipSmokeChecks,
 		skipHealthChecks:      args.SkipHealthChecks,
 		restartOnly:           args.RestartOnly,

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	BATCHING_CUTOFF     = 6
-	BATCHING_GROUP_SIZE = 5
+	batchingGroupCount = 5
+	// batchingCutoff should be at least batchingGroupCount + 1
+	batchingCutoff = 6
 )
 
 type ProcessGroupsDiff struct {
@@ -272,19 +273,98 @@ func suggestChangeWaitTimeout(err error, flagName string) error {
 	return err
 }
 
+// batcher is a helper for adapting a series of jobs into batches of work.
+// As you iterate through the jobs, you can call Add(jobInfo) to add a job to the current batch.
+// At the end of each iteration, loop over Batch() to get the current batch of jobs.
+// (it returns the current batch when it's ready to process)
+// E.g.
+//
+//	for _, a := range items {
+//	  itemToFurtherProcess := doSomething(a)
+//	  batcher.Add(itemToFurtherProcess)
+//	  for _, item := range batcher.Batch() {
+//	     doSomethingElse(item)
+//	  }
+//	}
+type batcher[T any] struct {
+	// How many items in total we will process
+	TotalJobs int
+	// How many groups we want to split the jobs into
+	GroupCount int
+	// If true, the first job will be processed by itself
+	SoloFirst bool
+
+	// current index into TotalJobs
+	idx int
+	// current batch number (out of GroupCount)
+	batchNum int
+	// index into the current batch
+	batchIdx int
+	// the jobs in the current batch
+	jobs []T
+}
+
+// Add a job to the current batch
+func (b *batcher[T]) Add(job T) {
+	b.jobs = append(b.jobs, job)
+	b.idx++
+	b.batchIdx++
+}
+
+// Ready returns true if the current batch is ready to be processed
+func (b *batcher[T]) Ready() bool {
+	// Normally index checks are 0-based, but at this point we've already added the job,
+	// which increments the index. So, for the first go-around, idx will =1 here.
+	if (b.SoloFirst && b.idx == 1) || b.idx == b.TotalJobs {
+		return true
+	}
+	// If we solo'd the first job, ignore it in batch calculations
+	batchedJobs := b.TotalJobs
+	if b.SoloFirst {
+		batchedJobs--
+	}
+	// Distribute the jobs evenly.
+	// If there's a remainder N, the first N batches will have 1 extra job
+	rem := batchedJobs % b.GroupCount
+	groupSize := batchedJobs / b.GroupCount
+	if b.batchNum < rem {
+		groupSize++
+	}
+	return b.batchIdx == groupSize
+}
+
+// Batch returns the current batch if it's Ready, otherwise nil
+// If the batch is returned, the batcher is reset
+// It's safe to just always loop over the result of Batch - if it's not ready,
+// the loop will exit immediately
+func (b *batcher[T]) Batch() []T {
+	if b.Ready() {
+		jobs := b.jobs
+		b.jobs = nil
+		b.batchNum++
+		b.batchIdx = 0
+		return jobs
+	}
+	return nil
+}
+
 func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateEntries []*machineUpdateEntry) error {
 	// FIXME: handle deploy strategy: rolling, immediate, canary, bluegreen
 	fmt.Fprintf(md.io.Out, "Updating existing machines in '%s' with %s strategy\n", md.colorize.Bold(md.app.Name), md.strategy)
 
 	useBatches := md.batchMachineWaits &&
 		(md.strategy == "rolling" || md.strategy == "canary") &&
-		len(updateEntries) >= BATCHING_CUTOFF
+		len(updateEntries) >= batchingCutoff
 
 	type batchJob struct {
 		lm       machine.LeasableMachine
 		indexStr string
 	}
-	var batch []batchJob
+	b := batcher[batchJob]{
+		TotalJobs:  len(updateEntries),
+		GroupCount: batchingGroupCount,
+		SoloFirst:  true,
+	}
 
 	waitForMachine := func(lm machine.LeasableMachine, inBatch bool, indexStr string) error {
 
@@ -377,16 +457,14 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 			continue
 		}
 
-		if useBatches && i != 0 {
+		if useBatches {
 
-			batch = append(batch, batchJob{lm, indexStr})
-			if len(batch) == BATCHING_GROUP_SIZE || i == len(updateEntries)-1 {
-				for _, job := range batch {
-					if err := waitForMachine(job.lm, true, job.indexStr); err != nil {
-						return err
-					}
+			b.Add(batchJob{lm, indexStr})
+
+			for _, job := range b.Batch() {
+				if err := waitForMachine(job.lm, true, job.indexStr); err != nil {
+					return err
 				}
-				batch = nil
 			}
 			md.logClearLinesAbove(1)
 		} else {


### PR DESCRIPTION
For rolling and canary, this batches machine updates where machines >= 6 into groups of 5. This speeds up deploys a _lot_.
The first update is always solo, so that the most common deploy issues are easy to troubleshoot.

There's also a flag `--strategy-batch=false` that can be used to disable batching.