### PR TITLE
Various extension provisioning updates

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -1101,6 +1101,7 @@ type ExtensionProviderData struct {
 	DetectPlatform       bool                                         `json:"detectPlatform"`
 	ResourceName         string                                       `json:"resourceName"`
 	NameSuffix           string                                       `json:"nameSuffix"`
+	Beta                 bool                                         `json:"beta"`
 	ExcludedRegions      []ExtensionProviderDataExcludedRegionsRegion `json:"excludedRegions"`
 }
 
@@ -1139,6 +1140,9 @@ func (v *ExtensionProviderData) GetResourceName() string { return v.ResourceName
 
 // GetNameSuffix returns ExtensionProviderData.NameSuffix, and is useful for accessing the field via an interface.
 func (v *ExtensionProviderData) GetNameSuffix() string { return v.NameSuffix }
+
+// GetBeta returns ExtensionProviderData.Beta, and is useful for accessing the field via an interface.
+func (v *ExtensionProviderData) GetBeta() bool { return v.Beta }
 
 // GetExcludedRegions returns ExtensionProviderData.ExcludedRegions, and is useful for accessing the field via an interface.
 func (v *ExtensionProviderData) GetExcludedRegions() []ExtensionProviderDataExcludedRegionsRegion {
@@ -1599,6 +1603,9 @@ func (v *GetAddOnProviderAddOnProvider) GetNameSuffix() string {
 	return v.ExtensionProviderData.NameSuffix
 }
 
+// GetBeta returns GetAddOnProviderAddOnProvider.Beta, and is useful for accessing the field via an interface.
+func (v *GetAddOnProviderAddOnProvider) GetBeta() bool { return v.ExtensionProviderData.Beta }
+
 // GetExcludedRegions returns GetAddOnProviderAddOnProvider.ExcludedRegions, and is useful for accessing the field via an interface.
 func (v *GetAddOnProviderAddOnProvider) GetExcludedRegions() []ExtensionProviderDataExcludedRegionsRegion {
 	return v.ExtensionProviderData.ExcludedRegions
@@ -1654,6 +1661,8 @@ type __premarshalGetAddOnProviderAddOnProvider struct {
 
 	NameSuffix string `json:"nameSuffix"`
 
+	Beta bool `json:"beta"`
+
 	ExcludedRegions []ExtensionProviderDataExcludedRegionsRegion `json:"excludedRegions"`
 }
 
@@ -1680,6 +1689,7 @@ func (v *GetAddOnProviderAddOnProvider) __premarshalJSON() (*__premarshalGetAddO
 	retval.DetectPlatform = v.ExtensionProviderData.DetectPlatform
 	retval.ResourceName = v.ExtensionProviderData.ResourceName
 	retval.NameSuffix = v.ExtensionProviderData.NameSuffix
+	retval.Beta = v.ExtensionProviderData.Beta
 	retval.ExcludedRegions = v.ExtensionProviderData.ExcludedRegions
 	return &retval, nil
 }
@@ -3898,6 +3908,7 @@ fragment ExtensionProviderData on AddOnProvider {
 	detectPlatform
 	resourceName
 	nameSuffix
+	beta
 	excludedRegions {
 		code
 	}

--- a/gql/generated.go
+++ b/gql/generated.go
@@ -292,6 +292,8 @@ type AppDataOrganization struct {
 	// Unmodified unique org slug
 	RawSlug  string `json:"rawSlug"`
 	PaidPlan bool   `json:"paidPlan"`
+	// Whether the organization can provision beta extensions
+	ProvisionsBetaExtensions bool `json:"provisionsBetaExtensions"`
 }
 
 // GetId returns AppDataOrganization.Id, and is useful for accessing the field via an interface.
@@ -305,6 +307,9 @@ func (v *AppDataOrganization) GetRawSlug() string { return v.RawSlug }
 
 // GetPaidPlan returns AppDataOrganization.PaidPlan, and is useful for accessing the field via an interface.
 func (v *AppDataOrganization) GetPaidPlan() bool { return v.PaidPlan }
+
+// GetProvisionsBetaExtensions returns AppDataOrganization.ProvisionsBetaExtensions, and is useful for accessing the field via an interface.
+func (v *AppDataOrganization) GetProvisionsBetaExtensions() bool { return v.ProvisionsBetaExtensions }
 
 type BuildFinalImageInput struct {
 	// Sha256 id of docker image
@@ -3548,6 +3553,7 @@ fragment AppData on App {
 		slug
 		rawSlug
 		paidPlan
+		provisionsBetaExtensions
 	}
 }
 `
@@ -3858,6 +3864,7 @@ fragment AppData on App {
 		slug
 		rawSlug
 		paidPlan
+		provisionsBetaExtensions
 	}
 }
 `
@@ -3958,6 +3965,7 @@ fragment AppData on App {
 		slug
 		rawSlug
 		paidPlan
+		provisionsBetaExtensions
 	}
 }
 `
@@ -4050,6 +4058,7 @@ fragment AppData on App {
 		slug
 		rawSlug
 		paidPlan
+		provisionsBetaExtensions
 	}
 }
 fragment AddOnData on AddOn {
@@ -4107,6 +4116,7 @@ fragment AppData on App {
 		slug
 		rawSlug
 		paidPlan
+		provisionsBetaExtensions
 	}
 }
 `

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -198,6 +198,7 @@ fragment ExtensionProviderData on AddOnProvider {
   detectPlatform
   resourceName
 	nameSuffix
+	beta
 	excludedRegions {
 		code
 	}

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -132,6 +132,7 @@ fragment AppData on App {
 		slug
 		rawSlug
 		paidPlan
+		provisionsBetaExtensions
 	}
 }
 

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -285,6 +285,7 @@ type AddOnPlanEdge {
 type AddOnProvider {
   asyncProvisioning: Boolean!
   autoProvision: Boolean!
+  beta: Boolean!
   detectPlatform: Boolean!
   displayName: String
   excludedRegions: [Region!]
@@ -7577,6 +7578,11 @@ type Organization implements Node {
   paidSupportEmail: String
 
   """
+  Whether the organization can provision beta extensions
+  """
+  provisionsBetaExtensions: Boolean!
+
+  """
   Unmodified unique org slug
   """
   rawSlug: String!
@@ -10975,6 +10981,7 @@ type VerifyUserPasswordPayload {
 type Volume implements Node {
   app: App!
   attachedAllocation: Allocation
+  attachedAllocationId: String
   attachedMachine: Machine
   createdAt: ISO8601DateTime!
   encrypted: Boolean!

--- a/internal/command/apps/apps.go
+++ b/internal/command/apps/apps.go
@@ -41,6 +41,7 @@ The LIST command will list all currently registered applications.
 		NewOpen(),
 		NewReleases(),
 		newSetPlatformVersion(),
+		newErrors(),
 	)
 
 	return apps

--- a/internal/command/apps/errors.go
+++ b/internal/command/apps/errors.go
@@ -1,4 +1,4 @@
-package sentry_ext
+package apps
 
 import (
 	"context"
@@ -11,12 +11,12 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 )
 
-func Dashboard() (cmd *cobra.Command) {
+func newErrors() (cmd *cobra.Command) {
 	const (
-		long = `View application errors in the Sentry dashboard`
+		long = `View application errors on Sentry.io`
 
 		short = long
-		usage = "dashboard"
+		usage = "errors"
 	)
 
 	cmd = command.New(usage, short, long, RunDashboard, command.RequireSession, command.RequireAppName)
@@ -25,7 +25,6 @@ func Dashboard() (cmd *cobra.Command) {
 		flag.App(),
 		flag.AppConfig(),
 	)
-	cmd.Aliases = []string{"errors"}
 	cmd.Args = cobra.NoArgs
 	return cmd
 }

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -360,7 +360,7 @@ func deployToMachines(
 		AllocPublicIP:         !flag.GetBool(ctx, "no-public-ips"),
 		UpdateOnly:            flag.GetBool(ctx, "update-only"),
 		Files:                 files,
-		ProvisionExtensions:   flag.GetBool(ctx, "provision-extensions"),
+		ExcludeRegions:        excludeRegions,
 		NoExtensions:          flag.GetBool(ctx, "no-extensions"),
 		OnlyRegions:           onlyRegions,
 	})

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -51,6 +51,10 @@ var CommonFlags = flag.Set{
 		Name:        "provision-extensions",
 		Description: "Provision any extensions assigned as a default to first deployments",
 	},
+	flag.Bool{
+		Name:        "no-extensions",
+		Description: "Do not provision Sentry nor other auto-provisioned extensions",
+	},
 	flag.StringArray{
 		Name:        "env",
 		Shorthand:   "e",
@@ -357,7 +361,7 @@ func deployToMachines(
 		UpdateOnly:            flag.GetBool(ctx, "update-only"),
 		Files:                 files,
 		ProvisionExtensions:   flag.GetBool(ctx, "provision-extensions"),
-		ExcludeRegions:        excludeRegions,
+		NoExtensions:          flag.GetBool(ctx, "no-extensions"),
 		OnlyRegions:           onlyRegions,
 	})
 	if err != nil {

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -26,7 +26,7 @@ func (md *machineDeployment) provisionFirstDeploy(ctx context.Context, allocPubl
 	if !md.noExtensions {
 		_, err := extensions_core.ProvisionExtension(ctx, md.app.Name, "sentry", true, gql.AddOnOptions{})
 		if err != nil {
-			fmt.Fprintf(md.io.ErrOut, "Failed to provision a Sentry project for this app. Use `fly ext sentry create` to try again. ERROR: %s", err)
+			fmt.Fprintf(md.io.ErrOut, "Failed to provision a Sentry project for this app. Use `fly ext sentry create` to try again.\nERROR: %s", err)
 		}
 	}
 	return nil

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -25,18 +25,12 @@ func (md *machineDeployment) provisionFirstDeploy(ctx context.Context, allocPubl
 
 	// Provision Sentry on first deployment, unless we're using CI, where we're more likely to see ephemeral applications
 	if !env.IsCI() && md.provisionExtensions {
-		if err := md.provisionSentryOnFirstDeploy(ctx); err != nil {
+		_, err := extensions_core.ProvisionExtension(ctx, md.app.Name, "sentry", true, gql.AddOnOptions{})
+		if err != nil {
 			fmt.Fprintf(md.io.ErrOut, "Failed to provision a Sentry project for this app. Use `fly ext sentry create` to try again. ERROR: %s", err)
-			return nil
 		}
 	}
-
 	return nil
-}
-
-func (md *machineDeployment) provisionSentryOnFirstDeploy(ctx context.Context) error {
-	_, err := extensions_core.ProvisionExtension(ctx, md.app.Name, "sentry", true, gql.AddOnOptions{})
-	return err
 }
 
 func (md *machineDeployment) provisionIpsOnFirstDeploy(ctx context.Context, allocPublicIPs bool) error {

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -8,7 +8,6 @@ import (
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/gql"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
-	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/prompt"
 )
 
@@ -23,8 +22,8 @@ func (md *machineDeployment) provisionFirstDeploy(ctx context.Context, allocPubl
 		return fmt.Errorf("failed to provision seed volumes: %w", err)
 	}
 
-	// Provision Sentry on first deployment, unless we're using CI, where we're more likely to see ephemeral applications
-	if !env.IsCI() && md.provisionExtensions {
+	// Provision Sentry on first deployment
+	if md.provisionExtensions {
 		_, err := extensions_core.ProvisionExtension(ctx, md.app.Name, "sentry", true, gql.AddOnOptions{})
 		if err != nil {
 			fmt.Fprintf(md.io.ErrOut, "Failed to provision a Sentry project for this app. Use `fly ext sentry create` to try again. ERROR: %s", err)

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -22,8 +22,8 @@ func (md *machineDeployment) provisionFirstDeploy(ctx context.Context, allocPubl
 		return fmt.Errorf("failed to provision seed volumes: %w", err)
 	}
 
-	// Provision Sentry on first deployment
-	if md.provisionExtensions {
+	// Provision Sentry on first deployment unless explicitly prevented by the --no-extensions option
+	if !md.noExtensions {
 		_, err := extensions_core.ProvisionExtension(ctx, md.app.Name, "sentry", true, gql.AddOnOptions{})
 		if err != nil {
 			fmt.Fprintf(md.io.ErrOut, "Failed to provision a Sentry project for this app. Use `fly ext sentry create` to try again. ERROR: %s", err)

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -53,6 +53,7 @@ type MachineDeploymentArgs struct {
 	UpdateOnly            bool
 	Files                 []*api.File
 	ProvisionExtensions   bool
+	NoExtensions          bool
 	ExcludeRegions        map[string]interface{}
 	OnlyRegions           map[string]interface{}
 }

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -86,7 +86,7 @@ type machineDeployment struct {
 	increasedAvailability bool
 	listenAddressChecked  map[string]struct{}
 	updateOnly            bool
-	provisionExtensions   bool
+	noExtensions          bool
 	excludeRegions        map[string]interface{}
 	onlyRegions           map[string]interface{}
 }
@@ -166,7 +166,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		listenAddressChecked:  make(map[string]struct{}),
 		updateOnly:            args.UpdateOnly,
 		machineGuest:          args.Guest,
-		provisionExtensions:   args.ProvisionExtensions,
+		noExtensions:          args.NoExtensions,
 		excludeRegions:        args.ExcludeRegions,
 		onlyRegions:           args.OnlyRegions,
 	}

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -51,6 +51,14 @@ func ProvisionExtension(ctx context.Context, appName string, providerName string
 		return extension, nil
 	}
 
+	// Stop auto-provisioning if this provider is in beta and the target org does is not allowed to provision beta extensions.\
+	// Standard provisioning will be stopped by the backend for the same reason, but there, we'll supply a better error message.
+
+	if auto && provider.Beta && !targetOrg.ProvisionsBetaExtensions {
+		fmt.Println("skipping provisioning")
+		return extension, nil
+	}
+
 	// Stop provisioning if this app already has an extension of this type, but only display an error for
 	// extensions that weren't automatically provisioned
 

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -43,10 +43,6 @@ func ProvisionExtension(ctx context.Context, appName string, providerName string
 		return
 	}
 
-	if !auto {
-		fmt.Fprintln(io.Out)
-	}
-
 	provider := resp.AddOnProvider.ExtensionProviderData
 
 	// Stop provisioning if this app already has an extension of this type, but only display an error for
@@ -55,6 +51,7 @@ func ProvisionExtension(ctx context.Context, appName string, providerName string
 	if len(appResponse.App.AddOns.Nodes) > 0 {
 		existsError := fmt.Errorf("A %s %s named %s already exists for app %s", provider.DisplayName, provider.ResourceName, colorize.Green(appResponse.App.AddOns.Nodes[0].Name), colorize.Green(appName))
 
+		// Don't display an error about an existing provisioned extension if auto-provisioning
 		if auto {
 			existsError = nil
 		}

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -45,13 +45,18 @@ func ProvisionExtension(ctx context.Context, appName string, providerName string
 
 	provider := resp.AddOnProvider.ExtensionProviderData
 
+	// Stop provisioning if being provisioned automatically, but the provider has auto-provisioning disabled
+
+	if auto && !provider.AutoProvision {
+		return extension, nil
+	}
+
 	// Stop provisioning if this app already has an extension of this type, but only display an error for
 	// extensions that weren't automatically provisioned
 
 	if len(appResponse.App.AddOns.Nodes) > 0 {
 		existsError := fmt.Errorf("A %s %s named %s already exists for app %s", provider.DisplayName, provider.ResourceName, colorize.Green(appResponse.App.AddOns.Nodes[0].Name), colorize.Green(appName))
 
-		// Don't display an error about an existing provisioned extension if auto-provisioning
 		if auto {
 			existsError = nil
 		}


### PR DESCRIPTION
In this PR we:

Introduce the `fly apps errors` as a more memorable alias of `fly ext sentry create`. Only "default" extensions like Sentry or PlanetScale get special command aliases like this.

We allow CI environments to auto-provision Sentry projects. The thought is that provisioning in CI is low risk, and could be useful for some customers. To prevent this behavior in CI, one may now pass `--no-extensions` to disable auto-provisioning.

We prevent beta extensions from being auto-provisioned if an org is not allow-listed.