### PR TITLE
prepend macaroon authorization scheme if missing

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -74,8 +74,16 @@ func GetAccessTokenForCLISession(ctx context.Context, id string) (string, error)
 const flyv1Scheme = "FlyV1"
 
 func AuthorizationHeader(token string) string {
+	token = strings.TrimSpace(token)
+
 	if scheme, _, ok := strings.Cut(token, " "); ok && scheme == flyv1Scheme {
 		return token
 	}
+
+	// macaroon without scheme
+	if strings.HasPrefix(token, "fm1r_") {
+		return strings.Join([]string{flyv1Scheme, token}, " ")
+	}
+
 	return fmt.Sprintf("Bearer %s", token)
 }

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -13,6 +13,10 @@ func TestAuthorizationHeader(t *testing.T) {
 	}
 
 	check("foobar", "Bearer foobar")
+	check(" foobar ", "Bearer foobar")
 	check("FlyV1 foobar", "FlyV1 foobar")
+	check(" FlyV1 foobar ", "FlyV1 foobar")
 	check("FlyV1foobar", "Bearer FlyV1foobar")
+	check("fm1r_hello", "FlyV1 fm1r_hello")
+	check(" fm1r_hello ", "FlyV1 fm1r_hello")
 }


### PR DESCRIPTION
### Change Summary

What and Why:

Help users who didn't include the `FlyV1` part of a deploy token.

How:

Add the authorization scheme if it's missing

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
