### PR TITLE
Handle SIGUSR2 and dump goroutines on the signal

### DIFF
--- a/debug_unix.go
+++ b/debug_unix.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"runtime/pprof"
+
+	"golang.org/x/sys/unix"
+)
+
+// handleDebugSignal handles SIGUSR2 and dumps debug information.
+func handleDebugSignal(ctx context.Context) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, unix.SIGUSR2)
+
+	for {
+		select {
+		case <-sigCh:
+			pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/debug_windows.go
+++ b/debug_windows.go
@@ -1,0 +1,7 @@
+package main
+
+import "context"
+
+// handleDebugSignal is no-op on Windows
+func handleDebugSignal(_ context.Context) {
+}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,8 @@ func run() (exitCode int) {
 	ctx, cancel := newContext()
 	defer cancel()
 
+	go handleDebugSignal(ctx)
+
 	if !buildinfo.IsDev() {
 		defer func() {
 			if r := recover(); r != nil {


### PR DESCRIPTION
When flyctl hangs, dumping all goroutines may be helpful to understand its internal state.

Docker uses SIGUSR1 for that, but it is already taken by wg/signals_unix.go.

https://community.fly.io/t/flyctl-v0-1-47-cannot-deploy-clone-and-list-machines/13940 https://github.com/moby/moby/blob/v24.0.2/daemon/debugtrap_unix.go#L17

### Change Summary

What and Why:

flyctl v0.1.47 was hanging occasionally and we had no clues. This change may help us understand what's going on.

How:

Handling SIGUSR2 and dumping all goroutines' stacktraces.

Related to:

https://community.fly.io/t/flyctl-v0-1-47-cannot-deploy-clone-and-list-machines/13940

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
