### PR TITLE
Support swapfile creation on machine init

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -554,6 +554,7 @@ type MachineInit struct {
 	Entrypoint []string `json:"entrypoint,omitempty"`
 	Cmd        []string `json:"cmd,omitempty"`
 	Tty        bool     `json:"tty,omitempty"`
+	SwapSizeMB int      `json:"swap_size_mb,omitempty"`
 }
 
 type DNSConfig struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -554,7 +554,7 @@ type MachineInit struct {
 	Entrypoint []string `json:"entrypoint,omitempty"`
 	Cmd        []string `json:"cmd,omitempty"`
 	Tty        bool     `json:"tty,omitempty"`
-	SwapSizeMB int      `json:"swap_size_mb,omitempty"`
+	SwapSizeMB *int     `json:"swap_size_mb,omitempty"`
 }
 
 type DNSConfig struct {

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -40,7 +40,7 @@ type Config struct {
 	PrimaryRegion  string        `toml:"primary_region,omitempty" json:"primary_region,omitempty"`
 	KillSignal     *string       `toml:"kill_signal,omitempty" json:"kill_signal,omitempty"`
 	KillTimeout    *api.Duration `toml:"kill_timeout,omitempty" json:"kill_timeout,omitempty"`
-	SwapSizeMB     int           `toml:"swap_size_mb,omitempty" json:"swap_size_mb,omitempty"`
+	SwapSizeMB     *int          `toml:"swap_size_mb,omitempty" json:"swap_size_mb,omitempty"`
 	ConsoleCommand string        `toml:"console_command,omitempty" json:"console_command,omitempty"`
 
 	// Sections that are typically short and benefit from being on top

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	PrimaryRegion  string        `toml:"primary_region,omitempty" json:"primary_region,omitempty"`
 	KillSignal     *string       `toml:"kill_signal,omitempty" json:"kill_signal,omitempty"`
 	KillTimeout    *api.Duration `toml:"kill_timeout,omitempty" json:"kill_timeout,omitempty"`
+	SwapSizeMB     int           `toml:"swap_size_mb,omitempty" json:"swap_size_mb,omitempty"`
 	ConsoleCommand string        `toml:"console_command,omitempty" json:"console_command,omitempty"`
 
 	// Sections that are typically short and benefit from being on top

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -167,6 +167,7 @@ func TestToDefinition(t *testing.T) {
 		"primary_region":  "sea",
 		"kill_signal":     "SIGTERM",
 		"kill_timeout":    "3s",
+		"swap_size_mb":    int64(512),
 		"console_command": "/bin/bash",
 
 		"build": map[string]any{

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -27,7 +27,8 @@ func (c *Config) ToReleaseMachineConfig() (*api.MachineConfig, error) {
 
 	mConfig := &api.MachineConfig{
 		Init: api.MachineInit{
-			Cmd: releaseCmd,
+			Cmd:        releaseCmd,
+			SwapSizeMB: c.SwapSizeMB,
 		},
 		Restart: api.MachineRestart{
 			Policy: api.MachineRestartPolicyNo,
@@ -67,7 +68,8 @@ func (c *Config) ToConsoleMachineConfig() (*api.MachineConfig, error) {
 			// command at all. That way we don't rely on /bin/sleep
 			// being available and working right. However, there's no
 			// way to do that yet.
-			Exec: []string{"/bin/sleep", "inf"},
+			Exec:       []string{"/bin/sleep", "inf"},
+			SwapSizeMB: c.SwapSizeMB,
 		},
 		Restart: api.MachineRestart{
 			Policy: api.MachineRestartPolicyNo,

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -118,6 +118,7 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 		mConfig.Init.Exec = c.Experimental.Exec
 	}
 	mConfig.Init.Cmd = cmd
+	mConfig.Init.SwapSizeMB = c.SwapSizeMB
 
 	// Metadata
 	mConfig.Metadata = lo.Assign(mConfig.Metadata, map[string]string{

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -48,7 +48,7 @@ func TestToMachineConfig(t *testing.T) {
 			Signal:  api.Pointer("SIGTERM"),
 		},
 		Init: api.MachineInit{
-			SwapSizeMB: 512,
+			SwapSizeMB: api.Pointer(512),
 		},
 	}
 
@@ -150,7 +150,7 @@ func TestToReleaseMachineConfig(t *testing.T) {
 	want := &api.MachineConfig{
 		Init: api.MachineInit{
 			Cmd:        []string{"migrate-db"},
-			SwapSizeMB: 512,
+			SwapSizeMB: api.Pointer(512),
 		},
 		Env: map[string]string{"FOO": "BAR", "PRIMARY_REGION": "mia", "RELEASE_COMMAND": "1", "FLY_PROCESS_GROUP": "fly_app_release_command"},
 		Metadata: map[string]string{
@@ -179,7 +179,7 @@ func TestToConsoleMachineConfig(t *testing.T) {
 	want := &api.MachineConfig{
 		Init: api.MachineInit{
 			Exec:       []string{"/bin/sleep", "inf"},
-			SwapSizeMB: 512,
+			SwapSizeMB: api.Pointer(512),
 		},
 		Env: map[string]string{
 			"FOO":               "BAR",

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -148,8 +148,11 @@ func TestToReleaseMachineConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	want := &api.MachineConfig{
-		Init: api.MachineInit{Cmd: []string{"migrate-db"}},
-		Env:  map[string]string{"FOO": "BAR", "PRIMARY_REGION": "mia", "RELEASE_COMMAND": "1", "FLY_PROCESS_GROUP": "fly_app_release_command"},
+		Init: api.MachineInit{
+			Cmd:        []string{"migrate-db"},
+			SwapSizeMB: 512,
+		},
+		Env: map[string]string{"FOO": "BAR", "PRIMARY_REGION": "mia", "RELEASE_COMMAND": "1", "FLY_PROCESS_GROUP": "fly_app_release_command"},
 		Metadata: map[string]string{
 			"fly_platform_version": "v2",
 			"fly_process_group":    "fly_app_release_command",

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -172,6 +172,37 @@ func TestToReleaseMachineConfig(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestToConsoleMachineConfig(t *testing.T) {
+	cfg, err := LoadConfig("./testdata/tomachine.toml")
+	require.NoError(t, err)
+
+	want := &api.MachineConfig{
+		Init: api.MachineInit{
+			Exec:       []string{"/bin/sleep", "inf"},
+			SwapSizeMB: 512,
+		},
+		Env: map[string]string{
+			"FOO":               "BAR",
+			"PRIMARY_REGION":    "mia",
+			"FLY_PROCESS_GROUP": "fly_app_console",
+		},
+		Metadata: map[string]string{
+			"fly_platform_version": "v2",
+			"fly_process_group":    "fly_app_console",
+			"fly_flyctl_version":   buildinfo.ParsedVersion().String(),
+		},
+		AutoDestroy: true,
+		Restart: api.MachineRestart{
+			Policy: api.MachineRestartPolicyNo,
+		},
+		DNS: &api.DNSConfig{SkipRegistration: true},
+	}
+
+	got, err := cfg.ToConsoleMachineConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
 func TestToMachineConfig_multiProcessGroups(t *testing.T) {
 	cfg, err := LoadConfig("./testdata/tomachine-processgroups.toml")
 	require.NoError(t, err)

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -47,6 +47,9 @@ func TestToMachineConfig(t *testing.T) {
 			Timeout: api.MustParseDuration("10s"),
 			Signal:  api.Pointer("SIGTERM"),
 		},
+		Init: api.MachineInit{
+			SwapSizeMB: 512,
+		},
 	}
 
 	got, err := cfg.ToMachineConfig("", nil)

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -415,6 +415,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 		AppName:          "foo",
 		KillSignal:       api.Pointer("SIGTERM"),
 		KillTimeout:      api.MustParseDuration("3s"),
+		SwapSizeMB:       512,
 		PrimaryRegion:    "sea",
 		ConsoleCommand:   "/bin/bash",
 		Experimental: &Experimental{

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -415,7 +415,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 		AppName:          "foo",
 		KillSignal:       api.Pointer("SIGTERM"),
 		KillTimeout:      api.MustParseDuration("3s"),
-		SwapSizeMB:       512,
+		SwapSizeMB:       api.Pointer(512),
 		PrimaryRegion:    "sea",
 		ConsoleCommand:   "/bin/bash",
 		Experimental: &Experimental{

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -1,6 +1,7 @@
 app = "foo"
 kill_signal = "SIGTERM"
 kill_timeout = "3s"
+swap_size_mb = 512
 primary_region = "sea"
 console_command = "/bin/bash"
 

--- a/internal/appconfig/testdata/tomachine.toml
+++ b/internal/appconfig/testdata/tomachine.toml
@@ -2,6 +2,7 @@ app = "foo"
 primary_region = "mia"
 kill_signal = "SIGTERM"
 kill_timeout = "10s"
+swap_size_mb = 512
 
 [deploy]
   release_command = "migrate-db"

--- a/internal/command/launch/srcinfo.go
+++ b/internal/command/launch/srcinfo.go
@@ -298,6 +298,10 @@ func setAppconfigFromSrcinfo(ctx context.Context, srcInfo *scanner.SourceInfo, a
 		appConfig.SetKillSignal(srcInfo.KillSignal)
 	}
 
+	if srcInfo.SwapSizeMB > 0 {
+		appConfig.SwapSizeMB = srcInfo.SwapSizeMB
+	}
+
 	// Append any requested Dockerfile entries
 	if len(srcInfo.DockerfileAppendix) > 0 {
 		if err := appendDockerfileAppendix(srcInfo.DockerfileAppendix); err != nil {

--- a/internal/command/launch/srcinfo.go
+++ b/internal/command/launch/srcinfo.go
@@ -299,7 +299,7 @@ func setAppconfigFromSrcinfo(ctx context.Context, srcInfo *scanner.SourceInfo, a
 	}
 
 	if srcInfo.SwapSizeMB > 0 {
-		appConfig.SwapSizeMB = srcInfo.SwapSizeMB
+		appConfig.SwapSizeMB = &srcInfo.SwapSizeMB
 	}
 
 	// Append any requested Dockerfile entries

--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -46,6 +46,7 @@ func configurePhoenix(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 	}
 
 	s.KillSignal = "SIGTERM"
+	s.SwapSizeMB = 512
 	s.Port = 8080
 	s.Env = map[string]string{
 		"PHX_HOST": "APP_FQDN",

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -42,6 +42,7 @@ type SourceInfo struct {
 	DockerCommand                string
 	DockerEntrypoint             string
 	KillSignal                   string
+	SwapSizeMB                   int
 	Buildpacks                   []string
 	Secrets                      []Secret
 	Files                        []SourceFile
@@ -137,7 +138,6 @@ func templatesExecute(name string, vars map[string]interface{}) (files []SourceF
 		template := template.Must(template.New("name").Parse(string(input)))
 		result := strings.Builder{}
 		err := template.Execute(&result, vars)
-
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
### Change Summary

What and Why:

This PR adds support to configure machine's memory swap as a file at /swapfile.

The rationale behind it is that there many documented attempts to do this using scripting but all of them demand running such commands as root user, and then dropping privileges to app processes.

Examples: 
* [dockerfile-node](https://flyio.sentry.io/issues/3614092649/?query=start%3D2023-07-21T12%3A00%3A23%26end%3D2023-07-21T18%3A00%3A23%26groupStatsPeriod%3Dauto&referrer=alerts-related-issues-issue-stream)
* [dockerfile-rails](https://github.com/fly-apps/dockerfile-rails/blob/29c5c79981f0f39d3ae6c35773749dba46db890e/lib/generators/templates/docker-entrypoint.erb#L10C1-L16)
* https://community.fly.io/t/swap-memory/2749/4
* [fly-apps/railsite](https://github.com/fly-apps/railsite/blob/3dbf77bf89dccf06e792495a0441c57687f0a589/lib/tasks/fly.rake#L30-L36)  
* Phoenix scanner support [reverted](https://github.com/superfly/flyctl/commit/00e7698df5a1253efa5dfdb1cf62fddbdab34ae1) because of lack of default user permissions reported on [community forum](https://community.fly.io/t/fly-deploy-returns-error-for-new-app/14280)

How:

Leverage on machine's `init` binary support to setup swap file before running image's entrypoint

Related to:

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
