### PR TITLE
Allow fixing fly.toml before migrating

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -717,7 +717,7 @@ func (m *v2PlatformMigrator) validate(ctx context.Context) error {
 	err, extraInfo := m.appConfig.ValidateForMachinesPlatform(ctx)
 	if err != nil {
 		fmt.Println(extraInfo)
-		fmt.Println("Edit fly.toml to address any configuration problem and rerun the migration with '--use-local-config' flag")
+		fmt.Println("Edit fly.toml, fix issues and rerun the migration with '--use-local-config' flag")
 		return fmt.Errorf("failed to validate config for Apps V2 platform: %w", err)
 	}
 	err = m.validateProcessGroupsOnAllocs(ctx)


### PR DESCRIPTION
### Change Summary

What and Why: When the remote app configuration isn't valid, (i.e. lacks processes for some service), it is not possible to edit fly.toml to fix the said issues and rerun the migration. 

How: This change adds `--use-local-config` migrate-to-v2 command flag so users can fix issues and rerun the migration from local fly.toml config.

Related to: https://community.fly.io/t/failed-to-validate-config-for-apps-v2-platform-app-configuration-is-not-valid/14510

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
