### PR TITLE
add support for adding, updating, and removing files in a machine via fly machine run/update

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -887,6 +887,9 @@ func determineMachineConfig(ctx context.Context, input *determineMachineConfigIn
 		file.RawValue = &rawValue
 		return nil
 	})
+	if err != nil {
+		return machineConf, fmt.Errorf("failed to read file-local: %w", err)
+	}
 	machineFiles = append(machineFiles, localFiles...)
 
 	literalFiles, err := parseFiles(ctx, "file-literal", func(value string, file *api.File) error {
@@ -894,6 +897,9 @@ func determineMachineConfig(ctx context.Context, input *determineMachineConfigIn
 		file.RawValue = &encodedValue
 		return nil
 	})
+	if err != nil {
+		return machineConf, fmt.Errorf("failed to read file-literal: %w", err)
+	}
 	machineFiles = append(machineFiles, literalFiles...)
 
 	secretFiles, err := parseFiles(ctx, "file-secret", func(value string, file *api.File) error {

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -2,7 +2,9 @@ package machine
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -148,6 +150,18 @@ var sharedFlags = flag.Set{
 	flag.StringSlice{
 		Name:        "standby-for",
 		Description: "Comma separated list of machine ids to watch for",
+	},
+	flag.StringArray{
+		Name:        "file-local",
+		Description: "Set of files in the form of /path/inside/machine=<local/path> pairs. Can be specified multiple times.",
+	},
+	flag.StringArray{
+		Name:        "file-literal",
+		Description: "Set of literals in the form of /path/inside/machine=VALUE pairs where VALUE is the content. Can be specified multiple times.",
+	},
+	flag.StringArray{
+		Name:        "file-secret",
+		Description: "Set of secrets in the form of /path/inside/machine=SECRET pairs where SECRET is the name of the secret. Can be specified multiple times.",
 	},
 }
 
@@ -862,5 +876,81 @@ func determineMachineConfig(ctx context.Context, input *determineMachineConfigIn
 		machineConf.Standbys = lo.Ternary(len(standbys) > 0, standbys, nil)
 	}
 
+	machineFiles := []*api.File{}
+
+	localFiles, err := parseFiles(ctx, "file-local", func(value string, file *api.File) error {
+		content, err := os.ReadFile(value)
+		if err != nil {
+			return fmt.Errorf("could not read file %s: %w", value, err)
+		}
+		rawValue := base64.StdEncoding.EncodeToString(content)
+		file.RawValue = &rawValue
+		return nil
+	})
+	machineFiles = append(machineFiles, localFiles...)
+
+	literalFiles, err := parseFiles(ctx, "file-literal", func(value string, file *api.File) error {
+		encodedValue := base64.StdEncoding.EncodeToString([]byte(value))
+		file.RawValue = &encodedValue
+		return nil
+	})
+	machineFiles = append(machineFiles, literalFiles...)
+
+	secretFiles, err := parseFiles(ctx, "file-secret", func(value string, file *api.File) error {
+		file.SecretName = &value
+		return nil
+	})
+	if err != nil {
+		return machineConf, fmt.Errorf("failed to read file-secret: %w", err)
+	}
+	machineFiles = append(machineFiles, secretFiles...)
+
+	for _, f := range machineFiles {
+		idx := slices.IndexFunc(machineConf.Files, func(i *api.File) bool {
+			return i.GuestPath == f.GuestPath
+		})
+
+		switch {
+		case idx == -1:
+			machineConf.Files = append(machineConf.Files, f)
+			continue
+		case f.RawValue == nil && f.SecretName == nil:
+			fmt.Printf("deleting %s\n", f.GuestPath)
+			machineConf.Files = slices.Delete(machineConf.Files, idx, idx+1)
+		default:
+			fmt.Printf("replacing %s\n", f.GuestPath)
+			machineConf.Files = slices.Replace(machineConf.Files, idx, idx+1, f)
+		}
+
+	}
+
 	return machineConf, nil
+}
+
+func parseFiles(ctx context.Context, flagName string, cb func(value string, file *api.File) error) ([]*api.File, error) {
+	flagFiles := flag.GetStringArray(ctx, flagName)
+	machineFiles := make([]*api.File, 0, len(flagFiles))
+
+	for _, f := range flagFiles {
+		guestPath, fileRef, ok := strings.Cut(f, "=")
+		file := api.File{
+			GuestPath: guestPath,
+		}
+		switch {
+		case !ok:
+			return nil, fmt.Errorf("invalid %s argument %s", flagName, f)
+		case !filepath.IsAbs(guestPath):
+			return nil, fmt.Errorf("guest path, %s, must be absolute", guestPath)
+		case fileRef == "":
+			// empty value is allowed to remove file from machine
+		default:
+			if err := cb(fileRef, &file); err != nil {
+				return nil, err
+			}
+		}
+
+		machineFiles = append(machineFiles, &file)
+	}
+
+	return machineFiles, nil
 }


### PR DESCRIPTION
### Change Summary

Adds 3 new flags to `fly machine run` and `fly machine update`:

```
--file-local
--file-literal
--file-secret
```

Each flag can be repeated to add multiple files. See help output for formats and expectations.

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
