### PR TITLE
`bluegreen`: return errors properly

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -323,7 +323,10 @@ func (md *machineDeployment) updateUsingBlueGreenStrategy(ctx context.Context, u
 	bg := BlueGreenStrategy(md, updateEntries)
 	if err := bg.Deploy(ctx); err != nil {
 		fmt.Fprintf(md.io.ErrOut, "Deployment failed after error: %s\n", err)
-		return bg.Rollback(ctx, err)
+		if rollbackErr := bg.Rollback(ctx, err); rollbackErr != nil {
+			return rollbackErr
+		}
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
### Change Summary

What and Why: Bluegreen would print errors but not return an error code unless rollback _also_ failed. Now we return the error. (this probably double-prints the error message, but we can refine that later)

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
