### PR TITLE
Handle docker images >2GB

### DIFF
--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -574,7 +574,7 @@ func (client *Client) ResolveImageForApp(ctx context.Context, appName, imageRef 
 					id
 					digest
 					ref
-					compressedSize
+					compressedSize: compressedSizeFull
 				}
 			}
 		}

--- a/api/types.go
+++ b/api/types.go
@@ -1210,7 +1210,7 @@ type Image struct {
 	ID             string
 	Digest         string
 	Ref            string
-	CompressedSize uint64
+	CompressedSize string
 }
 
 type ReleaseCommand struct {

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -5554,7 +5554,8 @@ type Identity {
 
 type Image {
   absoluteRef: String!
-  compressedSize: Int!
+  compressedSize: Int! @deprecated(reason: "Int cannot handle sizes over 2GB. Use compressed_size_full instead")
+  compressedSizeFull: BigInt!
   config: JSON!
   configDigest: JSON!
   createdAt: ISO8601DateTime!

--- a/internal/build/imgsrc/remote_image_resolver.go
+++ b/internal/build/imgsrc/remote_image_resolver.go
@@ -3,6 +3,7 @@ package imgsrc
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/iostreams"
@@ -31,10 +32,15 @@ func (s *remoteImageResolver) Run(ctx context.Context, _ *dockerClientFactory, s
 
 	fmt.Fprintf(streams.ErrOut, "image found: %s\n", img.ID)
 
+	size, err := strconv.ParseUint(img.CompressedSize, 10, 64)
+	if err != nil {
+		return nil, "", err
+	}
+
 	di := &DeploymentImage{
 		ID:   img.ID,
 		Tag:  img.Ref,
-		Size: int64(img.CompressedSize),
+		Size: int64(size),
 	}
 
 	return di, "", nil


### PR DESCRIPTION
Use a new compressedSizeFull BigInt field that can handle numbers > 2147483647, to support docker images >2GB