### PR TITLE
Bluegreen deploy failure improvements

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -255,6 +255,10 @@ func errorIsTimeout(err error) bool {
 		return true
 	}
 
+	if errors.Is(err, ErrWaitTimeout) {
+		return true
+	}
+
 	// Look for an underlying context.DeadlineExceeded error
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
@@ -285,7 +289,7 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 			if rollbackErr := bg.Rollback(ctx, err); rollbackErr != nil {
 				fmt.Fprintf(md.io.ErrOut, "Error in rollback: %s\n", rollbackErr)
 			}
-			return fmt.Errorf("Deployment failed after error: %s\n", err)
+			return suggestChangeWaitTimeout(fmt.Errorf("Deployment failed: %w\n", err), "wait-timeout")
 		}
 		return nil
 	}

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -282,8 +282,10 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 	if md.strategy == "bluegreen" {
 		bg := BlueGreenStrategy(md, updateEntries)
 		if err := bg.Deploy(ctx); err != nil {
-			fmt.Fprintf(md.io.ErrOut, "Deployment failed after error: %s\n", err)
-			return bg.Rollback(ctx, err)
+			if rollbackErr := bg.Rollback(ctx, err); rollbackErr != nil {
+				fmt.Fprintf(md.io.ErrOut, "Error in rollback: %s\n", rollbackErr)
+			}
+			return fmt.Errorf("Deployment failed after error: %s\n", err)
 		}
 		return nil
 	}

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	ErrAborted             = errors.New("deployment aborted by user")
-	ErrWaitTimeout         = errors.New("wait for goroutine timeout")
+	ErrWaitTimeout         = errors.New("wait timeout")
 	ErrCreateGreenMachine  = errors.New("failed to create green machines")
 	ErrWaitForStartedState = errors.New("could not get all green machines into started state")
 	ErrWaitForHealthy      = errors.New("could not get all green machines to be healthy")


### PR DESCRIPTION
Fixes #2651 and #2652.

- return error on bluegreen deploy failure (b0eb480f188630de113ddc467ae33ef1e7b7e114)
- update bluegreen deploy wait timeout error message, and add wait-timeout suggestion to timeout error (943714f6b804bd773b3321a0ab971c32d1702574)