### PR TITLE
Add a --debug flag that prints stacktraces

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,10 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/internal/task"
@@ -121,6 +123,10 @@ func printError(io *iostreams.IOStreams, cs *iostreams.ColorScheme, cmd *cobra.C
 	if docURL := flyerr.GetErrorDocUrl(err); docURL != "" {
 		fmt.Fprintln(io.ErrOut, "View more information at ", docURL)
 		fmt.Fprintln(io.ErrOut)
+	}
+
+	if bool, err := cmd.Flags().GetBool(flagnames.Debug); err == nil && bool {
+		fmt.Fprintf(io.ErrOut, "Stacktrace:\n%s\n", debug.Stack())
 	}
 
 }

--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -94,6 +94,7 @@ To read more, use the docs command to view Fly's help on the web.
 	fs := root.PersistentFlags()
 	_ = fs.StringP(flagnames.AccessToken, "t", "", "Fly API Access Token")
 	_ = fs.BoolP(flagnames.Verbose, "", false, "Verbose output")
+	_ = fs.BoolP(flagnames.Debug, "", false, "Print additional logs and traces")
 
 	flyctl.InitConfig()
 

--- a/internal/flag/flagnames/constants.go
+++ b/internal/flag/flagnames/constants.go
@@ -13,6 +13,9 @@ const (
 	// LocalOnly denotes the name of the local-only flag.
 	LocalOnly = "local-only"
 
+	// Deub denotes the name of the debug flag.
+	Debug = "debug"
+
 	// Org denotes the name of the org flag.
 	Org = "org"
 

--- a/internal/flag/flagnames/constants.go
+++ b/internal/flag/flagnames/constants.go
@@ -13,7 +13,7 @@ const (
 	// LocalOnly denotes the name of the local-only flag.
 	LocalOnly = "local-only"
 
-	// Deub denotes the name of the debug flag.
+	// Debug denotes the name of the debug flag.
 	Debug = "debug"
 
 	// Org denotes the name of the org flag.


### PR DESCRIPTION
### Change Summary

What and Why:

Being able to print stack traces upon encountering an error is *very* useful for debugging.

How:

This adds a new `--debug` flag that prints a stack trace if an error is encountered

Related to:

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
