### PR TITLE
Fix the sensitive environment variable warning

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -202,8 +202,8 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes
 	for _, potentialSecretSubstr := range commonSecretSubstrings {
 		for env := range appConfig.Env {
 			if strings.Contains(env, potentialSecretSubstr) {
-				warning := fmt.Sprintf("%s %s may be a potentially sensitive environment variable. Consider setting it as a secret, and removing it from the [env] section: https://fly.io/docs/reference/secrets/\n", aurora.Yellow("WARN"), potentialSecretSubstr)
-				fmt.Fprintln(io.ErrOut, warning, potentialSecretSubstr)
+				warning := fmt.Sprintf("%s %s may be a potentially sensitive environment variable. Consider setting it as a secret, and removing it from the [env] section: https://fly.io/docs/reference/secrets/\n", aurora.Yellow("WARN"), env)
+				fmt.Fprintln(io.ErrOut, warning)
 			}
 
 		}


### PR DESCRIPTION
### Change Summary

What and Why:
We're currently printing the substring that was matched, instead of the actual environment variable.

How:

Related to:
https://community.fly.io/t/remove-superfluous-warning-x-may-be-a-potentially-sensitive-environment-variable/14388

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
