### PR TITLE
Fix machine files from fly.toml

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -306,7 +306,7 @@ func (cfg *Config) MergeFiles(files []*api.File) error {
 
 	// Merge the config files with the provided files.
 	mConfig := &api.MachineConfig{
-		Files: files,
+		Files: cfgFiles,
 	}
 	machine.MergeFiles(mConfig, files)
 


### PR DESCRIPTION
The wrong slice was used, so the files specified in the config
were ignored.
