### PR TITLE
Define Go version in one place and use GoReleaser for preflight tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ on:
   push:
   workflow_dispatch:
 
+# We right now cannot use Go 1.20.6 due to
+# https://community.fly.io/t/git-hub-actions-deployment-error/14126
+env:
+  go_version: 1.20.5
+
 jobs:
   test_build:
     runs-on: ubuntu-latest
@@ -13,8 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.5
-          check-latest: true
+          go-version: ${{ env.go_version }}
       - name: "Place wintun.dll"
         run: cp deps/wintun/bin/amd64/wintun.dll ./
       - name: build
@@ -33,8 +37,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.5
-          check-latest: true
+          go-version: ${{ env.go_version }}
       - name: Get go version
         id: go-version
         run: echo "name=version::$(go env GOVERSION)" >> $GITHUB_OUTPUT
@@ -59,8 +62,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.5
-          check-latest: true
+          go-version: ${{ env.go_version }}
       - name: Get go version
         id: go-version
         run: echo "name=version::$(go env GOVERSION)" >> $GITHUB_OUTPUT
@@ -115,8 +117,7 @@ jobs:
           path: docs
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.5
-          check-latest: true
+          go-version: ${{ env.go_version }}
       - name: Publish CLI docs
         id: publish-cli-docs
         env:
@@ -132,8 +133,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.5
-          check-latest: true
+          go-version: ${{ env.go_version }}
       - name: Get go version
         id: go-version
         run: echo "name=version::$(go env GOVERSION)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ env:
 jobs:
   test_build:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -26,6 +25,11 @@ jobs:
         with:
           version: latest
           args: build --clean --snapshot
+      - name: Upload flyctl for preflight
+        uses: actions/upload-artifact@v3
+        with:
+          name: flyctl
+          path: dist/default_linux_amd64_v1/flyctl
 
   test:
     strategy:
@@ -185,3 +189,8 @@ jobs:
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: ${{ github.event.ref }}
           force_push: "true"
+
+  preflight:
+    needs: test_build
+    uses: ./.github/workflows/preflight.yml
+    secrets: inherit

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -10,7 +10,7 @@ on:
         required: false
         default: User initiated run
         type: string
-  push:
+  workflow_call:
 
 jobs:
   preflight-tests:
@@ -34,7 +34,10 @@ jobs:
         run: |
           curl -sfL https://raw.githubusercontent.com/Songmu/gotesplit/v0.2.1/install.sh | sh -s
           echo "FLY_PREFLIGHT_TEST_APP_PREFIX=pf-gha-$(openssl rand -hex 4)" >> "$GITHUB_ENV"
-          make
+      - uses: actions/download-artifact@v3
+        with:
+          name: flyctl
+          path: master-build
       - name: Run preflight tests
         id: preflight
         env:
@@ -44,6 +47,8 @@ jobs:
           FLY_PREFLIGHT_TEST_NO_PRINT_HISTORY_ON_FAIL: "true"
           FLY_FORCE_TRACE: "true"
         run: |
+          mv master-build/flyctl bin/flyctl
+          chmod +x bin/flyctl
           export PATH=$PWD/bin:$PATH
           echo -n failed= >> $GITHUB_OUTPUT
           ./scripts/preflight.sh -r "${{ github.ref }}" -t "${{ matrix.parallelism }}" -i "${{ matrix.index }}" -o $GITHUB_OUTPUT

--- a/.goreleaser.dev.yml
+++ b/.goreleaser.dev.yml
@@ -36,9 +36,12 @@ builds:
 
 archives:
   - id: windows
-    replacements:
-      windows: Windows
-      amd64: x86_64
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version}}_
+      {{- if eq .Os "windows" }}Windows
+      {{- else }}{{ .Os }}{{- end }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{- end }}
     builds:
       - windows
     files:
@@ -46,11 +49,13 @@ archives:
     wrap_in_directory: false
     format: zip
   - id: default
-    replacements:
-      darwin: macOS
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version}}_
+      {{- if eq .Os "darwin" }}macOS
+      {{- else if eq .Os "linux" }}Linux
+      {{- else }}{{ .Os }}{{- end }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{- end }}
     builds:
       - default
     files: [only-the-binary*]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,7 +81,7 @@ checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  name_template: "{{.Branch}}-{{.ShortCommit}}"
+  name_template: "{{incpatch .Version}}-{{.Branch}}+{{.ShortCommit}}"
 
 changelog:
   sort: asc

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,7 +81,7 @@ checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  name_template: "{{incpatch .Version}}-{{.Branch}}+{{.ShortCommit}}"
+  name_template: "{{incpatch .Version}}-snapshot.{{.Branch}}+{{.ShortCommit}}"
 
 changelog:
   sort: asc

--- a/internal/buildinfo/env.go
+++ b/internal/buildinfo/env.go
@@ -1,5 +1,7 @@
 package buildinfo
 
+import "strings"
+
 var environment = "development"
 
 func Environment() string {
@@ -7,7 +9,7 @@ func Environment() string {
 }
 
 func IsDev() bool {
-	return environment == "development"
+	return strings.Contains(version, "-snapshot.") || environment == "development"
 }
 
 func IsRelease() bool {


### PR DESCRIPTION
### Change Summary

What and Why:

During #2553, I hard-coded Go versions in N different places. This PR cleans up the mess and makes preflight tests closer to what customers would have.

How:

- The first commit cleans up #2553. I don't want to fix N different places for upgrade/downgrade Go versions.
- The second commit is not really used by this PR. I used dev_release job and realized that the file is broken. Then realized test_build was enough for the third commit.
- The third commit was connecting GoReleaser to preflight. So we can test what customers would use.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
