### PR TITLE
Add --bind-addr opt to proxy cmd.

### DIFF
--- a/internal/command/machine/proxy.go
+++ b/internal/command/machine/proxy.go
@@ -72,6 +72,7 @@ func runMachineProxy(ctx context.Context) error {
 	// ports := strings.Split(args[0], ":")
 
 	params := &proxy.ConnectParams{
+		BindAddr:         flag.GetBindAddr(ctx),
 		Ports:            []string{"4280"},
 		OrganizationSlug: orgSlug,
 		Dialer:           dialer,

--- a/internal/command/proxy/proxy.go
+++ b/internal/command/proxy/proxy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/proxy"
 )
@@ -41,6 +42,12 @@ func New() *cobra.Command {
 			Name:        "quiet",
 			Shorthand:   "q",
 			Description: "Don't print progress indicators for WireGuard",
+		},
+		flag.String{
+			Name:        flagnames.BindAddr,
+			Shorthand:   "b",
+			Default:     "127.0.0.1",
+			Description: "Local address to bind to",
 		},
 	)
 
@@ -101,6 +108,7 @@ func run(ctx context.Context) (err error) {
 	ports := strings.Split(args[0], ":")
 
 	params := &proxy.ConnectParams{
+		BindAddr:         flag.GetBindAddr(ctx),
 		Ports:            ports,
 		AppName:          appName,
 		OrganizationSlug: orgSlug,

--- a/internal/flag/context.go
+++ b/internal/flag/context.go
@@ -135,6 +135,11 @@ func GetAppConfigFilePath(ctx context.Context) string {
 	}
 }
 
+// GetBindAddr is shorthand for GetString(ctx, BindAddr).
+func GetBindAddr(ctx context.Context) string {
+	return GetString(ctx, flagnames.BindAddr)
+}
+
 // GetFlagsName returns the name of flags that have been set except unwanted flags.
 func GetFlagsName(ctx context.Context, ignoreFlags []string) []string {
 	flagsName := []string{}

--- a/internal/flag/flagnames/constants.go
+++ b/internal/flag/flagnames/constants.go
@@ -42,4 +42,7 @@ const (
 
 	// DetachName denotes the name of the detach flag.
 	Detach = "detach"
+
+	// BindAddr denotes the name of the local bind address flag.
+	BindAddr = "bind-addr"
 )

--- a/proxy/connect.go
+++ b/proxy/connect.go
@@ -17,6 +17,7 @@ type ConnectParams struct {
 	AppName          string
 	OrganizationSlug string
 	Dialer           agent.Dialer
+	BindAddr         string
 	Ports            []string
 	RemoteHost       string
 	PromptInstance   bool
@@ -52,12 +53,13 @@ func Start(ctx context.Context, p *ConnectParams) error {
 
 func NewServer(ctx context.Context, p *ConnectParams) (*Server, error) {
 	var (
-		io         = iostreams.FromContext(ctx)
-		client     = client.FromContext(ctx).API()
-		orgSlug    = p.OrganizationSlug
-		localPort  = p.Ports[0]
-		remotePort = localPort
-		remoteAddr string
+		io            = iostreams.FromContext(ctx)
+		client        = client.FromContext(ctx).API()
+		orgSlug       = p.OrganizationSlug
+		localBindAddr = p.BindAddr
+		localPort     = p.Ports[0]
+		remotePort    = localPort
+		remoteAddr    string
 	)
 
 	if len(p.Ports) > 1 {
@@ -96,7 +98,7 @@ func NewServer(ctx context.Context, p *ConnectParams) (*Server, error) {
 
 	if _, err := strconv.Atoi(localPort); err == nil {
 		// just numbers
-		addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("127.0.0.1:%s", localPort))
+		addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%s", localBindAddr, localPort))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Change Summary

What and Why:

A new option has been added to the proxy connect command that is used to specify a local ip address to bind to. This is currently hard-coded to 127.0.0.1, which does not work when flyctl is run inside a container. For this to work, flyctl should bind to 0.0.0.0. The default when this option is not provided is 127.0.0.1.

How:

I just copied other examples, however there might be some other pattern I should follow. I'll be happy to adjust this pull-request accordingly.

When the option is not provided...
```
$ ./flyctl -t $FLY_ACCESS_TOKEN proxy 8999:8999 -a app-name
Proxying local port 8999 to remote [app-name.internal]:8999
```

in another terminal, we can see that flyctl is bound to 127.0.0.1
```
$ ss -ltn
State      Recv-Q     Send-Q          Local Address:Port           Peer Address:Port     Process
LISTEN     0          0                   127.0.0.1:8999                0.0.0.0:*
```

When the option is provided...
```
$ ./flyctl -t $FLY_ACCESS_TOKEN proxy 8999:8999 -a app-name -b 0.0.0.0
Proxying local port 8999 to remote [app-name.internal]:8999
```

in another terminal, we can see that flyctl is bound to 0.0.0.0
```
$ ss -ltn
State      Recv-Q     Send-Q          Local Address:Port           Peer Address:Port     Process
LISTEN     0          0                           *:8999                      *:*
```

Invalid ip address produces an appropriate error:
```
flyctl -t $FLY_ACCESS_TOKEN proxy 8999:8999 -a app-name -b 1.1.1.1
Error: listen tcp 1.1.1.1:8999: bind: cannot assign requested address
```

Related to:

https://github.com/superfly/flyctl/issues/1606

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [*] n/a
