### PR TITLE
Remove restart_limit from app v2 configuration 

### DIFF
--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -100,10 +100,9 @@ func TestFromDefinition(t *testing.T) {
 				Processes: []string{"app"},
 				TCPChecks: []*ServiceTCPCheck{
 					{
-						Timeout:      api.MustParseDuration("2s"),
-						RestartLimit: 0,
-						Interval:     api.MustParseDuration("15s"),
-						GracePeriod:  api.MustParseDuration("1s"),
+						Timeout:     api.MustParseDuration("2s"),
+						Interval:    api.MustParseDuration("15s"),
+						GracePeriod: api.MustParseDuration("1s"),
 					},
 				},
 			},
@@ -219,7 +218,6 @@ func TestToDefinition(t *testing.T) {
 					"interval":        "1m21s",
 					"timeout":         "7s",
 					"grace_period":    "2s",
-					"restart_limit":   int64(4),
 					"method":          "GET",
 					"path":            "/",
 					"protocol":        "https",
@@ -326,10 +324,9 @@ func TestToDefinition(t *testing.T) {
 				},
 				"tcp_checks": []map[string]any{
 					{
-						"interval":      "21s",
-						"timeout":       "4s",
-						"grace_period":  "1s",
-						"restart_limit": int64(3),
+						"interval":     "21s",
+						"timeout":      "4s",
+						"grace_period": "1s",
 					},
 				},
 				"http_checks": []map[string]any{
@@ -337,7 +334,6 @@ func TestToDefinition(t *testing.T) {
 						"interval":        "1m21s",
 						"timeout":         "7s",
 						"grace_period":    "2s",
-						"restart_limit":   int64(4),
 						"method":          "GET",
 						"path":            "/",
 						"protocol":        "https",

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -491,7 +491,6 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 					Interval:          api.MustParseDuration("81s"),
 					Timeout:           api.MustParseDuration("7s"),
 					GracePeriod:       api.MustParseDuration("2s"),
-					RestartLimit:      4,
 					HTTPMethod:        api.Pointer("GET"),
 					HTTPPath:          api.Pointer("/"),
 					HTTPProtocol:      api.Pointer("https"),
@@ -580,10 +579,9 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 
 				TCPChecks: []*ServiceTCPCheck{
 					{
-						Interval:     api.MustParseDuration("21s"),
-						Timeout:      api.MustParseDuration("4s"),
-						GracePeriod:  api.MustParseDuration("1s"),
-						RestartLimit: 3,
+						Interval:    api.MustParseDuration("21s"),
+						Timeout:     api.MustParseDuration("4s"),
+						GracePeriod: api.MustParseDuration("1s"),
 					},
 				},
 
@@ -592,7 +590,6 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 						Interval:          api.MustParseDuration("81s"),
 						Timeout:           api.MustParseDuration("7s"),
 						GracePeriod:       api.MustParseDuration("2s"),
-						RestartLimit:      4,
 						HTTPMethod:        api.Pointer("GET"),
 						HTTPPath:          api.Pointer("/"),
 						HTTPProtocol:      api.Pointer("https"),

--- a/internal/appconfig/service.go
+++ b/internal/appconfig/service.go
@@ -27,16 +27,12 @@ type ServiceTCPCheck struct {
 	Interval    *api.Duration `json:"interval,omitempty" toml:"interval,omitempty"`
 	Timeout     *api.Duration `json:"timeout,omitempty" toml:"timeout,omitempty"`
 	GracePeriod *api.Duration `toml:"grace_period,omitempty" json:"grace_period,omitempty"`
-	// RestartLimit is only supported on V1 Apps
-	RestartLimit int `toml:"restart_limit,omitempty" json:"restart_limit,omitempty"`
 }
 
 type ServiceHTTPCheck struct {
 	Interval    *api.Duration `json:"interval,omitempty" toml:"interval,omitempty"`
 	Timeout     *api.Duration `json:"timeout,omitempty" toml:"timeout,omitempty"`
 	GracePeriod *api.Duration `toml:"grace_period,omitempty" json:"grace_period,omitempty"`
-	// RestartLimit is only supported on V1 Apps
-	RestartLimit int `toml:"restart_limit,omitempty" json:"restart_limit,omitempty"`
 
 	// HTTP Specifics
 	HTTPMethod        *string           `json:"method,omitempty" toml:"method,omitempty"`
@@ -182,10 +178,9 @@ func serviceFromMachineService(ms api.MachineService, processes []string) *Servi
 
 func tcpCheckFromMachineCheck(mc api.MachineCheck) *ServiceTCPCheck {
 	return &ServiceTCPCheck{
-		Interval:     mc.Interval,
-		Timeout:      mc.Timeout,
-		GracePeriod:  nil,
-		RestartLimit: 0,
+		Interval:    mc.Interval,
+		Timeout:     mc.Timeout,
+		GracePeriod: nil,
 	}
 }
 
@@ -203,7 +198,6 @@ func httpCheckFromMachineCheck(mc api.MachineCheck) *ServiceHTTPCheck {
 		Interval:          mc.Interval,
 		Timeout:           mc.Timeout,
 		GracePeriod:       nil,
-		RestartLimit:      0,
 		HTTPMethod:        mc.HTTPMethod,
 		HTTPPath:          mc.HTTPPath,
 		HTTPProtocol:      mc.HTTPProtocol,

--- a/internal/appconfig/setters.go
+++ b/internal/appconfig/setters.go
@@ -62,7 +62,6 @@ func (c *Config) SetHttpCheck(path string, headers map[string]string) {
 			Interval:          &api.Duration{Duration: 10 * time.Second},
 			Timeout:           &api.Duration{Duration: 2 * time.Second},
 			GracePeriod:       &api.Duration{Duration: 5 * time.Second},
-			RestartLimit:      0,
 		})
 	}
 }

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -50,7 +50,6 @@ console_command = "/bin/bash"
     interval = "1m21s"
     timeout = "7s"
     grace_period = "2s"
-    restart_limit = 4
     method = "GET"
     path = "/"
     protocol = "https"
@@ -142,13 +141,11 @@ console_command = "/bin/bash"
     interval = "21s"
     timeout = "4s"
     grace_period = "1s"
-    restart_limit = 3
 
   [[services.http_checks]]
     interval = "1m21s"
     timeout = "7s"
     grace_period = "2s"
-    restart_limit = 4
     method = "GET"
     path = "/"
     protocol = "https"


### PR DESCRIPTION
### Change Summary

What and Why: We are dumping restart_limit into fly.tomls as it was something for v2 apps but this setting is ignored

How: Remove references to it but left V1 app support intact

Relates to: https://community.fly.io/t/http-health-checks-failing-but-not-restarting-app/4277

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
