### PR TITLE
Feat/launch v2/cleanup plan

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -4,14 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/samber/lo"
 	"github.com/spf13/cobra"
-	"github.com/superfly/flyctl/api"
-	"github.com/superfly/flyctl/client"
-	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/deploy"
 	"github.com/superfly/flyctl/internal/command/launch/legacy"
@@ -136,113 +131,6 @@ func run(ctx context.Context) (err error) {
 	}
 
 	return nil
-}
-
-type launchState struct {
-	workingDir string
-	configPath string
-	plan       *launchPlan
-	planSource *launchPlanSource
-	env        map[string]string
-	appConfig  *appconfig.Config
-	sourceInfo *scanner.SourceInfo
-	cache      map[string]interface{}
-}
-
-func cacheGrab[T any](cache map[string]interface{}, key string, cb func() (T, error)) (T, error) {
-	if val, ok := cache[key]; ok {
-		return val.(T), nil
-	}
-	val, err := cb()
-	if err != nil {
-		return val, err
-	}
-	cache[key] = val
-	return val, nil
-}
-
-func (state *launchState) Org(ctx context.Context) (*api.Organization, error) {
-	apiClient := client.FromContext(ctx).API()
-	return cacheGrab(state.cache, "org,"+state.plan.OrgSlug, func() (*api.Organization, error) {
-		return apiClient.GetOrganizationBySlug(ctx, state.plan.OrgSlug)
-	})
-}
-
-func (state *launchState) Region(ctx context.Context) (api.Region, error) {
-
-	apiClient := client.FromContext(ctx).API()
-	regions, err := cacheGrab(state.cache, "regions", func() ([]api.Region, error) {
-		regions, _, err := apiClient.PlatformRegions(ctx)
-		if err != nil {
-			return nil, err
-		}
-		return regions, nil
-	})
-	if err != nil {
-		return api.Region{}, err
-	}
-
-	region, ok := lo.Find(regions, func(r api.Region) bool {
-		return r.Code == state.plan.RegionCode
-	})
-	if !ok {
-		return region, fmt.Errorf("region %state not found", state.plan.RegionCode)
-	}
-	return region, nil
-}
-
-// PlanSummary returns a human-readable summary of the launch plan.
-// Used to confirm the plan before executing it.
-func (state *launchState) PlanSummary(ctx context.Context) (string, error) {
-
-	guest := state.plan.Guest()
-
-	org, err := state.Org(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	region, err := state.Region(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	redisStr, err := state.plan.Redis.Describe(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	rows := [][]string{
-		{"Organization", org.Name, state.planSource.orgSource},
-		{"Name", state.plan.AppName, state.planSource.appNameSource},
-		{"Region", region.Name, state.planSource.regionSource},
-		{"App Machines", guest.String(), state.planSource.guestSource},
-		{"Postgres", state.plan.Postgres.Describe(), state.planSource.postgresSource},
-		{"Redis", redisStr, state.planSource.redisSource},
-	}
-
-	colLengths := []int{0, 0, 0}
-	for _, row := range rows {
-		for i, col := range row {
-			if len(col) > colLengths[i] {
-				colLengths[i] = len(col)
-			}
-		}
-	}
-
-	ret := ""
-	for _, row := range rows {
-
-		label := row[0]
-		value := row[1]
-		source := row[2]
-
-		labelSpaces := strings.Repeat(" ", colLengths[0]-len(label))
-		valueSpaces := strings.Repeat(" ", colLengths[1]-len(value))
-
-		ret += fmt.Sprintf("%state: %state%state %state(%state)\n", label, labelSpaces, value, valueSpaces, source)
-	}
-	return ret, nil
 }
 
 // familyToAppType returns a string that describes the app type based on the source info

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/deploy"
@@ -97,7 +101,7 @@ func run(ctx context.Context) (err error) {
 		return err
 	}
 
-	summary, err := state.plan.Summary(ctx)
+	summary, err := state.PlanSummary(ctx)
 	if err != nil {
 		return err
 	}
@@ -138,9 +142,107 @@ type launchState struct {
 	workingDir string
 	configPath string
 	plan       *launchPlan
+	planSource *launchPlanSource
 	env        map[string]string
 	appConfig  *appconfig.Config
 	sourceInfo *scanner.SourceInfo
+	cache      map[string]interface{}
+}
+
+func cacheGrab[T any](cache map[string]interface{}, key string, cb func() (T, error)) (T, error) {
+	if val, ok := cache[key]; ok {
+		return val.(T), nil
+	}
+	val, err := cb()
+	if err != nil {
+		return val, err
+	}
+	cache[key] = val
+	return val, nil
+}
+
+func (state *launchState) Org(ctx context.Context) (*api.Organization, error) {
+	apiClient := client.FromContext(ctx).API()
+	return cacheGrab(state.cache, "org,"+state.plan.OrgSlug, func() (*api.Organization, error) {
+		return apiClient.GetOrganizationBySlug(ctx, state.plan.OrgSlug)
+	})
+}
+
+func (state *launchState) Region(ctx context.Context) (api.Region, error) {
+
+	apiClient := client.FromContext(ctx).API()
+	regions, err := cacheGrab(state.cache, "regions", func() ([]api.Region, error) {
+		regions, _, err := apiClient.PlatformRegions(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return regions, nil
+	})
+	if err != nil {
+		return api.Region{}, err
+	}
+
+	region, ok := lo.Find(regions, func(r api.Region) bool {
+		return r.Code == state.plan.RegionCode
+	})
+	if !ok {
+		return region, fmt.Errorf("region %state not found", state.plan.RegionCode)
+	}
+	return region, nil
+}
+
+// PlanSummary returns a human-readable summary of the launch plan.
+// Used to confirm the plan before executing it.
+func (state *launchState) PlanSummary(ctx context.Context) (string, error) {
+
+	guest := state.plan.Guest()
+
+	org, err := state.Org(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	region, err := state.Region(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	redisStr, err := state.plan.Redis.Describe(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	rows := [][]string{
+		{"Organization", org.Name, state.planSource.orgSource},
+		{"Name", state.plan.AppName, state.planSource.appNameSource},
+		{"Region", region.Name, state.planSource.regionSource},
+		{"App Machines", guest.String(), state.planSource.guestSource},
+		{"Postgres", state.plan.Postgres.Describe(), state.planSource.postgresSource},
+		{"Redis", redisStr, state.planSource.redisSource},
+	}
+
+	colLengths := []int{0, 0, 0}
+	for _, row := range rows {
+		for i, col := range row {
+			if len(col) > colLengths[i] {
+				colLengths[i] = len(col)
+			}
+		}
+	}
+
+	ret := ""
+	for _, row := range rows {
+
+		label := row[0]
+		value := row[1]
+		source := row[2]
+
+		labelSpaces := strings.Repeat(" ", colLengths[0]-len(label))
+		valueSpaces := strings.Repeat(" ", colLengths[1]-len(value))
+
+		ret += fmt.Sprintf("%state: %state%state %state(%state)\n", label, labelSpaces, value, valueSpaces, source)
+	}
+	return ret, nil
 }
 
 // familyToAppType returns a string that describes the app type based on the source info

--- a/internal/command/launch/deploy.go
+++ b/internal/command/launch/deploy.go
@@ -53,7 +53,7 @@ func (state *launchState) firstDeploy(ctx context.Context) error {
 				path := appConfig.ConfigFilePath()
 				newCfg, err := appconfig.LoadConfig(path)
 				if err != nil {
-					return fmt.Errorf("failed to reload configuration file %s: %w", path, err)
+					return fmt.Errorf("failed to reload configuration file %state: %w", path, err)
 				}
 
 				if appConfig.ForMachines() {

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -76,7 +76,7 @@ func (state *launchState) updateConfig(ctx context.Context) {
 // createApp creates the fly.io app for the plan
 func (state *launchState) createApp(ctx context.Context) (*api.App, error) {
 	apiClient := client.FromContext(ctx).API()
-	org, err := state.plan.Org(ctx)
+	org, err := state.Org(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -99,19 +99,21 @@ func v2BuildPlan(ctx context.Context) (*launchState, error) {
 	}
 
 	lp := &launchPlan{
-		AppName:        appName,
+		AppName:       appName,
+		RegionCode:    region.Code,
+		OrgSlug:       org.Slug,
+		Postgres:      nil,
+		Redis:         nil,
+		ScannerFamily: scannerFamily,
+	}
+
+	planSource := &launchPlanSource{
 		appNameSource:  appNameExplanation,
-		RegionCode:     region.Code,
 		regionSource:   regionExplanation,
-		OrgSlug:        org.Slug,
 		orgSource:      orgExplanation,
 		guestSource:    guestExplanation,
-		Postgres:       nil,
 		postgresSource: "not implemented",
-		Redis:          nil,
 		redisSource:    "not implemented",
-		ScannerFamily:  scannerFamily,
-		cache:          map[string]interface{}{},
 	}
 
 	lp.SetGuestFields(guest)
@@ -120,9 +122,11 @@ func v2BuildPlan(ctx context.Context) (*launchState, error) {
 		workingDir: workingDir,
 		configPath: configPath,
 		plan:       lp,
+		planSource: planSource,
 		env:        envVars,
 		appConfig:  appConfig,
 		sourceInfo: srcInfo,
+		cache:      map[string]interface{}{},
 	}, nil
 }
 

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -1,0 +1,120 @@
+package launch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/samber/lo"
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/scanner"
+)
+
+type launchState struct {
+	workingDir string
+	configPath string
+	plan       *launchPlan
+	planSource *launchPlanSource
+	env        map[string]string
+	appConfig  *appconfig.Config
+	sourceInfo *scanner.SourceInfo
+	cache      map[string]interface{}
+}
+
+func cacheGrab[T any](cache map[string]interface{}, key string, cb func() (T, error)) (T, error) {
+	if val, ok := cache[key]; ok {
+		return val.(T), nil
+	}
+	val, err := cb()
+	if err != nil {
+		return val, err
+	}
+	cache[key] = val
+	return val, nil
+}
+
+func (state *launchState) Org(ctx context.Context) (*api.Organization, error) {
+	apiClient := client.FromContext(ctx).API()
+	return cacheGrab(state.cache, "org,"+state.plan.OrgSlug, func() (*api.Organization, error) {
+		return apiClient.GetOrganizationBySlug(ctx, state.plan.OrgSlug)
+	})
+}
+
+func (state *launchState) Region(ctx context.Context) (api.Region, error) {
+
+	apiClient := client.FromContext(ctx).API()
+	regions, err := cacheGrab(state.cache, "regions", func() ([]api.Region, error) {
+		regions, _, err := apiClient.PlatformRegions(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return regions, nil
+	})
+	if err != nil {
+		return api.Region{}, err
+	}
+
+	region, ok := lo.Find(regions, func(r api.Region) bool {
+		return r.Code == state.plan.RegionCode
+	})
+	if !ok {
+		return region, fmt.Errorf("region %state not found", state.plan.RegionCode)
+	}
+	return region, nil
+}
+
+// PlanSummary returns a human-readable summary of the launch plan.
+// Used to confirm the plan before executing it.
+func (state *launchState) PlanSummary(ctx context.Context) (string, error) {
+
+	guest := state.plan.Guest()
+
+	org, err := state.Org(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	region, err := state.Region(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	redisStr, err := state.plan.Redis.Describe(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	rows := [][]string{
+		{"Organization", org.Name, state.planSource.orgSource},
+		{"Name", state.plan.AppName, state.planSource.appNameSource},
+		{"Region", region.Name, state.planSource.regionSource},
+		{"App Machines", guest.String(), state.planSource.guestSource},
+		{"Postgres", state.plan.Postgres.Describe(), state.planSource.postgresSource},
+		{"Redis", redisStr, state.planSource.redisSource},
+	}
+
+	colLengths := []int{0, 0, 0}
+	for _, row := range rows {
+		for i, col := range row {
+			if len(col) > colLengths[i] {
+				colLengths[i] = len(col)
+			}
+		}
+	}
+
+	ret := ""
+	for _, row := range rows {
+
+		label := row[0]
+		value := row[1]
+		source := row[2]
+
+		labelSpaces := strings.Repeat(" ", colLengths[0]-len(label))
+		valueSpaces := strings.Repeat(" ", colLengths[1]-len(value))
+
+		ret += fmt.Sprintf("%state: %state%state %state(%state)\n", label, labelSpaces, value, valueSpaces, source)
+	}
+	return ret, nil
+}

--- a/internal/command/launch/webui.go
+++ b/internal/command/launch/webui.go
@@ -77,7 +77,6 @@ func (state *launchState) EditInWebUi(ctx context.Context) error {
 	}
 
 	state.plan.ScannerFamily = oldPlan.ScannerFamily
-	state.plan.cache = oldPlan.cache
 
 	return nil
 }


### PR DESCRIPTION
### Change Summary

What and Why: Splits private fields out of launchPlan, to start solidifying the idea that plans should be hot-swappable (not just for launch v2, but also to allow for `--manifest` launches.

Related to: Launch V2

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
