### PR TITLE
fix(#2543): override color 'white' to avoid usability issues

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -10,9 +10,10 @@ import (
 	"sync"
 
 	"github.com/AlecAivazis/survey/v2"
+	surveyCore "github.com/AlecAivazis/survey/v2/core"
 	"github.com/AlecAivazis/survey/v2/terminal"
+	"github.com/mgutz/ansi"
 	"github.com/samber/lo"
-	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
@@ -20,6 +21,7 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/future"
 	"github.com/superfly/flyctl/internal/sort"
+	"github.com/superfly/flyctl/iostreams"
 )
 
 type RegionParams struct {
@@ -184,6 +186,15 @@ func newSurveyIO(ctx context.Context) (survey.AskOpt, error) {
 	out, ok := io.Out.(terminal.FileWriter)
 	if !ok {
 		return nil, errNonInteractive
+	}
+
+	surveyCore.TemplateFuncsWithColor["color"] = func(style string) string {
+		switch style {
+		case "white":
+			return ansi.ColorCode("default")
+		default:
+			return ansi.ColorCode(style)
+		}
 	}
 
 	return survey.WithStdio(in, out, io.ErrOut), nil


### PR DESCRIPTION
### Change Summary

What and Why:

The color `white` from `survey` is overridden to avoid usability issues in lighter console emulator themes.

How:

I saw how the GitHub CLI approached this issue [here](https://github.com/cli/cli/blob/d9ea221b1a8b1af7856ed4896c92f67acbf295da/cmd/gh/main.go#L74-L81) and used the same approach. While the issue in question was #2543 and related to confirmation prompts, I believe this change should be done outside of the `Confirm` function under `internal/prompt` to avoid any other similar issues where `white` is used instead of the more sane `default`.

Related to:

- https://github.com/superfly/flyctl/issues/1831
- https://github.com/superfly/flyctl/issues/2543
