### PR TITLE
Use Go 1.20.5 instead of 1.20.6 due to workaround "http: invalid Host header"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version-file: "go.mod"
+          go-version: 1.20.5
           check-latest: true
       - name: "Place wintun.dll"
         run: cp deps/wintun/bin/amd64/wintun.dll ./
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version-file: "go.mod"
+          go-version: 1.20.5
           check-latest: true
       - name: Get go version
         id: go-version
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version-file: "go.mod"
+          go-version: 1.20.5
           check-latest: true
       - name: Get go version
         id: go-version
@@ -115,7 +115,7 @@ jobs:
           path: docs
       - uses: actions/setup-go@v4
         with:
-          go-version-file: "go.mod"
+          go-version: 1.20.5
           check-latest: true
       - name: Publish CLI docs
         id: publish-cli-docs
@@ -132,7 +132,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version-file: "go.mod"
+          go-version: 1.20.5
           check-latest: true
       - name: Get go version
         id: go-version


### PR DESCRIPTION
### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
