### PR TITLE
Add support for check's headers in array format

### DIFF
--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -285,6 +285,9 @@ func TestLoadTOMLAppConfigOldFormat(t *testing.T) {
 					{
 						Interval: api.MustParseDuration("30s"),
 						Timeout:  api.MustParseDuration("4s"),
+						HTTPHeaders: map[string]string{
+							"origin": "http://localhost:8000",
+						},
 					},
 					{
 						Interval: api.MustParseDuration("20s"),
@@ -324,7 +327,13 @@ func TestLoadTOMLAppConfigOldFormat(t *testing.T) {
 					{"interval": "20s", "timeout": "3s"},
 				},
 				"http_checks": []map[string]any{
-					{"interval": int64(30000), "timeout": int64(4000)},
+					{
+						"interval": int64(30000),
+						"timeout":  int64(4000),
+						"headers": []map[string]any{
+							{"name": "origin", "value": "http://localhost:8000"},
+						},
+					},
 					{
 						"interval": "20s",
 						"timeout":  "3s",

--- a/internal/appconfig/testdata/old-format.toml
+++ b/internal/appconfig/testdata/old-format.toml
@@ -34,6 +34,10 @@ build_target = "thalayer"
     interval = 30000
     timeout = 4000
 
+    [[services.http_checks.headers]]
+      name = "origin"
+      value = "http://localhost:8000"
+
   [[services.http_checks]]
     # Additional check of same type to ensure it is not overriden
     interval = "20s"

--- a/internal/command/config/validate.go
+++ b/internal/command/config/validate.go
@@ -35,9 +35,13 @@ func runValidate(ctx context.Context) error {
 
 	switch {
 	case flag.GetBool(ctx, "machines"):
-		cfg.SetMachinesPlatform()
+		if err := cfg.SetMachinesPlatform(); err != nil {
+			return err
+		}
 	case flag.GetBool(ctx, "nomad"):
-		cfg.SetNomadPlatform()
+		if err := cfg.SetNomadPlatform(); err != nil {
+			return err
+		}
 	}
 	err, extra_info := cfg.Validate(ctx)
 	fmt.Fprintln(io.Out, extra_info)


### PR DESCRIPTION
### Change Summary

What and Why:

Old apps uses a weird format to set http check headers

```
    [[services.http_checks.headers]]
      name = "origin"
      value = "https://localhost:8000"
```

How:

convert them to new format.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
