### PR TITLE
Move nodeFramework scanner after node (#2388)

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -90,10 +90,9 @@ func Scan(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
 		configurePhoenix,
 		configureRails,
 		configureRedwood,
-		configureNodeFramework,
 		/* frameworks scanners are placed before generic scanners,
-		   since they might mix languages or have a Dockerfile that
-			 doesn't work with Fly */
+		since they might mix languages or have a Dockerfile that
+		doesn't work with Fly */
 		configureDockerfile,
 		configureLucky,
 		configureRuby,
@@ -104,6 +103,7 @@ func Scan(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
 		configureNuxt,
 		configureNextJs,
 		configureNode,
+		configureNodeFramework,
 		configureStatic,
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why:
According to #2388 and local testing, `flyctl` was detecting Remix applications as generic NodeJs applications. This change aims to ensure the scanner package correctly distinguishes a Remix app from a NodeJs app.

How:
Looking at the [scanner function](https://github.com/superfly/flyctl/blob/master/scanner/scanner.go#L86), the `configureNodeFramework` scanner is being run before the `configureNode` scanner. However, the check for Remix occurs in the [configureNode](https://github.com/superfly/flyctl/blob/master/scanner/node.go#L19) scanner. As such, the `configureNodeFramework` scanner should run after the `configureNode` scanner as a fallback in case the `configureNode` scanner does not identify a framework.

Related to:
#2388

Testing:
Can be tested by first creating two separate apps (`npx create-remix@latest` for Remix and `npm init` for NodeJs) and then testing `flyctl launch` on each app.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
