### PR TITLE
Keep deps uptodate with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "go"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "/api"
+    labels:
+      - "dependencies"
+      - "go"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "actions"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
### Change Summary

What and Why:

As suggested by one user in https://github.com/superfly/flyctl/pull/2569, delegate keeping dependencies uptodate to Dependabot

How:

Adds dependabot configuration file.

Related to:

https://github.com/superfly/flyctl/pull/2569

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
