### PR TITLE
Better ephemeral machine cleanup

### DIFF
--- a/internal/machine/ephemeral.go
+++ b/internal/machine/ephemeral.go
@@ -121,7 +121,7 @@ func makeCleanupFunc(ctx context.Context, machine *api.Machine) func() {
 	)
 
 	return func() {
-		const stopTimeout = 5 * time.Second
+		const stopTimeout = 15 * time.Second
 
 		stopCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
 		stopCtx, cancel = ctrlc.HookCancelableContext(stopCtx, cancel)

--- a/internal/machine/ephemeral.go
+++ b/internal/machine/ephemeral.go
@@ -132,7 +132,7 @@ func makeCleanupFunc(ctx context.Context, machine *api.Machine) func() {
 			Timeout: api.Duration{Duration: stopTimeout},
 		}
 		if err := flapsClient.Stop(stopCtx, stopInput, ""); err != nil {
-			terminal.Warnf("Failed to stop ephemeral machine: %v\n", err)
+			terminal.Warnf("Failed to stop ephemeral machine: %v", err)
 			terminal.Warn("You may need to destroy it manually (`fly machine destroy`).")
 			return
 		}
@@ -140,7 +140,7 @@ func makeCleanupFunc(ctx context.Context, machine *api.Machine) func() {
 		fmt.Fprintf(io.Out, "Waiting for ephemeral machine %s to be destroyed ...", colorize.Bold(machine.ID))
 		if err := flapsClient.Wait(stopCtx, machine, api.MachineStateDestroyed, stopTimeout); err != nil {
 			fmt.Fprintf(io.Out, " %s!\n", colorize.Red("failed"))
-			terminal.Warnf("Failed to wait for ephemeral machine to be destroyed: %v\n", err)
+			terminal.Warnf("Failed to wait for ephemeral machine to be destroyed: %v", err)
 			terminal.Warn("You may need to destroy it manually (`fly machine destroy`).")
 		} else {
 			fmt.Fprintf(io.Out, " %s.\n", colorize.Green("done"))

--- a/internal/machine/ephemeral.go
+++ b/internal/machine/ephemeral.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/ctrlc"
 	"github.com/superfly/flyctl/internal/spinner"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/terminal"
@@ -123,6 +124,7 @@ func makeCleanupFunc(ctx context.Context, machine *api.Machine) func() {
 		const stopTimeout = 5 * time.Second
 
 		stopCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
+		stopCtx, cancel = ctrlc.HookCancelableContext(stopCtx, cancel)
 		defer cancel()
 
 		stopInput := api.StopMachineInput{


### PR DESCRIPTION
### Change Summary

What and Why:

* Allow ephemeral machine cleanup to be canceled with Ctrl-C.
* Bump the cleanup timeout to 15 seconds. Since cleanup is now cancelable with Ctrl-C, this shouldn't negatively impact the UX. Furthermore, based on some local testing, I think the `fly pg import` preflight tests are failing so frequently because this cleanup is timing out, so hopefully this will address that.
* It turns out that the `terminal.Warnf` calls don't need a newline, so fix it while I'm here.

How:

* Ctrl-C support uses the new `github.com/superfly/flyctl/internal/ctrlc` package. See #2593.

Related to:

* This will hopefully stop the preflight tests introduced in #2523 and #2662 from failing so often.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
