### PR TITLE
On deploy, attempt to replace the machine if host lacks resources to start it

### DIFF
--- a/internal/command/deploy/batcher_test.go
+++ b/internal/command/deploy/batcher_test.go
@@ -28,6 +28,14 @@ func prepBatch(total, groupCount int, soloFirst bool) []int {
 func Test_batcher(t *testing.T) {
 	assert.Equal(t, []int{1}, prepBatch(1, 1, true))
 	assert.Equal(t, []int{1}, prepBatch(1, 1, false))
+
+	assert.Equal(t, []int{1, 1}, prepBatch(2, 3, true))
+	assert.Equal(t, []int{1, 1}, prepBatch(2, 3, false))
+	assert.Equal(t, []int{1, 1, 1}, prepBatch(3, 3, true))
+	assert.Equal(t, []int{1, 1, 1}, prepBatch(3, 3, false))
+	assert.Equal(t, []int{2, 2, 2}, prepBatch(6, 3, false))
+	assert.Equal(t, []int{1, 2, 2, 1}, prepBatch(6, 3, true))
+
 	assert.Equal(t, []int{1, 1}, prepBatch(2, 1, true))
 	assert.Equal(t, []int{2}, prepBatch(2, 1, false))
 	assert.Equal(t, []int{1, 1}, prepBatch(2, 2, true))

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -120,15 +120,6 @@ var CommonFlags = flag.Set{
 		Description: "Memory (in megabytes) to attribute to the VM",
 		Aliases:     []string{"memory"},
 	},
-	flag.Bool{
-		Name: "strategy-batch",
-		Description: fmt.Sprintf(
-			"For \"rolling\" and \"canary\": batch Machine updates into %d groups when updating more than %d.",
-			batchingGroupCount,
-			batchingCutoff,
-		),
-		Default: true,
-	},
 	flag.StringArray{
 		Name:        "file-local",
 		Description: "Set of files in the form of /path/inside/machine=<local/path> pairs. Can be specified multiple times.",
@@ -209,7 +200,6 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes
 				warning := fmt.Sprintf("%s %s may be a potentially sensitive environment variable. Consider setting it as a secret, and removing it from the [env] section: https://fly.io/docs/reference/secrets/\n", aurora.Yellow("WARN"), env)
 				fmt.Fprintln(io.ErrOut, warning)
 			}
-
 		}
 	}
 
