### PR TITLE
tab completion: add descriptions

### DIFF
--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -58,6 +58,7 @@ func (client *Client) getAppsPage(ctx context.Context, orgID *string, role *stri
 					platformVersion
 					organization {
 						slug
+						name
 					}
 					currentRelease {
 						createdAt


### PR DESCRIPTION
### Change Summary

What and Why: add descriptions to tab completion for apps, regions, and orgs.

For apps, show org name and app status.
For regions, show full region name.
For orgs, show "full" name.

<img width="458" alt="image" src="https://github.com/superfly/flyctl/assets/13626644/b9f9fb84-ffca-490d-8461-3ce0b129c272">
<img width="501" alt="image" src="https://github.com/superfly/flyctl/assets/13626644/11802235-1117-494a-83ff-712cfc456e66">


---

### Documentation

- [X] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
