### PR TITLE
add --require-unique-zone to machine clone

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -78,7 +78,7 @@ func newClone() *cobra.Command {
 			Description: "Comma separated list of machine ids to watch for. You can use '--standby-for=source' to create a standby for the cloned machine",
 		},
 		flag.Bool{
-			Name:        "require-unique-zone",
+			Name:        "volume-requires-unique-zone",
 			Description: "Require volume to be placed in separate hardware zone from existing volumes. Default false",
 			Default:     false,
 		},
@@ -251,7 +251,7 @@ func runMachineClone(ctx context.Context) (err error) {
 				SizeGb:            mnt.SizeGb,
 				Encrypted:         mnt.Encrypted,
 				SnapshotID:        snapshotID,
-				RequireUniqueZone: flag.GetBool(ctx, "require-unique-zone"),
+				RequireUniqueZone: flag.GetBool(ctx, "volume-requires-unique-zone"),
 			}
 			vol, err = client.CreateVolume(ctx, volInput)
 			if err != nil {

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -77,6 +77,11 @@ func newClone() *cobra.Command {
 			Name:        "standby-for",
 			Description: "Comma separated list of machine ids to watch for. You can use '--standby-for=source' to create a standby for the cloned machine",
 		},
+		flag.Bool{
+			Name:        "require-unique-zone",
+			Description: "Require volume to be placed in separate hardware zone from existing volumes. Default false",
+			Default:     false,
+		},
 		flag.Detach(),
 	)
 
@@ -246,7 +251,7 @@ func runMachineClone(ctx context.Context) (err error) {
 				SizeGb:            mnt.SizeGb,
 				Encrypted:         mnt.Encrypted,
 				SnapshotID:        snapshotID,
-				RequireUniqueZone: false,
+				RequireUniqueZone: flag.GetBool(ctx, "require-unique-zone"),
 			}
 			vol, err = client.CreateVolume(ctx, volInput)
 			if err != nil {


### PR DESCRIPTION
### Change Summary

What and Why: You can now do `--volume-require-unique-zone` to create a machine with volume on another zone instead of having first to do `vol create --require-unique-zone` then `machine clone --atach-volume-id`. This will benefit folks trying to get out of capacity issues in builders too.

How: Added a flag `--volume-require-unique-zone` like we do in volumes

Related to: internal discussions about Volumes and Capacity

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
