### PR TITLE
Fixes for `fly doctor` DNS records check

### DIFF
--- a/internal/command/doctor/app_checks.go
+++ b/internal/command/doctor/app_checks.go
@@ -144,11 +144,11 @@ func (ac *AppChecker) checkDnsRecords(ipAddresses []api.IPAddress) {
 		case "private_v6":
 			// This is a valid type, but not of interest here.
 		default:
-			ac.lprint(nil, "Ip address %s has unexpected type '%s'. Please file a bug with this message at https://github.com/superfly/flyctl/issues/new?assignees=&labels=bug&template=flyctl-bug-report.md&title=", ip.Address, ip.Type)
+			ac.lprint(nil, "Ip address %s has unexpected type '%s'. Please file a bug with this message at https://github.com/superfly/flyctl/issues/new?assignees=&labels=bug&template=flyctl-bug-report.md&title=\n", ip.Address, ip.Type)
 		}
 	}
 	if len(v4s) == 0 && len(v6s) == 0 {
-		ac.lprint(nil, "No public ipv4 or ipv6 ip addresses allocated to app %s", ac.app.Name)
+		ac.lprint(nil, "No public ipv4 or ipv6 ip addresses allocated to app %s\n", ac.app.Name)
 		return
 	}
 

--- a/internal/command/doctor/app_checks.go
+++ b/internal/command/doctor/app_checks.go
@@ -141,12 +141,14 @@ func (ac *AppChecker) checkDnsRecords(ipAddresses []api.IPAddress) {
 			v4s[ip.Address] = true
 		case "v6":
 			v6s[ip.Address] = true
+		case "private_v6":
+			// This is a valid type, but not of interest here.
 		default:
 			ac.lprint(nil, "Ip address %s has unexpected type '%s'. Please file a bug with this message at https://github.com/superfly/flyctl/issues/new?assignees=&labels=bug&template=flyctl-bug-report.md&title=", ip.Address, ip.Type)
 		}
 	}
 	if len(v4s) == 0 && len(v6s) == 0 {
-		ac.lprint(nil, "No ipv4 or ipv6 ip addresses allocated to app %s", ac.app.Name)
+		ac.lprint(nil, "No public ipv4 or ipv6 ip addresses allocated to app %s", ac.app.Name)
 		return
 	}
 

--- a/internal/command/doctor/app_checks.go
+++ b/internal/command/doctor/app_checks.go
@@ -137,8 +137,7 @@ func (ac *AppChecker) checkDnsRecords(ipAddresses []api.IPAddress) {
 	v6s := make(map[string]bool)
 	for _, ip := range ipAddresses {
 		switch ip.Type {
-		case "v4":
-		case "shared_v4":
+		case "v4", "shared_v4":
 			v4s[ip.Address] = true
 		case "v6":
 			v6s[ip.Address] = true


### PR DESCRIPTION
Fixes #2559 and two other tiny things I found while looking at it.

* Don't ignore dedicated IPv4 addresses. (Just looks like a mistake—Go `case`s don't fall through.)
* Recognize and ignore `private_v6` addresses, instead of printing a warning asking for a bug report.
* Add missing newlines to the output.