### PR TITLE
Update docs for restartless volume extend

### DIFF
--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -20,9 +20,9 @@ import (
 
 func newExtend() *cobra.Command {
 	const (
-		long = `Extends a target volume to the size specified. Volumes with attached nomad allocations
-		will be restarted automatically. Machines will require a manual restart to increase the size
-		of the FS.`
+		long = `Extends a target volume to the size specified. The instance is automatically restarted for Nomad (V1) apps. 
+		Most Machines (V2 apps) don't require a restart. Older Machines get a message to manually restart the Machine
+		to increase the size of the FS.`
 
 		short = "Extend a target volume"
 


### PR DESCRIPTION
### Change Summary

What and Why: Update the description for the `fly vol extend` command to reflect the new restartless volume extend functionality.

How: n/a

Related to: 
- https://community.fly.io/t/restartless-volume-extension/14130
- https://github.com/superfly/flyctl/pull/2513

---

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a
