### PR TITLE
Faster Preflight Tests

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        parallelism: [5]
-        index: [0,1,2,3,4]
+        parallelism: [10]
+        index: [0,1,2,3,4,5,6,7,8,9]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test: FORCE
 # to run one test, use: make preflight-test T=TestAppsV2ConfigSave
 preflight-test: build
 	if [ -r .direnv/preflight ]; then . .direnv/preflight; fi; \
-	go test ./test/preflight --tags=integration -v -timeout 60m --run="$(T)"
+	go test --parallel=4 ./test/preflight --tags=integration -v -timeout 60m --run="$(T)"
 
 ci-preflight:
 	$(MAKE) preflight-test FLY_PREFLIGHT_TEST_NO_PRINT_HISTORY_ON_FAIL=true

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test: FORCE
 # to run one test, use: make preflight-test T=TestAppsV2ConfigSave
 preflight-test: build
 	if [ -r .direnv/preflight ]; then . .direnv/preflight; fi; \
-	go test --parallel=4 ./test/preflight --tags=integration -v -timeout 60m --run="$(T)"
+	go test --parallel=4 ./test/preflight --tags=integration -v -timeout 10m --run="$(T)"
 
 ci-preflight:
 	$(MAKE) preflight-test FLY_PREFLIGHT_TEST_NO_PRINT_HISTORY_ON_FAIL=true

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -47,7 +47,7 @@ gotesplit \
     -total "$total" \
     -index "$index" \
     github.com/superfly/flyctl/test/preflight/... \
-    -- --tags=integration -v -timeout=60m $test_opts | tee "$test_log"
+    -- -parallel=8 -p8 --tags=integration -v -timeout=60m $test_opts | tee "$test_log"
 test_status=$?
 
 set -e

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -47,7 +47,7 @@ gotesplit \
     -total "$total" \
     -index "$index" \
     github.com/superfly/flyctl/test/preflight/... \
-    -- -parallel=8 -p8 --tags=integration -v -timeout=60m $test_opts | tee "$test_log"
+    -- --parallel=8 --tags=integration -v -timeout=60m $test_opts | tee "$test_log"
 test_status=$?
 
 set -e

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -47,7 +47,7 @@ gotesplit \
     -total "$total" \
     -index "$index" \
     github.com/superfly/flyctl/test/preflight/... \
-    -- --parallel=8 --tags=integration -v -timeout=60m $test_opts | tee "$test_log"
+    -- --parallel=4 --tags=integration -v -timeout=60m $test_opts | tee "$test_log"
 test_status=$?
 
 set -e

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -47,7 +47,7 @@ gotesplit \
     -total "$total" \
     -index "$index" \
     github.com/superfly/flyctl/test/preflight/... \
-    -- --parallel=4 --tags=integration -v -timeout=60m $test_opts | tee "$test_log"
+    -- --parallel=4 --tags=integration -v -timeout=10m $test_opts | tee "$test_log"
 test_status=$?
 
 set -e

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -530,14 +530,14 @@ func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
 	require.Equal(f, "machines", platformVersion)
 
 	machines := f.MachinesList(appName)
