### PR TITLE
install.sh: fix installing specific version

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -56,4 +56,4 @@ main() {
 	fi
 }
 
-main
+main "$1"


### PR DESCRIPTION
### Change Summary

What and Why:

Fixes installing a specific version (after 274a7643951b10382608dee525489ca04c007264, the version isn't passed to main() function)

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
