### PR TITLE
ips private command works with apps running on machines

### DIFF
--- a/api/resource_monitoring.go
+++ b/api/resource_monitoring.go
@@ -53,22 +53,6 @@ func (c *Client) GetAppStatus(ctx context.Context, appName string, showCompleted
 						name
 					}
 				}
-				machines {
-					nodes {
-						id
-						name
-						state
-						region
-						ips {
-							nodes {
-								family
-								kind
-								ip
-								maskSize
-							}
-						}
-					}
-				}
 			}
 		}
 	`

--- a/api/resource_monitoring.go
+++ b/api/resource_monitoring.go
@@ -27,6 +27,7 @@ func (c *Client) GetAppStatus(ctx context.Context, appName string, showCompleted
 					healthyCount
 					unhealthyCount
 				}
+				platformVersion
 				allocations(showCompleted: $showCompleted) {
 					id
 					idShort
@@ -50,6 +51,22 @@ func (c *Client) GetAppStatus(ctx context.Context, appName string, showCompleted
 						status
 						output
 						name
+					}
+				}
+				machines {
+					nodes {
+						id
+						name
+						state
+						region
+						ips {
+							nodes {
+								family
+								kind
+								ip
+								maskSize
+							}
+						}
 					}
 				}
 			}

--- a/api/types.go
+++ b/api/types.go
@@ -537,9 +537,6 @@ type AppStatus struct {
 	Organization     Organization
 	DeploymentStatus *DeploymentStatus
 	Allocations      []*AllocationStatus
-	Machines         struct {
-		Nodes []*GqlMachine
-	}
 }
 
 type AppConfig struct {

--- a/api/types.go
+++ b/api/types.go
@@ -532,10 +532,14 @@ type AppStatus struct {
 	Status           string
 	Hostname         string
 	Version          int
+	PlatformVersion  string
 	AppURL           string
 	Organization     Organization
 	DeploymentStatus *DeploymentStatus
 	Allocations      []*AllocationStatus
+	Machines         struct {
+		Nodes []*GqlMachine
+	}
 }
 
 type AppConfig struct {

--- a/internal/command/ips/private.go
+++ b/internal/command/ips/private.go
@@ -3,7 +3,9 @@ package ips
 import (
 	"context"
 
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -56,7 +58,10 @@ func runPrivateIPAddressesList(ctx context.Context) error {
 
 		renderPrivateTable(ctx, appstatus.Allocations, backupRegions)
 	case appconfig.MachinesPlatform:
-		renderPrivateTableMachines(ctx, appstatus.Machines.Nodes)
+		machines := lo.Filter(appstatus.Machines.Nodes, func(m *api.GqlMachine, _ int) bool {
+			return !(m.State == "destroyed")
+		})
+		renderPrivateTableMachines(ctx, machines)
 	}
 
 	return nil

--- a/internal/command/ips/private.go
+++ b/internal/command/ips/private.go
@@ -41,17 +41,23 @@ func runPrivateIPAddressesList(ctx context.Context) error {
 		return err
 	}
 
-	_, backupRegions, err := client.ListAppRegions(ctx, appName)
-	if err != nil {
-		return err
+	switch appstatus.PlatformVersion {
+	case appconfig.NomadPlatform:
+		_, backupRegions, err := client.ListAppRegions(ctx, appName)
+		if err != nil {
+			return err
+		}
+
+		out := iostreams.FromContext(ctx).Out
+		if conf := config.FromContext(ctx); conf.JSONOutput {
+			_ = render.JSON(out, appstatus.Allocations)
+			return nil
+		}
+
+		renderPrivateTable(ctx, appstatus.Allocations, backupRegions)
+	case appconfig.MachinesPlatform:
+		renderPrivateTableMachines(ctx, appstatus.Machines.Nodes)
 	}
 
-	out := iostreams.FromContext(ctx).Out
-	if conf := config.FromContext(ctx); conf.JSONOutput {
-		_ = render.JSON(out, appstatus.Allocations)
-		return nil
-	}
-
-	renderPrivateTable(ctx, appstatus.Allocations, backupRegions)
 	return nil
 }

--- a/internal/command/ips/render.go
+++ b/internal/command/ips/render.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"strings"
 
-	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/internal/format"
 	"github.com/superfly/flyctl/internal/render"
@@ -56,15 +55,11 @@ func renderPrivateTable(ctx context.Context, allocations []*api.AllocationStatus
 	render.Table(out, "", rows, "ID", "Region", "IP")
 }
 
-func renderPrivateTableMachines(ctx context.Context, machines []*api.GqlMachine) {
+func renderPrivateTableMachines(ctx context.Context, machines []*api.Machine) {
 	rows := make([][]string, 0, len(machines))
 
 	for _, machine := range machines {
-		privateIp := lo.Filter(machine.IPs.Nodes, func(ip *api.MachineIP, _ int) bool {
-			return ip.Kind == "privatenet"
-		})[0]
-
-		rows = append(rows, []string{machine.ID, machine.Region, privateIp.IP})
+		rows = append(rows, []string{machine.ID, machine.Region, machine.PrivateIP})
 	}
 
 	out := iostreams.FromContext(ctx).Out

--- a/internal/command/ips/render.go
+++ b/internal/command/ips/render.go
@@ -55,6 +55,23 @@ func renderPrivateTable(ctx context.Context, allocations []*api.AllocationStatus
 	render.Table(out, "", rows, "ID", "Region", "IP")
 }
 
+func renderPrivateTableMachines(ctx context.Context, machines []*api.GqlMachine) {
+	rows := make([][]string, 0, len(machines))
+
+	for _, machine := range machines {
+		var privateIp string
+		for _, ip := range machine.IPs.Nodes {
+			if ip.Kind == "privatenet" {
+				privateIp = ip.IP
+			}
+		}
+		rows = append(rows, []string{machine.ID, machine.Region, privateIp})
+	}
+
+	out := iostreams.FromContext(ctx).Out
+	render.Table(out, "", rows, "ID", "Region", "IP")
+}
+
 func renderSharedTable(ctx context.Context, ip net.IP) {
 	rows := make([][]string, 0, 1)
 

--- a/internal/command/ips/render.go
+++ b/internal/command/ips/render.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/internal/format"
 	"github.com/superfly/flyctl/internal/render"
@@ -59,13 +60,11 @@ func renderPrivateTableMachines(ctx context.Context, machines []*api.GqlMachine)
 	rows := make([][]string, 0, len(machines))
 
 	for _, machine := range machines {
-		var privateIp string
-		for _, ip := range machine.IPs.Nodes {
-			if ip.Kind == "privatenet" {
-				privateIp = ip.IP
-			}
-		}
-		rows = append(rows, []string{machine.ID, machine.Region, privateIp})
+		privateIp := lo.Filter(machine.IPs.Nodes, func(ip *api.MachineIP, _ int) bool {
+			return ip.Kind == "privatenet"
+		})[0]
+
+		rows = append(rows, []string{machine.ID, machine.Region, privateIp.IP})
 	}
 
 	out := iostreams.FromContext(ctx).Out


### PR DESCRIPTION
### Change Summary

What and Why:

`fly ips private` output an empty list if an app is running on the machines platform.

How:

If running on machines, we query machines from flaps and write out their private ips.

Example output
```
ID              REGION  IP                               
e784e7d0c2YYYY  sjc     fdaa:2:xxxx:yyyy:zzzz:4fe7:965f:2 
5683d299b7YYYY  sjc     fdaa:2:xxxx:yyyy:zzzz:c030:83d1:2 
e286595ea7YYYY  iad     fdaa:2:xxxx:yyyy:zzzz:a1ac:36fd:2 
3287354f02YYYY  iad     fdaa:2:xxxx:yyyy:zzzz:c9a4:afba:2
```

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
