### PR TITLE
Wait for resource provisioning when a provider does async provisioning

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -1350,11 +1350,12 @@ func (v *GetAddOnAddOnOrganization) GetPaidPlan() bool { return v.PaidPlan }
 
 // GetAddOnProviderAddOnProvider includes the requested fields of the GraphQL type AddOnProvider.
 type GetAddOnProviderAddOnProvider struct {
-	Id              string                                               `json:"id"`
-	Name            string                                               `json:"name"`
-	TosUrl          string                                               `json:"tosUrl"`
-	DisplayName     string                                               `json:"displayName"`
-	ExcludedRegions []GetAddOnProviderAddOnProviderExcludedRegionsRegion `json:"excludedRegions"`
+	Id                string                                               `json:"id"`
+	Name              string                                               `json:"name"`
+	TosUrl            string                                               `json:"tosUrl"`
+	DisplayName       string                                               `json:"displayName"`
+	AsyncProvisioning bool                                                 `json:"asyncProvisioning"`
+	ExcludedRegions   []GetAddOnProviderAddOnProviderExcludedRegionsRegion `json:"excludedRegions"`
 }
 
 // GetId returns GetAddOnProviderAddOnProvider.Id, and is useful for accessing the field via an interface.
@@ -1368,6 +1369,9 @@ func (v *GetAddOnProviderAddOnProvider) GetTosUrl() string { return v.TosUrl }
 
 // GetDisplayName returns GetAddOnProviderAddOnProvider.DisplayName, and is useful for accessing the field via an interface.
 func (v *GetAddOnProviderAddOnProvider) GetDisplayName() string { return v.DisplayName }
+
+// GetAsyncProvisioning returns GetAddOnProviderAddOnProvider.AsyncProvisioning, and is useful for accessing the field via an interface.
+func (v *GetAddOnProviderAddOnProvider) GetAsyncProvisioning() bool { return v.AsyncProvisioning }
 
 // GetExcludedRegions returns GetAddOnProviderAddOnProvider.ExcludedRegions, and is useful for accessing the field via an interface.
 func (v *GetAddOnProviderAddOnProvider) GetExcludedRegions() []GetAddOnProviderAddOnProviderExcludedRegionsRegion {
@@ -3503,6 +3507,7 @@ query GetAddOnProvider ($name: String!) {
 		name
 		tosUrl
 		displayName
+		asyncProvisioning
 		excludedRegions {
 			code
 		}

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -175,6 +175,7 @@ query GetAddOnProvider($name: String!) {
 		name
 		tosUrl
 		displayName
+		asyncProvisioning
 		excludedRegions {
 			code
 		}

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -283,6 +283,7 @@ type AddOnPlanEdge {
 }
 
 type AddOnProvider {
+  asyncProvisioning: Boolean!
   displayName: String
   excludedRegions: [Region!]
   id: ID!
@@ -1662,7 +1663,7 @@ input BuildVolumeInput {
   Desired volume size, in GB
   """
   sizeGb: Int!
-  snapshotId: ID
+  snapshot: ID
 }
 
 """
@@ -1674,6 +1675,8 @@ type BuildVolumePayload {
   """
   clientMutationId: String
   ok: Boolean!
+  restoreKey: String
+  vaultSecretPath: String
 }
 
 input BuilderMetaInput {
@@ -2557,7 +2560,7 @@ input CreateAppInput {
   """
   clientMutationId: String
   heroku: Boolean
-  machines: Boolean = false
+  machines: Boolean = true
 
   """
   The name of the new application. Defaults to a random name.
@@ -5036,6 +5039,7 @@ type ExtendVolumePayload {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  needsRestart: Boolean!
   volume: Volume!
 }
 


### PR DESCRIPTION
Some extension providers, like PlanetScale, can't guarantee synchronously provisioned databases. This allows us to kick off provisioning, then poll for status, until a ready state is reached.

This prevents a poor experience of someone tries to use a database before it's ready.