### PR TITLE
Add --max-unavailable flag to fly deploy

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -102,6 +102,11 @@ var CommonFlags = flag.Set{
 		Description: "Perform smoke checks during deployment",
 		Default:     true,
 	},
+	flag.Float64{
+		Name:        "max-unavailable",
+		Description: "Max number of unavailable machines during rolling updates. A number between 0 and 1 means percent of total machines",
+		Default:     0.33,
+	},
 	flag.Bool{
 		Name:        "no-public-ips",
 		Description: "Do not allocate any new public IP addresses",
@@ -321,6 +326,7 @@ func deployToMachines(
 		SkipHealthChecks:      flag.GetDetach(ctx),
 		WaitTimeout:           time.Duration(flag.GetInt(ctx, "wait-timeout")) * time.Second,
 		LeaseTimeout:          time.Duration(flag.GetInt(ctx, "lease-timeout")) * time.Second,
+		MaxUnavailable:        flag.GetFloat64(ctx, "max-unavailable"),
 		ReleaseCmdTimeout:     releaseCmdTimeout,
 		Guest:                 guest,
 		IncreasedAvailability: flag.GetBool(ctx, "ha"),

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -41,6 +41,7 @@ type MachineDeploymentArgs struct {
 	PrimaryRegionFlag     string
 	SkipSmokeChecks       bool
 	SkipHealthChecks      bool
+	MaxUnavailable        float64
 	RestartOnly           bool
 	WaitTimeout           time.Duration
 	LeaseTimeout          time.Duration
@@ -70,6 +71,7 @@ type machineDeployment struct {
 	releaseVersion        int
 	skipSmokeChecks       bool
 	skipHealthChecks      bool
+	maxUnavailable        float64
 	restartOnly           bool
 	waitTimeout           time.Duration
 	leaseTimeout          time.Duration
@@ -143,6 +145,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		skipSmokeChecks:       args.SkipSmokeChecks,
 		skipHealthChecks:      args.SkipHealthChecks,
 		restartOnly:           args.RestartOnly,
+		maxUnavailable:        args.MaxUnavailable,
 		waitTimeout:           waitTimeout,
 		leaseTimeout:          leaseTimeout,
 		leaseDelayBetween:     leaseDelayBetween,

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -27,6 +27,7 @@ const (
 	DefaultReleaseCommandTimeout = 5 * time.Minute
 	DefaultLeaseTtl              = 13 * time.Second
 	DefaultVMSize                = "shared-cpu-1x"
+	DefaultMaxUnavailable        = 0.33
 )
 
 type MachineDeployment interface {
@@ -133,6 +134,12 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	}
 	io := iostreams.FromContext(ctx)
 	apiClient := client.FromContext(ctx).API()
+
+	maxUnavailable := DefaultMaxUnavailable
+	if mu := args.MaxUnavailable; mu > 0 {
+		maxUnavailable = mu
+	}
+
 	md := &machineDeployment{
 		apiClient:             apiClient,
 		gqlClient:             apiClient.GenqClient,
@@ -145,7 +152,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		skipSmokeChecks:       args.SkipSmokeChecks,
 		skipHealthChecks:      args.SkipHealthChecks,
 		restartOnly:           args.RestartOnly,
-		maxUnavailable:        args.MaxUnavailable,
+		maxUnavailable:        maxUnavailable,
 		waitTimeout:           waitTimeout,
 		leaseTimeout:          leaseTimeout,
 		leaseDelayBetween:     leaseDelayBetween,

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"strconv"
 	"strings"
@@ -339,13 +340,22 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 		return md.updateUsingBlueGreenStrategy(ctx, updateEntries)
 	}
 
+	var groupCount int
+	if mu := md.maxUnavailable; mu > 0 && mu < 1 {
+		groupCount = int(math.Floor(1.0 / mu))
+	} else if mu >= 1 {
+		groupCount = int(math.Ceil(float64(len(updateEntries)) / mu))
+	} else {
+		return fmt.Errorf("Invalid --max-unavailable value: %v", mu)
+	}
+
 	type batchJob struct {
 		lm       machine.LeasableMachine
 		indexStr string
 	}
 	b := batcher[batchJob]{
 		TotalJobs:  len(updateEntries),
-		GroupCount: batchingGroupCount,
+		GroupCount: groupCount,
 		SoloFirst:  true,
 	}
 

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -21,10 +21,6 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-const (
-	batchingGroupCount = 3
-)
-
 type ProcessGroupsDiff struct {
 	machinesToRemove      []machine.LeasableMachine
 	groupsToRemove        map[string]int

--- a/internal/flag/context.go
+++ b/internal/flag/context.go
@@ -60,6 +60,16 @@ func GetInt(ctx context.Context, name string) int {
 	}
 }
 
+// GetFloat64 returns the value of the named int flag ctx carries. It panics
+// in case ctx carries no flags or in case the named flag isn't an int one.
+func GetFloat64(ctx context.Context, name string) float64 {
+	if v, err := FromContext(ctx).GetFloat64(name); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
 // GetStringArray returns the values of the named string flag ctx carries.
 // Preserves commas (unlike the following `GetStringSlice`): in `--flag x,y` the value is string[]{`x,y`}.
 // This is useful to pass key-value pairs like environment variables or build arguments.

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -12,7 +12,6 @@ import (
 )
 
 func makeAlias[T any](template T, name string) T {
-
 	var ret T
 	value := reflect.ValueOf(&ret).Elem()
 
@@ -145,6 +144,38 @@ func (i Int) addTo(cmd *cobra.Command) {
 		_ = flags.IntP(i.Name, i.Shorthand, i.Default, i.Description)
 	} else {
 		_ = flags.Int(i.Name, i.Default, i.Description)
+	}
+
+	f := flags.Lookup(i.Name)
+	f.Hidden = i.Hidden
+
+	// Aliases
+	for _, name := range i.Aliases {
+		makeAlias(i, name).addTo(cmd)
+	}
+	err := cmd.Flags().SetAnnotation(f.Name, "flyctl_alias", i.Aliases)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Int wraps the set of int flags.
+type Float64 struct {
+	Name        string
+	Shorthand   string
+	Description string
+	Default     float64
+	Hidden      bool
+	Aliases     []string
+}
+
+func (i Float64) addTo(cmd *cobra.Command) {
+	flags := cmd.Flags()
+
+	if i.Shorthand != "" {
+		_ = flags.Float64P(i.Name, i.Shorthand, i.Default, i.Description)
+	} else {
+		_ = flags.Float64(i.Name, i.Default, i.Description)
 	}
 
 	f := flags.Lookup(i.Name)


### PR DESCRIPTION
What:  At the moment it is not possible to control the size of the batches on a rolling update, it is fixed at 33% and proved to be too aggressive for some apps. 

How: Add --max-unavailable param so it is possible to set the maximum number of unavailable machines on deploys for values greater-than-or-equal to 1, or percent of total machines  for values between 0 and 1.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
