### PR TITLE
fly deploy: add --only-regions and --exclude-regions flags

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -320,12 +320,18 @@ func deployToMachines(
 	}
 
 	excludeRegions := make(map[string]interface{})
-	for _, reg := range flag.GetStringSlice(ctx, "exclude-regions") {
-		excludeRegions[reg] = struct{}{}
+	for _, r := range flag.GetStringSlice(ctx, "exclude-regions") {
+		reg := strings.TrimSpace(r)
+		if reg != "" {
+			excludeRegions[reg] = struct{}{}
+		}
 	}
 	onlyRegions := make(map[string]interface{})
-	for _, reg := range flag.GetStringSlice(ctx, "only-regions") {
-		onlyRegions[reg] = struct{}{}
+	for _, r := range flag.GetStringSlice(ctx, "only-regions") {
+		reg := strings.TrimSpace(r)
+		if reg != "" {
+			onlyRegions[reg] = struct{}{}
+		}
 	}
 
 	md, err := NewMachineDeployment(ctx, MachineDeploymentArgs{

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -132,6 +132,14 @@ var CommonFlags = flag.Set{
 		Name:        "file-secret",
 		Description: "Set of secrets in the form of /path/inside/machine=SECRET pairs where SECRET is the name of the secret. Can be specified multiple times.",
 	},
+	flag.StringSlice{
+		Name:        "exclude-regions",
+		Description: "Deploy to all machines except machines in these regions. Multiple regions can be specified with comma separated values or by providing the flag multiple times. --exclude-regions iad,sea --exclude-regions syd will exclude all three iad, sea, and syd regions. Applied after --only-regions. V2 machines platform only.",
+	},
+	flag.StringSlice{
+		Name:        "only-regions",
+		Description: "Deploy to machines only in these regions. Multiple regions can be specified with comma separated values or by providing the flag multiple times. --only-regions iad,sea --only-regions syd will deploy to all three iad, sea, and syd regions. Applied before --exclude-regions. V2 machines platform only.",
+	},
 }
 
 func New() (cmd *cobra.Command) {
@@ -311,6 +319,15 @@ func deployToMachines(
 		_ = ApplyFlagsToGuest(ctx, guest)
 	}
 
+	excludeRegions := make(map[string]interface{})
+	for _, reg := range flag.GetStringSlice(ctx, "exclude-regions") {
+		excludeRegions[reg] = struct{}{}
+	}
+	onlyRegions := make(map[string]interface{})
+	for _, reg := range flag.GetStringSlice(ctx, "only-regions") {
+		onlyRegions[reg] = struct{}{}
+	}
+
 	md, err := NewMachineDeployment(ctx, MachineDeploymentArgs{
 		AppCompact:            appCompact,
 		DeploymentImage:       img.Tag,
@@ -328,6 +345,8 @@ func deployToMachines(
 		UpdateOnly:            flag.GetBool(ctx, "update-only"),
 		Files:                 files,
 		ProvisionExtensions:   flag.GetBool(ctx, "provision-extensions"),
+		ExcludeRegions:        excludeRegions,
+		OnlyRegions:           onlyRegions,
 	})
 	if err != nil {
 		sentry.CaptureExceptionWithAppInfo(err, "deploy", appCompact)
@@ -429,6 +448,7 @@ func determineAppConfig(ctx context.Context) (cfg *appconfig.Config, err error) 
 		cfg.SetEnvVariables(parsedEnv)
 	}
 
+	// FIXME: this is a confusing flag; I thought it meant only update machines in the provided region, which resulted in a minor disaster :-)
 	if v := flag.GetRegion(ctx); v != "" {
 		cfg.PrimaryRegion = v
 	}


### PR DESCRIPTION
These flags enable developers to deploy to specific groups of machines based on regions. The motivation is we have an app that has machines deployed globally. There is a primary region where it is safer to deploy each of those machines one-at-a-time, and once that is done we can safely concurrently update all the other machines in the other regions.

This is what the deploy script looks like with these flags:

```
tag=deploy-$(date '+%Y%m%d%H%M%S')-$(git rev-parse --short HEAD)
img=registry.fly.io/my-app-name:${tag}
fly deploy --build-only --image-label ${tag}
fly deploy --image ${img} --only-regions sea --strategy rolling
fly deploy --image ${img} --exclude-regions sea
```

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
