### PR TITLE
install.sh: rename into place

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -18,18 +18,20 @@ main() {
 	flyctl_install="${FLYCTL_INSTALL:-$HOME/.fly}"
 
 	bin_dir="$flyctl_install/bin"
+	tmp_dir="$flyctl_install/tmp"
 	exe="$bin_dir/flyctl"
 	simexe="$bin_dir/fly"
 
-	if [ ! -d "$bin_dir" ]; then
-		mkdir -p "$bin_dir"
-	fi
+	mkdir -p "$bin_dir"
+	mkdir -p "$tmp_dir"
 
-	curl -q --fail --location --progress-bar --output "$exe.tar.gz" "$flyctl_uri"
-	cd "$bin_dir"
-	tar xzf "$exe.tar.gz"
-	chmod +x "$exe"
-	rm "$exe.tar.gz"
+	curl -q --fail --location --progress-bar --output "$tmp_dir/flyctl.tar.gz" "$flyctl_uri"
+	# extract to tmp dir so we don't open existing executable file for writing:
+	tar -C "$tmp_dir" -xzf "$tmp_dir/flyctl.tar.gz"
+	chmod +x "$tmp_dir/flyctl"
+	# atomically rename into place:
+	mv "$tmp_dir/flyctl" "$exe"
+	rm -rf "$tmp_dir"
 
 	ln -sf $exe $simexe
 

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -31,7 +31,7 @@ main() {
 	chmod +x "$tmp_dir/flyctl"
 	# atomically rename into place:
 	mv "$tmp_dir/flyctl" "$exe"
-	rm -rf "$tmp_dir"
+	rm "$tmp_dir/flyctl.tar.gz"
 
 	ln -sf $exe $simexe
 

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -4,50 +4,54 @@
 
 set -e
 
-os=$(uname -s)
-arch=$(uname -m)
-version=${1:-latest}
+main() {
+	os=$(uname -s)
+	arch=$(uname -m)
+	version=${1:-latest}
 
-flyctl_uri=$(curl -s ${FLY_FORCE_TRACE:+ -H "Fly-Force-Trace: $FLY_FORCE_TRACE"} https://api.fly.io/app/flyctl_releases/$os/$arch/$version)
-if [ ! "$flyctl_uri" ]; then
-	echo "Error: Unable to find a flyctl release for $os/$arch/$version - see github.com/superfly/flyctl/releases for all versions" 1>&2
-	exit 1
-fi
+	flyctl_uri=$(curl -s ${FLY_FORCE_TRACE:+ -H "Fly-Force-Trace: $FLY_FORCE_TRACE"} https://api.fly.io/app/flyctl_releases/$os/$arch/$version)
+	if [ ! "$flyctl_uri" ]; then
+		echo "Error: Unable to find a flyctl release for $os/$arch/$version - see github.com/superfly/flyctl/releases for all versions" 1>&2
+		exit 1
+	fi
 
-flyctl_install="${FLYCTL_INSTALL:-$HOME/.fly}"
+	flyctl_install="${FLYCTL_INSTALL:-$HOME/.fly}"
 
-bin_dir="$flyctl_install/bin"
-exe="$bin_dir/flyctl"
-simexe="$bin_dir/fly"
+	bin_dir="$flyctl_install/bin"
+	exe="$bin_dir/flyctl"
+	simexe="$bin_dir/fly"
 
-if [ ! -d "$bin_dir" ]; then
- 	mkdir -p "$bin_dir"
-fi
+	if [ ! -d "$bin_dir" ]; then
+		mkdir -p "$bin_dir"
+	fi
 
-curl -q --fail --location --progress-bar --output "$exe.tar.gz" "$flyctl_uri"
-cd "$bin_dir"
-tar xzf "$exe.tar.gz"
-chmod +x "$exe"
-rm "$exe.tar.gz"
+	curl -q --fail --location --progress-bar --output "$exe.tar.gz" "$flyctl_uri"
+	cd "$bin_dir"
+	tar xzf "$exe.tar.gz"
+	chmod +x "$exe"
+	rm "$exe.tar.gz"
 
-ln -sf $exe $simexe
+	ln -sf $exe $simexe
 
-if [ "${1}" = "prerel" ] || [ "${1}" = "pre" ]; then
-	"$exe" version -s "shell-prerel"
-else
-	"$exe" version -s "shell"
-fi
+	if [ "${1}" = "prerel" ] || [ "${1}" = "pre" ]; then
+		"$exe" version -s "shell-prerel"
+	else
+		"$exe" version -s "shell"
+	fi
 
-echo "flyctl was installed successfully to $exe"
-if command -v flyctl >/dev/null; then
-	echo "Run 'flyctl --help' to get started"
-else
-	case $SHELL in
-	/bin/zsh) shell_profile=".zshrc" ;;
-	*) shell_profile=".bash_profile" ;;
-	esac
-	echo "Manually add the directory to your \$HOME/$shell_profile (or similar)"
-	echo "  export FLYCTL_INSTALL=\"$flyctl_install\""
-	echo "  export PATH=\"\$FLYCTL_INSTALL/bin:\$PATH\""
-	echo "Run '$exe --help' to get started"
-fi
+	echo "flyctl was installed successfully to $exe"
+	if command -v flyctl >/dev/null; then
+		echo "Run 'flyctl --help' to get started"
+	else
+		case $SHELL in
+		/bin/zsh) shell_profile=".zshrc" ;;
+		*) shell_profile=".bash_profile" ;;
+		esac
+		echo "Manually add the directory to your \$HOME/$shell_profile (or similar)"
+		echo "  export FLYCTL_INSTALL=\"$flyctl_install\""
+		echo "  export PATH=\"\$FLYCTL_INSTALL/bin:\$PATH\""
+		echo "Run '$exe --help' to get started"
+	fi
+}
+
+main


### PR DESCRIPTION
There's actually two changes in this PR, but they would conflict if I split them out into separate PRs so I've combined them into one PR. [Diff best viewed ignoring whitespace changes](https://github.com/superfly/flyctl/pull/2603/files?w=1).

The first commit wraps the entire install script in a `main` function which is immediately invoked at the end of the script. This is necessary because we suggest users to pipe curl to shell, and if the curl transfer fails, `sh` will happily execute the partial script. This might seem pedantic, but the hairs on my neck started standing up as I was writing `rm -rf`, so I thought it best to be extra careful.

The second commit, and the main change that prompted this PR, changes the behaviour of the install script to extract the flyctl tarball to a temporary directory first, chmod +x's the binary there, and then renames into place.

This is necessary to avoid this race condition:

![image](https://github.com/superfly/flyctl/assets/179065/4e8fc101-c882-4f56-bd04-dbbc22b7d905)

What I think is happening here is the auto-updater happens to be running in the background at the same time I ran that first `fly m stop` command in the screenshot. `tar` had `~/.fly/bin/flyctl` open for writing, and as a result, we get an error trying to execute it. This race condition could also manifest as a permission denied error in the case that the user tries to invoke `flyctl` in between `tar` exiting and `chmod` doing its thing.

The usual way to work around this kind of problem on unix is to exploit the atomicity of the `rename(2)` syscall by doing all of our work in a temporary directory before finally renaming into place. Because `rename(2)` is guaranteed to be atomic, it's not possible for a `flyctl` invocation to race with it - it'll cleanly execute either the old or the new version.