### PR TITLE
Status:display machine metadata.role if not empty

### DIFF
--- a/internal/command/status/machines.go
+++ b/internal/command/status/machines.go
@@ -169,10 +169,10 @@ func RenderMachineStatus(ctx context.Context, app *api.AppCompact, out io.Writer
 			if len(machine.Config.Standbys) > 0 {
 				hasStandbys = true
 			}
-			var role = "N/A"
+			var role string
 
-			if machine.Config.Metadata["role"] != "" {
-				role = machine.Config.Metadata["role"]
+			if v := machine.Config.Metadata["role"]; v != "" {
+				role = v
 			}
 			rows = append(rows, []string{
 				getProcessgroup(machine),

--- a/internal/command/status/machines.go
+++ b/internal/command/status/machines.go
@@ -169,12 +169,18 @@ func RenderMachineStatus(ctx context.Context, app *api.AppCompact, out io.Writer
 			if len(machine.Config.Standbys) > 0 {
 				hasStandbys = true
 			}
+			var role = "N/A"
+
+			if machine.Config.Metadata["role"] != "" {
+				role = machine.Config.Metadata["role"]
+			}
 			rows = append(rows, []string{
 				getProcessgroup(machine),
 				machine.ID,
 				getReleaseVersion(machine),
 				machine.Region,
 				machine.State,
+				role,
 				render.MachineHealthChecksSummary(machine),
 				machine.UpdatedAt,
 			})
@@ -184,7 +190,7 @@ func RenderMachineStatus(ctx context.Context, app *api.AppCompact, out io.Writer
 			return slices.Compare(rows[i], rows[j]) < 0
 		})
 
-		err := render.Table(out, "Machines", rows, "Process", "ID", "Version", "Region", "State", "Checks", "Last Updated")
+		err := render.Table(out, "Machines", rows, "Process", "ID", "Version", "Region", "State", "Role", "Checks", "Last Updated")
 		if err != nil {
 			return err
 		}
@@ -265,7 +271,7 @@ func renderPGStatus(ctx context.Context, app *api.AppCompact, machines []*api.Ma
 		if postgres.IsFlex(machines[0]) {
 			yes, note := isQuorumMet(machines)
 			if !yes {
-				fmt.Fprintf(out, colorize.Yellow(note))
+				fmt.Fprint(out, colorize.Yellow(note))
 			}
 		}
 	} else {


### PR DESCRIPTION
### Change Summary

What and Why:

`fly status` should display a role column if one is specified in the machine metadata

LiteFS for example now sets a role metadata key that can be replica or primary. This makes it easy to identify different machines in a cluster.

How:

Related to:

https://community.fly.io/t/dynamic-machine-metadata/13115
---

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a
