### PR TITLE
Add deployemnt id

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -24,6 +24,7 @@ import (
 	"github.com/superfly/flyctl/internal/cache"
 	"github.com/superfly/flyctl/internal/cmdutil/preparers"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/deployment"
 	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/logger"
@@ -616,4 +617,8 @@ func ChangeWorkingDirectory(ctx context.Context, wd string) (context.Context, er
 	}
 
 	return state.WithWorkingDirectory(ctx, wd), nil
+}
+
+func CreateDeploymentID(ctx context.Context) (context.Context, error) {
+	return deployment.WithDeployID(ctx, deployment.ID()), nil
 }

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -139,6 +139,7 @@ func New() (cmd *cobra.Command) {
 		command.RequireSession,
 		command.ChangeWorkingDirectoryToFirstArgIfPresent,
 		command.RequireAppName,
+		command.CreateDeploymentID,
 	)
 
 	cmd.Args = cobra.MaximumNArgs(1)

--- a/internal/deployment/context.go
+++ b/internal/deployment/context.go
@@ -1,0 +1,13 @@
+package deployment
+
+import "context"
+
+type deploymentIdKey struct{}
+
+func WithDeployID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, deploymentIdKey{}, id)
+}
+
+func DeployIDFromContext(ctx context.Context) string {
+	return ctx.Value(deploymentIdKey{}).(string)
+}

--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -1,0 +1,19 @@
+package deployment
+
+import "math/rand"
+
+// ID generates a unique ID for every flyctl deploy call
+func ID() string {
+	return "deploy-" + randString(8)
+}
+
+// randString generates a random string of length n
+func randString(n int) string {
+	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))] //nolint:gosec
+	}
+	return string(b)
+}

--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -1,19 +1,25 @@
 package deployment
 
-import "math/rand"
+import (
+	"crypto/rand"
+	"math/big"
+)
 
 // ID generates a unique ID for every flyctl deploy call
 func ID() string {
 	return "deploy-" + randString(8)
 }
 
-// randString generates a random string of length n
 func randString(n int) string {
 	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))] //nolint:gosec
+		val, err := rand.Int(rand.Reader, big.NewInt(int64(len(letterRunes))))
+		if err != nil {
+			panic(err) // handle error appropriately in your real code
+		}
+		b[i] = letterRunes[val.Int64()]
 	}
 	return string(b)
 }


### PR DESCRIPTION
### Change Summary

What and Why:

We need a way to track individual deployments(fly deploy) and associate them with the API calls they make

How:

The unique deployment id we generate here will be recorded by our metrics app and could also be sent to sentry.

Related to:

* flyctl metrics
* observability
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
