### PR TITLE
Support tls checks cert verification

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -366,6 +366,7 @@ type MachineCheck struct {
 	HTTPPath          *string             `json:"path,omitempty"`
 	HTTPProtocol      *string             `json:"protocol,omitempty"`
 	HTTPSkipTLSVerify *bool               `json:"tls_skip_verify,omitempty"`
+	HTTPTLSServerName *string             `json:"tls_server_name,omitempty"`
 	HTTPHeaders       []MachineHTTPHeader `json:"headers,omitempty"`
 }
 

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -224,6 +224,7 @@ func TestToDefinition(t *testing.T) {
 					"path":            "/",
 					"protocol":        "https",
 					"tls_skip_verify": true,
+					"tls_server_name": "sni2.com",
 					"headers": map[string]any{
 						"My-Custom-Header": "whatever",
 					},
@@ -297,6 +298,7 @@ func TestToDefinition(t *testing.T) {
 				"path":            "/status",
 				"protocol":        "https",
 				"tls_skip_verify": true,
+				"tls_server_name": "sni3.com",
 				"headers": map[string]any{
 					"Content-Type":  "application/json",
 					"Authorization": "super-duper-secret",
@@ -340,6 +342,7 @@ func TestToDefinition(t *testing.T) {
 						"path":            "/",
 						"protocol":        "https",
 						"tls_skip_verify": true,
+						"tls_server_name": "sni.com",
 						"headers": map[string]any{
 							"My-Custom-Header": "whatever",
 						},

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -496,6 +496,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 					HTTPPath:          api.Pointer("/"),
 					HTTPProtocol:      api.Pointer("https"),
 					HTTPTLSSkipVerify: api.Pointer(true),
+					HTTPTLSServerName: api.Pointer("sni2.com"),
 					HTTPHeaders: map[string]string{
 						"My-Custom-Header": "whatever",
 					},
@@ -547,6 +548,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 				HTTPPath:          api.Pointer("/status"),
 				HTTPProtocol:      api.Pointer("https"),
 				HTTPTLSSkipVerify: api.Pointer(true),
+				HTTPTLSServerName: api.Pointer("sni3.com"),
 				HTTPHeaders: map[string]string{
 					"Content-Type":  "application/json",
 					"Authorization": "super-duper-secret",
@@ -595,6 +597,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 						HTTPPath:          api.Pointer("/"),
 						HTTPProtocol:      api.Pointer("https"),
 						HTTPTLSSkipVerify: api.Pointer(true),
+						HTTPTLSServerName: api.Pointer("sni.com"),
 						HTTPHeaders: map[string]string{
 							"My-Custom-Header": "whatever",
 						},

--- a/internal/appconfig/service.go
+++ b/internal/appconfig/service.go
@@ -43,6 +43,7 @@ type ServiceHTTPCheck struct {
 	HTTPPath          *string           `json:"path,omitempty" toml:"path,omitempty"`
 	HTTPProtocol      *string           `json:"protocol,omitempty" toml:"protocol,omitempty"`
 	HTTPTLSSkipVerify *bool             `json:"tls_skip_verify,omitempty" toml:"tls_skip_verify,omitempty"`
+	HTTPTLSServerName *string           `json:"tls_server_name,omitempty" toml:"tls_server_name,omitempty"`
 	HTTPHeaders       map[string]string `json:"headers,omitempty" toml:"headers,omitempty"`
 }
 
@@ -125,6 +126,7 @@ func (chk *ServiceHTTPCheck) toMachineCheck() *api.MachineCheck {
 		HTTPPath:          chk.HTTPPath,
 		HTTPProtocol:      chk.HTTPProtocol,
 		HTTPSkipTLSVerify: chk.HTTPTLSSkipVerify,
+		HTTPTLSServerName: chk.HTTPTLSServerName,
 		HTTPHeaders: lo.MapToSlice(
 			chk.HTTPHeaders, func(k string, v string) api.MachineHTTPHeader {
 				return api.MachineHTTPHeader{Name: k, Values: []string{v}}
@@ -206,6 +208,7 @@ func httpCheckFromMachineCheck(mc api.MachineCheck) *ServiceHTTPCheck {
 		HTTPPath:          mc.HTTPPath,
 		HTTPProtocol:      mc.HTTPProtocol,
 		HTTPTLSSkipVerify: mc.HTTPSkipTLSVerify,
+		HTTPTLSServerName: mc.HTTPTLSServerName,
 		HTTPHeaders:       headers,
 	}
 }

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -55,6 +55,7 @@ console_command = "/bin/bash"
     path = "/"
     protocol = "https"
     tls_skip_verify = true
+    tls_server_name = "sni2.com"
     [http_service.checks.headers]
       My-Custom-Header = "whatever"
 
@@ -115,6 +116,7 @@ console_command = "/bin/bash"
   path = "/status"
   protocol = "https"
   tls_skip_verify = true
+  tls_server_name = "sni3.com"
   [checks.status.headers]
     Content-Type = "application/json"
     Authorization = "super-duper-secret"
@@ -151,6 +153,7 @@ console_command = "/bin/bash"
     path = "/"
     protocol = "https"
     tls_skip_verify = true
+    tls_server_name = "sni.com"
     [services.http_checks.headers]
       My-Custom-Header = "whatever"
 

--- a/internal/appconfig/toplevelcheck.go
+++ b/internal/appconfig/toplevelcheck.go
@@ -20,6 +20,7 @@ type ToplevelCheck struct {
 	HTTPPath          *string           `json:"path,omitempty" toml:"path,omitempty"`
 	HTTPProtocol      *string           `json:"protocol,omitempty" toml:"protocol,omitempty"`
 	HTTPTLSSkipVerify *bool             `json:"tls_skip_verify,omitempty" toml:"tls_skip_verify,omitempty"`
+	HTTPTLSServerName *string           `json:"tls_server_name,omitempty" toml:"tls_server_name,omitempty"`
 	HTTPHeaders       map[string]string `json:"headers,omitempty" toml:"headers,omitempty"`
 	Processes         []string          `json:"processes,omitempty" toml:"processes,omitempty"`
 }
@@ -44,6 +45,7 @@ func topLevelCheckFromMachineCheck(mc api.MachineCheck) *ToplevelCheck {
 		HTTPPath:          mc.HTTPPath,
 		HTTPProtocol:      mc.HTTPProtocol,
 		HTTPTLSSkipVerify: mc.HTTPSkipTLSVerify,
+		HTTPTLSServerName: mc.HTTPTLSServerName,
 		HTTPHeaders:       headers,
 	}
 }
@@ -62,6 +64,7 @@ func (chk *ToplevelCheck) toMachineCheck() (*api.MachineCheck, error) {
 		HTTPPath:          chk.HTTPPath,
 		HTTPProtocol:      chk.HTTPProtocol,
 		HTTPSkipTLSVerify: chk.HTTPTLSSkipVerify,
+		HTTPTLSServerName: chk.HTTPTLSServerName,
 	}
 	if chk.HTTPMethod != nil {
 		res.HTTPMethod = api.Pointer(strings.ToUpper(*chk.HTTPMethod))


### PR DESCRIPTION
### Change Summary

What and Why:

At the moment it is not possible to verify the TLS certificates provided by https services served directly from user's apps. 
The http checks are performed using the ipv4 address of the machine leading to errors like:

```
x509: cannot validate certificate for 172.19.187.18 because it doesn't contain any IP SANs
```

the only option at the moment is to skip cert verification by setting `tls_skip_verify = true` but this is not good enough for people that would like to validate their certs as part of the check. 

How:

Adds tls_server_name check field that is going to be used as SNI for cert verification.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
