### PR TITLE
restartless volume extension

### DIFF
--- a/api/resource_volumes.go
+++ b/api/resource_volumes.go
@@ -86,7 +86,7 @@ func (c *Client) CreateVolume(ctx context.Context, input CreateVolumeInput) (*Vo
 	return &data.CreateVolume.Volume, nil
 }
 
-func (c *Client) ExtendVolume(ctx context.Context, input ExtendVolumeInput) (*Volume, error) {
+func (c *Client) ExtendVolume(ctx context.Context, input ExtendVolumeInput) (*Volume, bool, error) {
 	query := `
 		mutation($input: ExtendVolumeInput!) {
 			extendVolume(input: $input) {
@@ -108,6 +108,7 @@ func (c *Client) ExtendVolume(ctx context.Context, input ExtendVolumeInput) (*Vo
 						id
 					}
 				}
+				needsRestart
 			}
 		}
 	`
@@ -118,10 +119,10 @@ func (c *Client) ExtendVolume(ctx context.Context, input ExtendVolumeInput) (*Vo
 
 	data, err := c.RunWithContext(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return &data.ExtendVolume.Volume, nil
+	return &data.ExtendVolume.Volume, data.ExtendVolume.NeedsRestart, nil
 }
 
 func (c *Client) DeleteVolume(ctx context.Context, volID string, lockId string) (App *App, err error) {

--- a/api/types.go
+++ b/api/types.go
@@ -419,8 +419,9 @@ type CreateVolumePayload struct {
 }
 
 type ExtendVolumePayload struct {
-	App    App
-	Volume Volume
+	App          App
+	Volume       Volume
+	NeedsRestart bool
 }
 
 type DeleteVolumeInput struct {

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -94,7 +94,7 @@ func runExtend(ctx context.Context) error {
 		SizeGb:   flag.GetInt(ctx, "size"),
 	}
 
-	volume, err := client.ExtendVolume(ctx, input)
+	volume, needsRestart, err := client.ExtendVolume(ctx, input)
 	if err != nil {
 		return fmt.Errorf("failed to extend volume: %w", err)
 	}
@@ -110,7 +110,11 @@ func runExtend(ctx context.Context) error {
 	}
 
 	if app.PlatformVersion == "machines" {
-		fmt.Fprintln(out, colorize.Yellow("You will need to stop and start your machine to increase the size of the FS"))
+		if needsRestart {
+			fmt.Fprintln(out, colorize.Yellow("You will need to stop and start your machine to increase the size of the FS"))
+		} else {
+			fmt.Fprintln(out, colorize.Green("Your machine got its file size extended without a restart"))
+		}
 	}
 
 	return nil

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -113,7 +113,7 @@ func runExtend(ctx context.Context) error {
 		if needsRestart {
 			fmt.Fprintln(out, colorize.Yellow("You will need to stop and start your machine to increase the size of the FS"))
 		} else {
-			fmt.Fprintln(out, colorize.Green("Your machine got its file size extended without a restart"))
+			fmt.Fprintln(out, colorize.Green("Your machine got its volume size extended without needing a restart"))
 		}
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why: show customers when their machine got a volume extension that doesn't need a restart

How: our internal apis will send a `needsRestart` flag we can read

Related to: PRs in private repos

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
