### PR TITLE
Fix "fly open" failing when there is no fly.toml (#2359)

### DIFF
--- a/internal/appconfig/remote.go
+++ b/internal/appconfig/remote.go
@@ -20,6 +20,18 @@ func FromRemoteApp(ctx context.Context, appName string) (*Config, error) {
 		return nil, fmt.Errorf("error getting app: %w", err)
 	}
 
+	return getConfig(ctx, apiClient, appCompact)
+}
+
+func FromAppCompact(ctx context.Context, appCompact *api.AppCompact) (*Config, error) {
+	apiClient := client.FromContext(ctx).API()
+
+	return getConfig(ctx, apiClient, appCompact)
+}
+
+func getConfig(ctx context.Context, apiClient *api.Client, appCompact *api.AppCompact) (*Config, error) {
+	appName := appCompact.Name
+
 	switch appCompact.PlatformVersion {
 	// Need a more elegant way to find out what side of detached we are on
 	case NomadPlatform, "detached":

--- a/internal/command/apps/open.go
+++ b/internal/command/apps/open.go
@@ -56,6 +56,12 @@ func runOpen(ctx context.Context) error {
 	}
 
 	appConfig := appconfig.ConfigFromContext(ctx)
+	if appConfig == nil {
+		if appConfig, err = appconfig.FromAppCompact(ctx, app); err != nil {
+			return errors.New("The app config could not be found")
+		}
+	}
+
 	appURL := appConfig.URL()
 	if appURL == nil {
 		return errors.New("The app doesn't exspose a public http service")


### PR DESCRIPTION
The `appconfig.ConfigFromContext` can return `nil`, which was not being checked [here](https://github.com/superfly/flyctl/blob/master/internal/command/apps/open.go#L58). The simple fix would be to add something like this, which is what the [deploy command does](https://github.com/superfly/flyctl/blob/master/internal/command/deploy/deploy.go#L343):
```go
 if appConfig == nil {
 	if appConfig, err = appconfig.FromRemoteApp(ctx, appName); err != nil {
 		return errors.New("The app config could not be found")
 	}
}
```

However, this invokes a duplicate API call that is made prior in the `runOpen` function. So, I opted to just make another version of [FromRemoteApp](https://github.com/superfly/flyctl/blob/master/internal/appconfig/remote.go#L15) called `FromAppCompact` so that you can re-use the appCompact that was fetched earlier.