### PR TITLE
feat: add new Files field to MachineConfig

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -515,6 +515,8 @@ type MachineConfig struct {
 
 	StopConfig *StopConfig `json:"stop_config,omitempty"`
 
+	Files []*File `json:"files,omitempty"`
+
 	// Deprecated: use Guest instead
 	VMSize string `json:"size,omitempty"`
 	// Deprecated: use Service.Autostart instead
@@ -561,6 +563,19 @@ type DNSConfig struct {
 type StopConfig struct {
 	Timeout *Duration `json:"timeout,omitempty"`
 	Signal  *string   `json:"signal,omitempty"`
+}
+
+// File represents a file that will be written to the machine. One of RawValue or SecretName must be set.
+type File struct {
+	// GuestPath is the path on the machine where the file will be written and must be an absolute path.
+	// i.e. /full/path/to/file.json
+	GuestPath string `json:"guest_path,omitempty"`
+
+	// RawValue containts the base64 encoded string of the file contents.
+	RawValue *string `json:"raw_value,omitempty"`
+
+	// SecretName is the name of the secret that contains the base64 encoded file contents.
+	SecretName *string `json:"secret_name,omitempty"`
 }
 
 type MachineLease struct {


### PR DESCRIPTION
I'll have a follow-up PR to make use of the new feature with `fly machine run/update`.

### Change Summary

What and Why:

Machines now support the ability to define files in the VM from a base64 encoded string or from a secret (which should also be base64 encode).

How:

By defining the following on the `"config"` when POSTing to the API:

```
{
  ...
  "files": [
    {
      "guest_path": "/etc/foo/bar.json",
      "raw_value": "ewogICJjb25maWciOiB7CiAgICAic29tZXRoaW5nIjogImNvbmZpZ3VyYWJsZSIKICB9Cn0K"
    }
  ]
}
```

or 

```
{
  ...
  "files": [
    {
      "guest_path": "/etc/db/config.json",
      "secret_name": "DB_CONFIG"
    }
  ]
}
```
Related to:

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
