### PR TITLE
Postgres fork-from fixes

### DIFF
--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -232,7 +232,8 @@ func run(ctx context.Context) (err error) {
 
 		// Resolve the fork-from app manager
 		params.Manager = resolveForkFromManager(ctx, machines)
-		// Attempt to resolve the fork-from app image ref
+		// Attempt to resolve the image ref from the machine tied to the
+		// fork volume.
 		params.ImageRef = resolveImageFromForkVolume(vol, machines)
 		params.ForkFrom = vol.ID
 	}


### PR DESCRIPTION
### Change Summary

The postgres `--fork-from` feature will now attempt to resolve the source image.  If we are unable to do so, the latest image will be used by default.

Users can override this by manually specifying the `--image-ref` flag.  