### PR TITLE
Feat/update/brew validate version

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -275,6 +275,15 @@ func startQueryingForNewRelease(ctx context.Context) (context.Context, error) {
 				break
 			}
 
+			// The API won't return yanked versions, but we don't have a good way
+			// to yank homebrew releases. If we're under homebrew, we'll validate through the API
+			if update.IsUnderHomebrew() {
+				if relErr := update.ValidateRelease(ctx, r.Version); relErr != nil {
+					logger.Debugf("latest release %s is invalid: %v", r.Version, relErr)
+					break
+				}
+			}
+
 			cache.SetLatestRelease(channel, r)
 
 			logger.Debugf("querying for release resulted to %v", r.Version)

--- a/internal/command/version/upgrade.go
+++ b/internal/command/version/upgrade.go
@@ -45,6 +45,14 @@ func runUpgrade(ctx context.Context) error {
 		return fmt.Errorf("failed querying latest release information: %w", err)
 	}
 
+	// The API won't return yanked versions, but we don't have a good way
+	// to yank homebrew releases. If we're under homebrew, we'll validate through the API
+	if update.IsUnderHomebrew() {
+		if relErr := update.ValidateRelease(ctx, release.Version); relErr != nil {
+			return fmt.Errorf("latest version on homebrew is invalid: %s\nplease try again later", relErr)
+		}
+	}
+
 	latest, err := semver.ParseTolerant(release.Version)
 	if err != nil {
 		return fmt.Errorf("error parsing latest release version number %q: %w",

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -48,14 +49,69 @@ func Check() bool {
 	}
 }
 
+type InvalidReleaseError struct {
+	status int
+	msg    string
+}
+
+func (i InvalidReleaseError) Error() string {
+	return i.msg
+}
+func (i InvalidReleaseError) StatusCode() int {
+	return i.status
+}
+
+// ValidateRelease reports whether the given release is valid via an API call.
+// If the version is invalid, the error will be an InvalidReleaseError.
+// Note that other errors may be returned if the API call fails.
+func ValidateRelease(ctx context.Context, version string) error {
+
+	if version[0] == 'v' {
+		version = version[1:]
+	}
+
+	updateUrl := fmt.Sprintf("https://api.fly.io/app/flyctl_validate/v%s", version)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", updateUrl, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Accept", "text/plain")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := resp.Body.Close()
+		if err != nil {
+			terminal.Debugf("error closing response body: %s", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		return &InvalidReleaseError{
+			status: resp.StatusCode,
+			msg:    string(body),
+		}
+	}
+
+	return nil
+}
+
 // LatestRelease reports the latest release for the given channel.
 func LatestRelease(ctx context.Context, channel string) (*Release, error) {
-	updateUrl := fmt.Sprintf("https://api.fly.io/app/flyctl_releases/%s/%s/%s", runtime.GOOS, runtime.GOARCH, channel)
 
 	// If running under homebrew, use the homebrew API to get the latest release
 	if IsUnderHomebrew() {
 		return latestHomebrewRelease(ctx, channel)
 	}
+
+	updateUrl := fmt.Sprintf("https://api.fly.io/app/flyctl_releases/%s/%s/%s", runtime.GOOS, runtime.GOARCH, channel)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", updateUrl, nil)
 	if err != nil {


### PR DESCRIPTION
### Change Summary

Prevent the homebrew updater from updating to a version if it's been yanked.
A change to `web` made it so that the in-house releases API would not return yanked versions, but we don't have that kind of control over homebrew afaik. This makes the built-in homebrew updater validate the version returned from homebrew with our API first, so that if we yank a version, it won't update to it.

This doesn't prevent manually updating through the homebrew CLI, but it's definitely better than nothing

Related to: (internal) https://github.com/superfly/web/pull/2086

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
