### PR TITLE
feat: add simple verions cmd

### DIFF
--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -39,6 +39,22 @@ type info struct {
 	Environment  string
 }
 
+type simpleInfo struct {
+	Name    string
+	Version semver.Version
+}
+
+func (s simpleInfo) String() string {
+	return fmt.Sprintf("v%d.%d.%d\n", s.Version.Major, s.Version.Minor, s.Version.Patch)
+}
+
+func SimpleInfo(i info) simpleInfo {
+	return simpleInfo{
+		Name:    i.Name,
+		Version: i.Version,
+	}
+}
+
 func (i info) String() string {
 	res := fmt.Sprintf("%s v%s %s/%s Commit: %s BuildDate: %s",
 		i.Name,

--- a/internal/command/version/version.go
+++ b/internal/command/version/version.go
@@ -60,15 +60,22 @@ func run(ctx context.Context) (err error) {
 	}
 
 	var (
-		cfg  = config.FromContext(ctx)
-		info = buildinfo.Info()
-		out  = iostreams.FromContext(ctx).Out
+		cfg        = config.FromContext(ctx)
+		info       = buildinfo.Info()
+		simpleInfo = buildinfo.SimpleInfo(info)
+		out        = iostreams.FromContext(ctx).Out
+		verbose    = flag.GetBool(ctx, "verbose")
 	)
 
-	if cfg.JSONOutput {
+	switch {
+	case cfg.JSONOutput && verbose:
 		err = json.NewEncoder(out).Encode(info)
-	} else {
+	case cfg.JSONOutput && !verbose:
+		err = json.NewEncoder(out).Encode(simpleInfo)
+	case !cfg.JSONOutput && verbose:
 		_, err = fmt.Fprintln(out, info)
+	default:
+		_, err = fmt.Fprintln(out, simpleInfo)
 	}
 
 	return


### PR DESCRIPTION
### Change Summary

What and Why:
- Default version will print all info of `flyctl`, so need to make it simple to display `vx.x.x`
How:
- Add a new struct to display simple: `simpleInfo` and check condition of the command input
Related to:

[2460](https://github.com/superfly/flyctl/issues/2460)
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
