### PR TITLE
Avoid crashing when provisioning an extension when primary region cannot be deduced

### DIFF
--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -88,9 +88,12 @@ func ProvisionExtension(ctx context.Context, provider string) (addOn *gql.AddOn,
 
 	cfg := appconfig.ConfigFromContext(ctx)
 
-	primaryRegion = cfg.PrimaryRegion
+	if cfg != nil && cfg.PrimaryRegion != "" {
 
-	if cfg.PrimaryRegion == "" {
+		primaryRegion = cfg.PrimaryRegion
+
+	} else {
+
 		region, err := prompt.Region(ctx, !targetOrg.PaidPlan, prompt.RegionParams{
 			Message:             "Choose the primary region (can't be changed later)",
 			ExcludedRegionCodes: excludedRegions,


### PR DESCRIPTION
For example, `flyctl mysql create -a myapp` will not be able to discover the primary region without an available `fly.toml` file. So, we prompt for a region using the nearest available region as the default.
