### PR TITLE
Wait 60m to delete preflight apps

### DIFF
--- a/scripts/clean-up-preflight-apps/main.go
+++ b/scripts/clean-up-preflight-apps/main.go
@@ -52,7 +52,7 @@ func run() error {
 		return err
 	}
 	for _, app := range resp.Organization.Apps.Nodes {
-		if time.Since(app.CreatedAt) > 30*time.Minute {
+		if time.Since(app.CreatedAt) > 60*time.Minute {
 			flyctlBin := "flyctl"
 			cmdStr := fmt.Sprintf("%s apps destroy --yes %s", flyctlBin, app.Id)
 			cmdParts, err := shlex.Split(cmdStr)


### PR DESCRIPTION
Otherwise, we sometimes destroy apps mid-test

### Change Summary

What and Why:
Increase the amount of time needed before we destroy an app.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
