### PR TITLE
fix/bluegreen deployment

### DIFF
--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -136,11 +136,11 @@ func (bg *blueGreen) renderMachineStates(state map[string]int) func() {
 
 func (bg *blueGreen) allMachinesStarted(stateMap map[string]int) bool {
 	started := 0
-	bg.stateLock.Lock()
+	bg.stateLock.RLock()
 	for _, v := range stateMap {
 		started += v
 	}
-	bg.stateLock.Unlock()
+	bg.stateLock.RUnlock()
 
 	return started == len(stateMap)
 }
@@ -274,6 +274,11 @@ func (bg *blueGreen) WaitForGreenMachinesToBeHealthy(ctx context.Context) error 
 				bg.healthLock.Lock()
 				machineIDToHealthStatus[m.FormattedMachineId()] = status
 				bg.healthLock.Unlock()
+
+				if status.Total == 0 {
+					continue
+				}
+
 				if status.Total == status.Passing {
 					return
 				}


### PR DESCRIPTION
eventual consistency kicking me in the back. 
context - the checks are not always registered in corrosion by the time the first getmachine call is made. it takes 1 second for the sync to happen but clearly, that's not fast enough.