### PR TITLE
Allow passing replica regions non-interactively for Upstash Redis

### DIFF
--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -30,6 +30,7 @@ func newCreate() (cmd *cobra.Command) {
 	flag.Add(cmd,
 		flag.Org(),
 		flag.Region(),
+		flag.ReplicaRegions(),
 		flag.String{
 			Name:        "name",
 			Shorthand:   "n",
@@ -125,7 +126,7 @@ func Create(ctx context.Context, org *api.Organization, name string, region *api
 	excludedRegions = append(excludedRegions, region.Code)
 
 	if !disallowReplicas {
-		readRegions, err = prompt.MultiRegion(ctx, "Optionally, choose one or more replica regions (can be changed later):", !org.PaidPlan, []string{}, excludedRegions)
+		readRegions, err = prompt.MultiRegion(ctx, "Optionally, choose one or more replica regions (can be changed later):", !org.PaidPlan, []string{}, excludedRegions, "replica-regions")
 
 		if err != nil {
 			return

--- a/internal/command/redis/update.go
+++ b/internal/command/redis/update.go
@@ -28,6 +28,7 @@ func newUpdate() (cmd *cobra.Command) {
 	flag.Add(cmd,
 		flag.Org(),
 		flag.Region(),
+		flag.ReplicaRegions(),
 	)
 	cmd.Args = cobra.ExactArgs(1)
 	return cmd
@@ -55,7 +56,7 @@ func runUpdate(ctx context.Context) (err error) {
 	}
 	excludedRegions = append(excludedRegions, addOn.PrimaryRegion)
 
-	readRegions, err := prompt.MultiRegion(ctx, "Choose replica regions, or unselect to remove replica regions:", !addOn.Organization.PaidPlan, addOn.ReadRegions, excludedRegions)
+	readRegions, err := prompt.MultiRegion(ctx, "Choose replica regions, or unselect to remove replica regions:", !addOn.Organization.PaidPlan, addOn.ReadRegions, excludedRegions, "replica-regions")
 	if err != nil {
 		return
 	}

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -282,6 +282,14 @@ func Region() String {
 	}
 }
 
+func ReplicaRegions() String {
+	return String{
+		Name:         "replica-regions",
+		Description:  "Comma-separated list of regions to deploy read replicas (see 'flyctl platform regions')",
+		CompletionFn: completion.CompleteRegions,
+	}
+}
+
 // Yes returns a yes bool flag.
 func Yes() Bool {
 	return Bool{


### PR DESCRIPTION
This PR adds a `replica-regions` flag to `flyctl redis create/update` to allow fully non-interactive setup of Redis clusters. 