### PR TITLE
Use Buildkit's native client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/miekg/dns v1.1.43
 	github.com/moby/buildkit v0.9.0
-	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635
 	github.com/morikuni/aec v1.0.0
 	github.com/muesli/termenv v0.7.4
 	github.com/nats-io/nats.go v1.13.1-0.20220308171302-2f2f6968e98d
@@ -78,6 +77,7 @@ require (
 	github.com/google/btree v1.0.1 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
+	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/tools v0.8.0 // indirect

--- a/internal/build/imgsrc/archive.go
+++ b/internal/build/imgsrc/archive.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/docker/builder/dockerignore"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/fileutils"
+	"github.com/moby/buildkit/frontend/dockerfile/dockerignore"
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/terminal"
 )

--- a/internal/build/imgsrc/buildkit.go
+++ b/internal/build/imgsrc/buildkit.go
@@ -1,27 +1,15 @@
 package imgsrc
 
 import (
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
+	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
-
-	"context"
 
 	"github.com/docker/docker/api/types"
 	dockerclient "github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/jsonmessage"
-	controlapi "github.com/moby/buildkit/api/services/control"
-	buildkitClient "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth"
-	"github.com/pkg/errors"
-	"github.com/spf13/viper"
-	"github.com/superfly/flyctl/flyctl"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -37,105 +25,10 @@ func buildkitEnabled(docker *dockerclient.Client) (buildkitEnabled bool, err err
 	if buildkitEnv := os.Getenv("DOCKER_BUILDKIT"); buildkitEnv != "" {
 		buildkitEnabled, err = strconv.ParseBool(buildkitEnv)
 		if err != nil {
-			return false, errors.Wrap(err, "DOCKER_BUILDKIT environment variable expects boolean value")
+			return false, fmt.Errorf("DOCKER_BUILDKIT environment variable expects boolean value: %w", err)
 		}
 	}
 	return buildkitEnabled, nil
-}
-
-func createBuildSession(contextDir string) (*session.Session, error) {
-	sharedKey := getBuildSharedKey(contextDir)
-	s, err := session.NewSession(context.Background(), filepath.Base(contextDir), sharedKey)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create session")
-	}
-	return s, nil
-}
-
-func getBuildSharedKey(dir string) string {
-	// build session is hash of build dir with node based randomness
-	s := sha256.Sum256([]byte(fmt.Sprintf("%s:%s", getBuildNodeID(), dir)))
-	return hex.EncodeToString(s[:])
-}
-
-func getBuildNodeID() string {
-	buildNodeID := viper.GetString(flyctl.BuildKitNodeID)
-	if buildNodeID == "" {
-		b := make([]byte, 32)
-		if _, err := rand.Read(b); err != nil {
-			return flyctl.ConfigDir()
-		}
-
-		buildNodeID = hex.EncodeToString(b)
-		viper.Set(flyctl.BuildKitNodeID, buildNodeID)
-		if err := flyctl.SaveConfig(); err != nil {
-			fmt.Println("error writing config", err)
-			return flyctl.ConfigDir()
-		}
-	}
-	return buildNodeID
-}
-
-type tracer struct {
-	displayCh chan *buildkitClient.SolveStatus
-}
-
-func newTracer() *tracer {
-	return &tracer{
-		displayCh: make(chan *buildkitClient.SolveStatus),
-	}
-}
-
-func (t *tracer) write(msg jsonmessage.JSONMessage) {
-	var resp controlapi.StatusResponse
-
-	if msg.ID != "moby.buildkit.trace" {
-		return
-	}
-
-	var dt []byte
-	// ignoring all messages that are not understood
-	if err := json.Unmarshal(*msg.Aux, &dt); err != nil {
-		return
-	}
-	if err := (&resp).Unmarshal(dt); err != nil {
-		return
-	}
-
-	s := buildkitClient.SolveStatus{}
-	for _, v := range resp.Vertexes {
-		s.Vertexes = append(s.Vertexes, &buildkitClient.Vertex{
-			Digest:    v.Digest,
-			Inputs:    v.Inputs,
-			Name:      v.Name,
-			Started:   v.Started,
-			Completed: v.Completed,
-			Error:     v.Error,
-			Cached:    v.Cached,
-		})
-	}
-	for _, v := range resp.Statuses {
-		s.Statuses = append(s.Statuses, &buildkitClient.VertexStatus{
-			ID:        v.ID,
-			Vertex:    v.Vertex,
-			Name:      v.Name,
-			Total:     v.Total,
-			Current:   v.Current,
-			Timestamp: v.Timestamp,
-			Started:   v.Started,
-			Completed: v.Completed,
-		})
-	}
-	for _, v := range resp.Logs {
-		s.Logs = append(s.Logs, &buildkitClient.VertexLog{
-			Vertex:    v.Vertex,
-			Stream:    int(v.Stream),
-			Data:      v.Msg,
-			Timestamp: v.Timestamp,
-		})
-	}
-
-	t.displayCh <- &s
 }
 
 func newBuildkitAuthProvider(token string) session.Attachable {

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -1,7 +1,6 @@
 package imgsrc
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -17,11 +16,9 @@ import (
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
-	"github.com/docker/docker/pkg/stringid"
 	"github.com/moby/buildkit/client"
-	"github.com/moby/buildkit/session/secrets/secretsprovider"
+	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/util/progress/progressui"
-	"github.com/moby/term"
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/cmdfmt"
@@ -55,6 +52,50 @@ func (out *lastProgressOutput) WriteProgress(prog progress.Progress) error {
 	return out.output.WriteProgress(prog)
 }
 
+func makeBuildContext(dockerfile string, opts ImageOptions, isRemote bool) (io.ReadCloser, error) {
+	archiveOpts := archiveOptions{
+		sourcePath: opts.WorkingDir,
+		compressed: isRemote,
+	}
+
+	var relativedockerfilePath string
+
+	// copy dockerfile into the archive if it's outside the context dir
+	if !isPathInRoot(dockerfile, opts.WorkingDir) {
+		dockerfileData, err := os.ReadFile(dockerfile)
+		if err != nil {
+			return nil, errors.Wrap(err, "error reading Dockerfile")
+		}
+		archiveOpts.additions = map[string][]byte{
+			"Dockerfile": dockerfileData,
+		}
+	} else {
+		// pass the relative path to Dockerfile within the context
+		p, err := filepath.Rel(opts.WorkingDir, dockerfile)
+		if err != nil {
+			return nil, err
+		}
+		// On Windows, convert \ to a slash / as the docker build will
+		// run in a Linux VM at the end.
+		relativedockerfilePath = filepath.ToSlash(p)
+	}
+
+	excludes, err := readDockerignore(opts.WorkingDir, opts.IgnorefilePath, relativedockerfilePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "error reading .dockerignore")
+	}
+	archiveOpts.exclusions = excludes
+
+	// Start tracking this build
+
+	// Create the docker build context as a compressed tar stream
+	r, err := archiveDirectory(archiveOpts)
+	if err != nil {
+		return nil, errors.Wrap(err, "error archiving build context")
+	}
+	return r, nil
+}
+
 func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFactory, streams *iostreams.IOStreams, opts ImageOptions, build *build) (*DeploymentImage, string, error) {
 	build.BuildStart()
 	if !dockerFactory.mode.IsAvailable() {
@@ -82,6 +123,18 @@ func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 		return nil, "", nil
 	}
 
+	var relDockerfile string
+	if isPathInRoot(dockerfile, opts.WorkingDir) {
+		// pass the relative path to Dockerfile within the context
+		p, err := filepath.Rel(opts.WorkingDir, dockerfile)
+		if err != nil {
+			return nil, "", err
+		}
+		// On Windows, convert \ to a slash / as the docker build will
+		// run in a Linux VM at the end.
+		relDockerfile = filepath.ToSlash(p)
+	}
+
 	build.BuilderInitStart()
 	docker, err := dockerFactory.buildFn(ctx, build)
 	if err != nil {
@@ -90,6 +143,14 @@ func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 		return nil, "", errors.Wrap(err, "error connecting to docker")
 	}
 	defer docker.Close() // skipcq: GO-S2307
+
+	buildkitEnabled, err := buildkitEnabled(docker)
+	terminal.Debugf("buildkitEnabled %v", buildkitEnabled)
+	if err != nil {
+		build.BuildFinish()
+		build.BuilderInitFinish()
+		return nil, "", fmt.Errorf("error checking for buildkit support: %w", err)
+	}
 
 	build.BuilderInitFinish()
 	defer func() {
@@ -101,67 +162,32 @@ func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 		}
 	}()
 
