### PR TITLE
Fix for `fly apps restart` with positional arguments

### DIFF
--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -57,6 +58,9 @@ func runRestart(ctx context.Context) error {
 
 	if appName == "" {
 		appName = appconfig.NameFromContext(ctx)
+		if appName == "" {
+			return errors.New("no app name was provided, and none is available from the environment or fly.toml")
+		}
 	}
 
 	app, err := client.GetAppCompact(ctx, appName)

--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -26,7 +26,7 @@ func newRestart() *cobra.Command {
 
 	cmd := command.New(usage, short, long, runRestart,
 		command.RequireSession,
-		command.RequireAppNameNoFlag,
+		command.LoadAppNameIfPresentNoFlag,
 	)
 	cmd.Args = cobra.MaximumNArgs(1)
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -583,6 +583,17 @@ func LoadAppNameIfPresent(ctx context.Context) (context.Context, error) {
 	return localCtx, err
 }
 
+// LoadAppNameIfPresentNoFlag is like LoadAppNameIfPresent, but it does not check for the --app flag.
+func LoadAppNameIfPresentNoFlag(ctx context.Context) (context.Context, error) {
+	localCtx, err := RequireAppNameNoFlag(ctx)
+
+	if errors.Is(err, ErrRequireAppName) {
+		return appconfig.WithName(ctx, ""), nil
+	}
+
+	return localCtx, err
+}
+
 func ChangeWorkingDirectoryToFirstArgIfPresent(ctx context.Context) (context.Context, error) {
 	wd := flag.FirstArg(ctx)
 	if wd == "" {


### PR DESCRIPTION
Should fix #2465. We shouldn't *require* an app name from `FLY_APP` or `fly.toml` with a preparer, since if we have a positional argument, then we don't need them.