### PR TITLE
Remove surrounding double quotes from secrets

### DIFF
--- a/internal/command/secrets/parser.go
+++ b/internal/command/secrets/parser.go
@@ -37,10 +37,15 @@ func parseSecrets(reader io.Reader) (map[string]string, error) {
 				// Switch to multiline
 				parserState = parserStateMultiline
 				parsedKey = parts[0]
-				parsedVal.WriteString(strings.TrimPrefix(parts[1], "\"\"\""))
+				parsedVal.WriteString(strings.TrimPrefix(parts[1], `"""`))
 				parsedVal.WriteString("\n")
 			} else {
-				secrets[parts[0]] = parts[1]
+				value := parts[1]
+				if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
+					// Remove double quotes
+					value = value[1 : len(value)-1]
+				}
+				secrets[parts[0]] = value
 			}
 		case parserStateMultiline:
 			if strings.HasSuffix(line, `"""`) {

--- a/internal/command/secrets/parser_test.go
+++ b/internal/command/secrets/parser_test.go
@@ -81,3 +81,12 @@ func Test_parse_with_equal(t *testing.T) {
 		"FOO": "BAR BAZ",
 	}, secrets)
 }
+
+func Test_parse_with_double_quotes(t *testing.T) {
+	reader := strings.NewReader(`FOO="BAR BAZ"`)
+	secrets, err := parseSecrets(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"FOO": "BAR BAZ",
+	}, secrets)
+}


### PR DESCRIPTION
### Change Summary

What and Why:
If secrets have surrounding double quotes, remove them before setting the secret. Environment variables may contain prefixed and suffixed double quotes to escape special characters. When including the double quotes in secrets, they lead to problems when using them.

How:
If the string starts with " or ends with ", the double quotes are removed. This should respect escaped double quotes as the first character then no longer is a double quote but a backslash.

With regards to line 40: The backtick syntax in Go is a raw string literal and it can contain arbitrary characters, including newlines, backslashes, and even double quotes. There is no need to escape them.

Related to:
This PR addresses issues #589 and #1437.

Please note that this is my first PR in this codebase and that I have not been able to test the below code. I just noticed the issue is open for a long time already and I am personally in need of a fix 😄 Any feedback is appreciated, thanks for considering my PR.
