### PR TITLE
Require an app name in SSH commands

### DIFF
--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -102,7 +102,7 @@ func newConsole() *cobra.Command {
 		usage = "console"
 	)
 
-	cmd := command.New(usage, short, long, runConsole, command.RequireSession, command.LoadAppNameIfPresent)
+	cmd := command.New(usage, short, long, runConsole, command.RequireSession, command.RequireAppName)
 
 	cmd.Args = cobra.MaximumNArgs(1)
 

--- a/internal/command/ssh/sftp.go
+++ b/internal/command/ssh/sftp.go
@@ -49,7 +49,7 @@ func newSFTPShell() *cobra.Command {
 		usage = "shell"
 	)
 
-	cmd := command.New(usage, short, long, runShell, command.RequireSession, command.LoadAppNameIfPresent)
+	cmd := command.New(usage, short, long, runShell, command.RequireSession, command.RequireAppName)
 
 	stdArgsSSH(cmd)
 
@@ -63,7 +63,7 @@ func newFind() *cobra.Command {
 		usage = "find [path]"
 	)
 
-	cmd := command.New(usage, short, long, runLs, command.RequireSession, command.LoadAppNameIfPresent)
+	cmd := command.New(usage, short, long, runLs, command.RequireSession, command.RequireAppName)
 
 	stdArgsSSH(cmd)
 
@@ -77,7 +77,7 @@ func newGet() *cobra.Command {
 		usage = "get <path>"
 	)
 
-	cmd := command.New(usage, short, long, runGet, command.RequireSession, command.LoadAppNameIfPresent)
+	cmd := command.New(usage, short, long, runGet, command.RequireSession, command.RequireAppName)
 
 	cmd.Args = cobra.MaximumNArgs(2)
 


### PR DESCRIPTION
### Change Summary

When no app name is available, `ssh console` and the `ssh sftp` commands currently attempt to look up the app whose name is the empty string. The error ends up being `Could not find App`, which doesn't really describe the problem.

Require an app name (through the `RequireAppName` preparer) for these commands, so that flyctl will emit the standard error message (`the config for your app is missing an app name, add an app field to the fly.toml file or specify with the -a flag`).

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
