### PR TITLE
Add test for a slow metrics server

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ const (
 	AccessTokenFileKey    = "access_token"
 	MetricsTokenEnvKey    = envKeyPrefix + "METRICS_TOKEN"
 	MetricsTokenFileKey   = "metrics_token"
+	SendMetricsEnvKey     = envKeyPrefix + "SEND_METRICS"
 	SendMetricsFileKey    = "send_metrics"
 	AutoUpdateFileKey     = "auto_update"
 	WireGuardStateFileKey = "wire_guard_state"
@@ -126,6 +127,7 @@ func (cfg *Config) ApplyEnv() {
 	cfg.APIBaseURL = env.FirstOrDefault(cfg.APIBaseURL, apiBaseURLEnvKey)
 	cfg.FlapsBaseURL = env.FirstOrDefault(cfg.FlapsBaseURL, flapsBaseURLEnvKey)
 	cfg.MetricsBaseURL = env.FirstOrDefault(cfg.MetricsBaseURL, metricsBaseURLEnvKey)
+	cfg.SendMetrics = env.IsTruthy(SendMetricsEnvKey) || cfg.SendMetrics
 }
 
 // ApplyFile sets the properties of cfg which may be set via configuration file

--- a/test/preflight/testlib/test_env.go
+++ b/test/preflight/testlib/test_env.go
@@ -53,6 +53,25 @@ func (f *FlyctlTestEnv) OtherRegions() []string {
 	return f.otherRegions
 }
 
+// Great name I know
+func NewTestEnvFromEnvWithEnv(t testing.TB, envVariables map[string]string) *FlyctlTestEnv {
+	tempDir := socketSafeTempDir(t)
+	_, noHistoryOnFail := os.LookupEnv("FLY_PREFLIGHT_TEST_NO_PRINT_HISTORY_ON_FAIL")
+	testEnv := NewTestEnvFromConfig(t, TestEnvConfig{
+		homeDir:         tempDir,
+		workDir:         tempDir,
+		flyctlBin:       os.Getenv("FLY_PREFLIGHT_TEST_FLYCTL_BINARY_PATH"),
+		orgSlug:         os.Getenv("FLY_PREFLIGHT_TEST_FLY_ORG"),
+		primaryRegion:   primaryRegionFromEnv(),
+		otherRegions:    otherRegionsFromEnv(),
+		accessToken:     os.Getenv("FLY_PREFLIGHT_TEST_ACCESS_TOKEN"),
+		logLevel:        os.Getenv("FLY_PREFLIGHT_TEST_LOG_LEVEL"),
+		noHistoryOnFail: noHistoryOnFail,
+		envVariables:    envVariables,
+	})
+	return testEnv
+}
+
 func NewTestEnvFromEnv(t testing.TB) *FlyctlTestEnv {
 	tempDir := socketSafeTempDir(t)
 	_, noHistoryOnFail := os.LookupEnv("FLY_PREFLIGHT_TEST_NO_PRINT_HISTORY_ON_FAIL")


### PR DESCRIPTION
### Change Summary

What and Why:
This test should hopefully find any regressions in flyctl regarding handling a slow metrics server

How:
There's a metrics server running on flyctl-metrics-slow.fly.dev that takes 15 minutes to respond to requests (but not to authentication). This should be a good test to make sure the metrics server won't mess with flyctl again.
I'm debating on whether the metrics server should be slow to accept connections, or to receiving messages. I could always test both, though.

Related to:
[this metrics branch](https://github.com/superfly/flyctl-metrics/tree/slow-req-dbg)

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
