### PR TITLE
support defining files with fly deploy

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -499,7 +499,8 @@ type MachineConfig struct {
 	Statics  []*Static               `json:"statics,omitempty"`
 
 	// Set by fly deploy or fly machines commands
-	Image string `json:"image,omitempty"`
+	Image string  `json:"image,omitempty"`
+	Files []*File `json:"files,omitempty"`
 
 	// The following fields can only be set or updated by `fly machines run|update` commands
 	// "fly deploy" must preserve them, if you add anything here, ensure it is propagated on deploys
@@ -515,8 +516,6 @@ type MachineConfig struct {
 	Standbys []string `json:"standbys,omitempty"`
 
 	StopConfig *StopConfig `json:"stop_config,omitempty"`
-
-	Files []*File `json:"files,omitempty"`
 
 	// Deprecated: use Guest instead
 	VMSize string `json:"size,omitempty"`

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -53,6 +53,7 @@ type MachineDeploymentArgs struct {
 	IncreasedAvailability bool
 	AllocPublicIP         bool
 	UpdateOnly            bool
+	Files                 []*api.File
 }
 
 type machineDeployment struct {
@@ -83,6 +84,7 @@ type machineDeployment struct {
 	increasedAvailability bool
 	listenAddressChecked  map[string]struct{}
 	updateOnly            bool
+	files                 []*api.File
 }
 
 func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (MachineDeployment, error) {
@@ -152,6 +154,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		increasedAvailability: args.IncreasedAvailability,
 		listenAddressChecked:  make(map[string]struct{}),
 		updateOnly:            args.UpdateOnly,
+		files:                 args.Files,
 	}
 	if err := md.setStrategy(); err != nil {
 		return nil, err

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -7,6 +7,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/internal/buildinfo"
+	machinecmd "github.com/superfly/flyctl/internal/command/machine"
 	"github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/terminal"
 )
@@ -46,6 +47,8 @@ func (md *machineDeployment) launchInputForLaunch(processGroup string, guest *ap
 	if len(standbyFor) > 0 {
 		mConfig.Standbys = standbyFor
 	}
+
+	mConfig.Files = md.files
 
 	return &api.LaunchMachineInput{
 		Region:     region,
@@ -127,6 +130,8 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 	if len(mConfig.Services) > 0 && len(mConfig.Standbys) > 0 {
 		mConfig.Standbys = nil
 	}
+
+	machinecmd.MergeFiles(mConfig, md.files)
 
 	return &api.LaunchMachineInput{
 		ID:                  mID,


### PR DESCRIPTION
### Change Summary

Currently, only `fly machine run|update` support the flags for adding files to a machine and these changes brings that feature to `fly deploy`.

What and Why:

Additional flags added for specifying files to be added to a machine config and created in the VM.

How:

```
--file-local=/path/inside/machine=<local/path>
--file-literal=/path/inside/machine=VALUE
--file-secret=/path/inside/machine=SECRET
```

Related to: https://github.com/superfly/flyctl/pull/2506

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