-	require.Equal(f, 10, len(machines))
+	require.Equal(f, 4, len(machines))
 
 	for _, machine := range machines {
 		services := machine.Config.Services
 		require.Equal(f, 1, len(services))
 
 		service := services[0]
-		require.Equal(f, *service.MinMachinesRunning, 3)
+		require.Equal(f, *service.MinMachinesRunning, 2)
 	}
 
 	result = f.Fly("config show -a %s", appName)

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -27,6 +27,7 @@ func TestAppsV2Example(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	t.Parallel()
 
 	var (
 		err    error
@@ -120,6 +121,8 @@ ENV BUILT_BY_DOCKERFILE=true
 }
 
 func TestAppsV2ConfigChanges(t *testing.T) {
+	t.Parallel()
+
 	var (
 		err            error
 		f              = testlib.NewTestEnvFromEnv(t)
@@ -159,6 +162,8 @@ func TestAppsV2ConfigChanges(t *testing.T) {
 }
 
 func TestAppsV2ConfigSave_ProcessGroups(t *testing.T) {
+	t.Parallel()
+
 	var (
 		err            error
 		f              = testlib.NewTestEnvFromEnv(t)
@@ -208,6 +213,8 @@ func TestAppsV2ConfigSave_OneMachineNoAppConfig(t *testing.T) {
 }
 
 func TestAppsV2Config_ParseExperimental(t *testing.T) {
+	t.Parallel()
+
 	var (
 		err            error
 		f              = testlib.NewTestEnvFromEnv(t)
@@ -232,6 +239,8 @@ func TestAppsV2Config_ParseExperimental(t *testing.T) {
 }
 
 func TestAppsV2Config_ProcessGroups(t *testing.T) {
+	t.Parallel()
+
 	var (
 		f              = testlib.NewTestEnvFromEnv(t)
 		appName        = f.CreateRandomAppMachines()
@@ -423,6 +432,8 @@ web = "nginx -g 'daemon off;'"
 }
 
 func TestAppsV2MigrateToV2(t *testing.T) {
+	t.Parallel()
+
 	var (
 		err     error
 		f       = testlib.NewTestEnvFromEnv(t)
@@ -444,6 +455,8 @@ func TestAppsV2MigrateToV2(t *testing.T) {
 
 // This test takes forever. I'm sorry.
 func TestAppsV2MigrateToV2_Volumes(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.Skip()
 	}
@@ -510,6 +523,8 @@ primary_region = "%s"
 
 // this test is really slow :(
 func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
+	t.Parallel()
+
 	var (
 		err     error
 		f       = testlib.NewTestEnvFromEnv(t)
@@ -549,6 +564,8 @@ func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
 }
 
 func TestNoPublicIPDeployMachines(t *testing.T) {
+	t.Parallel()
+
 	var (
 		result *testlib.FlyctlResult
 
@@ -563,6 +580,8 @@ func TestNoPublicIPDeployMachines(t *testing.T) {
 }
 
 func TestLaunchCpusMem(t *testing.T) {
+	t.Parallel()
+
 	var (
 		f       = testlib.NewTestEnvFromEnv(t)
 		appName = f.CreateRandomAppName()

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -517,7 +517,7 @@ func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
 	)
 	f.Fly("launch --org %s --name %s --region %s --now --internal-port 80 --force-nomad --image nginx", f.OrgSlug(), appName, f.PrimaryRegion())
 	time.Sleep(3 * time.Second)
-	f.Fly("autoscale set min=3 max=10")
+	f.Fly("autoscale set min=2 max=4")
 	f.Fly("migrate-to-v2 --primary-region %s --yes", f.PrimaryRegion())
 	result := f.Fly("status --json")
 

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -557,7 +557,7 @@ func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
 
 	result = f.Fly("config show -a %s", appName)
 
-	require.Contains(f, result.StdOut().String(), `"min_machines_running": 3,`)
+	require.Contains(f, result.StdOut().String(), `"min_machines_running": 2,`)
 	require.Contains(f, result.StdOut().String(), `"auto_start_machines": true,`)
 	require.Contains(f, result.StdOut().String(), `"auto_stop_machines": true,`)
 

--- a/test/preflight/fly_deploy_test.go
+++ b/test/preflight/fly_deploy_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestFlyDeployHA(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -39,6 +41,8 @@ func TestFlyDeployHA(t *testing.T) {
 }
 
 func TestFlyDeploy_DeployToken_Simple(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 	f.Fly("launch --org %s --name %s --region %s --image nginx --internal-port 80 --force-machines --ha=false", f.OrgSlug(), appName, f.PrimaryRegion())
@@ -47,6 +51,8 @@ func TestFlyDeploy_DeployToken_Simple(t *testing.T) {
 }
 
 func TestFlyDeploy_DeployToken_FailingSmokeCheck(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 	f.Fly("launch --org %s --name %s --region %s --image nginx --internal-port 80 --force-machines --ha=false", f.OrgSlug(), appName, f.PrimaryRegion())
@@ -64,6 +70,8 @@ func TestFlyDeploy_DeployToken_FailingSmokeCheck(t *testing.T) {
 }
 
 func TestFlyDeploy_DeployToken_FailingReleaseCommand(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 	f.Fly("launch --org %s --name %s --region %s --image nginx --internal-port 80 --force-machines --ha=false", f.OrgSlug(), appName, f.PrimaryRegion())
@@ -81,6 +89,8 @@ func TestFlyDeploy_DeployToken_FailingReleaseCommand(t *testing.T) {
 }
 
 func TestFlyDeploy_Dockerfile(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 	f.WriteFile("Dockerfile", `FROM nginx

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -28,6 +28,8 @@ import (
 // - Primary region found in imported fly.toml must be reused if set and no --region is passed
 // - As we are reusing an existing app, the --org param is not needed after the first call
 func TestFlyLaunchV2(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -68,6 +70,8 @@ func TestFlyLaunchV2(t *testing.T) {
 
 // Same as case01 but for Nomad apps
 func TestFlyLaunchV1(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -123,6 +127,8 @@ func TestFlyLaunchV1(t *testing.T) {
 
 // Run fly launch from a template Fly App directory (fly.toml without app name)
 func TestFlyLaunchWithTOML(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -159,6 +165,8 @@ func TestFlyLaunchWithTOML(t *testing.T) {
 
 // Trying to import an invalid fly.toml should fail before creating the app
 func TestFlyLaunchWithInvalidTOML(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -177,6 +185,8 @@ app = "foo"
 // Fail if the existing app doesn't match the forced platform version
 // V2 app forced as V1
 func TestFlyLaunchForceV1(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 
 	appName := f.CreateRandomAppName()
@@ -187,6 +197,8 @@ func TestFlyLaunchForceV1(t *testing.T) {
 
 // test --generate-name, --name and reuse imported name
 func TestFlyLaunchReuseName(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 
 	// V2 app forced as V1
@@ -218,6 +230,8 @@ primary_region = "%s"
 
 // test volumes are created on first launch
 func TestFlyLaunchWithVolumes(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -246,6 +260,8 @@ func TestFlyLaunchWithVolumes(t *testing.T) {
 
 // test --vm-size sets the machine guest on first deploy
 func TestFlyLaunchWithSize(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -261,6 +277,8 @@ func TestFlyLaunchWithSize(t *testing.T) {
 
 // test default HA setup
 func TestFlyLaunchHA(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -304,11 +322,13 @@ func TestFlyLaunchHA(t *testing.T) {
 	require.Equal(f, 1, len(groups["disk"]))
 
 	isStandby := func(m *api.Machine) bool { return len(m.Config.Standbys) > 0 }
+
 	require.Equal(f, 0, lo.CountBy(groups["app"], isStandby))
 	require.Equal(f, 1, lo.CountBy(groups["task"], isStandby))
 	require.Equal(f, 0, lo.CountBy(groups["disk"], isStandby))
 
 	hasServices := func(m *api.Machine) bool { return len(m.Config.Services) > 0 }
+
 	require.Equal(f, 2, lo.CountBy(groups["app"], hasServices))
 	require.Equal(f, 0, lo.CountBy(groups["task"], hasServices))
 	require.Equal(f, 0, lo.CountBy(groups["disk"], hasServices))
@@ -316,6 +336,8 @@ func TestFlyLaunchHA(t *testing.T) {
 
 // test first deploy with single mount for multiple processes
 func TestFlyLaunchSigleMount(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 

--- a/test/preflight/fly_machine_test.go
+++ b/test/preflight/fly_machine_test.go
@@ -14,6 +14,8 @@ import (
 
 // test --port and --autostart --autostop flags
 func TestFlyMachineRun_autoStartStop(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
 
@@ -67,6 +69,8 @@ func TestFlyMachineRun_autoStartStop(t *testing.T) {
 
 // test --standby-for
 func TestFlyMachineRun_standbyFor(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
 
@@ -129,6 +133,8 @@ func TestFlyMachineRun_standbyFor(t *testing.T) {
 
 // test --port (add, update, remove services and ports)
 func TestFlyMachineRun_port(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
 

--- a/test/preflight/fly_postgres_test.go
+++ b/test/preflight/fly_postgres_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestPostgres_singleNode(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -25,6 +27,8 @@ func TestPostgres_singleNode(t *testing.T) {
 }
 
 func TestPostgres_autostart(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -52,6 +56,8 @@ func TestPostgres_autostart(t *testing.T) {
 }
 
 func TestPostgres_FlexFailover(t *testing.T) {
+	t.Parallel()
+
 	if testing.Short() {
 		t.Skip()
 	}
@@ -83,6 +89,8 @@ func TestPostgres_FlexFailover(t *testing.T) {
 }
 
 func TestPostgres_NoMachines(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -97,6 +105,8 @@ func TestPostgres_NoMachines(t *testing.T) {
 }
 
 func TestPostgres_haConfigSave(t *testing.T) {
+	t.Parallel()
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 

--- a/test/preflight/testlib/test_env.go
+++ b/test/preflight/testlib/test_env.go
@@ -177,7 +177,6 @@ func (f *FlyctlTestEnv) FlyContextAndConfig(ctx context.Context, cfg FlyCmdConfi
 		stdErr:        stdErr,
 	}
 	cmd := exec.CommandContext(ctx, f.flyctlBin, res.args...)
-	fmt.Printf("CMD: %s\n", res.args)
 
 	var env []string
 


### PR DESCRIPTION
### Change Summary
Preflight tests should now run faster, making our CI as a whole go faster.

One issue with this PR is that running at higher parallelism levels locally (`go test --parallel=16`), tests will fail for reasons I can't quite decipher. (They also fail running `make preflight` on master, so I think this is an issue with my setup).

What and Why:
Eventually, preflight tests passing should be a requirement for new fly releases, to help avoid regressions.

How:
This PR adds more Github workers, as well as making some changes to tests so they can be run in parallel.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
