### PR TITLE
proxy_proto_options makes no sense on http_service

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -556,6 +556,7 @@ type MachineInit struct {
 	Cmd        []string `json:"cmd,omitempty"`
 	Tty        bool     `json:"tty,omitempty"`
 	SwapSizeMB *int     `json:"swap_size_mb,omitempty"`
+	KernelArgs []string `json:"kernel_args,omitempty"`
 }
 
 type DNSConfig struct {

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -211,9 +211,6 @@ func TestToDefinition(t *testing.T) {
 					},
 				},
 			},
-			"proxy_proto_options": map[string]any{
-				"version": "v2",
-			},
 			"checks": []map[string]any{
 				{
 					"interval":        "1m21s",

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -65,23 +65,32 @@ func TestLoadTOMLAppConfigServicePorts(t *testing.T) {
 	want := []Service{{
 		Protocol:     "tcp",
 		InternalPort: 8080,
-		Ports: []api.MachinePort{{
-			Port: api.Pointer(80),
-			TLSOptions: &api.TLSOptions{
-				ALPN:     []string{"h2", "http/1.1"},
-				Versions: []string{"TLSv1.2", "TLSv1.3"},
-			},
-			HTTPOptions: &api.HTTPOptions{
-				Compress: api.Pointer(true),
-				Response: &api.HTTPResponseOptions{
-					Headers: map[string]any{
-						"fly-request-id": false,
-						"fly-wasnt-here": "yes, it was",
-						"multi-valued":   []any{"value1", "value2"},
+		Ports: []api.MachinePort{
+			{
+				Port: api.Pointer(80),
+				TLSOptions: &api.TLSOptions{
+					ALPN:     []string{"h2", "http/1.1"},
+					Versions: []string{"TLSv1.2", "TLSv1.3"},
+				},
+				HTTPOptions: &api.HTTPOptions{
+					Compress: api.Pointer(true),
+					Response: &api.HTTPResponseOptions{
+						Headers: map[string]any{
+							"fly-request-id": false,
+							"fly-wasnt-here": "yes, it was",
+							"multi-valued":   []any{"value1", "value2"},
+						},
 					},
 				},
 			},
-		}},
+			{
+				Port:     api.Pointer(82),
+				Handlers: []string{"proxy_proto"},
+				ProxyProtoOptions: &api.ProxyProtoOptions{
+					Version: "v2",
+				},
+			},
+		},
 	}}
 
 	assert.Equal(t, want, p.Services)
@@ -482,9 +491,6 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 						"multi-valued":   []any{"value1", "value2"},
 					},
 				},
-			},
-			ProxyProtoOptions: &api.ProxyProtoOptions{
-				Version: "v2",
 			},
 			HTTPChecks: []*ServiceHTTPCheck{
 				{

--- a/internal/appconfig/service.go
+++ b/internal/appconfig/service.go
@@ -58,7 +58,6 @@ type HTTPService struct {
 	Concurrency        *api.MachineServiceConcurrency `toml:"concurrency,omitempty" json:"concurrency,omitempty"`
 	TLSOptions         *api.TLSOptions                `json:"tls_options,omitempty" toml:"tls_options,omitempty"`
 	HTTPOptions        *api.HTTPOptions               `json:"http_options,omitempty" toml:"http_options,omitempty"`
-	ProxyProtoOptions  *api.ProxyProtoOptions         `json:"proxy_proto_options,omitempty" toml:"proxy_proto_options,omitempty"`
 	HTTPChecks         []*ServiceHTTPCheck            `json:"checks,omitempty" toml:"checks,omitempty"`
 }
 
@@ -70,17 +69,15 @@ func (s *HTTPService) ToService() *Service {
 		Processes:    s.Processes,
 		HTTPChecks:   s.HTTPChecks,
 		Ports: []api.MachinePort{{
-			Port:              api.IntPointer(80),
-			Handlers:          []string{"http"},
-			ForceHTTPS:        s.ForceHTTPS,
-			HTTPOptions:       s.HTTPOptions,
-			ProxyProtoOptions: s.ProxyProtoOptions,
+			Port:        api.IntPointer(80),
+			Handlers:    []string{"http"},
+			ForceHTTPS:  s.ForceHTTPS,
+			HTTPOptions: s.HTTPOptions,
 		}, {
-			Port:              api.IntPointer(443),
-			Handlers:          []string{"http", "tls"},
-			HTTPOptions:       s.HTTPOptions,
-			TLSOptions:        s.TLSOptions,
-			ProxyProtoOptions: s.ProxyProtoOptions,
+			Port:        api.IntPointer(443),
+			Handlers:    []string{"http", "tls"},
+			HTTPOptions: s.HTTPOptions,
+			TLSOptions:  s.TLSOptions,
 		}},
 		AutoStopMachines:   s.AutoStopMachines,
 		AutoStartMachines:  s.AutoStartMachines,

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -78,9 +78,6 @@ console_command = "/bin/bash"
     fly-wasnt-here = "yes, it was"
     multi-valued = ["value1", "value2"]
 
-  [http_service.proxy_proto_options]
-    version = "v2"
-
 [[statics]]
   guest_path = "/path/to/statics"
   url_prefix = "/static-assets"

--- a/internal/appconfig/testdata/services-ports.toml
+++ b/internal/appconfig/testdata/services-ports.toml
@@ -19,3 +19,10 @@ app = "foo"
     fly-request-id = false
     fly-wasnt-here = "yes, it was"
     multi-valued = ["value1", "value2"]
+
+  [[services.ports]]
+    port = 82
+    handlers = ["proxy_proto"]
+
+    [services.ports.proxy_proto_options]
+    version = "v2"


### PR DESCRIPTION
### Change Summary

What and Why: While working on proxy_proto_options documentation it came up this option have no difference for http_service.

How:

Related to: https://github.com/superfly/docs/pull/905

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
