### PR TITLE
Rename the auto-confirm flag to yes

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -60,7 +60,7 @@ var CommonFlags = flag.Set{
 		Shorthand:   "e",
 		Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
 	},
-	flag.Yes().SetDescription("Will automatically confirm changes when running non-interactively."),
+	flag.Yes(),
 	flag.Int{
 		Name:        "wait-timeout",
 		Description: "Seconds to wait for individual machines to transition states and become healthy.",

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -60,10 +60,7 @@ var CommonFlags = flag.Set{
 		Shorthand:   "e",
 		Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
 	},
-	flag.Bool{
-		Name:        "auto-confirm",
-		Description: "Will automatically confirm changes when running non-interactively.",
-	},
+	flag.Yes().SetDescription("Will automatically confirm changes when running non-interactively."),
 	flag.Int{
 		Name:        "wait-timeout",
 		Description: "Seconds to wait for individual machines to transition states and become healthy.",
@@ -199,7 +196,7 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	return DeployWithConfig(ctx, appConfig, flag.GetBool(ctx, "auto-confirm"), nil)
+	return DeployWithConfig(ctx, appConfig, flag.HasYes(ctx), nil)
 }
 
 func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes bool, optionalGuest *api.MachineGuest) (err error) {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -196,7 +196,7 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	return DeployWithConfig(ctx, appConfig, flag.HasYes(ctx), nil)
+	return DeployWithConfig(ctx, appConfig, flag.GetYes(ctx), nil)
 }
 
 func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes bool, optionalGuest *api.MachineGuest) (err error) {

--- a/internal/command/ips/allocate.go
+++ b/internal/command/ips/allocate.go
@@ -30,10 +30,7 @@ func newAllocatev4() *cobra.Command {
 			Description: "Allocates a shared IPv4",
 			Default:     false,
 		},
-		flag.Bool{
-			Name:        "yes",
-			Description: "Auto-confirm IPv4 allocation",
-		},
+		flag.Yes().SetDescription("Auto-confirm IPv4 allocation"),
 		flag.App(),
 		flag.AppConfig(),
 		flag.Region(),

--- a/internal/command/ips/allocate.go
+++ b/internal/command/ips/allocate.go
@@ -30,7 +30,7 @@ func newAllocatev4() *cobra.Command {
 			Description: "Allocates a shared IPv4",
 			Default:     false,
 		},
-		flag.Yes().SetDescription("Auto-confirm IPv4 allocation"),
+		flag.Yes(),
 		flag.App(),
 		flag.AppConfig(),
 		flag.Region(),

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -72,7 +72,6 @@ func New() (cmd *cobra.Command) {
 			Description: "Use the Launch V2 interface",
 			Hidden:      true,
 		},
-		//FIXME: Do i need a flag.Yes() here?
 	)
 
 	return

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -72,6 +72,7 @@ func New() (cmd *cobra.Command) {
 			Description: "Use the Launch V2 interface",
 			Hidden:      true,
 		},
+		//FIXME: Do i need a flag.Yes() here?
 	)
 
 	return