-	build.ContextBuildStart()
-	tb := render.NewTextBlock(ctx, "Creating build context")
+	// Without Buildkit, we need to explicitly build a build context beforehand.
+	var buildContext io.ReadCloser
+	if !buildkitEnabled {
+		build.ContextBuildStart()
 
-	archiveOpts := archiveOptions{
-		sourcePath: opts.WorkingDir,
-		compressed: dockerFactory.IsRemote(),
-	}
+		tb := render.NewTextBlock(ctx, "Creating build context")
 
-	var relativedockerfilePath string
-
-	// copy dockerfile into the archive if it's outside the context dir
-	if !isPathInRoot(dockerfile, opts.WorkingDir) {
-		dockerfileData, err := os.ReadFile(dockerfile)
-		if err != nil {
-			build.BuildFinish()
-			build.ContextBuildFinish()
-			return nil, "", errors.Wrap(err, "error reading Dockerfile")
-		}
-		archiveOpts.additions = map[string][]byte{
-			"Dockerfile": dockerfileData,
-		}
-	} else {
-		// pass the relative path to Dockerfile within the context
-		p, err := filepath.Rel(opts.WorkingDir, dockerfile)
+		r, err := makeBuildContext(dockerfile, opts, dockerFactory.IsRemote())
 		if err != nil {
 			build.BuildFinish()
 			build.ContextBuildFinish()
 			return nil, "", err
 		}
-		// On Windows, convert \ to a slash / as the docker build will
-		// run in a Linux VM at the end.
-		relativedockerfilePath = filepath.ToSlash(p)
-	}
 
-	excludes, err := readDockerignore(opts.WorkingDir, opts.IgnorefilePath, relativedockerfilePath)
-	if err != nil {
-		build.BuildFinish()
+		tb.Done("Creating build context done")
+
 		build.ContextBuildFinish()
-		return nil, "", errors.Wrap(err, "error reading .dockerignore")
+
+		// Setup an upload progress bar
+		progressOutput := streamformatter.NewProgressOutput(streams.Out)
+		if !streams.IsStdoutTTY() {
+			progressOutput = &lastProgressOutput{output: progressOutput}
+		}
+
+		buildContext = progress.NewProgressReader(r, progressOutput, 0, "", "Sending build context to Docker daemon")
 	}
-	archiveOpts.exclusions = excludes
-
-	// Start tracking this build
-
-	// Create the docker build context as a compressed tar stream
-	r, err := archiveDirectory(archiveOpts)
-	if err != nil {
-		build.BuildFinish()
-		build.ContextBuildFinish()
-		return nil, "", errors.Wrap(err, "error archiving build context")
-	}
-	build.ContextBuildFinish()
-	tb.Done("Creating build context done")
-
-	// Setup an upload progress bar
-	progressOutput := streamformatter.NewProgressOutput(streams.Out)
-	if !streams.IsStdoutTTY() {
-		progressOutput = &lastProgressOutput{output: progressOutput}
-	}
-
-	r = progress.NewProgressReader(r, progressOutput, 0, "", "Sending build context to Docker daemon")
 
 	var imageID string
 
@@ -192,19 +218,9 @@ func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 		return nil, "", fmt.Errorf("error parsing build args: %w", err)
 	}
 
