### PR TITLE
feat(redis): add proxy command

### DIFF
--- a/internal/command/redis/proxy.go
+++ b/internal/command/redis/proxy.go
@@ -1,0 +1,94 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/agent"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/gql"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/proxy"
+	"github.com/superfly/flyctl/terminal"
+)
+
+func newProxy() (cmd *cobra.Command) {
+	const (
+		long = `Proxy to a Redis database`
+
+		short = long
+		usage = "proxy"
+	)
+
+	cmd = command.New(usage, short, long, runProxy, command.RequireSession)
+
+	flag.Add(cmd,
+		flag.Org(),
+		flag.Region(),
+	)
+
+	return cmd
+}
+
+func runProxy(ctx context.Context) (err error) {
+	localProxyPort := "16379"
+	params, password, err := getRedisProxyParams(ctx, localProxyPort)
+	if err != nil {
+		return err
+	}
+
+	terminal.Infof("Proxying redis to port \"%s\" with password \"%s\"", localProxyPort, password)
+
+	return proxy.Connect(ctx, params)
+}
+
+func getRedisProxyParams(ctx context.Context, localProxyPort string) (*proxy.ConnectParams, string, error) {
+	client := client.FromContext(ctx).API()
+
+	var index int
+	var options []string
+
+	result, err := gql.ListAddOns(ctx, client.GenqClient, "redis")
+	if err != nil {
+		return nil, "", err
+	}
+
+	databases := result.AddOns.Nodes
+
+	for _, database := range databases {
+		options = append(options, fmt.Sprintf("%s (%s) %s", database.Name, database.PrimaryRegion, database.Organization.Slug))
+	}
+
+	err = prompt.Select(ctx, &index, "Select a database to connect to", "", options...)
+	if err != nil {
+		return nil, "", err
+	}
+
+	response, err := gql.GetAddOn(ctx, client.GenqClient, databases[index].Name)
+	if err != nil {
+		return nil, "", err
+	}
+
+	database := response.AddOn
+
+	agentclient, err := agent.Establish(ctx, client)
+	if err != nil {
+		return nil, "", err
+	}
+
+	dialer, err := agentclient.ConnectToTunnel(ctx, database.Organization.Slug)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return &proxy.ConnectParams{
+		Ports:            []string{localProxyPort, "6379"},
+		OrganizationSlug: database.Organization.Slug,
+		Dialer:           dialer,
+		RemoteHost:       database.PrivateIp,
+	}, database.Password, nil
+
+}

--- a/internal/command/redis/redis.go
+++ b/internal/command/redis/redis.go
@@ -29,6 +29,7 @@ func New() (cmd *cobra.Command) {
 		newConnect(),
 		newDashboard(),
 		newReset(),
+		newProxy(),
 	)
 
 	return cmd


### PR DESCRIPTION
### Change Summary

What and Why:
Adds a command to redis `fly redis proxy`
Sometimes `redis connect` doesn't work because redis-cli doesn't exist, but we want to proxy the redis db to test it locally.


How:
adds a new file in the redis package that manages creating the proxy.
also moved the logic of creating the proxy params to `getProxyParams` that is shared between `fly redis connect` and the new command

Related to: #2497 

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
