### PR TITLE
Fix background task runner, use for metrics

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -7,10 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/metrics"
+	"github.com/superfly/flyctl/internal/task"
 
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/graphql"
@@ -42,6 +44,8 @@ func Run(ctx context.Context, io *iostreams.IOStreams, args ...string) int {
 	}
 
 	ctx = logger.NewContext(ctx, logger.FromEnv(io.ErrOut).AndLogToFile())
+	// initialize the background task runner early so command preparers can start running stuff immediately
+	ctx = task.NewWithContext(ctx)
 
 	httptracing.Init()
 	defer httptracing.Finish()
@@ -54,13 +58,17 @@ func Run(ctx context.Context, io *iostreams.IOStreams, args ...string) int {
 
 	cs := io.ColorScheme()
 
-	defer metrics.FlushPending()
-
 	cmd, err = cmd.ExecuteContextC(ctx)
+
+	if err != nil {
+		metrics.RecordCommandFinish(cmd)
+	}
+
+	// shutdown background tasks, giving up to 5s for them to finish
+	task.FromContext(ctx).ShutdownWithTimeout(5 * time.Second)
 
 	switch {
 	case err == nil:
-		metrics.RecordCommandFinish(cmd)
 		return 0
 	case errors.Is(err, context.Canceled), errors.Is(err, terminal.InterruptErr):
 		return 127

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -4,12 +4,16 @@ package task
 import (
 	"context"
 	"sync"
+	"time"
+
+	"github.com/superfly/flyctl/internal/logger"
+	"github.com/superfly/flyctl/terminal"
 )
 
 type contextKey struct{}
 
-// NewContext derives a Context that carries the given Manager from ctx.
-func NewContext(ctx context.Context, m Manager) context.Context {
+// WithContext derives a Context that carries the given Manager from ctx.
+func WithContext(ctx context.Context, m Manager) context.Context {
 	return context.WithValue(ctx, contextKey{}, m)
 }
 
@@ -19,14 +23,16 @@ func FromContext(ctx context.Context) Manager {
 	return ctx.Value(contextKey{}).(Manager)
 }
 
+// NewWithContext derives a Context that carries a new Manager
+func NewWithContext(ctx context.Context) context.Context {
+	return WithContext(ctx, New())
+}
+
 // New initializes and returns a Manager which runs its tasks on the chain
 // of the given parent context.
-func New(parent context.Context) Manager {
-	ctx, cancel := context.WithCancel(parent)
-
+func New() Manager {
 	return &manager{
-		Context:    ctx,
-		CancelFunc: cancel,
+		queue: make(chan Task, 10),
 	}
 }
 
@@ -37,33 +43,84 @@ type Task func(context.Context)
 type Manager interface {
 	pkg() // internal
 
-	// Run runs the task in its own goroutine.
+	// Start begins running background tasks with the provided context.
+	Start(context.Context)
+
+	// Run enqueues the task to run in the background.
 	Run(Task)
+
+	// RunFinalizer enqueues the task to run in the background after Shutdown.
+	RunFinalizer(Task)
 
 	// Shutdown instructs all the tasks to shutdown and waits until they've done
 	// so.
 	Shutdown()
+
+	// ShutdownWithTimeout instructs all the tasks to shutdown and waits up until the timeout for them to complete.
+	ShutdownWithTimeout(time.Duration)
 }
 
 type manager struct {
-	context.Context
-	context.CancelFunc
+	queue chan Task
 	sync.WaitGroup
 }
 
 func (*manager) pkg() {}
 
-func (m *manager) Run(t Task) {
-	m.WaitGroup.Add(1)
+func (m *manager) Start(ctx context.Context) {
+	log := logger.FromContext(ctx)
+
+	ctx, cancel := context.WithCancel(ctx)
 
 	go func() {
-		defer m.WaitGroup.Done()
+		defer cancel()
 
-		t(m.Context)
+		log.Debug("Starting task manager")
+
+		for t := range m.queue {
+			t := t
+			go func() {
+				defer m.WaitGroup.Done()
+				t(ctx)
+			}()
+		}
+
+		log.Debug("Task manager done")
 	}()
 }
 
+func (m *manager) Run(t Task) {
+	m.WaitGroup.Add(1)
+	m.queue <- t
+}
+
+func (m *manager) RunFinalizer(t Task) {
+	m.Run(func(ctx context.Context) {
+		// wait until the context is done before running the task
+		<-ctx.Done()
+
+		t(ctx)
+	})
+}
+
 func (m *manager) Shutdown() {
-	m.CancelFunc()
+	close(m.queue)
 	m.WaitGroup.Wait()
+}
+
+func (m *manager) ShutdownWithTimeout(timeout time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	done := make(chan struct{}, 1)
+	go func() {
+		m.Shutdown()
+		done <- struct{}{}
+	}()
+
+	select {
+	case <-ctx.Done():
+		terminal.Debug("Shutdown timed out, exiting")
+	case <-done:
+	}
 }

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -14,6 +14,6 @@ func TestFromContextPanics(t *testing.T) {
 func TestClient(t *testing.T) {
 	exp := new(manager)
 
-	ctx := NewContext(context.Background(), exp)
+	ctx := WithContext(context.Background(), exp)
 	assert.Same(t, exp, FromContext(ctx))
 }


### PR DESCRIPTION
This PR makes the following changes to the background task runner so it's safer and actually useful for more things:
- Initialize the task manager before the command invocation starts so it's available for command preparers and finalizers immediately
- Add a Start function that accepts a context which will get passed to tasks rather than using a context provided when the task manager was initialized. This lets command preparers enqueue and use context values later on in tasks
- Add a ShutdownWithTimeout function that waits up to the timeout for tasks to finish
- Add a RunFinalizer function that accepts a task to run _after_ Shutdown is called. This provides a safe way to run stuff before exiting with the safety of a global timeout

With those changes in place, metrics can now be safely flushed before exit using a `RunFinalizer` task.