### PR TITLE
Reduce the batch count to account for 33% concurrent rolling deployments

### DIFF
--- a/internal/command/deploy/batcher_test.go
+++ b/internal/command/deploy/batcher_test.go
@@ -40,4 +40,7 @@ func Test_batcher(t *testing.T) {
 	assert.Equal(t, []int{2, 2, 1, 1, 1}, prepBatch(7, 5, false))
 	assert.Equal(t, []int{1, 5, 5, 5, 4, 4}, prepBatch(24, 5, true))
 	assert.Equal(t, []int{5, 5, 5, 5, 4}, prepBatch(24, 5, false))
+
+	assert.Equal(t, []int{1, 2, 2, 2}, prepBatch(7, 3, true))
+	assert.Equal(t, []int{1, 8, 8, 7}, prepBatch(24, 3, true))
 }

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	batchingGroupCount = 5
+	batchingGroupCount = 3
 	// batchingCutoff should be at least batchingGroupCount + 1
-	batchingCutoff = 6
+	batchingCutoff = 4
 )
 
 type ProcessGroupsDiff struct {


### PR DESCRIPTION
### Change Summary

What and Why:

Faster deployments by batching more aggresively

How:

Reduce the batches to 3 plus first solo 

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
