### PR TITLE
migrate-to-v2: bugfix validate volumes after resolving them

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -729,11 +729,6 @@ func (m *v2PlatformMigrator) validate(ctx context.Context) error {
 		fmt.Println(extraInfo)
 		return fmt.Errorf("failed to validate config for Apps V2 platform: %w", err)
 	}
-
-	err = m.validateVolumes(ctx)
-	if err != nil {
-		return err
-	}
 	err = m.validateProcessGroupsOnAllocs(ctx)
 	if err != nil {
 		return err

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -351,6 +351,10 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 		return nil, err
 	}
 	migrator.resolveOldVolumes()
+	err = migrator.validateVolumes(ctx)
+	if err != nil {
+		return nil, err
+	}
 	err = migrator.prepMachinesToCreate(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
previously, (at least some) migrations with volumes would not try to migrate the volumes, because the migration setup was not setting usesForkedVolumes. Now, we run the volume validation after resolving volumes to ensure it gets set correctly.
