### PR TITLE
fly version update no longer returns an error if nothing to update

### DIFF
--- a/internal/command/version/upgrade.go
+++ b/internal/command/version/upgrade.go
@@ -51,11 +51,12 @@ func runUpgrade(ctx context.Context) error {
 			release.Version, err)
 	}
 
-	if buildinfo.Version().GTE(latest) {
-		return errors.New("no available update")
-	}
-
 	io := iostreams.FromContext(ctx)
+
+	if buildinfo.Version().GTE(latest) {
+		fmt.Fprintf(io.Out, "Already running latest flyctl v%s\n", buildinfo.Version().String())
+		return nil
+	}
 
 	homebrew := update.IsUnderHomebrew()
 


### PR DESCRIPTION
`fly version update` now logs the following and no longer returns an error - 

```
fly version update
Already running latest flyctl v0.1.38
```

Previous behavior - 

```
fly version update
Error: no available update
```

