### PR TITLE
also publish docker image to ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,17 @@ jobs:
       - name: Get go version
         id: go-version
         run: echo "name=version::$(go env GOVERSION)" >> $GITHUB_OUTPUT
-      - name: Docker Login
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-        run: |
-          echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
       - name: Place wintun.dll
         run: cp -r deps/wintun/bin/amd64/wintun.dll ./
       - name: generate release notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Place wintun.dll
         run: cp -r deps/wintun/bin/amd64/wintun.dll ./
       - name: generate release notes

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,8 +73,8 @@ dockers:
     image_templates:
       - "flyio/flyctl:latest"
       - "flyio/flyctl:v{{ .Version }}"
-      - "gcr.io/superfly/flyctl:latest"
-      - "gcr.io/superfly/flyctl:v{{ .Version }}"
+      - "ghcr.io/superfly/flyctl:latest"
+      - "ghcr.io/superfly/flyctl:v{{ .Version }}"
     skip_push: auto
 
 checksum:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,6 +73,8 @@ dockers:
     image_templates:
       - "flyio/flyctl:latest"
       - "flyio/flyctl:v{{ .Version }}"
+      - "gcr.io/superfly/flyctl:latest"
+      - "gcr.io/superfly/flyctl:v{{ .Version }}"
     skip_push: auto
 
 checksum:


### PR DESCRIPTION
### Change Summary

**What and Why:**

Docker Hub has [annoying rate limits](https://docs.docker.com/docker-hub/download-rate-limit/), which sometimes break our CI. As GitHub has an integrated container registry (ghcr.io), it makes sense to also publish the docker image there.

**How:**

Adjusts the CI and goreleaser config to publish to two registries.

This might need permission adjustments for the `GORELEASER_GITHUB_TOKEN` (see [docs](https://goreleaser.com/ci/actions/#token-permissions)) to also contain the `packages: write` permission

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a

To my knowledge, the docker image is undocumented, so no documentation for the other release target.