### PR TITLE
Distributed Elixir support for fly launch

### DIFF
--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -2,7 +2,6 @@ package scanner
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -105,7 +104,7 @@ a Postgresql database.
 	return s, nil
 }
 
-func PhoenixCallback(appName string, srcInfo *SourceInfo, options map[string]bool) error {
+func PhoenixCallback(appName string, _ *SourceInfo, options map[string]bool) error {
 	envEExPath := "rel/env.sh.eex"
 	envEExContents := `
 # configure node for distributed erlang with IPV6 support
@@ -120,27 +119,23 @@ export RELEASE_NODE="${FLY_APP_NAME}-${FLY_IMAGE_REF##*-}@${FLY_PRIVATE_IP}"
 		fmt.Fprintln(os.Stdout, "Generating rel/env.sh.eex for distributed Elixir support")
 		contents := fmt.Sprintf("#!/bin/sh\n%s", envEExContents)
 
-		if err := os.MkdirAll("rel", 0o755); err != nil {
-			log.Fatal(err)
+		if err := os.MkdirAll("rel", 0o755); err != nil { // skipcq: GSC-G301
 			return err
 		}
 
-		if err := os.WriteFile(envEExPath, []byte(contents), 0o755); err != nil {
-			log.Fatal(err)
+		if err := os.WriteFile(envEExPath, []byte(contents), 0o755); err != nil { // skipcq: GSC-G302
 			return err
 		}
 	} else if !fileContains(envEExPath, "RELEASE_NODE") {
 		fmt.Fprintln(os.Stdout, "Updating rel/env.sh.eex for distributed Elixir support")
 		appendedContents := fmt.Sprintf("# appended by fly launch: configure node for distributed erlang with IPV6 support\n%s", envEExContents)
-		f, err := os.OpenFile(envEExPath, os.O_APPEND|os.O_WRONLY, 0o755)
+		f, err := os.OpenFile(envEExPath, os.O_APPEND|os.O_WRONLY, 0o755) // skipcq: GSC-G302
 		if err != nil {
-			log.Fatal(err)
 			return err
 		}
-		defer f.Close()
+		defer f.Close() // skipcq: GO-S2307
 
 		if _, err := f.WriteString(appendedContents); err != nil {
-			log.Fatal(err)
 			return err
 		}
 	}

--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -1,6 +1,8 @@
 package scanner
 
 import (
+	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,7 +17,8 @@ func configurePhoenix(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 	}
 
 	s := &SourceInfo{
-		Family: "Phoenix",
+		Family:   "Phoenix",
+		Callback: PhoenixCallback,
 		Concurrency: map[string]int{
 			"soft_limit": 1000,
 			"hard_limit": 1000,
@@ -46,12 +49,8 @@ func configurePhoenix(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 	s.KillSignal = "SIGTERM"
 	s.Port = 8080
 	s.Env = map[string]string{
-		"PORT":     "8080",
 		"PHX_HOST": "APP_FQDN",
-	}
-	s.DockerfileAppendix = []string{
-		"ENV ECTO_IPV6 true",
-		"ENV ERL_AFLAGS \"-proto_dist inet6_tcp\"",
+		"PORT":     "8080",
 	}
 	s.InitCommands = []InitCommand{
 		{
@@ -104,4 +103,46 @@ a Postgresql database.
 	}
 
 	return s, nil
+}
+
+func PhoenixCallback(appName string, srcInfo *SourceInfo, options map[string]bool) error {
+	envEExPath := "rel/env.sh.eex"
+	envEExContents := `
+# configure node for distributed erlang with IPV6 support
+export ERL_AFLAGS="-proto_dist inet6_tcp"
+export ECTO_IPV6="true"
+export DNS_CLUSTER_QUERY="${FLY_APP_NAME}.internal"
+export RELEASE_DISTRIBUTION="name"
+export RELEASE_NODE="${FLY_APP_NAME}-${FLY_IMAGE_REF##*-}@${FLY_PRIVATE_IP}"
+`
+	_, err := os.Stat(envEExPath)
+	if os.IsNotExist(err) {
+		fmt.Fprintln(os.Stdout, "Generating rel/env.sh.eex for distributed Elixir support")
+		contents := fmt.Sprintf("#!/bin/sh\n%s", envEExContents)
+
+		if err := os.MkdirAll("rel", 0o755); err != nil {
+			log.Fatal(err)
+			return err
+		}
+
+		if err := os.WriteFile(envEExPath, []byte(contents), 0o755); err != nil {
+			log.Fatal(err)
+			return err
+		}
+	} else if !fileContains(envEExPath, "RELEASE_NODE") {
+		fmt.Fprintln(os.Stdout, "Updating rel/env.sh.eex for distributed Elixir support")
+		appendedContents := fmt.Sprintf("# appended by fly launch: configure node for distributed erlang with IPV6 support\n%s", envEExContents)
+		f, err := os.OpenFile(envEExPath, os.O_APPEND|os.O_WRONLY, 0o755)
+		if err != nil {
+			log.Fatal(err)
+			return err
+		}
+		defer f.Close()
+
+		if _, err := f.WriteString(appendedContents); err != nil {
+			log.Fatal(err)
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
### Change Summary

What and Why:
Today `fly launch` Just Works™ for a vanilla Phoenix app, but it lacks support for distributed elixir out-of-the-box, which is one of the best features of Phoenix + Fly. This change will make distributed elixir Just Work™ for fly apps on the next release of Phoenix.

How:
The phoenix team released https://github.com/phoenixframework/dns_cluster , which provides simple DNS poll based clustering. The next Phoenix release will include this dependency by default when generating a `phx.new` project.

In addition to the automatic clustering, I am also using the unique Docker image id from `FLY_IMAGE_REF` as the node basename. This ensures only matching nodes across deployments will connect to eachother. This change can be merged ahead of Phoenix release and will still work for older phoenix applications.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
