### PR TITLE
`deploy`: add `--update-only`: no new machines for empty process groups

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -147,6 +147,12 @@ func New() (cmd *cobra.Command) {
 		CommonFlags,
 		flag.App(),
 		flag.AppConfig(),
+		// Not in CommonFlags because it's not relevant to a first deploy
+		flag.Bool{
+			Name:        "update-only",
+			Description: "Do not create Machines for new process groups",
+			Default:     false,
+		},
 	)
 
 	return
@@ -275,6 +281,7 @@ func deployToMachines(ctx context.Context, appConfig *appconfig.Config, appCompa
 		VMCPUKind:             flag.GetString(ctx, "vm-cpukind"),
 		IncreasedAvailability: flag.GetBool(ctx, "ha"),
 		AllocPublicIP:         !flag.GetBool(ctx, "no-public-ips"),
+		UpdateOnly:            flag.GetBool(ctx, "update-only"),
 	})
 	if err != nil {
 		sentry.CaptureExceptionWithAppInfo(err, "deploy", appCompact)

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -52,6 +52,7 @@ type MachineDeploymentArgs struct {
 	VMCPUKind             string
 	IncreasedAvailability bool
 	AllocPublicIP         bool
+	UpdateOnly            bool
 }
 
 type machineDeployment struct {
@@ -81,6 +82,7 @@ type machineDeployment struct {
 	machineGuest          *api.MachineGuest
 	increasedAvailability bool
 	listenAddressChecked  map[string]struct{}
+	updateOnly            bool
 }
 
 func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (MachineDeployment, error) {
@@ -149,6 +151,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		releaseCmdTimeout:     args.ReleaseCmdTimeout,
 		increasedAvailability: args.IncreasedAvailability,
 		listenAddressChecked:  make(map[string]struct{}),
+		updateOnly:            args.UpdateOnly,
 	}
 	if err := md.setStrategy(); err != nil {
 		return nil, err


### PR DESCRIPTION
### Change Summary

What and Why: Adds a flag `--update-only` to deploy that prevents new/empty process groups from getting new machines on deploy. 

Related to:
  * https://community.fly.io/t/bug-deploy-of-multi-process-app-reactivates-process-groups-that-had-been-set-to-0/14122/3

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a

Pretty sure docs for flyctl command flags get autogenerated? In that case, this is self-documenting
