### PR TITLE
Update "fly vol fork" usage and flags

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -93,11 +93,6 @@ func newMigrateToV2() *cobra.Command {
 			Hidden:      true,
 		},
 		flag.Bool{
-			Name:        "remote-fork",
-			Description: "PLACEHOLDER - this is the default now",
-			Hidden:      true,
-		},
-		flag.Bool{
 			Name:        "use-local-config",
 			Description: "Use local fly.toml. Do not attempt to remotely fetch the app configuration from the latest deployed release",
 			Default:     false,


### PR DESCRIPTION
`fly volume fork` now defaults to remote forking in all cases and was lacking an option to set requireUniqueZone

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