--- a/internal/command/launch/legacy/launch.go
+++ b/internal/command/launch/legacy/launch.go
@@ -386,7 +386,7 @@ func determineBaseAppConfig(ctx context.Context) (*appconfig.Config, bool, error
 			var err error
 			copyConfig, err = prompt.Confirm(ctx, "Would you like to copy its configuration to the new app?")
 			switch {
-			case prompt.IsNonInteractive(err) && !flag.HasYes(ctx):
+			case prompt.IsNonInteractive(err) && !flag.GetYes(ctx):
 				return nil, false, err
 			case err != nil:
 				return nil, false, err

--- a/internal/command/launch/legacy/launch.go
+++ b/internal/command/launch/legacy/launch.go
@@ -386,7 +386,7 @@ func determineBaseAppConfig(ctx context.Context) (*appconfig.Config, bool, error
 			var err error
 			copyConfig, err = prompt.Confirm(ctx, "Would you like to copy its configuration to the new app?")
 			switch {
-			case prompt.IsNonInteractive(err) && !flag.GetBool(ctx, "auto-confirm"):
+			case prompt.IsNonInteractive(err) && !flag.HasYes(ctx):
 				return nil, false, err
 			case err != nil:
 				return nil, false, err

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -149,7 +149,7 @@ func v2DetermineBaseAppConfig(ctx context.Context) (*appconfig.Config, bool, err
 			var err error
 			copyConfig, err = prompt.Confirm(ctx, "Would you like to copy its configuration to the new app?")
 			switch {
-			case prompt.IsNonInteractive(err) && !flag.GetBool(ctx, "auto-confirm"):
+			case prompt.IsNonInteractive(err) && !flag.HasYes(ctx):
 				return nil, false, err
 			case err != nil:
 				return nil, false, err

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -149,7 +149,7 @@ func v2DetermineBaseAppConfig(ctx context.Context) (*appconfig.Config, bool, err
 			var err error
 			copyConfig, err = prompt.Confirm(ctx, "Would you like to copy its configuration to the new app?")
 			switch {
-			case prompt.IsNonInteractive(err) && !flag.HasYes(ctx):
+			case prompt.IsNonInteractive(err) && !flag.GetYes(ctx):
 				return nil, false, err
 			case err != nil:
 				return nil, false, err

--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -256,7 +256,7 @@ func resolveConfigChanges(ctx context.Context, app *api.AppCompact, manager stri
 		dialer = agent.DialerFromContext(ctx)
 
 		force       = flag.GetBool(ctx, "force")
-		autoConfirm = flag.GetBool(ctx, "yes")
+		autoConfirm = flag.HasYes(ctx)
 	)
 
 	// Identify requested configuration changes.
@@ -318,7 +318,7 @@ func resolveConfigChanges(ctx context.Context, app *api.AppCompact, manager stri
 					return false, nil, nil
 				}
 			case prompt.IsNonInteractive(err):
-				return false, nil, prompt.NonInteractiveError("auto-confirm flag must be specified when not running interactively")
+				return false, nil, prompt.NonInteractiveError("yes flag must be specified when not running interactively")
 			default:
 				return false, nil, err
 			}

--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -256,7 +256,7 @@ func resolveConfigChanges(ctx context.Context, app *api.AppCompact, manager stri
 		dialer = agent.DialerFromContext(ctx)
 
 		force       = flag.GetBool(ctx, "force")
-		autoConfirm = flag.HasYes(ctx)
+		autoConfirm = flag.GetYes(ctx)
 	)
 
 	// Identify requested configuration changes.

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -78,7 +78,7 @@ func runExtend(ctx context.Context) error {
 	}
 
 	if app.PlatformVersion == "nomad" {
-		if !flag.HasYes(ctx) {
+		if !flag.GetYes(ctx) {
 			switch confirmed, err := prompt.Confirm(ctx, "Extending this volume will result in a VM restart. Continue?"); {
 			case err == nil:
 				if !confirmed {

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -44,10 +44,7 @@ func newExtend() *cobra.Command {
 			Shorthand:   "s",
 			Description: "Target volume size in gigabytes",
 		},
-		flag.Bool{
-			Name:        "auto-confirm",
-			Description: "Will automatically confirm changes without an interactive prompt.",
-		},
+		flag.Yes(),
 	)
 
 	flag.Add(cmd, flag.JSONOutput())
@@ -81,14 +78,14 @@ func runExtend(ctx context.Context) error {
 	}
 
 	if app.PlatformVersion == "nomad" {
-		if !flag.GetBool(ctx, "auto-confirm") {
+		if !flag.HasYes(ctx) {
 			switch confirmed, err := prompt.Confirm(ctx, "Extending this volume will result in a VM restart. Continue?"); {
 			case err == nil:
 				if !confirmed {
 					return nil
 				}
 			case prompt.IsNonInteractive(err):
-				return prompt.NonInteractiveError("auto-confirm flag must be specified when not running interactively")
+				return prompt.NonInteractiveError("yes flag must be specified when not running interactively")
 			default:
 				return err
 			}

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -336,11 +336,6 @@ func Yes() Bool {
 	}
 }
 
-// Checks whether the --yes flag or the --auto-confirm flag is present
-func HasYes(ctx context.Context) bool {
-	return GetBool(ctx, "yes")
-}
-
 // App returns an app string flag.
 func App() String {
 	return String{

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -62,11 +62,6 @@ type Bool struct {
 	Aliases     []string
 }
 
-func (b Bool) SetDescription(description string) Bool {
-	b.Description = description
-	return b
-}
-
 func (b Bool) addTo(cmd *cobra.Command) {
 	flags := cmd.Flags()
 

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -62,6 +62,11 @@ type Bool struct {
 	Aliases     []string
 }
 
+func (b Bool) SetDescription(description string) Bool {
+	b.Description = description
+	return b
+}
+
 func (b Bool) addTo(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
@@ -327,7 +332,13 @@ func Yes() Bool {
 		Name:        flagnames.Yes,
 		Shorthand:   "y",
 		Description: "Accept all confirmations",
+		Aliases:     []string{"auto-confirm"},
 	}
+}
+
+// Checks whether the --yes flag or the --auto-confirm flag is present
+func HasYes(ctx context.Context) bool {
+	return GetBool(ctx, "yes") || GetBool(ctx, "auto-confirm")
 }
 
 // App returns an app string flag.

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -338,7 +338,7 @@ func Yes() Bool {
 
 // Checks whether the --yes flag or the --auto-confirm flag is present
 func HasYes(ctx context.Context) bool {
-	return GetBool(ctx, "yes") || GetBool(ctx, "auto-confirm")
+	return GetBool(ctx, "yes")
 }
 
 // App returns an app string flag.

--- a/internal/machine/config.go
+++ b/internal/machine/config.go
@@ -47,7 +47,7 @@ func ConfirmConfigChanges(ctx context.Context, machine *api.Machine, targetConfi
 			return false, nil
 		}
 	case prompt.IsNonInteractive(err):
-		return false, prompt.NonInteractiveError("auto-confirm flag must be specified when not running interactively")
+		return false, prompt.NonInteractiveError("yes flag must be specified when not running interactively")
 	default:
 		return false, err
 	}


### PR DESCRIPTION
### Change Summary

What and Why:

This makes auto-confirming much more consistent across the CLI. The tests were purposely not changed to test backwards compatibility.

How:

Use `flag.Yes()` everywhere, and make `--auto-confirm` and alias for `--yes` so it shouldn't break anything

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
