### PR TITLE
`logging`: log equiv. of `LOG_LEVEL=debug` to files in `~/.fly/logs`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -37,7 +37,7 @@ func FromToken(token string) *Client {
 }
 
 func NewClient(token string) *api.Client {
-	return api.NewClient(token, buildinfo.Name(), buildinfo.Version().String(), logger.FromEnv(iostreams.System().ErrOut))
+	return api.NewClient(token, buildinfo.Name(), buildinfo.Version().String(), logger.FromEnv(iostreams.System().ErrOut).AndLogToFile())
 }
 
 type NewClientOpts struct {

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -2,13 +2,13 @@ package buildinfo
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"runtime/debug"
 	"strconv"
 	"time"
 
 	"github.com/blang/semver"
-	"github.com/superfly/flyctl/terminal"
 )
 
 var (
@@ -100,7 +100,7 @@ func BuildDate() time.Time {
 func parseVesion(v string) semver.Version {
 	parsedV, err := semver.ParseTolerant(v)
 	if err != nil {
-		terminal.Warnf("error parsing version number '%s': %s\n", v, err)
+		fmt.Printf("WARN: error parsing version number '%s': %s\n", v, err)
 		return semver.Version{}
 	}
 	return parsedV

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -100,6 +100,7 @@ func BuildDate() time.Time {
 func parseVesion(v string) semver.Version {
 	parsedV, err := semver.ParseTolerant(v)
 	if err != nil {
+		// Can't use terminal.Warnf here because of a circular dependency
 		fmt.Printf("WARN: error parsing version number '%s': %s\n", v, err)
 		return semver.Version{}
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -41,7 +41,7 @@ func Run(ctx context.Context, io *iostreams.IOStreams, args ...string) int {
 		}()
 	}
 
-	ctx = logger.NewContext(ctx, term2.DefaultLogger)
+	ctx = logger.NewContext(ctx, logger.FromEnv(io.ErrOut).AndLogToFile())
 
 	httptracing.Init()
 	defer httptracing.Finish()

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -19,6 +19,8 @@ import (
 	"github.com/superfly/flyctl/internal/httptracing"
 	"github.com/superfly/flyctl/internal/logger"
 
+	term2 "github.com/superfly/flyctl/terminal"
+
 	"github.com/superfly/flyctl/internal/command/root"
 )
 
@@ -26,7 +28,20 @@ import (
 // exit code the application should exit with.
 func Run(ctx context.Context, io *iostreams.IOStreams, args ...string) int {
 	ctx = iostreams.NewContext(ctx, io)
-	ctx = logger.NewContext(ctx, logger.FromEnv(io.ErrOut))
+
+	err := logger.InitLogFile()
+	if err != nil {
+		term2.Debugf("failed to initialize file logger: %s", err)
+	} else {
+		defer func() {
+			err := logger.CloseLogFile()
+			if err != nil {
+				term2.Debugf("failed to close file logger: %s", err)
+			}
+		}()
+	}
+
+	ctx = logger.NewContext(ctx, term2.DefaultLogger)
 
 	httptracing.Init()
 	defer httptracing.Finish()
@@ -41,7 +56,7 @@ func Run(ctx context.Context, io *iostreams.IOStreams, args ...string) int {
 
 	defer metrics.FlushPending()
 
-	cmd, err := cmd.ExecuteContextC(ctx)
+	cmd, err = cmd.ExecuteContextC(ctx)
 
 	switch {
 	case err == nil:

--- a/internal/logger/file_logger.go
+++ b/internal/logger/file_logger.go
@@ -1,0 +1,55 @@
+package logger
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+)
+
+type logFile struct {
+	file      *os.File
+	writer    *bufio.Writer
+	lock      sync.Mutex
+	destroyed bool
+}
+
+var (
+	logfileAlreadyClosedError      = errors.New("logfile already closed")
+	logfileAlreadyInitializedError = errors.New("logfile already initialized")
+)
+
+func (l *logFile) WriteLog(_ Level, line string) {
+	fmt.Fprint(l, line)
+}
+
+func (l *logFile) UseAnsi() bool {
+	return false
+}
+
+func (l *logFile) Write(p []byte) (n int, err error) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	if l.destroyed {
+		return 0, logfileAlreadyClosedError
+	}
+	return l.writer.Write(p)
+}
+
+func (l *logFile) Close() error {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	if l.destroyed {
+		return logfileAlreadyClosedError
+	}
+	l.destroyed = true
+	if err := l.writer.Flush(); err != nil {
+		return err
+	}
+	return l.file.Close()
+}
+
+func (l *logFile) Level() Level {
+	return NoLogLevel
+}

--- a/internal/logger/global_logfile.go
+++ b/internal/logger/global_logfile.go
@@ -1,0 +1,37 @@
+package logger
+
+import (
+	"bufio"
+
+	"github.com/superfly/flyctl/internal/logger/logfile"
+)
+
+var globalLogFile = logFile{
+	destroyed: true,
+}
+
+func InitLogFile() error {
+	if !globalLogFile.destroyed {
+		return logfileAlreadyInitializedError
+	}
+	rawFile, err := logfile.CreateLogFile()
+	globalLogFile = logFile{
+		file:      rawFile,
+		writer:    bufio.NewWriter(rawFile),
+		destroyed: false,
+	}
+	return err
+}
+
+func CloseLogFile() error {
+	if globalLogFile.destroyed {
+		return logfileAlreadyClosedError
+	}
+	defer func() {
+		globalLogFile.writer = nil
+		globalLogFile.file = nil
+		globalLogFile.destroyed = true
+	}()
+
+	return globalLogFile.Close()
+}

--- a/internal/logger/logfile/fs.go
+++ b/internal/logger/logfile/fs.go
@@ -1,0 +1,98 @@
+package logfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+func logDir() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	dir := filepath.Join(homeDir, ".fly", "logs")
+
+	dirStat, err := os.Stat(dir)
+	if err == nil && !dirStat.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", dir)
+	} else if err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(dir, 0o700); err != nil {
+				return "", err
+			}
+		} else {
+			return "", err
+		}
+	}
+
+	return dir, nil
+}
+
+// retainLogs ensures that the number of logs in the logs directory is less than or equal to keepLogs.
+func retainLogs(logsDir string) error {
+
+	type logEntry struct {
+		path string
+		time time.Time
+	}
+	var matchingLogs []logEntry
+
+	// Iterate through the log directory, and take note of all log files fitting the flyctl-*.log pattern.
+	err := filepath.Walk(logsDir, func(path string, info os.FileInfo, err error) error {
+		if filepath.Ext(path) == ".log" && strings.HasPrefix(info.Name(), "flyctl-") {
+			date, err := parseLogName(info.Name())
+			if err != nil {
+				return err
+			}
+			matchingLogs = append(matchingLogs, logEntry{
+				path: path,
+				time: date,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Sort logs by timestamp
+	sort.Slice(matchingLogs, func(i, j int) bool {
+		return matchingLogs[i].time.After(matchingLogs[j].time)
+	})
+
+	// Delete all but the most recent [keepLogs] logs
+	var lastErr error
+	for i := keepLogs; i < len(matchingLogs); i++ {
+		if err := os.Remove(matchingLogs[i].path); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+func CreateLogFile() (*os.File, error) {
+
+	logsDir, err := logDir()
+	if err != nil {
+		return nil, err
+	}
+
+	fileName := formatLogName(time.Now())
+	filePath := filepath.Join(logsDir, fileName)
+
+	rawFile, err := os.Create(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := retainLogs(logsDir); err != nil {
+		return nil, err
+	}
+
+	return rawFile, nil
+}

--- a/internal/logger/logfile/name.go
+++ b/internal/logger/logfile/name.go
@@ -1,0 +1,21 @@
+package logfile
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	timeSpec = time.RFC3339
+	keepLogs = 10
+)
+
+func formatLogName(fileTime time.Time) string {
+	return fmt.Sprintf("flyctl-%s.log", fileTime.Format(timeSpec))
+}
+func parseLogName(fileName string) (time.Time, error) {
+	date := strings.TrimSuffix(strings.TrimPrefix(fileName, "flyctl-"), filepath.Ext(fileName))
+	return time.Parse(timeSpec, date)
+}

--- a/internal/logger/split_logger.go
+++ b/internal/logger/split_logger.go
@@ -1,0 +1,41 @@
+package logger
+
+import "github.com/superfly/flyctl/internal/cmdutil"
+
+type SplitLogger struct {
+	terminal logSink
+	file     logSink
+}
+
+func (l *SplitLogger) WriteLog(level Level, line string) {
+	if l.terminal != nil {
+		l.terminal.WriteLog(level, line)
+	}
+	if l.file != nil {
+		sanitized := line
+		if !l.file.UseAnsi() && l.terminal != nil && l.terminal.UseAnsi() {
+			sanitized = cmdutil.StripANSI(line)
+		}
+		l.file.WriteLog(level, sanitized)
+	}
+}
+
+func (l *SplitLogger) UseAnsi() bool {
+	if l.terminal != nil {
+		return l.terminal.UseAnsi()
+	}
+	if l.file != nil {
+		return l.file.UseAnsi()
+	}
+	return true
+}
+
+func (l *SplitLogger) Level() Level {
+	if l.terminal != nil {
+		return l.terminal.Level()
+	}
+	if l.file != nil {
+		return l.file.Level()
+	}
+	return NoLogLevel
+}

--- a/internal/logger/writer_logger.go
+++ b/internal/logger/writer_logger.go
@@ -1,0 +1,27 @@
+package logger
+
+import (
+	"fmt"
+	"io"
+)
+
+type WriterLogger struct {
+	out    io.Writer
+	level  Level
+	isTerm bool
+}
+
+func (l *WriterLogger) WriteLog(level Level, line string) {
+	if level < l.level {
+		return
+	}
+	fmt.Fprint(l.out, line)
+}
+
+func (l *WriterLogger) UseAnsi() bool {
+	return l.isTerm
+}
+
+func (l *WriterLogger) Level() Level {
+	return l.level
+}

--- a/iostreams/iostreams.go
+++ b/iostreams/iostreams.go
@@ -334,6 +334,16 @@ func (w writerWithFd) Fd() uintptr {
 	return w.orig.Fd()
 }
 
+func IsTerminalWriter(w io.Writer) bool {
+	if w == os.Stdout || w == os.Stderr {
+		return true
+	}
+	if wf, ok := w.(writerWithFd); ok {
+		return wf.Fd() == os.Stdout.Fd() || wf.Fd() == os.Stderr.Fd()
+	}
+	return false
+}
+
 // colorableOut transforms a file writer into one where it is safe to write ANSI escape codes to.
 func colorableOut(w terminal.FileWriter) terminal.FileWriter {
 	if f, ok := w.(*os.File); ok {

--- a/terminal/logging.go
+++ b/terminal/logging.go
@@ -1,153 +1,66 @@
 package terminal
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
-	"github.com/logrusorgru/aurora"
+	"github.com/superfly/flyctl/internal/logger"
 )
 
-type LogLevel int
-
-const (
-	LevelDebug LogLevel = iota
-	LevelInfo
-	LevelWarn
-	LevelError
-)
-
-var DefaultLogger = &Logger{level: LevelInfo}
-
-type Logger struct {
-	level LogLevel
-}
+var DefaultLogger *logger.Logger
 
 func init() {
+
+	var level logger.Level
+
 	switch strings.ToLower(os.Getenv("LOG_LEVEL")) {
 	case "debug":
-		DefaultLogger.SetLogLevel(LevelDebug)
+		level = logger.Debug
 	case "info":
-		DefaultLogger.SetLogLevel(LevelInfo)
+		level = logger.Info
 	case "warn":
-		DefaultLogger.SetLogLevel(LevelWarn)
+		level = logger.Warn
 	case "error":
-		DefaultLogger.SetLogLevel(LevelError)
+		level = logger.Error
 	default:
-		DefaultLogger.SetLogLevel(LevelInfo)
+		level = logger.Info
 	}
+
+	DefaultLogger = logger.New(os.Stdout, level, true).AndLogToFile()
 }
 
-func (l *Logger) SetLogLevel(lvl LogLevel) {
-	l.level = lvl
-}
-
-func (l *Logger) GetLogLevel() LogLevel {
-	return l.level
+func GetLogLevel() logger.Level {
+	return DefaultLogger.Level()
 }
 
 func Debug(v ...interface{}) {
 	DefaultLogger.Debug(v...)
 }
 
-func (l *Logger) Debug(v ...interface{}) {
-	if l.level > LevelDebug {
-		return
-	}
-
-	fmt.Println(
-		aurora.Sprintf(
-			aurora.Faint("DEBUG %s"),
-			fmt.Sprint(v...),
-		),
-	)
-}
-
 func Debugf(format string, v ...interface{}) {
 	DefaultLogger.Debugf(format, v...)
-}
-
-func (l *Logger) Debugf(format string, v ...interface{}) {
-	if l.level > LevelDebug {
-		return
-	}
-
-	fmt.Printf(
-		aurora.Sprintf(
-			aurora.Faint(fmt.Sprintf("DEBUG %s", format)),
-			v...,
-		),
-	)
 }
 
 func Info(v ...interface{}) {
 	DefaultLogger.Info(v...)
 }
 
-func (l *Logger) Info(v ...interface{}) {
-	if l.level > LevelInfo {
-		return
-	}
-	fmt.Print("INFO ")
-	fmt.Println(v...)
-}
-
 func Infof(format string, v ...interface{}) {
 	DefaultLogger.Infof(format, v...)
-}
-
-func (l *Logger) Infof(format string, v ...interface{}) {
-	if l.level > LevelInfo {
-		return
-	}
-	fmt.Print("INFO ")
-	fmt.Printf(format, v...)
 }
 
 func Warn(v ...interface{}) {
 	DefaultLogger.Warn(v...)
 }
 
-func (l *Logger) Warn(v ...interface{}) {
-	if l.level > LevelWarn {
-		return
-	}
-	fmt.Print(aurora.Yellow("WARN "))
-	fmt.Println(v...)
-}
-
 func Warnf(format string, v ...interface{}) {
 	DefaultLogger.Warnf(format, v...)
-}
-
-func (l *Logger) Warnf(format string, v ...interface{}) {
-	if l.level > LevelWarn {
-		return
-	}
-	fmt.Print(aurora.Yellow("WARN "))
-	fmt.Printf(format, v...)
 }
 
 func Error(v ...interface{}) {
 	DefaultLogger.Error(v...)
 }
 
-func (l *Logger) Error(v ...interface{}) {
-	if l.level > LevelError {
-		return
-	}
-	fmt.Print(aurora.Red("ERROR "))
-	fmt.Println(v...)
-}
-
 func Errorf(format string, v ...interface{}) {
 	DefaultLogger.Errorf(format, v...)
-}
-
-func (l *Logger) Errorf(format string, v ...interface{}) {
-	if l.level > LevelError {
-		return
-	}
-	fmt.Print(aurora.Red("ERROR "))
-	fmt.Printf(format, v...)
 }

--- a/wg/state.go
+++ b/wg/state.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/terminal"
 	"golang.zx2c4.com/wireguard/device"
 )
@@ -59,10 +60,10 @@ func (s *WireGuardState) TunnelConfig() *Config {
 	wgr := IPNet(*rnet)
 
 	var wgLogLevel int
-	switch terminal.DefaultLogger.GetLogLevel() {
-	case terminal.LevelDebug:
+	switch terminal.GetLogLevel() {
+	case logger.Debug:
 		wgLogLevel = device.LogLevelVerbose
-	case terminal.LevelInfo | terminal.LevelWarn | terminal.LevelError:
+	case logger.Info | logger.Warn | logger.Error:
 		wgLogLevel = device.LogLevelError
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why:

To make troubleshooting easier and issues more reproducible, we'll keep logs for the last 10 (this is a totally arbitrary number) runs of flyctl. These logs are the equivalent of `LOG_LEVEL=debug`, although they won't contain the actual output - only the debug logs.

How:

A lot of cleanup around logging and the `terminal` package. We had like four reimplementations of this logging system scattered around flyctl lmao, this consolidates most of it.

Related to: [internal discussion](https://flyio.discourse.team/t/flyctl-diagnostics-pipeline/3403)

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a (this is more a tool for support rather than something user-facing)

----

Sorry about the mega-commit! I kind of dug myself into a hole, and had to rewrite things to get out of it - in the process I just totally lost any hope of a reasonable commit history.
