### PR TITLE
fly deploy: check health checks more quickly

### DIFF
--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -296,9 +296,8 @@ func (lm *leasableMachine) WaitForHealthchecksToPass(ctx context.Context, timeou
 		}
 	}
 	b := &backoff.Backoff{
-		Min:    shortestInterval / 2,
-		Max:    2 * shortestInterval,
-		Factor: 2,
+		Min:    1 * time.Second,
+		Max:    2 * time.Second,
 		Jitter: true,
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why:
Check the status of healthchecks more frequently when deploying machines. Now we check every 1–2 seconds with some jitter. We want to move on as soon as the health check passes, which this better achieves than the previous strategy.

This change combined with `--smoke-checks=false` reduced the `fly deploy` time for an app with 37 machines from 10 minutes to 3 minutes.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
