### PR TITLE
Default to remote forks for machines

### DIFF
--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -13,7 +13,6 @@ import (
 	"github.com/superfly/flyctl/helpers"
 
 	"github.com/superfly/flyctl/internal/buildinfo"
-	"github.com/superfly/flyctl/internal/flag"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/watch"
 
@@ -189,8 +188,8 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 				AppID:          app.ID,
 				SourceVolumeID: config.ForkFrom,
 				MachinesOnly:   true,
+				Remote:         true,
 				Name:           "pg_data",
-				Remote:         flag.GetBool(ctx, "remote-fork"),
 			}
 
 			vol, err = l.client.ForkVolume(ctx, volInput)

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -67,12 +67,6 @@ func newCreate() *cobra.Command {
 			Name:        "fork-from",
 			Description: "Specify a source Postgres application to fork from. Format: <app-name> or <app-name>:<volume-id>",
 		},
-		flag.Bool{
-			Name:        "remote-fork",
-			Description: "Enables experimental cross-host volume forking",
-			Hidden:      true,
-			Default:     false,
-		},
 		flag.String{
 			Name:        "image-ref",
 			Description: "Specify a non-default base image for the Postgres app",

--- a/internal/command/volumes/fork.go
+++ b/internal/command/volumes/fork.go
@@ -95,7 +95,7 @@ func runFork(ctx context.Context) error {
 		SourceVolumeID: vol.ID,
 		Name:           name,
 		MachinesOnly:   machinesOnly,
-		Remote:         flag.GetBool(ctx, "remote-fork"),
+		Remote:         machinesOnly,
 	}
 
 	volume, err := client.ForkVolume(ctx, input)


### PR DESCRIPTION
### Change Summary

Postgres `--form-from` and `fly volumes fork` will now default to using remote forks.  Remote forks are cross-host compatible and are not restricted to the same host as the source. 