-	buildkitEnabled, err := buildkitEnabled(docker)
-	terminal.Debugf("buildkitEnabled %v", buildkitEnabled)
-	if err != nil {
-		if dockerFactory.IsRemote() {
-			metrics.SendNoData(ctx, "remote_builder_failure")
-		}
-		build.ImageBuildFinish()
-		build.BuildFinish()
-		return nil, "", errors.Wrap(err, "error checking for buildkit support")
-	}
 	build.SetBuilderMetaPart2(buildkitEnabled, serverInfo.ServerVersion, fmt.Sprintf("%s/%s/%s", serverInfo.OSType, serverInfo.Architecture, serverInfo.OSVersion))
 	if buildkitEnabled {
-		imageID, err = runBuildKitBuild(ctx, streams, docker, r, opts, relativedockerfilePath, buildArgs)
+		imageID, err = runBuildKitBuild(ctx, docker, opts, relDockerfile, buildArgs)
 		if err != nil {
 			if dockerFactory.IsRemote() {
 				metrics.SendNoData(ctx, "remote_builder_failure")
@@ -214,7 +230,7 @@ func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 			return nil, "", errors.Wrap(err, "error building")
 		}
 	} else {
-		imageID, err = runClassicBuild(ctx, streams, docker, r, opts, relativedockerfilePath, buildArgs)
+		imageID, err = runClassicBuild(ctx, streams, docker, buildContext, opts, relDockerfile, buildArgs)
 		if err != nil {
 			if dockerFactory.IsRemote() {
 				metrics.SendNoData(ctx, "remote_builder_failure")
@@ -296,142 +312,76 @@ func runClassicBuild(ctx context.Context, streams *iostreams.IOStreams, docker *
 	return imageID, nil
 }
 
-const uploadRequestRemote = "upload-request"
+func solveOptFromImageOptions(opts ImageOptions, dockerfilePath string, buildArgs map[string]*string) client.SolveOpt {
+	attrs := map[string]string{"filename": filepath.Base(dockerfilePath)}
+	attrs["target"] = opts.Target
+	if opts.NoCache {
+		attrs["no-cache"] = ""
+	}
 
-func runBuildKitBuild(ctx context.Context, streams *iostreams.IOStreams, docker *dockerclient.Client, r io.ReadCloser, opts ImageOptions, dockerfilePath string, buildArgs map[string]*string) (imageID string, err error) {
-	io := iostreams.FromContext(ctx)
-	s, err := createBuildSession(opts.WorkingDir)
+	for k, v := range buildArgs {
+		if v == nil {
+			continue
+		}
+		attrs["build-arg:"+k] = *v
+	}
+
+	return client.SolveOpt{
+		Frontend:      "dockerfile.v0",
+		FrontendAttrs: attrs,
+		LocalDirs: map[string]string{
+			"dockerfile": filepath.Dir(dockerfilePath),
+			"context":    opts.WorkingDir,
+		},
+		// Docker Engine's worker only supports three exporters.
+		// "moby" exporter works best for flyctl, since we want to keep images in
+		// Docker Engine's image store. The others are exporting images to somewhere else.
+		// https://github.com/moby/moby/blob/v20.10.24/builder/builder-next/worker/worker.go#L221
+		Exports: []client.ExportEntry{
+			{Type: "moby", Attrs: map[string]string{"name": opts.Tag}},
+		},
+	}
+}
+
+func runBuildKitBuild(ctx context.Context, docker *dockerclient.Client, opts ImageOptions, dockerfilePath string, buildArgs map[string]*string) (string, error) {
+	// Connect to Docker Engine's embedded Buildkit.
+	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
+		return docker.DialHijack(ctx, "/grpc", "h2c", map[string][]string{})
+	}
+	bc, err := client.New(ctx, "", client.WithContextDialer(dialer), client.WithFailFast)
 	if err != nil {
-		panic(err)
-	}
-	s.Allow(newBuildkitAuthProvider(config.FromContext(ctx).AccessToken))
-
-	if s == nil {
-		panic("buildkit not supported")
-	}
-
-	finalSecrets := make(map[string][]byte)
-
-	for k, v := range opts.BuildSecrets {
-		finalSecrets[k] = []byte(v)
-	}
-
-	s.Allow(secretsprovider.FromMap(finalSecrets))
-
-	eg, errCtx := errgroup.WithContext(ctx)
-
-	dialSession := func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) {
-		return docker.DialHijack(errCtx, "/session", proto, meta)
-	}
-	eg.Go(func() error {
-		return s.Run(context.TODO(), dialSession)
-	})
-
-	buildID := stringid.GenerateRandomID()
-	eg.Go(func() error {
-		buildOptions := types.ImageBuildOptions{
-			Version: types.BuilderBuildKit,
-			BuildID: uploadRequestRemote + ":" + buildID,
-		}
-
-		response, err := docker.ImageBuild(ctx, r, buildOptions)
-		if err != nil {
-			return err
-		}
-		defer response.Body.Close() // skipcq: GO-S2307
-		return nil
-	})
-
-	eg.Go(func() error {
-		defer s.Close()
-
-		buildOpts := types.ImageBuildOptions{
-			Tags:          []string{opts.Tag},
-			BuildArgs:     buildArgs,
-			Version:       types.BuilderBuildKit,
-			AuthConfigs:   authConfigs(config.FromContext(ctx).AccessToken),
-			SessionID:     s.ID(),
-			RemoteContext: uploadRequestRemote,
-			BuildID:       buildID,
-			Platform:      "linux/amd64",
-			Dockerfile:    dockerfilePath,
-			Target:        opts.Target,
-			NoCache:       opts.NoCache,
-		}
-
-		return func() error {
-			resp, err := docker.ImageBuild(ctx, nil, buildOpts)
-			if err != nil {
-				return err
-			}
-			defer resp.Body.Close() // skipcq: GO-S2307
-
-			done := make(chan struct{})
-			defer close(done)
-
-			eg.Go(func() error {
-				select {
-				case <-ctx.Done():
-					return docker.BuildCancel(context.TODO(), buildOpts.BuildID)
-				case <-done:
-				}
-				return nil
-			})
-
-			// TODO: replace with iostreams
-			termFd, isTerm := term.GetFdInfo(os.Stderr)
-			tracer := newTracer()
-			var c2 console.Console
-			if io.ColorEnabled() {
-				if cons, err := console.ConsoleFromFile(os.Stderr); err == nil {
-					c2 = cons
-				}
-			}
-
-			consoleLogs := make(chan *client.SolveStatus)
-
-			eg.Go(func() error {
-				defer close(consoleLogs)
-
-				for v := range tracer.displayCh {
-					consoleLogs <- v
-				}
-				return nil
-			})
-
-			eg.Go(func() error {
-				return progressui.DisplaySolveStatus(context.TODO(), "", c2, os.Stderr, consoleLogs)
-			})
-
-			auxCallback := func(m jsonmessage.JSONMessage) {
-				if m.ID == "moby.image.id" {
-					var result types.BuildResult
-					if err := json.Unmarshal(*m.Aux, &result); err != nil {
-						fmt.Fprintf(streams.Out, "failed to parse aux message: %v", err)
-					}
-					imageID = result.ID
-					return
-				}
-
-				tracer.write(m)
-			}
-			defer close(tracer.displayCh)
-
-			buf := bytes.NewBuffer(nil)
-
-			if err := jsonmessage.DisplayJSONMessagesStream(resp.Body, buf, termFd, isTerm, auxCallback); err != nil {
-				return err
-			}
-
-			return nil
-		}()
-	})
-
-	if err := eg.Wait(); err != nil {
 		return "", err
 	}
 
-	return imageID, nil
+	// Build the image.
+	ch := make(chan *client.SolveStatus)
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		con, err := console.ConsoleFromFile(os.Stderr)
+		if err != nil {
+			return err
+		}
+		return progressui.DisplaySolveStatus(ctx, "", con, os.Stdout, ch)
+	})
+	var res *client.SolveResponse
+	eg.Go(func() error {
+		// To pull images from local Docker Engine with Fly's access token,
+		// we need to pass the provider. Remote builders don't need that.
+		provider := newBuildkitAuthProvider(config.FromContext(ctx).AccessToken)
+		options := solveOptFromImageOptions(opts, dockerfilePath, buildArgs)
+		options.Session = append(options.Session, provider)
+
+		res, err = bc.Solve(ctx, nil, options, ch)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	err = eg.Wait()
+	if err != nil {
+		return "", err
+	}
+	return res.ExporterResponse[exptypes.ExporterImageDigestKey], nil
 }
 
 func pushToFly(ctx context.Context, docker *dockerclient.Client, streams *iostreams.IOStreams, tag string) error {


### PR DESCRIPTION
### Change Summary

What and Why:

Since 23.0.0, Docker uses Buildx as its default client. Buildx doesn't use
Docker's ImageBuild API and much smarter regarding making a build context.

This change switches our Buildkit path ot use Buildkit's native client,
as like Buildx.

Fixes https://github.com/superfly/flyctl/issues/456.

How:

Switching from Docker's ImageBuild API to Buildkit's native client.

Related to:

#456

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
