### PR TITLE
Add a unique invocation id to each flyctl invocation

### DIFF
--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -34,7 +34,7 @@ import (
 const (
 	NonceHeader        = "fly-machine-lease-nonce"
 	headerFlyRequestId = "fly-request-id"
-	invocationIDHeader = "Invocation-ID"
+	invocationIDHeader = "fly-invocation-id"
 )
 
 type Client struct {

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/pelletier/go-toml v1.9.4
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.5
+	github.com/rs/xid v1.5.0
 	github.com/samber/lo v1.38.1
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1237,6 +1237,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/xid v1.5.0 h1:mKX4bl4iPYJtEIxp6CYiUuLQ/8DYMoz0PUdtGgMFRVc=
+github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -63,6 +63,7 @@ var commonPreparers = []preparers.Preparer{
 	promptAndAutoUpdate,
 	preparers.InitClient,
 	killOldAgent,
+	createInvocationID,
 	startMetrics,
 }
 
@@ -671,4 +672,12 @@ func ChangeWorkingDirectory(ctx context.Context, wd string) (context.Context, er
 	}
 
 	return state.WithWorkingDirectory(ctx, wd), nil
+}
+
+func createInvocationID(ctx context.Context) (context.Context, error) {
+	cmd := FromContext(ctx)
+
+	invocationID := fmt.Sprintf("%s-%d", cmd.UseLine(), time.Now().UnixNano())
+
+	return state.WithInvocationID(ctx, invocationID), nil
 }

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/blang/semver"
@@ -675,9 +676,11 @@ func ChangeWorkingDirectory(ctx context.Context, wd string) (context.Context, er
 }
 
 func createInvocationID(ctx context.Context) (context.Context, error) {
-	cmd := FromContext(ctx)
+	command := FromContext(ctx).CommandPath()
 
-	invocationID := fmt.Sprintf("%s-%d", cmd.UseLine(), time.Now().UnixNano())
+	invocationID := fmt.Sprintf("%s-%d", strings.ReplaceAll(command, " ", "-"), time.Now().UnixNano())
+
+	logger.FromContext(ctx).Debugf("Invocation id: %s", invocationID)
 
 	return state.WithInvocationID(ctx, invocationID), nil
 }

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/blang/semver"
@@ -677,12 +676,7 @@ func ChangeWorkingDirectory(ctx context.Context, wd string) (context.Context, er
 }
 
 func createInvocationID(ctx context.Context) (context.Context, error) {
-	var (
-		command = FromContext(ctx).CommandPath()
-		guid    = xid.New()
-	)
-
-	invocationID := fmt.Sprintf("%s-%s", strings.ReplaceAll(command, " ", "-"), guid.String())
+	invocationID := xid.New().String()
 
 	logger.FromContext(ctx).Debugf("Invocation ID: %s", invocationID)
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/logrusorgru/aurora"
+	"github.com/rs/xid"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/iostreams"
@@ -676,11 +677,14 @@ func ChangeWorkingDirectory(ctx context.Context, wd string) (context.Context, er
 }
 
 func createInvocationID(ctx context.Context) (context.Context, error) {
-	command := FromContext(ctx).CommandPath()
+	var (
+		command = FromContext(ctx).CommandPath()
+		guid    = xid.New()
+	)
 
-	invocationID := fmt.Sprintf("%s-%d", strings.ReplaceAll(command, " ", "-"), time.Now().UnixNano())
+	invocationID := fmt.Sprintf("%s-%s", strings.ReplaceAll(command, " ", "-"), guid.String())
 
-	logger.FromContext(ctx).Debugf("Invocation id: %s", invocationID)
+	logger.FromContext(ctx).Debugf("Invocation ID: %s", invocationID)
 
 	return state.WithInvocationID(ctx, invocationID), nil
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -16,6 +16,7 @@ const (
 	workDirKey
 	userHomeDirKey
 	configDirKey
+	invocationIDKey
 )
 
 // WithHostname returns a copy of ctx that carries hostname.
@@ -69,6 +70,16 @@ func ConfigDirectory(ctx context.Context) string {
 // ctx carries no config directory.
 func ConfigFile(ctx context.Context) string {
 	return filepath.Join(ConfigDirectory(ctx), config.FileName)
+}
+
+// InvocationID returns the unique id that identifies this particular invocation of flyctl
+func InvocationID(ctx context.Context) string {
+	return get(ctx, invocationIDKey).(string)
+}
+
+// WithInvocationID derives a Context that carries the given invocation id from ctx.
+func WithInvocationID(ctx context.Context, id string) context.Context {
+	return set(ctx, invocationIDKey, id)
 }
 
 func get(ctx context.Context, key contextKeyType) interface{} {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -17,6 +17,7 @@ func TestStrings(t *testing.T) {
 		"WorkingDirectory":  {WorkingDirectory, WithWorkingDirectory},
 		"UserHomeDirectory": {UserHomeDirectory, WithUserHomeDirectory},
 		"ConfigDirectory":   {ConfigDirectory, WithConfigDirectory},
+		"InvocationID":      {InvocationID, WithInvocationID},
 	}
 
 	for name := range cases {


### PR DESCRIPTION
### Change Summary

What and Why:
A new flyctl command preparer/middleware that create a unique id we can use to track a particular 
command invocation throught the stack. It will be particulary useful for tracing cause unlike the request id
it can be used to correlate all API calls to a single command invocation.

How:
```sh

➜  flyctl git:(invocation-id) ✗ LOG_LEVEL=debug ./bin/flyctl m start 9080e792c60d87 --app ubuntu-sandbox
DEBUG Loaded flyctl config from/Users/<username>/.fly/config.yml
DEBUG determined hostname: "local"
DEBUG determined working directory: "/Users/<username>flyctl"
DEBUG determined user home directory: "/Users/<username>"
DEBUG determined config directory: "/Users/<username>/.fly"
DEBUG ensured config directory exists.
DEBUG ensured config directory perms.
DEBUG cache loaded.
DEBUG config initialized.
DEBUG skipped querying for new release
DEBUG client initialized.
DEBUG Invocation id: flyctl-machine-start-1689597920296476000
```

Related to:

Help people help us debug their problems. 
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
