### PR TITLE
Remove local test parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test: FORCE
 # to run one test, use: make preflight-test T=TestAppsV2ConfigSave
 preflight-test: build
 	if [ -r .direnv/preflight ]; then . .direnv/preflight; fi; \
-	go test --parallel=4 ./test/preflight --tags=integration -v -timeout 10m --run="$(T)"
+	go test ./test/preflight --tags=integration -v -timeout 10m --run="$(T)"
 
 ci-preflight:
 	$(MAKE) preflight-test FLY_PREFLIGHT_TEST_NO_PRINT_HISTORY_ON_FAIL=true

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -47,7 +47,7 @@ gotesplit \
     -total "$total" \
     -index "$index" \
     github.com/superfly/flyctl/test/preflight/... \
-    -- --parallel=4 --tags=integration -v -timeout=10m $test_opts | tee "$test_log"
+    -- --tags=integration -v -timeout=10m $test_opts | tee "$test_log"
 test_status=$?
 
 set -e


### PR DESCRIPTION
### Change Summary

Tests will no longer run parallel using `go test`, but it still will for Github Actions

What and Why:'

So initially, I thought this was a [web issue](https://flyio.discourse.team/t/preflight-tests-failing-with-500-errors/3605), but after spending quite a bit of time with this, I can't be sure. It looks like *something* in fly can't handle mutliple commands runnning at the same time, possibly because some state is overwritten. For now, I think the best way of handling this is just disabling go test concurrency, whhile keeping it in Github Actions.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