@@ -325,7 +315,6 @@ func deployToMachines(
 		AppCompact:            appCompact,
 		DeploymentImage:       img.Tag,
 		Strategy:              flag.GetString(ctx, "strategy"),
-		BatchMachineWaits:     flag.GetBool(ctx, "strategy-batch"),
 		EnvFromFlags:          flag.GetStringArray(ctx, "env"),
 		PrimaryRegionFlag:     appConfig.PrimaryRegion,
 		SkipSmokeChecks:       flag.GetDetach(ctx) || !flag.GetBool(ctx, "smoke-checks"),

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -37,7 +37,6 @@ type MachineDeploymentArgs struct {
 	AppCompact            *api.AppCompact
 	DeploymentImage       string
 	Strategy              string
-	BatchMachineWaits     bool
 	EnvFromFlags          []string
 	PrimaryRegionFlag     string
 	SkipSmokeChecks       bool
@@ -67,7 +66,6 @@ type machineDeployment struct {
 	releaseCommandMachine machine.MachineSet
 	volumes               map[string][]api.Volume
 	strategy              string
-	batchMachineWaits     bool
 	releaseId             string
 	releaseVersion        int
 	skipSmokeChecks       bool
@@ -142,7 +140,6 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		app:                   args.AppCompact,
 		appConfig:             appConfig,
 		img:                   args.DeploymentImage,
-		batchMachineWaits:     args.BatchMachineWaits,
 		skipSmokeChecks:       args.SkipSmokeChecks,
 		skipHealthChecks:      args.SkipHealthChecks,
 		restartOnly:           args.RestartOnly,

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -352,7 +352,6 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 	}
 
 	for i, e := range updateEntries {
-		lm := e.leasableMachine
 		indexStr := formatIndex(i, len(updateEntries))
 
 		if err := md.updateMachine(ctx, e, indexStr); err != nil {
@@ -363,7 +362,7 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 			return err
 		}
 
-		b.Add(batchJob{lm, indexStr})
+		b.Add(batchJob{e.leasableMachine, indexStr})
 		for _, job := range b.Batch() {
 			if err := md.waitForMachine(ctx, job.lm, true, job.indexStr); err != nil {
 				return err
@@ -417,6 +416,7 @@ func (md *machineDeployment) updateMachineByReplace(ctx context.Context, e *mach
 	lm = machine.NewLeasableMachine(md.flapsClient, md.io, newMachineRaw)
 	fmt.Fprintf(md.io.ErrOut, "  %s Created machine %s\n", indexStr, md.colorize.Bold(lm.FormattedMachineId()))
 	defer lm.ReleaseLease(ctx)
+	e.leasableMachine = lm
 	return nil
 }
 

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -272,6 +272,53 @@ func suggestChangeWaitTimeout(err error, flagName string) error {
 	return err
 }
 
+func (md *machineDeployment) waitForMachine(ctx context.Context, lm machine.LeasableMachine, inBatch bool, indexStr string) error {
+	if md.strategy == "immediate" {
+		return nil
+	}
+
+	if !md.skipHealthChecks {
+		if err := lm.WaitForState(ctx, api.MachineStateStarted, md.waitTimeout, indexStr, false); err != nil {
+			err = suggestChangeWaitTimeout(err, "wait-timeout")
+			return err
+		}
+	}
+
+	if err := md.doSmokeChecks(ctx, lm, indexStr); err != nil {
+		return err
+	}
+
+	if !md.skipHealthChecks {
+		if err := lm.WaitForHealthchecksToPass(ctx, md.waitTimeout, indexStr); err != nil {
+			md.warnAboutIncorrectListenAddress(ctx, lm)
+			err = suggestChangeWaitTimeout(err, "wait-timeout")
+			return err
+		}
+		// FIXME: combine this wait with the wait for start as one update line (or two per in noninteractive case)
+		md.logClearLinesAbove(1)
+		fmt.Fprintf(md.io.ErrOut, "  %s Machine %s update finished: %s\n",
+			indexStr,
+			md.colorize.Bold(lm.FormattedMachineId()),
+			md.colorize.Green("success"),
+		)
+		if inBatch {
+			fmt.Fprint(md.io.ErrOut, "\n")
+		}
+	}
+
+	md.warnAboutIncorrectListenAddress(ctx, lm)
+	return nil
+}
+
+func (md *machineDeployment) updateUsingBlueGreenStrategy(ctx context.Context, updateEntries []*machineUpdateEntry) error {
+	bg := BlueGreenStrategy(md, updateEntries)
+	if err := bg.Deploy(ctx); err != nil {
+		fmt.Fprintf(md.io.ErrOut, "Deployment failed after error: %s\n", err)
+		return bg.Rollback(ctx, err)
+	}
+	return nil
+}
+
 func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateEntries []*machineUpdateEntry) error {
 	if len(updateEntries) == 0 {
 		return nil
@@ -280,17 +327,8 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 	fmt.Fprintf(md.io.Out, "Updating existing machines in '%s' with %s strategy\n", md.colorize.Bold(md.app.Name), md.strategy)
 
 	if md.strategy == "bluegreen" {
-		bg := BlueGreenStrategy(md, updateEntries)
-		if err := bg.Deploy(ctx); err != nil {
-			fmt.Fprintf(md.io.ErrOut, "Deployment failed after error: %s\n", err)
-			return bg.Rollback(ctx, err)
-		}
-		return nil
+		return md.updateUsingBlueGreenStrategy(ctx, updateEntries)
 	}
-
-	useBatches := md.batchMachineWaits &&
-		(md.strategy == "rolling" || md.strategy == "canary") &&
-		len(updateEntries) >= batchingCutoff
 
 	type batchJob struct {
 		lm       machine.LeasableMachine
@@ -302,89 +340,20 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 		SoloFirst:  true,
 	}
 
-	waitForMachine := func(lm machine.LeasableMachine, inBatch bool, indexStr string) error {
-		if md.strategy == "immediate" {
-			return nil
-		}
-
-		if !md.skipHealthChecks {
-			if err := lm.WaitForState(ctx, api.MachineStateStarted, md.waitTimeout, indexStr, false); err != nil {
-				err = suggestChangeWaitTimeout(err, "wait-timeout")
-				return err
-			}
-		}
-
-		if err := md.doSmokeChecks(ctx, lm, indexStr); err != nil {
-			return err
-		}
-
-		if !md.skipHealthChecks {
-			if err := lm.WaitForHealthchecksToPass(ctx, md.waitTimeout, indexStr); err != nil {
-				md.warnAboutIncorrectListenAddress(ctx, lm)
-				err = suggestChangeWaitTimeout(err, "wait-timeout")
-				return err
-			}
-			// FIXME: combine this wait with the wait for start as one update line (or two per in noninteractive case)
-			md.logClearLinesAbove(1)
-			fmt.Fprintf(md.io.ErrOut, "  %s Machine %s update finished: %s\n",
-				indexStr,
-				md.colorize.Bold(lm.FormattedMachineId()),
-				md.colorize.Green("success"),
-			)
-			if inBatch {
-				fmt.Fprint(md.io.ErrOut, "\n")
-			}
-		}
-
-		md.warnAboutIncorrectListenAddress(ctx, lm)
-		return nil
-	}
-
 	for i, e := range updateEntries {
 		lm := e.leasableMachine
-		launchInput := e.launchInput
 		indexStr := formatIndex(i, len(updateEntries))
 
-		if launchInput.RequiresReplacement {
-			// If machine requires replacement, destroy old machine and launch a new one
-			// This can be the case for machines that changes its volumes.
-			fmt.Fprintf(md.io.ErrOut, "  %s Replacing %s by new machine\n", indexStr, md.colorize.Bold(lm.FormattedMachineId()))
-			if err := lm.Destroy(ctx, true); err != nil {
-				if md.strategy != "immediate" {
-					return err
-				}
-				fmt.Fprintf(md.io.ErrOut, "Continuing after error: %s\n", err)
+		if err := md.updateMachine(ctx, e, indexStr); err != nil {
+			if md.strategy != "immediate" {
+				return err
 			}
-
-			// Acquire a lease on the new machine to ensure external factors can't stop or update it
-			// while we wait for its state and/or health checks
-			launchInput.LeaseTTL = int(md.waitTimeout.Seconds())
-
-			newMachineRaw, err := md.flapsClient.Launch(ctx, *launchInput)
-			if err != nil {
-				if md.strategy != "immediate" {
-					return err
-				}
-				fmt.Fprintf(md.io.ErrOut, "Continuing after error: %s\n", err)
-				continue
-			}
-
-			lm = machine.NewLeasableMachine(md.flapsClient, md.io, newMachineRaw)
-			fmt.Fprintf(md.io.ErrOut, "  %s Created machine %s\n", indexStr, md.colorize.Bold(lm.FormattedMachineId()))
-			defer lm.ReleaseLease(ctx)
-
-		} else {
-			fmt.Fprintf(md.io.ErrOut, "  %s Updating %s\n", indexStr, md.colorize.Bold(lm.FormattedMachineId()))
-			if err := lm.Update(ctx, *launchInput); err != nil {
-				if md.strategy != "immediate" {
-					return err
-				}
-				fmt.Fprintf(md.io.ErrOut, "Continuing after error: %s\n", err)
-			}
+			fmt.Fprintf(md.io.ErrOut, "Continuing after error: %s\n", err)
+			continue
 		}
 
 		// Don't wait for Standby machines, they are updated but not started
-		if len(launchInput.Config.Standbys) > 0 {
+		if len(e.launchInput.Config.Standbys) > 0 {
 			md.logClearLinesAbove(1)
 			fmt.Fprintf(md.io.ErrOut, "  %s Machine %s update finished: %s\n",
 				indexStr,
@@ -394,23 +363,61 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 			continue
 		}
 
-		if useBatches {
-			b.Add(batchJob{lm, indexStr})
-
-			for _, job := range b.Batch() {
-				if err := waitForMachine(job.lm, true, job.indexStr); err != nil {
-					return err
-				}
-			}
-			md.logClearLinesAbove(1)
-		} else {
-			if err := waitForMachine(lm, false, indexStr); err != nil {
+		b.Add(batchJob{lm, indexStr})
+		for _, job := range b.Batch() {
+			if err := md.waitForMachine(ctx, job.lm, true, job.indexStr); err != nil {
 				return err
 			}
 		}
+		md.logClearLinesAbove(1)
 	}
 
 	fmt.Fprintf(md.io.ErrOut, "  Finished deploying\n")
+	return nil
+}
+
+func (md *machineDeployment) updateMachine(ctx context.Context, e *machineUpdateEntry, indexStr string) error {
+	if e.launchInput.RequiresReplacement {
+		return md.updateMachineByReplace(ctx, e, indexStr)
+	}
+
+	err := md.updateMachineInPlace(ctx, e, indexStr)
+	return err
+}
+
+func (md *machineDeployment) updateMachineByReplace(ctx context.Context, e *machineUpdateEntry, indexStr string) error {
+	lm := e.leasableMachine
+	// If machine requires replacement, destroy old machine and launch a new one
+	// This can be the case for machines that changes its volumes.
+	fmt.Fprintf(md.io.ErrOut, "  %s Replacing %s by new machine\n", indexStr, md.colorize.Bold(lm.FormattedMachineId()))
+	if err := lm.Destroy(ctx, true); err != nil {
+		return err
+	}
+
+	// Acquire a lease on the new machine to ensure external factors can't stop or update it
+	// while we wait for its state and/or health checks
+	e.launchInput.LeaseTTL = int(md.waitTimeout.Seconds())
+
+	newMachineRaw, err := md.flapsClient.Launch(ctx, *e.launchInput)
+	if err != nil {
+		return err
+	}
+
+	lm = machine.NewLeasableMachine(md.flapsClient, md.io, newMachineRaw)
+	fmt.Fprintf(md.io.ErrOut, "  %s Created machine %s\n", indexStr, md.colorize.Bold(lm.FormattedMachineId()))
+	defer lm.ReleaseLease(ctx)
+	return nil
+}
+
+func (md *machineDeployment) updateMachineInPlace(ctx context.Context, e *machineUpdateEntry, indexStr string) error {
+	lm := e.leasableMachine
+	fmt.Fprintf(md.io.ErrOut, "  %s Updating %s\n", indexStr, md.colorize.Bold(lm.FormattedMachineId()))
+	if err := lm.Update(ctx, *e.launchInput); err != nil {
+		if md.strategy != "immediate" {
+			return err
+		}
+		fmt.Fprintf(md.io.ErrOut, "Continuing after error: %s\n", err)
+	}
 	return nil
 }
 

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -22,8 +22,6 @@ import (
 
 const (
 	batchingGroupCount = 3
-	// batchingCutoff should be at least batchingGroupCount + 1
-	batchingCutoff = 4
 )
 
 type ProcessGroupsDiff struct {


### PR DESCRIPTION
A machine update could fail if for some reason the host is having a shortage of resources. This PR attempts to replace the machine instead of updating it in place whenever possible.

A few *extra* things happening:
* The updateExistingMachines function splits into smaller functions
* Batching is enabled and will behave the same whether the entries count is below or above 3
* Code is prepped to run in worker pool