### PR TITLE
Add build tags to `debug_*.go`

### DIFF
--- a/debug_unix.go
+++ b/debug_unix.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package main
 
 import (

--- a/debug_windows.go
+++ b/debug_windows.go
@@ -1,3 +1,6 @@
+//go:build windows
+// +build windows
+
 package main
 
 import "context"


### PR DESCRIPTION
### Change Summary

#### What and Why:

Go doesn't recognize the `_unix.go` suffix, so I think it's trying to compile both `debug_unix.go` and `debug_windows.go` on Windows. This is causing the `test_build` job to fail in CI:

```
  ⨯ build failed after 7m49s                 error=failed to build for windows_amd64_v1: exit status 1: # github.com/superfly/flyctl
Error: ./debug_windows.go:6:6: handleDebugSignal redeclared in this block
Error: 	./debug_unix.go:13:6: other declaration of handleDebugSignal
Error: ./debug_unix.go:15:28: undefined: unix.SIGUSR2
```

#### How:

This just adds Go build tags to each file, so that the right files are built on each platform. (Note that for Unix, the tag is not actually `unix` but `!windows`, like it is in the rest of flyctl AFAICT.)

#### Related to:

* #2526 (added these files)

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
