### PR TITLE
Check if API call takes more than 5 minutes

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -125,8 +125,19 @@ func (c *Client) Logger() Logger { return c.logger }
 func (c *Client) RunWithContext(ctx context.Context, req *graphql.Request) (Query, error) {
 	if instrumenter != nil {
 		start := time.Now()
+		finished := make(chan bool)
+
+		go func() {
+			time.Sleep(5 * time.Minute)
+			// Check if the api call finished within 5 minutes
+			if len(finished) == 0 {
+				fmt.Println("API call", req.Query(), "failed")
+			}
+
+		}()
 		defer func() {
 			instrumenter.ReportCallTiming(time.Since(start))
+			finished <- true
 		}()
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why:

This PR mostly exists to debug why preflight tests are so flappy. It exists as a draft PR mostly so other people can take a look at the data, but I'm thinking of merging this eventually (and giving a sentry error).

How:

Currently, it returns an error if any calls to web take more than a minute (since they really shouldn't).

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
