### PR TITLE
Pass build secrets to Buildkit correctly

### DIFF
--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -97,6 +97,8 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgs
 		Buildpacks:      build.Buildpacks,
 	}
 
+	// flyctl supports key=value form while Docker supports id=key,src=/path/to/secret form.
+	// https://docs.docker.com/engine/reference/commandline/buildx_build/#secret
 	cliBuildSecrets, err := cmdutil.ParseKVStringsToMap(flag.GetStringArray(ctx, "build-secret"))
 	if err != nil {
 		return


### PR DESCRIPTION
### Change Summary

What and Why:

It was broken since #2549. I missed `opts.BuildSecrets`.

How:

Passing opts.BuildSecrets. I've added preflight tests too.

Related to:

https://community.fly.io/t/deploys-stopped-working-secret-not-found/14301

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
