### PR TITLE
Move on.schedule from preflight.yml to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build
+on:
+  schedule:
+    - cron: '21 */2 * * *'
+  push:
+  pull_request:
+
+# We right now cannot use Go 1.20.6 due to
+# https://community.fly.io/t/git-hub-actions-deployment-error/14126
+env:
+  go_version: 1.20.5
+
+jobs:
+  test_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.go_version }}
+      - name: "Place wintun.dll"
+        run: cp deps/wintun/bin/amd64/wintun.dll ./
+      - name: build
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          args: build --clean --snapshot
+      - name: Upload flyctl for preflight
+        uses: actions/upload-artifact@v3
+        with:
+          name: flyctl
+          path: dist/default_linux_amd64_v1/flyctl
+
+  preflight:
+    needs: test_build
+    uses: ./.github/workflows/preflight.yml
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,27 +9,6 @@ env:
   go_version: 1.20.5
 
 jobs:
-  test_build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.go_version }}
-      - name: "Place wintun.dll"
-        run: cp deps/wintun/bin/amd64/wintun.dll ./
-      - name: build
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          version: latest
-          args: build --clean --snapshot
-      - name: Upload flyctl for preflight
-        uses: actions/upload-artifact@v3
-        with:
-          name: flyctl
-          path: dist/default_linux_amd64_v1/flyctl
 
   test:
     strategy:
@@ -189,8 +168,3 @@ jobs:
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: ${{ github.event.ref }}
           force_push: "true"
-
-  preflight:
-    needs: test_build
-    uses: ./.github/workflows/preflight.yml
-    secrets: inherit

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,8 +1,6 @@
 name: Preflight Tests
 
 on:
-  schedule:
-    - cron: '21 */2 * * *'
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION


### Change Summary

What and Why:

#2556 accidentally broke preflight tests's schedule run. This PR fixes the breakage.

How:

After this change,
- build.yml runs every two hours
- preflight.yml is called from either build.yml or ci.yml

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
