### PR TITLE
Scale command can scale apps with volumes

### DIFF
--- a/internal/command/scale/count.go
+++ b/internal/command/scale/count.go
@@ -36,6 +36,8 @@ For pricing, see https://fly.io/docs/about/pricing/`
 		flag.Int{Name: "max-per-region", Description: "Max number of VMs per region", Default: -1},
 		flag.String{Name: "region", Description: "Comma separated list of regions to act on. Defaults to all regions where there is at least one machine running for the app"},
 		flag.String{Name: "process-group", Description: "The process group to scale"},
+		flag.Bool{Name: "with-new-volumes", Description: "New machines each get a new volumes even if there are unattached volumes available"},
+		flag.String{Name: "from-snapshot", Description: "New volumes are restored from snapshot, use 'last' for most recent snapshot. The default is an empty volume"},
 	)
 	return cmd
 }

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -96,14 +96,14 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 		if len(action.MachineConfig.Mounts) > 0 && action.Delta > 0 {
 			numExistingVolumesUsed := lo.Min([]int{action.Delta, len(action.Volumes)})
 			numNewVolumesNeeded := action.Delta - numExistingVolumesUsed
-
 			withNewVolumes := flag.GetBool(ctx, "with-new-volumes")
+
 			if numExistingVolumesUsed > 0 && numNewVolumesNeeded > 0 && !withNewVolumes {
-				fmt.Fprintf(io.Out, "%+4d new volumes for group '%s' and using %d existing volumes in region '%s'\n", numNewVolumesNeeded, action.GroupName, numExistingVolumesUsed, action.Region)
+				fmt.Fprintf(io.Out, "%+4d new volumes and using %d existing volumes for group '%s' in region '%s'\n", numNewVolumesNeeded, numExistingVolumesUsed, action.GroupName, action.Region)
 			} else if numExistingVolumesUsed > 0 && !withNewVolumes {
 				fmt.Fprintf(io.Out, "  Using %d existing volumes for group '%s' in region '%s'\n", numExistingVolumesUsed, action.GroupName, action.Region)
-			} else if numNewVolumesNeeded > 0 {
-				fmt.Fprintf(io.Out, "%+4d new volumes for group '%s' in region '%s'\n", numNewVolumesNeeded, action.GroupName, action.Region)
+			} else {
+				fmt.Fprintf(io.Out, "%+4d new volumes for group '%s' in region '%s'\n", action.Delta, action.GroupName, action.Region)
 			}
 		}
 	}

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -98,11 +98,11 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 
 			withNewVolumes := flag.GetBool(ctx, "with-new-volumes")
 			if numExistingVolumesUsed > 0 && numNewVolumesNeeded > 0 && !withNewVolumes {
-				fmt.Fprintf(io.Out, "%+4d new volumes and using %d existing volumes in region '%s'\n", numNewVolumesNeeded, numExistingVolumesUsed, action.Region)
+				fmt.Fprintf(io.Out, "%+4d new volumes for group '%s' and using %d existing volumes in region '%s'\n", numNewVolumesNeeded, action.GroupName, numExistingVolumesUsed, action.Region)
 			} else if numExistingVolumesUsed > 0 && !withNewVolumes {
-				fmt.Fprintf(io.Out, "  Using %d existing volumes in region '%s'\n", numExistingVolumesUsed, action.Region)
+				fmt.Fprintf(io.Out, "  Using %d existing volumes for group '%s' in region '%s'\n", numExistingVolumesUsed, action.GroupName, action.Region)
 			} else if numNewVolumesNeeded > 0 {
-				fmt.Fprintf(io.Out, "%+4d new volumes in region '%s'\n", numNewVolumesNeeded, action.Region)
+				fmt.Fprintf(io.Out, "%+4d new volumes for group '%s' in region '%s'\n", numNewVolumesNeeded, action.GroupName, action.Region)
 			}
 		}
 	}

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -133,7 +133,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 					}
 				}
 
-				m, v, err := launchMachine(ctx, action, volume, appCompact)
+				m, v, err := launchMachine(ctx, *action, volume, appCompact)
 				if err != nil {
 					return err
 				}
@@ -159,7 +159,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 	return nil
 }
 
-func launchMachine(ctx context.Context, action *planItem, volume *api.Volume, appCompact *api.AppCompact) (*api.Machine, *api.Volume, error) {
+func launchMachine(ctx context.Context, action planItem, volume *api.Volume, appCompact *api.AppCompact) (*api.Machine, *api.Volume, error) {
 	flapsClient := flaps.FromContext(ctx)
 	var err error
 
@@ -172,14 +172,14 @@ func launchMachine(ctx context.Context, action *planItem, volume *api.Volume, ap
 			{
 				Volume: volume.ID,
 				Path:   mnt.Path,
-				Name:   volume.Name,
+				Name:   mnt.Name,
 			},
 		}
 	}
 
 	input := api.LaunchMachineInput{
 		Region: action.Region,
-		Config: action.MachineConfig,
+		Config: &action.MachineConfig,
 	}
 
 	m, err := flapsClient.Launch(ctx, input)
@@ -257,7 +257,7 @@ type planItem struct {
 	Region        string
 	Delta         int
 	Machines      []*api.Machine
-	MachineConfig *api.MachineConfig
+	MachineConfig api.MachineConfig
 	Volumes       []*availableVolume
 }
 
@@ -316,7 +316,7 @@ func computeActions(machines []*api.Machine, expectedGroupCounts map[string]int,
 				Region:        regionName,
 				Delta:         delta,
 				Machines:      perRegionMachines[regionName],
-				MachineConfig: mConfig,
+				MachineConfig: *mConfig,
 				Volumes:       availableVols,
 			})
 		}
@@ -350,7 +350,7 @@ func computeActions(machines []*api.Machine, expectedGroupCounts map[string]int,
 				GroupName:     groupName,
 				Region:        regionName,
 				Delta:         delta,
-				MachineConfig: mConfig,
+				MachineConfig: *mConfig,
 				Volumes:       availableVolumes,
 			})
 		}

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -321,11 +321,19 @@ func computeActions(machines []*api.Machine, expectedGroupCounts map[string]int,
 		}
 
 		for regionName, delta := range regionDiffs {
+			var availableVolumes []api.Volume
+			if len(mConfig.Mounts) > 0 {
+				availableVolumes = lo.Filter(volumes, func(v api.Volume, _ int) bool {
+					return !v.IsAttached() && v.Region == regionName
+				})
+			}
+
 			actions = append(actions, &planItem{
 				GroupName:     groupName,
 				Region:        regionName,
 				Delta:         delta,
 				MachineConfig: mConfig,
+				Volumes:       availableVolumes,
 			})
 		}
 	}


### PR DESCRIPTION
### Change Summary

#### What and Why:

Currently, `fly scale count`does not support scaling apps with volumes (instead, you have to run `fly machine clone`). This work adds that support. This creates a consistent experience as devs can reach for the same command to scale their app count up/down.

How:

There's different behaviours depending on whether the machine count is being scaled up or down.

For up:
1. We check if there are existing, unattached volumes in the region the machine is being created
2. If there are, then those are attached to the newly created machines
3. If there are no available volumes, we create a new volume for every machine that is created

For down, we don't do anything to the volume. They just become unattached. The user can manually delete them later.

#### Thoughts

We should probably support a few options to tweak the behaviour:

1. To create machines with new volumes, even if there are existing volumes
2. ~~To delete the volumes attached to machines when the machines are deleted~~
3. To specify a snapshot ID so a volume can be cloned from a snapshot of an existing volume

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
