### PR TITLE
Fix Detatch Flag

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -496,11 +496,6 @@ func (md *machineDeployment) spawnMachineInGroup(ctx context.Context, groupName 
 
 	// Otherwise wait for the machine to start
 	indexStr := formatIndex(i, total)
-	if err := lm.WaitForState(ctx, api.MachineStateStarted, md.waitTimeout, indexStr, false); err != nil {
-		err = suggestChangeWaitTimeout(err, "wait-timeout")
-		return nil, err
-	}
-
 	if err := md.doSmokeChecks(ctx, lm, indexStr); err != nil {
 		return nil, err
 	}

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -307,9 +307,11 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 			return nil
 		}
 
-		if err := lm.WaitForState(ctx, api.MachineStateStarted, md.waitTimeout, indexStr, false); err != nil {
-			err = suggestChangeWaitTimeout(err, "wait-timeout")
-			return err
+		if !md.skipHealthChecks {
+			if err := lm.WaitForState(ctx, api.MachineStateStarted, md.waitTimeout, indexStr, false); err != nil {
+				err = suggestChangeWaitTimeout(err, "wait-timeout")
+				return err
+			}
 		}
 
 		if err := md.doSmokeChecks(ctx, lm, indexStr); err != nil {

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -507,6 +507,12 @@ func (md *machineDeployment) spawnMachineInGroup(ctx context.Context, groupName 
 
 	// And wait (or not) for successful health checks
 	if !md.skipHealthChecks {
+		// Don't wait for state if the --detach flag isn't specified
+		if err := lm.WaitForState(ctx, api.MachineStateStarted, md.waitTimeout, indexStr, false); err != nil {
+			err = suggestChangeWaitTimeout(err, "wait-timeout")
+			return nil, err
+		}
+
 		if err := lm.WaitForHealthchecksToPass(ctx, md.waitTimeout, indexStr); err != nil {
 			md.warnAboutIncorrectListenAddress(ctx, lm)
 			err = suggestChangeWaitTimeout(err, "wait-timeout")

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -595,3 +595,17 @@ func TestLaunchCpusMem(t *testing.T) {
 	require.Equal(f, 8192, firstMachineGuest.MemoryMB)
 	require.Equal(f, "performance", firstMachineGuest.CPUKind)
 }
+
+func TestDeployDetach(t *testing.T) {
+	t.Parallel()
+
+	var (
+		f       = testlib.NewTestEnvFromEnv(t)
+		appName = f.CreateRandomAppName()
+	)
+
+	res := f.Fly("launch --org %s --name %s --region %s --now --internal-port 80 --image nginx --auto-confirm --detach", f.OrgSlug(), appName, f.PrimaryRegion())
+	require.Equal(strings.Contains(res.StdOut().String(), "started"), false)
+	require.Equal(strings.Contains(res.StdOut().String(), "stopped"), false)
+	require.Equal(strings.Contains(res.StdOut().String(), "starting"), false)
+}

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -596,7 +596,7 @@ func TestLaunchCpusMem(t *testing.T) {
 	require.Equal(f, "performance", firstMachineGuest.CPUKind)
 }
 
-func TestDeployDetach(t *testing.T) {
+func TestLaunchDetach(t *testing.T) {
 	t.Parallel()
 
 	var (
@@ -605,7 +605,45 @@ func TestDeployDetach(t *testing.T) {
 	)
 
 	res := f.Fly("launch --org %s --name %s --region %s --now --internal-port 80 --image nginx --auto-confirm --detach", f.OrgSlug(), appName, f.PrimaryRegion())
-	require.Equal(strings.Contains(res.StdOut().String(), "started"), false)
-	require.Equal(strings.Contains(res.StdOut().String(), "stopped"), false)
-	require.Equal(strings.Contains(res.StdOut().String(), "starting"), false)
+	require.NotContains(f, res.StdErr().String(), "success")
+
+	res = f.Fly("apps destroy --yes %s", appName)
+
+	res = f.Fly("launch --org %s --name %s --region %s --now --internal-port 80 --image nginx --auto-confirm --copy-config", f.OrgSlug(), appName, f.PrimaryRegion())
+	require.Contains(f, res.StdErr().String(), "success")
+}
+
+func TestDeployDetach(t *testing.T) {
+	t.Parallel()
+
+	var (
+		f       = testlib.NewTestEnvFromEnv(t)
+		appName = f.CreateRandomAppName()
+	)
+
+	f.Fly("launch --org %s --name %s --region %s --now --internal-port 80 --image nginx --auto-confirm", f.OrgSlug(), appName, f.PrimaryRegion())
+
+	res := f.Fly("deploy --detach")
+	require.NotContains(f, res.StdErr().String(), "started")
+
+	res = f.Fly("deploy")
+	require.Contains(f, res.StdErr().String(), "started")
+}
+
+func TestDeployDetachBatching(t *testing.T) {
+	t.Parallel()
+
+	var (
+		f       = testlib.NewTestEnvFromEnv(t)
+		appName = f.CreateRandomAppName()
+	)
+
+	f.Fly("launch --org %s --name %s --region %s --now --internal-port 80 --image nginx --auto-confirm", f.OrgSlug(), appName, f.PrimaryRegion())
+	f.Fly("scale count 6 --yes")
+
+	res := f.Fly("deploy --detach")
+	require.NotContains(f, res.StdErr().String(), "started", false)
+
+	res = f.Fly("deploy")
+	require.Contains(f, res.StdErr().String(), "started", false)
 }


### PR DESCRIPTION
What and Why:

We no longer wait for machine state, like what the detach command says it does

How:

We just check if SkipHealthCheck is true (which is basically just the --detatch flag)

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a (just a small bug fix)