### PR TITLE
Disable automatic top level check generation for bluegreen deployments

### DIFF
--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -284,7 +284,7 @@ func (bg *blueGreen) WaitForGreenMachinesToBeHealthy(ctx context.Context) error 
 					return
 				}
 
-				status := updateMachine.TopLevelChecks()
+				status := updateMachine.AllHealthChecks()
 				bg.healthLock.Lock()
 				machineIDToHealthStatus[m.FormattedMachineId()] = status
 				bg.healthLock.Unlock()


### PR DESCRIPTION
In order to allow users use bluegreen strategy without requiring them to manually add toplevel checks, we(well I) resorted to generating top level checks for the deployment and deleting them after. 

thing is, these checks don't really disappear and we have code in many places to give the impression that it's gone. there is work ongoing in flyd & corrosion to cordon/uncordon machines properly.

they'll be merged soon and we don't need autogeneration anymore, this removes the autogeneration code.