### PR TITLE
Add `app delete/remove/rm` as an alias for `app destroy`.

### DIFF
--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -35,6 +35,7 @@ from the Fly platform.
 
 	destroy.ValidArgsFunction = completion.Adapt(completion.CompleteApps)
 
+	destroy.Aliases = []string{"rm"}
 	return destroy
 }
 

--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -35,7 +35,7 @@ from the Fly platform.
 
 	destroy.ValidArgsFunction = completion.Adapt(completion.CompleteApps)
 
-	destroy.Aliases = []string{"rm"}
+	destroy.Aliases = []string{"delete", "remove", "rm"}
 	return destroy
 }
 


### PR DESCRIPTION
### Change Summary

Add `fly apps delete/remove/rm` as aliases for `fly apps destroy`.

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
