### PR TITLE
Ignore empty durations in old formats

### DIFF
--- a/internal/appconfig/patches.go
+++ b/internal/appconfig/patches.go
@@ -423,7 +423,7 @@ func _patchChecks(rawChecks any) ([]map[string]any, error) {
 }
 
 func _patchCheck(check map[string]any) (map[string]any, error) {
-	for _, attr := range []string{"interval", "timeout"} {
+	for _, attr := range []string{"interval", "timeout", "grace_period"} {
 		if v, ok := check[attr]; ok {
 			check[attr] = _castDuration(v, time.Millisecond)
 		}

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -335,9 +335,10 @@ func TestLoadTOMLAppConfigOldFormat(t *testing.T) {
 						},
 					},
 					{
-						"interval": "20s",
-						"timeout":  "3s",
-						"headers":  map[string]any{"fly-healthcheck": int64(1), "astring": "string", "metoo": true},
+						"interval":     "20s",
+						"timeout":      "3s",
+						"grace_period": "",
+						"headers":      map[string]any{"fly-healthcheck": int64(1), "astring": "string", "metoo": true},
 					},
 				},
 			}},

--- a/internal/appconfig/testdata/old-format.toml
+++ b/internal/appconfig/testdata/old-format.toml
@@ -42,6 +42,7 @@ build_target = "thalayer"
     # Additional check of same type to ensure it is not overriden
     interval = "20s"
     timeout = "3s"
+    grace_period = "" # empty duration must be ignored
 
     [services.http_checks.headers]
       fly-healthcheck = 1


### PR DESCRIPTION
### Change Summary

What and Why:

Found another case of old app using an empty string to set a default grace_period

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
