### PR TITLE
Automatic updating

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -377,8 +377,13 @@ func promptAndAutoUpdate(ctx context.Context) (context.Context, error) {
 			} else if err := update.Relaunch(ctx, silent); err != nil {
 				return nil, fmt.Errorf("failed to relaunch after updating: %w", err)
 			}
-		} else if err := update.BackgroundUpdate(); err != nil {
-			fmt.Fprintf(io.ErrOut, "failed to autoupdate: %s\n", err)
+		} else if runtime.GOOS == "windows" {
+			// Background auto-update has terrible UX on windows,
+			// with flickery powershell progress bars and UAC prompts.
+			// For Windows, we just prompt for updates, and only auto-update in dire circumstances.
+			if err := update.BackgroundUpdate(); err != nil {
+				fmt.Fprintf(io.ErrOut, "failed to autoupdate: %s\n", err)
+			}
 		}
 	}
 	if !silent {

--- a/internal/command/settings/analytics.go
+++ b/internal/command/settings/analytics.go
@@ -13,13 +13,13 @@ import (
 )
 
 func newAnalytics() *cobra.Command {
-	metricsRoot := command.New("analytics", "Control anonymized analytics collection", "", runStatus)
+	metricsRoot := command.New("analytics", "Control anonymized analytics collection", "", runAnalyticsStatus)
 
 	optIn := command.New("enable", "Enable analytics", "", func(ctx context.Context) error {
-		return setMetricsEnabled(ctx, true)
+		return setAnalyticsEnabled(ctx, true)
 	})
 	optOut := command.New("disable", "Disable analytics", "", func(ctx context.Context) error {
-		return setMetricsEnabled(ctx, false)
+		return setAnalyticsEnabled(ctx, false)
 	})
 
 	metricsRoot.AddCommand(optIn)
@@ -28,7 +28,7 @@ func newAnalytics() *cobra.Command {
 	return metricsRoot
 }
 
-func printEnabled(ctx context.Context, enabled bool) {
+func printAnalyticsEnabled(ctx context.Context, enabled bool) {
 
 	enabledStr := lo.Ternary(enabled, "enabled", "disabled")
 
@@ -36,20 +36,20 @@ func printEnabled(ctx context.Context, enabled bool) {
 	fmt.Fprintf(io.Out, "Anonymized analytics: %s\n", enabledStr)
 }
 
-func runStatus(ctx context.Context) error {
+func runAnalyticsStatus(ctx context.Context) error {
 	var (
 		cfg = config.FromContext(ctx)
 		io  = iostreams.FromContext(ctx)
 	)
 
-	printEnabled(ctx, cfg.SendMetrics)
+	printAnalyticsEnabled(ctx, cfg.SendMetrics)
 
 	fmt.Fprintf(io.Out, "\nThis can be controlled with 'fly settings analytics <enable/disable>'\n")
 
 	return nil
 }
 
-func setMetricsEnabled(ctx context.Context, enabled bool) error {
+func setAnalyticsEnabled(ctx context.Context, enabled bool) error {
 	path := state.ConfigFile(ctx)
 
 	if err := config.SetSendMetrics(path, enabled); err != nil {
@@ -57,7 +57,7 @@ func setMetricsEnabled(ctx context.Context, enabled bool) error {
 			config.SendMetricsFileKey, path, err)
 	}
 
-	printEnabled(ctx, enabled)
+	printAnalyticsEnabled(ctx, enabled)
 
 	return nil
 }

--- a/internal/command/settings/autoupdate.go
+++ b/internal/command/settings/autoupdate.go
@@ -13,7 +13,7 @@ import (
 )
 
 func newAutoUpdate() *cobra.Command {
-	metricsRoot := command.New("autoupdate", "Control automatic updates", "", runAutoupdateStatus)
+	autoupdateRoot := command.New("autoupdate", "Control automatic updates", "", runAutoupdateStatus)
 
 	optIn := command.New("enable", "Enable automatic updates", "", func(ctx context.Context) error {
 		return setAutoupdateEnabled(ctx, true)
@@ -22,10 +22,10 @@ func newAutoUpdate() *cobra.Command {
 		return setAutoupdateEnabled(ctx, false)
 	})
 
-	metricsRoot.AddCommand(optIn)
-	metricsRoot.AddCommand(optOut)
+	autoupdateRoot.AddCommand(optIn)
+	autoupdateRoot.AddCommand(optOut)
 
-	return metricsRoot
+	return autoupdateRoot
 }
 
 func printAutoupdateEnabled(ctx context.Context, enabled bool) {
@@ -42,7 +42,7 @@ func runAutoupdateStatus(ctx context.Context) error {
 		io  = iostreams.FromContext(ctx)
 	)
 
-	printAutoupdateEnabled(ctx, cfg.SendMetrics)
+	printAutoupdateEnabled(ctx, cfg.AutoUpdate)
 
 	fmt.Fprintf(io.Out, "\nThis can be controlled with 'fly settings autoupdate <enable/disable>'\n")
 
@@ -52,7 +52,7 @@ func runAutoupdateStatus(ctx context.Context) error {
 func setAutoupdateEnabled(ctx context.Context, enabled bool) error {
 	path := state.ConfigFile(ctx)
 
-	if err := config.SetSendMetrics(path, enabled); err != nil {
+	if err := config.SetAutoUpdate(path, enabled); err != nil {
 		return fmt.Errorf("failed persisting %s in %s: %w\n",
 			config.AutoUpdateFileKey, path, err)
 	}

--- a/internal/command/settings/autoupdate.go
+++ b/internal/command/settings/autoupdate.go
@@ -1,0 +1,63 @@
+package settings
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/state"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newAutoUpdate() *cobra.Command {
+	metricsRoot := command.New("autoupdate", "Control automatic updates", "", runAutoupdateStatus)
+
+	optIn := command.New("enable", "Enable automatic updates", "", func(ctx context.Context) error {
+		return setAutoupdateEnabled(ctx, true)
+	})
+	optOut := command.New("disable", "Disable automatic updates", "", func(ctx context.Context) error {
+		return setAutoupdateEnabled(ctx, false)
+	})
+
+	metricsRoot.AddCommand(optIn)
+	metricsRoot.AddCommand(optOut)
+
+	return metricsRoot
+}
+
+func printAutoupdateEnabled(ctx context.Context, enabled bool) {
+
+	enabledStr := lo.Ternary(enabled, "enabled", "disabled")
+
+	io := iostreams.FromContext(ctx)
+	fmt.Fprintf(io.Out, "Automatic updating: %s\n", enabledStr)
+}
+
+func runAutoupdateStatus(ctx context.Context) error {
+	var (
+		cfg = config.FromContext(ctx)
+		io  = iostreams.FromContext(ctx)
+	)
+
+	printAutoupdateEnabled(ctx, cfg.SendMetrics)
+
+	fmt.Fprintf(io.Out, "\nThis can be controlled with 'fly settings autoupdate <enable/disable>'\n")
+
+	return nil
+}
+
+func setAutoupdateEnabled(ctx context.Context, enabled bool) error {
+	path := state.ConfigFile(ctx)
+
+	if err := config.SetSendMetrics(path, enabled); err != nil {
+		return fmt.Errorf("failed persisting %s in %s: %w\n",
+			config.AutoUpdateFileKey, path, err)
+	}
+
+	printAutoupdateEnabled(ctx, enabled)
+
+	return nil
+}

--- a/internal/command/settings/settings.go
+++ b/internal/command/settings/settings.go
@@ -10,6 +10,7 @@ func New() *cobra.Command {
 
 	cmd.AddCommand(
 		newAnalytics(),
+		newAutoUpdate(),
 	)
 
 	return cmd

--- a/internal/command/version/upgrade.go
+++ b/internal/command/version/upgrade.go
@@ -60,7 +60,7 @@ func runUpgrade(ctx context.Context) error {
 
 	homebrew := update.IsUnderHomebrew()
 
-	if err = update.UpgradeInPlace(ctx, io, release.Prerelease); err != nil {
+	if err = update.UpgradeInPlace(ctx, io, release.Prerelease, false); err != nil {
 		return err
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ const (
 	MetricsTokenEnvKey    = envKeyPrefix + "METRICS_TOKEN"
 	MetricsTokenFileKey   = "metrics_token"
 	SendMetricsFileKey    = "send_metrics"
+	AutoUpdateFileKey     = "auto_update"
 	WireGuardStateFileKey = "wire_guard_state"
 	APITokenEnvKey        = envKeyPrefix + "API_TOKEN"
 	orgEnvKey             = envKeyPrefix + "ORG"
@@ -69,6 +70,9 @@ type Config struct {
 
 	// SendMetrics denotes whether the user wants to send metrics.
 	SendMetrics bool
+
+	// AutoUpdate denotes whether the user wants to automatically update flyctl.
+	AutoUpdate bool
 
 	// Organization denotes the organizational slug the user has selected.
 	Organization string
@@ -134,13 +138,16 @@ func (cfg *Config) ApplyFile(path string) (err error) {
 		AccessToken  string `yaml:"access_token"`
 		MetricsToken string `yaml:"metrics_token"`
 		SendMetrics  bool   `yaml:"send_metrics"`
+		AutoUpdate   bool   `yaml:"auto_update"`
 	}
 	w.SendMetrics = true
+	w.AutoUpdate = true
 
 	if err = unmarshal(path, &w); err == nil {
 		cfg.AccessToken = w.AccessToken
 		cfg.MetricsToken = w.MetricsToken
 		cfg.SendMetrics = w.SendMetrics
+		cfg.AutoUpdate = w.AutoUpdate
 	}
 
 	return

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -36,6 +36,14 @@ func SetSendMetrics(path string, sendMetrics bool) error {
 	})
 }
 
+// SetAutoUpdate sets the value of the autoupdate flag at the configuration file
+// found at path.
+func SetAutoUpdate(path string, autoUpdate bool) error {
+	return set(path, map[string]interface{}{
+		AutoUpdateFileKey: autoUpdate,
+	})
+}
+
 // Clear clears the access token, metrics token, and wireguard-related keys of the configuration
 // file found at path.
 func Clear(path string) (err error) {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -201,13 +201,10 @@ func UpgradeInPlace(ctx context.Context, io *iostreams.IOStreams, prelease, sile
 	return cmd.Run()
 }
 
-// UpgradeAndRelaunch does not return on success.
-func UpgradeAndRelaunch(ctx context.Context, io *iostreams.IOStreams, prerelease, silent bool) error {
+// Relaunch only returns on error
+func Relaunch(ctx context.Context, silent bool) error {
 
-	err := UpgradeInPlace(ctx, io, prerelease, silent)
-	if err != nil {
-		return err
-	}
+	io := iostreams.FromContext(ctx)
 
 	if !silent {
 		// Divide between update logging and the output from the actual command the user is running
@@ -282,4 +279,21 @@ func currentWindowsBinaries() ([]string, error) {
 		canonicalPath,
 		filepath.Join(filepath.Dir(canonicalPath), "wintun.dll"),
 	}, nil
+}
+
+// BackgroundUpdate begins an update in the background.
+func BackgroundUpdate() error {
+
+	binPath, err := exec.LookPath(os.Args[0])
+	if err != nil {
+		return err
+	}
+	terminal.Debugf("launching `%s version update` with binary %s\n", os.Args[0], binPath)
+
+	cmd := exec.Command(binPath, "version", "upgrade")
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -186,7 +186,6 @@ func UpgradeInPlace(ctx context.Context, io *iostreams.IOStreams, prelease, sile
 			shellToUse = "/bin/bash"
 		}
 	}
-	fmt.Println(shellToUse, switchToUse)
 
 	command := upgradeCommand(prelease)
 	cmd := exec.Command(shellToUse, switchToUse, command)


### PR DESCRIPTION
### Change Summary

What and Why: Adds autoupdating to flyctl. Staying up-to-date is now much more important than it used to be, so this not only provides a gentle nudge towards keeping things up-to-date, but it makes it potentially more convenient.

There is a config setting to disable autoupdating, and it's automatically disabled in CI environments.

How:

* If the version cache is out-of-date (more than a week old), the latest version info will be synchronously downloaded. If it's not more than a week old, we'll retain previous behavior and download async.
  * The benefit here is that an installation of flyctl that's lain dormant for months should be able to be run, and in that single run determine that it's out of date, update, _then_ run the user's command.

* If the CLI is "severely" out-of-date (defined currently as `0.0.5` versions behind), it'll download the new version, then re-run the command against the newer version.

* If the CLI is out of date, but not severely, it will either:
   * For linux/macOS, update flyctl in the background while running the original command.
      * This is seamless and provides wonderful UX.
   * For Windows users, prompt to update. I couldn't get background updates seamless on Windows for various reasons.
      * Between prompting and autoupdating when severely out of date, this is _fine_. Still an improvement over the status quo!

Related to:
 1. Project board (internal): https://github.com/orgs/superfly/projects/59/views/1
 2. Community announcement: [Flyctl Versions, Autoupdating, and the CLI Apocalypse](https://community.fly.io/t/flyctl-versions-autoupdating-and-the-cli-apocalypse/13794)

---

### Documentation

- [X] [Fresh Produce](https://community.fly.io/t/flyctl-versions-autoupdating-and-the-cli-apocalypse/13794)
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a

---

### TODO 
 - [x] Test that this works. I'm going to be using prereleases to test this.
 - [x] Tone-down the updates so that it's every couple versions or something - non-stop updating would get frustrating real fast.
 - [x] Check for updates synchronously if state.yml doesn't exist or if its modification date is > one week. This ensures that people spinning up dusty copies of flyctl will always get updates.
