### PR TITLE
Cast non-string http_checks headers

### DIFF
--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -289,6 +289,11 @@ func TestLoadTOMLAppConfigOldFormat(t *testing.T) {
 					{
 						Interval: api.MustParseDuration("20s"),
 						Timeout:  api.MustParseDuration("3s"),
+						HTTPHeaders: map[string]string{
+							"fly-healthcheck": "1",
+							"metoo":           "true",
+							"astring":         "string",
+						},
 					},
 				},
 			},
@@ -320,7 +325,11 @@ func TestLoadTOMLAppConfigOldFormat(t *testing.T) {
 				},
 				"http_checks": []map[string]any{
 					{"interval": int64(30000), "timeout": int64(4000)},
-					{"interval": "20s", "timeout": "3s"},
+					{
+						"interval": "20s",
+						"timeout":  "3s",
+						"headers":  map[string]any{"fly-healthcheck": int64(1), "astring": "string", "metoo": true},
+					},
 				},
 			}},
 		},

--- a/internal/appconfig/testdata/old-format.toml
+++ b/internal/appconfig/testdata/old-format.toml
@@ -39,6 +39,11 @@ build_target = "thalayer"
     interval = "20s"
     timeout = "3s"
 
+    [services.http_checks.headers]
+      fly-healthcheck = 1
+      metoo = true
+      astring = "string"
+
 [experimental]
   # GQL GetConfig always returns an experimental section even if empty
 


### PR DESCRIPTION
### Change Summary

What and Why:

Migrations are blocked because old fly.toml files have checks header values as non-strings

How:

Cast values to string before parsing

Related to:

V2 migration

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
