### PR TITLE
`fly deploy`: don't wait for standby machines

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -275,13 +275,6 @@ func (md *machineDeployment) waitForMachine(ctx context.Context, lm machine.Leas
 		return nil
 	}
 
-	if !md.skipHealthChecks {
-		if err := lm.WaitForState(ctx, api.MachineStateStarted, md.waitTimeout, indexStr, false); err != nil {
-			err = suggestChangeWaitTimeout(err, "wait-timeout")
-			return err
-		}
-	}
-
 	// Don't wait for Standby machines, they are updated but not started
 	if len(lm.Machine().Config.Standbys) > 0 {
 		md.logClearLinesAbove(1)
@@ -291,6 +284,13 @@ func (md *machineDeployment) waitForMachine(ctx context.Context, lm machine.Leas
 			md.colorize.Green("success"),
 		)
 		return nil
+	}
+
+	if !md.skipHealthChecks {
+		if err := lm.WaitForState(ctx, api.MachineStateStarted, md.waitTimeout, indexStr, false); err != nil {
+			err = suggestChangeWaitTimeout(err, "wait-timeout")
+			return err
+		}
 	}
 
 	if err := md.doSmokeChecks(ctx, lm, indexStr); err != nil {


### PR DESCRIPTION
### Change Summary

What and Why:

The standby check appears to have been misplaced relative to the `WaitForState` call.

Related to:

* Should fix an apparent bug introduced in #2660.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
