### PR TITLE
Fix various issues in Django scanner

### DIFF
--- a/scanner/django.go
+++ b/scanner/django.go
@@ -58,7 +58,7 @@ func configureDjango(sourceDir string, config *ScannerConfig) (*SourceInfo, erro
 			// We pin versions if they're beta or RC and, as such, don't have a
 			// minor version equivalent Docker tag.
 			pythonVersion = pythonFullVersion
-			s.Notice += fmt.Sprintf(`%s It looks like you have Python %s %s installed, which is not an official release. This version is being explicitly pinned in the generated Dockerfile, and should be changed to an official release before deploying to production.`, aurora.Yellow("[WARNING]"), pythonFullVersion, aurora.Yellow("[WARNING]"))
+			s.Notice += fmt.Sprintf(`%s It looks like you have Python %s installed, which is not an official release. This version is being explicitly pinned in the generated Dockerfile, and should be changed to an official release before deploying to production.`, aurora.Yellow("[WARNING]"), pythonFullVersion)
 		} else {
 			userVersion, userErr := semver.ParseTolerant(pythonFullVersion)
 			supportedVersion, supportedErr := semver.ParseTolerant(pythonLatestSupported)
@@ -233,7 +233,7 @@ func extractPythonVersion() (string, bool, error) {
 		}
 	}
 
-	re := regexp.MustCompile(`"Python ([0-9]+\.[0-9]+\.[0-9]+(?:[a-zA-Z]+[0-9]+)?)`)
+	re := regexp.MustCompile(`Python ([0-9]+\.[0-9]+\.[0-9]+(?:[a-zA-Z]+[0-9]+)?)`)
 	match := re.FindStringSubmatch(pythonVersionOutput)
 
 	if len(match) > 1 {

--- a/scanner/django.go
+++ b/scanner/django.go
@@ -186,12 +186,11 @@ Optionally, you can use django.core.management.utils.get_random_secret_key() to 
 		}
 	}
 
-	s.Files = templatesExecute("templates/django", vars)
-
 	// check if project has a postgres dependency
 	if checksPass(sourceDir, dirContains("requirements.txt", "psycopg")) ||
 		checksPass(sourceDir, dirContains("Pipfile", "psycopg")) ||
 		checksPass(sourceDir, dirContains("pyproject.toml", "psycopg")) {
+		vars["hasPostgres"] = true
 		s.ReleaseCmd = "python manage.py migrate"
 
 		if !checksPass(sourceDir, dirContains("requirements.txt", "django-environ", "dj-database-url")) {
@@ -210,6 +209,8 @@ For detailed documentation, see https://fly.dev/docs/django/
 		`
 		}
 	}
+
+	s.Files = templatesExecute("templates/django", vars)
 
 	return s, nil
 }

--- a/scanner/django.go
+++ b/scanner/django.go
@@ -73,7 +73,7 @@ func configureDjango(sourceDir string, config *ScannerConfig) (*SourceInfo, erro
 						pythonVersion = fmt.Sprintf("%d.%d", v.Major, v.Minor)
 					}
 					s.Notice += fmt.Sprintf(`
-%s Python %s was detected. 'python:%s-slim-buster' image will be set in the Dockerfile.
+%s Python %s was detected. 'python:%s-slim-bullseye' image will be set in the Dockerfile.
 `, aurora.Faint("[INFO]"), pythonFullVersion, pythonVersion)
 				} else {
 					s.Notice += fmt.Sprintf(`

--- a/scanner/templates/django/Dockerfile
+++ b/scanner/templates/django/Dockerfile
@@ -1,3 +1,6 @@
+{{ if .pinnedPythonVersion -}}
+# TODO: Change to an officially released version of Python before deploying to production.
+{{ end -}}
 ARG PYTHON_VERSION={{ .pythonVersion }}-slim-buster
 
 FROM python:${PYTHON_VERSION}

--- a/scanner/templates/django/Dockerfile
+++ b/scanner/templates/django/Dockerfile
@@ -8,6 +8,15 @@ FROM python:${PYTHON_VERSION}
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
+{{ if .hasPostgres -}}
+# install psycopg2 dependencies.
+RUN apt-get update && apt-get install -y \                                                                                                                                    
+    libpq-dev \                                                                                                                                                               
+    gcc \                                                                                                                                                                     
+    && rm -rf /var/lib/apt/lists/*                                                                                                                                            
+
+{{ end -}}
+
 RUN mkdir -p /code
 
 WORKDIR /code

--- a/scanner/templates/django/Dockerfile
+++ b/scanner/templates/django/Dockerfile
@@ -1,7 +1,7 @@
 {{ if .pinnedPythonVersion -}}
 # TODO: Change to an officially released version of Python before deploying to production.
 {{ end -}}
-ARG PYTHON_VERSION={{ .pythonVersion }}-slim-buster
+ARG PYTHON_VERSION={{ .pythonVersion }}-slim-bullseye
 
 FROM python:${PYTHON_VERSION}
 

--- a/scanner/templates/django/Dockerfile
+++ b/scanner/templates/django/Dockerfile
@@ -10,10 +10,10 @@ ENV PYTHONUNBUFFERED 1
 
 {{ if .hasPostgres -}}
 # install psycopg2 dependencies.
-RUN apt-get update && apt-get install -y \                                                                                                                                    
-    libpq-dev \                                                                                                                                                               
-    gcc \                                                                                                                                                                     
-    && rm -rf /var/lib/apt/lists/*                                                                                                                                            
+RUN apt-get update && apt-get install -y \
+    libpq-dev \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
 
 {{ end -}}
 


### PR DESCRIPTION
### Change Summary

Our Django scanner had the following issues:
* Failure to determine an existing image if the locally-installed Python was a beta.
* Failure to install necessary build dependencies if psycopg was required.

These changes do the following:
* If the version number of the locally-installed Python contains any non-numeric components (E.g. "3.12.0b4), then that version is used explicitly and pinned, otherwise the existing version logic that uses a minor version continues to work as normal.
* If we pin a version, we explicitly call that out in the terminal output and in a comment in the Dockerfile advising the user to select an official release before deploying to production. IMO this strikes a good balance between getting users up and running while advising them about the compromise we made along the way.
* Images based on Debian Buster are no longer being built, so I bump to the Bullseye-based images instead.
* If psycopg is detected, then gcc and libpq-dev are installed so the image builds.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
