### PR TITLE
update deno scanner

### DIFF
--- a/scanner/deno.go
+++ b/scanner/deno.go
@@ -1,7 +1,13 @@
 package scanner
 
 func configureDeno(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
-	if !checksPass(sourceDir, dirContains("*.ts", "denopkg", "deno.land")) {
+	if !checksPass(
+		sourceDir,
+		// default config files: https://deno.land/manual@v1.35.2/getting_started/configuration_file
+		fileExists("deno.json", "deno.jsonc"),
+		// deno.land and denopkg.com imports
+		dirContains("*.ts", "\"https?://deno\\.land/.*\"", "\"https?://denopkg\\.com/.*\""),
+	) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why: deno scanner updated to check for default config files, import regex also fixed.

How: use scanner helper functions

Related to: fixes https://github.com/superfly/flyctl/issues/2599

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
