### PR TITLE
`fly deploy --strategy=bluegreen`: don't wait for standby machines

### DIFF
--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -144,6 +144,11 @@ func (bg *blueGreen) WaitForGreenMachinesToBeStarted(ctx context.Context) error 
 	for _, gm := range bg.greenMachines {
 		id := gm.FormattedMachineId()
 
+		if len(gm.Machine().Config.Standbys) > 0 {
+			machineIDToState[id] = 1
+			continue
+		}
+
 		go func(lm machine.LeasableMachine) {
 			err := machine.WaitForStartOrStop(ctx, lm.Machine(), "start", bg.timeout)
 			if err != nil {


### PR DESCRIPTION
### Change Summary

#### What and Why:

Standby machines don't start when created (and shouldn't), so don't wait for them to start during blue-green deployments.

The output will still say that these are "started," which is not true, but for the time being I just want to get the fix shipped.

#### Related to:

* https://github.com/superfly/flyctl/pull/2678

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
