### PR TITLE
autoupdate: be proactive against update loops

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -346,6 +346,7 @@ func promptAndAutoUpdate(ctx context.Context) (context.Context, error) {
 	cfg := config.FromContext(ctx)
 	if shouldIgnore(ctx, [][]string{
 		{"version", "upgrade"},
+		{"settings", "autoupdate"},
 	}) {
 		return ctx, nil
 	}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -356,7 +356,7 @@ func Relaunch(ctx context.Context, silent bool) error {
 
 	// Wait a bit for the update to take effect.
 	// Windows seemed to need this for whatever reason.
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(400 * time.Millisecond)
 
 	binPath, err := GetCurrentBinaryPath()
 	if err != nil {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -309,6 +309,8 @@ func Relaunch(ctx context.Context, silent bool) error {
 	cmd.Stdout = io.Out
 	cmd.Stderr = io.ErrOut
 	cmd.Stdin = io.In
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, "FLY_NO_UPDATE_CHECK=1")
 
 	if err := cmd.Start(); err != nil {
 		return err


### PR DESCRIPTION
### Change Summary

What and Why: Three things:
1. blocks autoupdate checking for `fly settings autoupdate` for obvious reasons.
2. Sets the `FLY_NO_UPDATE_CHECK` environment variable when autoupdate relaunches flyctl, to make it impossible for an update loop to occur
3. Attempts to use the binary `$(brew prefix)/bin/flyctl` if we were running in homebrew before, because homebrew does strange things with symlinks that *might* be making updates inconsistent. When not under homebrew, we do what we did before: `realpath(argv[0])`
4. wait a little longer after updates before re-running. let fs operations settle down and everything before expecting flyctl to be fully updated.

Related to: this person's unfortunate error https://community.fly.io/t/flyctl-versions-autoupdating-and-the-cli-apocalypse/13794/3?u=allison

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
