### PR TITLE
Fix Preflight tests (reenable Nomad apps in development, fix outdated test cases)

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -715,7 +715,7 @@ type CreateAppInput struct {
 	PreferredRegion *string `json:"preferredRegion,omitempty"`
 	Network         *string `json:"network,omitempty"`
 	AppRoleID       string  `json:"appRoleId,omitempty"`
-	Machines        bool    `json:"machines,omitempty"`
+	Machines        bool    `json:"machines"`
 }
 
 type LogEntry struct {

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -185,19 +185,6 @@ func TestFlyLaunchForceV1(t *testing.T) {
 	require.Contains(f, x.StdErr().String(), `--force-nomad won't work for existing app in machines platform`)
 }
 
-// V1 app forced as V2
-func TestFlyLaunchForceV2(t *testing.T) {
-	f := testlib.NewTestEnvFromEnv(t)
-
-	appName := f.CreateRandomAppName()
-	// Sadly creating a new app with --nomad doesn't set its platform to Nomad until first deploy
-	f.Fly("apps create %s -o %s --nomad", appName, f.OrgSlug())
-	f.Fly("launch --now --image nginx --name %s --reuse-app --region=%s --force-nomad", appName, f.PrimaryRegion())
-
-	x := f.FlyAllowExitFailure("launch --no-deploy --copy-config=false --reuse-app --name %s --region %s --force-machines", appName, f.PrimaryRegion())
-	require.Contains(f, x.StdErr().String(), `--force-machines won't work for existing app in nomad platform`)
-}
-
 // test --generate-name, --name and reuse imported name
 func TestFlyLaunchReuseName(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)


### PR DESCRIPTION
### Change Summary

What and Why: web now defaults to machines: true, and because machines was omitempty, machines: false was never respected

How:

Related to: migrate-to-v2 tests failing

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
