### PR TITLE
infer region if attach-volume specified in clone

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -121,7 +121,7 @@ func runMachineClone(ctx context.Context) (err error) {
 		}
 	} else if vol != nil && region == "" {
 		region = vol.Region
-	} else {
+	} else if region == "" {
 		region = source.Region
 	}
 

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -117,7 +117,7 @@ func runMachineClone(ctx context.Context) (err error) {
 	region := flag.GetString(ctx, "region")
 	if vol != nil && region != "" {
 		if vol.Region != region {
-			return fmt.Errorf("specified region %s but volume is in region %s, use the same region as the volume", region, vol.Region)
+			return fmt.Errorf("specified region %s but volume is in region %s, use the same region as the volume", colorize.Bold(region), colorize.Bold(vol.Region))
 		}
 	} else if vol != nil && region == "" {
 		region = vol.Region


### PR DESCRIPTION
### Change Summary

What and Why:
When running the command `fly m clone <machine> --attach-volume=<vol id>:<mount path>` and the region flag is not specified, the region is not inferred from the volume. This causes failures if you clone a machine in a different region from the volume you are trying to attach. This remedies that issue.

How:

The logic is changed to follow these rules:

* If a volume is specified and the region is specified, check if they are in the same region. If not, fail
* If a volume is specified and the region is not specified, infer the region from the volume
* If only the region is specified, use it
* If none of the above, infer from the region of the machine

Related to:
n/a
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
