### PR TITLE
Handles [[processes]] fly.toml key

### DIFF
--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -336,6 +336,32 @@ func TestLoadTOMLAppConfigOldFormat(t *testing.T) {
 	}, cfg)
 }
 
+func TestLoadTOMLAppConfigOldProcesses(t *testing.T) {
+	const path = "./testdata/old-processes.toml"
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	assert.Equal(t, &Config{
+		configFilePath:   "./testdata/old-processes.toml",
+		defaultGroupName: "app",
+		Processes: map[string]string{
+			"web":    "./web",
+			"worker": "./worker",
+		},
+		RawDefinition: map[string]any{
+			"processes": []map[string]any{
+				{
+					"name":    "web",
+					"command": "./web",
+				},
+				{
+					"name":    "worker",
+					"command": "./worker",
+				},
+			},
+		},
+	}, cfg)
+}
+
 func TestLoadTOMLAppConfigOldChecksFormat(t *testing.T) {
 	const path = "./testdata/old-pg-checks.toml"
 	cfg, err := LoadConfig(path)

--- a/internal/appconfig/testdata/old-processes.toml
+++ b/internal/appconfig/testdata/old-processes.toml
@@ -1,0 +1,7 @@
+[[processes]]
+name = "web"
+command = "./web"
+
+[[processes]]
+name = "worker"
+command = "./worker"


### PR DESCRIPTION
### Change Summary

What and Why:

Old Nomad apps have a different format to define processes that is not compatible with V2 definition. This prevents the migration from working without manual intervention.

How:

Convert old format to latest supported fly.toml format

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
