### PR TITLE
Don't change volume name on app migration

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -968,7 +968,7 @@ func (m *v2PlatformMigrator) ConfirmChanges(ctx context.Context) (bool, error) {
 	}
 	if m.usesForkedVolumes {
 		fmt.Fprintf(m.io.Out, " * Create clones of each volume in use, for the new machines\n")
-		fmt.Fprintf(m.io.Out, "   * These cloned volumes will have the suffix '%s' appended to their names\n", forkedVolSuffix)
+		fmt.Fprintf(m.io.Out, "   * These cloned volumes will have the same name but different id\n")
 		fmt.Fprintf(m.io.Out, "   * Please note that your old volumes will not be removed.\n")
 		fmt.Fprintf(m.io.Out, "     (you can do this manually, after making sure the migration was a success)\n")
 	}

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -219,7 +219,7 @@ type v2PlatformMigrator struct {
 	recovery             recoveryState
 	usesForkedVolumes    bool
 	createdVolumes       []*NewVolume
-	replacedVolumes      map[string]int
+	replacedVolumes      map[string][]string
 	isPostgres           bool
 	pgConsulUrl          string
 	targetImg            string
@@ -325,7 +325,7 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 		oldAllocs:               allocs,
 		machineGuests:           machineGuests,
 		isPostgres:              appCompact.IsPostgresApp(),
-		replacedVolumes:         map[string]int{},
+		replacedVolumes:         map[string][]string{},
 		verbose:                 flag.GetBool(ctx, "verbose"),
 		recovery: recoveryState{
 			platformVersion: appFull.PlatformVersion,

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -96,9 +96,8 @@ func newMigrateToV2() *cobra.Command {
 		},
 		flag.Bool{
 			Name:        "remote-fork",
-			Description: "Enables experimental cross-host volume forking",
+			Description: "PLACEHOLDER - this is the default now",
 			Hidden:      true,
-			Default:     false,
 		},
 	)
 
@@ -219,7 +218,6 @@ type v2PlatformMigrator struct {
 	newMachines          machine.MachineSet
 	recovery             recoveryState
 	usesForkedVolumes    bool
-	usesRemoteVolumeFork bool
 	createdVolumes       []*NewVolume
 	replacedVolumes      map[string]int
 	isPostgres           bool
@@ -332,10 +330,9 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 		recovery: recoveryState{
 			platformVersion: appFull.PlatformVersion,
 		},
-		backupMachines:       map[string]int{},
-		machineWaitTimeout:   flag.GetDuration(ctx, "wait-timeout"),
-		skipHealthChecks:     flag.GetBool(ctx, "skip-health-checks"),
-		usesRemoteVolumeFork: flag.GetBool(ctx, "remote-fork"),
+		backupMachines:     map[string]int{},
+		machineWaitTimeout: flag.GetDuration(ctx, "wait-timeout"),
+		skipHealthChecks:   flag.GetBool(ctx, "skip-health-checks"),
 	}
 	if migrator.isPostgres {
 		consul, err := apiClient.EnablePostgresConsul(ctx, appCompact.Name)

--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -58,7 +58,6 @@ func (m *v2PlatformMigrator) validateVolumes(ctx context.Context) error {
 
 func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 	m.appConfig.SetMounts(lo.Map(m.appConfig.Mounts, func(v appconfig.Mount, _ int) appconfig.Mount {
-		v.Source = nomadVolNameToV2VolName(v.Source)
 		if len(v.Processes) == 0 {
 			v.Processes = m.appConfig.ProcessNames()
 		}
@@ -70,9 +69,9 @@ func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 			AppID:          m.appFull.ID,
 			SourceVolumeID: vol.ID,
 			MachinesOnly:   true,
-			Name:           nomadVolNameToV2VolName(vol.Name),
+			Remote:         true,
+			Name:           vol.Name,
 			LockID:         m.appLock,
-			Remote:         m.usesRemoteVolumeFork,
 		})
 		if err != nil && strings.HasSuffix(err.Error(), " is not a valid candidate") {
 			return fmt.Errorf("unfortunately the worker hosting your volume %s (%s) does not have capacity for another volume to support the migration; some other options: 1) try again later and there might be more space on the worker, 2) run a manual migration https://community.fly.io/t/manual-migration-to-apps-v2/11870, or 3) wait until we support volume migrations across workers (we're working on it!)", vol.ID, vol.Name)
@@ -112,13 +111,8 @@ func (m *v2PlatformMigrator) nomadVolPath(v *api.Volume, group string) string {
 	if v.AttachedAllocation == nil {
 		return ""
 	}
-
-	// The config has already been patched to use the v2 volume names,
-	// so we have to account for that here
-	name := nomadVolNameToV2VolName(v.Name)
-
 	for _, mount := range m.appConfig.Mounts {
-		if mount.Source == name && lo.Contains(mount.Processes, group) {
+		if mount.Source == v.Name && lo.Contains(mount.Processes, group) {
 			return mount.Destination
 		}
 	}
@@ -149,10 +143,6 @@ func (m *v2PlatformMigrator) printReplacedVolumes() {
 	for _, name := range keys {
 		num := m.replacedVolumes[name]
 		s := lo.Ternary(num == 1, "", "s")
-		fmt.Fprintf(m.io.Out, " * %d volume%s named '%s' [replaced by '%s']\n", num, s, name, nomadVolNameToV2VolName(name))
+		fmt.Fprintf(m.io.Out, " * %d volume%s named '%s'\n", num, s, name)
 	}
-}
-
-func nomadVolNameToV2VolName(name string) string {
-	return name + forkedVolSuffix
 }

--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -102,7 +102,7 @@ func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 			previousAllocId: allocId,
 			mountPoint:      path,
 		})
-		m.replacedVolumes[vol.Name]++
+		m.replacedVolumes[vol.Name] = append(m.replacedVolumes[vol.Name], vol.ID)
 	}
 	return nil
 }
@@ -141,8 +141,9 @@ func (m *v2PlatformMigrator) printReplacedVolumes() {
 	keys := lo.Keys(m.replacedVolumes)
 	slices.Sort(keys)
 	for _, name := range keys {
-		num := m.replacedVolumes[name]
+		volIds := m.replacedVolumes[name]
+		num := len(volIds)
 		s := lo.Ternary(num == 1, "", "s")
-		fmt.Fprintf(m.io.Out, " * %d volume%s named '%s'\n", num, s, name)
+		fmt.Fprintf(m.io.Out, " * %d volume%s named '%s' with ids: %v\n", num, s, name, volIds)
 	}
 }

--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -137,7 +137,7 @@ func (m *v2PlatformMigrator) printReplacedVolumes() {
 	if len(m.replacedVolumes) == 0 {
 		return
 	}
-	fmt.Fprintf(m.io.Out, "The following volumes have been migrated to new volumes, and are no longer needed:\n")
+	fmt.Fprintf(m.io.Out, "The following volumes have been migrated to new volumes, and are no longer needed, remove them once you are sure your data is safe to prevent extra costs\n")
 	keys := lo.Keys(m.replacedVolumes)
 	slices.Sort(keys)
 	for _, name := range keys {

--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -11,10 +11,6 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-const (
-	forkedVolSuffix = "_machines"
-)
-
 func (m *v2PlatformMigrator) validateVolumes(ctx context.Context) error {
 	if m.isPostgres {
 		return nil

--- a/internal/command/volumes/fork.go
+++ b/internal/command/volumes/fork.go
@@ -46,6 +46,12 @@ but is currently restricted to same-host forks and may not be available for near
 			Hidden:      true,
 			Default:     false,
 		},
+		flag.Bool{
+			Name:        "machines-only",
+			Description: "volume will be visible to machines platform only",
+			Hidden:      true,
+			Default:     false,
+		},
 	)
 
 	flag.Add(cmd, flag.JSONOutput())
@@ -79,11 +85,16 @@ func runFork(ctx context.Context) error {
 		name = flag.GetString(ctx, "name")
 	}
 
+	machinesOnly := (app.PlatformVersion == "machines")
+	if flag.IsSpecified(ctx, "machines-only") {
+		machinesOnly = flag.GetBool(ctx, "machines-only")
+	}
+
 	input := api.ForkVolumeInput{
 		AppID:          app.ID,
 		SourceVolumeID: vol.ID,
 		Name:           name,
-		MachinesOnly:   app.PlatformVersion == "machines",
+		MachinesOnly:   machinesOnly,
 		Remote:         flag.GetBool(ctx, "remote-fork"),
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why:

For projects that deploys the same codebase to different fly apps (prod, staging, ..) migrating one at a time is cumbersome because mounts sections of fly.toml are not backward compatible. 

and be honest, the `_machines` suffix doesn't look good on people's volume 👅 and once migrated it is hard to revert to the nonprefixed version. 

How:

Ensure forked volumes are picked up by machines platform only.
This also uses remote volume forking by default, which is much more stable and likely to work than local forks. 

Also improve messaging displaying ids for the volumes that can be removed once the migration is done.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
