### PR TITLE
update: only update if our installation is updateable

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -392,7 +392,7 @@ func promptAndAutoUpdate(ctx context.Context) (context.Context, error) {
 
 	// The env.IsCI check is technically redundant (it should be done in update.Check), but
 	// it's nice to be extra cautious.
-	if cfg.AutoUpdate && !env.IsCI() {
+	if cfg.AutoUpdate && !env.IsCI() && update.CanUpdateThisInstallation() {
 		if versionInvalidMsg != "" || current.SeverelyOutdated(latest) {
 			if !silent {
 				fmt.Fprintln(io.ErrOut, colorize.Green(fmt.Sprintf("Automatically updating %s -> %s.", current, latestRel.Version)))

--- a/internal/command/version/upgrade.go
+++ b/internal/command/version/upgrade.go
@@ -65,6 +65,10 @@ func runUpgrade(ctx context.Context) error {
 		return nil
 	}
 
+	if !update.CanUpdateThisInstallation() {
+		return errors.New("cannot update this installation.\nthe environment variable FLYCTL_INSTALL must be set to the installation directory")
+	}
+
 	homebrew := update.IsUnderHomebrew()
 
 	if err = update.UpgradeInPlace(ctx, io, release.Prerelease, false); err != nil {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -357,6 +357,29 @@ func GetCurrentBinaryPath() (string, error) {
 	return binPath, nil
 }
 
+func CanUpdateThisInstallation() bool {
+	if IsUnderHomebrew() {
+		return true
+	}
+	binaryPath, err := GetCurrentBinaryPath()
+	if err != nil {
+		return false
+	}
+	installDir := os.Getenv("FLYCTL_INSTALL")
+	if installDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return false
+		}
+		installDir = filepath.Join(homeDir, ".fly")
+	}
+	installDirRealpath, err := filepath.EvalSymlinks(installDir)
+	if err == nil {
+		installDir = installDirRealpath
+	}
+	return strings.HasPrefix(binaryPath, installDir+string(filepath.Separator))
+}
+
 // Relaunch only returns on error
 func Relaunch(ctx context.Context, silent bool) error {
 


### PR DESCRIPTION
### Change Summary

What and Why: Disable updating when flyctl binary is not in `FLYCTL_INSTALL`, `~/.fly`, or `$(brew --prefix)/bin`. This won't work, and just leads to update loops.

Related to: https://community.fly.io/t/flyctl-versions-autoupdating-and-the-cli-apocalypse/13794/7?u=allison

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
