### PR TITLE
Skip wait in FlushPending if metrics are disabled

### DIFF
--- a/internal/metrics/api.go
+++ b/internal/metrics/api.go
@@ -139,6 +139,10 @@ func shouldSendMetrics(ctx context.Context) bool {
 }
 
 func FlushPending() {
+	if !Enabled {
+		return
+	}
+
 	// this just waits for metrics to hit write(2) on the websocket connection
 	// there is no need to wait on a response from the collector
 	done.Wait()


### PR DESCRIPTION
https://github.com/superfly/flyctl/pull/2263 disables metric writes if metrics are disabled, which is helpful to make subcommands like `flyctl auth token` exit faster by not having to wait on flushing metric writes to the network.

Since merging that PR however, we started sending some metrics before we run the preparers for a subcommand, which means that before `flyctl auth token` has a chance to disable metrics, we've already opened the connection and sent something, which we then wait on before exiting.

This PR fixes this by returning early from `FlushMetrics` if metrics are disabled, just like we do when sending a metric.