### PR TITLE
Add preflight tests for `fly console` and `fly pg import`

### DIFF
--- a/test/preflight/fly_console_test.go
+++ b/test/preflight/fly_console_test.go
@@ -1,0 +1,42 @@
+//go:build integration
+// +build integration
+
+package preflight
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/flyctl/test/preflight/testlib"
+)
+
+func TestFlyConsole(t *testing.T) {
+	t.Parallel()
+
+	f := testlib.NewTestEnvFromEnv(t)
+	appName := f.CreateRandomAppMachines()
+	targetOutput := "console test in " + appName
+
+	f.WriteFlyToml(`
+app = "%s"
+console_command = "/bin/echo '%s'"
+
+[build]
+  image = "nginx"
+
+[processes]
+  app = "/bin/sleep inf"
+`,
+		appName, targetOutput,
+	)
+
+	f.Fly("deploy --ha=false")
+
+	result := f.Fly("console")
+	output := result.StdOut().String()
+	require.Contains(f, output, targetOutput)
+
+	// The console machine should have been destroyed.
+	ml := f.MachinesList(appName)
+	require.Equal(f, 1, len(ml))
+}


### PR DESCRIPTION
This adds basic preflight tests to make sure that `fly console` and `fly pg import` work as expected. The specific impetus for this is to be sure that #2523 doesn't break anything when merged.