### PR TITLE
Write error output to stderr as before

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -105,10 +105,7 @@ func isUnchangedError(err error) bool {
 }
 
 func printError(io *iostreams.IOStreams, cs *iostreams.ColorScheme, cmd *cobra.Command, err error) {
-	fmt.Fprint(io.ErrOut, cs.Red("Error: "))
-	fmt.Fprint(io.Out, err.Error())
-
-	fmt.Fprintln(io.ErrOut)
+	fmt.Fprint(io.ErrOut, cs.Red("Error: "), err.Error(), "\n")
 
 	if description := flyerr.GetErrorDescription(err); description != "" && err.Error() != description {
 		fmt.Fprintln(io.ErrOut, description)

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -662,16 +662,16 @@ func TestErrOutput(t *testing.T) {
 	firstMachine := machList[0]
 
 	res = f.FlyAllowExitFailure("machine update --vm-cpus 3 %s --yes", firstMachine.ID)
-	require.Equal(f, res.StdOut().String(), "invalid number of CPUs")
+	require.Contains(f, res.StdErr().String(), "invalid number of CPUs")
 
 	res = f.FlyAllowExitFailure("machine update --vm-memory 10 %s --yes", firstMachine.ID)
-	require.Equal(f, res.StdOut().String(), "invalid memory size")
+	require.Contains(f, res.StdErr().String(), "invalid memory size")
 
 	f.Fly("machine update --vm-cpus 4 %s --vm-memory 2048 --yes", firstMachine.ID)
 
 	res = f.FlyAllowExitFailure("machine update --vm-memory 256 %s --yes", firstMachine.ID)
-	require.Equal(f, res.StdOut().String(), "memory size for config is too low")
+	require.Contains(f, res.StdErr().String(), "memory size for config is too low")
 
 	res = f.FlyAllowExitFailure("machine update --vm-memory 16384 %s --yes", firstMachine.ID)
-	require.Equal(f, res.StdOut().String(), "memory size for config is too high")
+	require.Contains(f, res.StdErr().String(), "memory size for config is too high")
 }


### PR DESCRIPTION
### Change Summary

What and Why: Preflight tests are broken since https://github.com/superfly/flyctl/pull/2692

How: Write the error message to stderr as was done before the change 

Related to: https://github.com/superfly/flyctl/pull/2692

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
