### PR TITLE
chore: don't run Preflight Tests Cleanup workflow on forks

### DIFF
--- a/.github/workflows/preflight_cleanup.yml
+++ b/.github/workflows/preflight_cleanup.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   preflight-tests:
+    if: ${{ github.repository == 'superfly/flyctl' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I constantly get notified about this workflow failing in my fork

https://github.com/MichaelDeBoey/flyctl/actions/runs/5410167737/jobs/9831250798