### PR TITLE
Improve VM size error message for `fly pg create`

### DIFF
--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -390,7 +390,7 @@ func resolveVMSize(ctx context.Context, targetSize string) (*api.VMSize, error) 
 			}
 		}
 
-		return nil, fmt.Errorf("vm size %q is not valid", targetSize)
+		return nil, fmt.Errorf("VM size %q is not valid. For a full list of supported sizes use the command 'flyctl platform vm-sizes'", targetSize)
 	}
 	// prompt user to select machine specific size.
 	return prompt.SelectVMSize(ctx, MachineVMSizes())


### PR DESCRIPTION
### Change Summary

What and Why:

Add a helpful command in the error output when you have tried to create a new PG cluster with an invalid VM size.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
