### PR TITLE
Force linux/amd64 to build Fly-compatible images on Apple silicon

### DIFF
--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -313,7 +313,13 @@ func runClassicBuild(ctx context.Context, streams *iostreams.IOStreams, docker *
 }
 
 func solveOptFromImageOptions(opts ImageOptions, dockerfilePath string, buildArgs map[string]*string) client.SolveOpt {
-	attrs := map[string]string{"filename": filepath.Base(dockerfilePath)}
+	attrs := map[string]string{
+		"filename": filepath.Base(dockerfilePath),
+		"target":   opts.Target,
+		// Fly.io only supports linux/amd64, but local Docker Engine could be running on ARM,
+		// including Apple Silicon.
+		"platform": "linux/amd64",
+	}
 	attrs["target"] = opts.Target
 	if opts.NoCache {
 		attrs["no-cache"] = ""


### PR DESCRIPTION
### Change Summary

What and Why:

Apple silicon Macs' local Docker Engine by default creates images for linux/arm64, which doesn't work on Fly.io.

How:

Hardcoding "linux/amd64"

Related to:

https://community.fly.io/t/flyctl-deploy-local-only-error-building-failed-to-dial-grpc-http-invalid-host-header/14169/17?u=kaz

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
