### PR TITLE
Feature: Support for Launching .NET Web Applications

### DIFF
--- a/scanner/dotnet.go
+++ b/scanner/dotnet.go
@@ -1,0 +1,90 @@
+package scanner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+func configureDotnet(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
+	if !checksPass(sourceDir, dirContains("*.csproj", "Microsoft.NET.Sdk.Web")) {
+		return nil, nil
+	}
+
+	csprojName, csprojPath, err := findCSProjFile(sourceDir)
+	if err != nil {
+		return nil, nil
+	}
+
+	dotnetSdkVersion, err := extractDotnetTargetFramework(csprojPath)
+	if err != nil {
+		return nil, nil
+	}
+
+	// we don't support .NET Framework or .NET version below 6.0
+	isDotnetFramework := !strings.Contains(dotnetSdkVersion, ".")
+	if isDotnetFramework || dotnetSdkVersion < "6.0" {
+		if isDotnetFramework {
+			fmt.Println("The .NET Framework is not supported.")
+		} else {
+			fmt.Println("The .NET version found is", dotnetSdkVersion)
+		}
+		fmt.Println("We only supports projects with .NET version 6.0 or above.")
+
+		return nil, nil
+	}
+
+	s := &SourceInfo{
+		Family: ".NET",
+		Port:   8080,
+	}
+
+	vars := make(map[string]interface{})
+	vars["dotnetAppName"] = csprojName
+	vars["dotnetSdkVersion"] = dotnetSdkVersion
+	s.Files = templatesExecute("templates/dotnet", vars)
+
+	return s, nil
+}
+
+func findCSProjFile(dir string) (string, string, error) {
+	var csprojName, csprojPath string
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() && filepath.Ext(path) == ".csproj" {
+			csprojName = strings.TrimSuffix(info.Name(), ".csproj")
+			csprojPath = path
+			return filepath.SkipDir // Stop walking the directory
+		}
+
+		return nil
+	})
+
+	return csprojName, csprojPath, err
+}
+
+func extractDotnetTargetFramework(filePath string) (string, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %v", err)
+	}
+
+	pattern := `<TargetFramework>(.*?)<\/TargetFramework>`
+
+	re := regexp.MustCompile(pattern)
+	match := re.FindStringSubmatch(string(content))
+
+	if len(match) > 1 {
+		sdkVersion := strings.TrimPrefix(match[1], "net")
+		sdkVersion = strings.TrimPrefix(sdkVersion, "coreapp") // Handle .NET Core
+		return sdkVersion, nil
+	}
+
+	return "", fmt.Errorf("failed to extract .NET version")
+}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -106,6 +106,7 @@ func Scan(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
 		configureNextJs,
 		configureNode,
 		configureStatic,
+		configureDotnet,
 	}
 
 	for _, scanner := range scanners {

--- a/scanner/templates/dotnet/.dockerignore
+++ b/scanner/templates/dotnet/.dockerignore
@@ -1,0 +1,9 @@
+# directories
+**/bin/
+**/obj/
+**/out/
+
+# files
+fly.toml
+Dockerfile*
+**/*.md

--- a/scanner/templates/dotnet/Dockerfile
+++ b/scanner/templates/dotnet/Dockerfile
@@ -1,0 +1,22 @@
+# Adjust DOTNET_OS_VERSION as desired
+ARG DOTNET_OS_VERSION="-alpine"
+ARG DOTNET_SDK_VERSION={{ .dotnetSdkVersion }}
+
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_SDK_VERSION}${DOTNET_OS_VERSION} AS build
+WORKDIR /src
+
+# copy everything
+COPY . ./
+# restore as distinct layers
+RUN dotnet restore
+# build and publish a release
+RUN dotnet publish -c Release -o /app
+
+# final stage/image
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_SDK_VERSION}
+ENV ASPNETCORE_URLS http://+:8080
+ENV ASPNETCORE_ENVIRONMENT Production
+EXPOSE 8080
+WORKDIR /app
+COPY --from=build /app .
+ENTRYPOINT [ "dotnet", "{{ .dotnetAppName }}.dll" ]


### PR DESCRIPTION
### Change Summary

**What and Why:**

This pull request adds support for launching .NET web applications.

By including support for .NET applications, we make the flyctl more useful and appealing to a larger group of developers. Many developers use the .NET, and there have been requests from the community for this feature. This addition has the potential to attract new users and encourage collaboration within the .NET developer community.

**How:**

First, we search for a `.csproj` file that contain the `Microsoft.NET.Sdk.Web` keyword, indicating the presence of a .NET web application. Next, we extract the .NET version from the project file. If the application is using `.NET Framework` or a version of `.NET` below `6.0` (6.0 is the current LTS), we stop further processing. Assuming everything is in order, we proceed to generate a Dockerfile.

---

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs - [PR](https://github.com/superfly/docs/pull/876)
- [ ] n/a
