### PR TITLE
retry less aggresively

### DIFF
--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -275,11 +275,7 @@ func (bg *blueGreen) WaitForGreenMachinesToBeHealthy(ctx context.Context) error 
 				machineIDToHealthStatus[m.FormattedMachineId()] = status
 				bg.healthLock.Unlock()
 
-				if status.Total == 0 {
-					continue
-				}
-
-				if status.Total == status.Passing {
+				if (status.Total == status.Passing) && (status.Total != 0) {
 					return
 				}
 


### PR DESCRIPTION
don't immediately retry the request, rather allow sleep to occur.
https://community.fly.io/t/finally-bluegreen-deployments-for-appsv2/13851/8