### PR TITLE
Revert "Merge pull request #2673 from superfly/reserve_resource_err"

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -408,11 +408,7 @@ func (md *machineDeployment) updateMachineByReplace(ctx context.Context, e *mach
 
 	newMachineRaw, err := md.flapsClient.Launch(ctx, *e.launchInput)
 	if err != nil {
-		if strings.Contains(err.Error(), "could not reserve resource for machine") {
-			return errors.New("The region you're trying to deploy is likely at capacity. Consider deploying to a new region with fly deploy --region <region> or trying again in a few hours\n")
-		} else {
-			return err
-		}
+		return err
 	}
 
 	lm = machine.NewLeasableMachine(md.flapsClient, md.io, newMachineRaw)


### PR DESCRIPTION
This reverts commit 3f5e0567b10190150ed6a25d85e58b232adb72d6, reversing changes made to 2ca36c31c8d6bbd3cb3a77cd870bf71cb60a3ac6.

I merged just before some important comments were given

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
