### PR TITLE
'fly secrets deploy' command for deploying staged secrets

### DIFF
--- a/internal/command/secrets/deploy.go
+++ b/internal/command/secrets/deploy.go
@@ -1,0 +1,59 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+)
+
+func newDeploy() (cmd *cobra.Command) {
+	const (
+		long  = `Deploy staged secrets for an application`
+		short = long
+		usage = "deploy [flags]"
+	)
+
+	cmd = command.New(usage, short, long, runDeploy, command.RequireSession, command.RequireAppName)
+
+	flag.Add(cmd,
+		sharedFlags,
+	)
+
+	return cmd
+}
+
+func runDeploy(ctx context.Context) (err error) {
+	client := client.FromContext(ctx).API()
+	appName := appconfig.NameFromContext(ctx)
+	app, err := client.GetAppCompact(ctx, appName)
+	if err != nil {
+		return err
+	}
+
+	flapsClient, err := flaps.New(ctx, app)
+	if err != nil {
+		return fmt.Errorf("could not create flaps client: %w", err)
+	}
+
+	machines, _, err := flapsClient.ListFlyAppsMachines(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !app.Deployed && len(machines) == 0 {
+		return errors.New("before using 'fly secrets deploy', you must first deploy your app at least once using 'fly deploy'")
+	}
+
+	if app.PlatformVersion != appconfig.MachinesPlatform {
+		return errors.New("secrets deploy is only supported for machine apps")
+	}
+
+	return DeploySecrets(ctx, app, flag.GetBool(ctx, "stage"), flag.GetBool(ctx, "detach"))
+}

--- a/internal/command/secrets/deploy.go
+++ b/internal/command/secrets/deploy.go
@@ -23,7 +23,9 @@ func newDeploy() (cmd *cobra.Command) {
 	cmd = command.New(usage, short, long, runDeploy, command.RequireSession, command.RequireAppName)
 
 	flag.Add(cmd,
-		sharedFlags,
+		flag.App(),
+		flag.AppConfig(),
+		flag.Detach(),
 	)
 
 	return cmd
@@ -55,5 +57,5 @@ func runDeploy(ctx context.Context) (err error) {
 		return errors.New("secrets deploy is only supported for machine apps")
 	}
 
-	return DeploySecrets(ctx, app, flag.GetBool(ctx, "stage"), flag.GetBool(ctx, "detach"))
+	return DeploySecrets(ctx, app, false, flag.GetBool(ctx, "detach"))
 }

--- a/internal/command/secrets/deploy.go
+++ b/internal/command/secrets/deploy.go
@@ -41,7 +41,9 @@ func runDeploy(ctx context.Context) (err error) {
 
 	flapsClient, err := flaps.New(ctx, app)
 	if err != nil {
-		return fmt.Errorf("could not create flaps client: %w", err)
+		return flyerr.GenericErr{
+			Err:      fmt.Sprintf("could not create flaps client: %w", err),
+		}
 	}
 
 	machines, _, err := flapsClient.ListFlyAppsMachines(ctx)

--- a/internal/command/secrets/deploy.go
+++ b/internal/command/secrets/deploy.go
@@ -65,4 +65,3 @@ func runDeploy(ctx context.Context) (err error) {
 
 	return DeploySecrets(ctx, app, false, flag.GetBool(ctx, "detach"))
 }
-

--- a/internal/command/secrets/deploy.go
+++ b/internal/command/secrets/deploy.go
@@ -49,12 +49,12 @@ func runDeploy(ctx context.Context) (err error) {
 		return err
 	}
 
-	if !app.Deployed && len(machines) == 0 {
-		return errors.New("before using 'fly secrets deploy', you must first deploy your app at least once using 'fly deploy'")
-	}
-
 	if app.PlatformVersion != appconfig.MachinesPlatform {
 		return errors.New("secrets deploy is only supported for machine apps")
+	}
+
+	if !app.Deployed && len(machines) == 0 {
+		return errors.New("before using 'fly secrets deploy', you must first deploy your app at least once using 'fly deploy'")
 	}
 
 	return DeploySecrets(ctx, app, false, flag.GetBool(ctx, "detach"))

--- a/internal/command/secrets/deploy.go
+++ b/internal/command/secrets/deploy.go
@@ -42,7 +42,7 @@ func runDeploy(ctx context.Context) (err error) {
 	flapsClient, err := flaps.New(ctx, app)
 	if err != nil {
 		return flyerr.GenericErr{
-			Err:      fmt.Sprintf("could not create flaps client: %w", err),
+			Err:      fmt.Sprintf("could not create flaps client: %v", err),
 		}
 	}
 

--- a/internal/command/secrets/deploy.go
+++ b/internal/command/secrets/deploy.go
@@ -42,7 +42,7 @@ func runDeploy(ctx context.Context) (err error) {
 	flapsClient, err := flaps.New(ctx, app)
 	if err != nil {
 		return flyerr.GenericErr{
-			Err:      fmt.Sprintf("could not create flaps client: %v", err),
+			Err: fmt.Sprintf("could not create flaps client: %v", err),
 		}
 	}
 
@@ -53,7 +53,7 @@ func runDeploy(ctx context.Context) (err error) {
 
 	if app.PlatformVersion != appconfig.MachinesPlatform {
 		return flyerr.GenericErr{
-				Err:      "secrets deploy is only supported for machine apps",
+			Err: "secrets deploy is only supported for machine apps",
 		}
 	}
 

--- a/internal/command/secrets/deploy.go
+++ b/internal/command/secrets/deploy.go
@@ -39,6 +39,12 @@ func runDeploy(ctx context.Context) (err error) {
 		return err
 	}
 
+	if app.PlatformVersion != appconfig.MachinesPlatform {
+		return flyerr.GenericErr{
+			Err: "secrets deploy is only supported for machine apps",
+		}
+	}
+
 	flapsClient, err := flaps.New(ctx, app)
 	if err != nil {
 		return flyerr.GenericErr{
@@ -49,12 +55,6 @@ func runDeploy(ctx context.Context) (err error) {
 	machines, _, err := flapsClient.ListFlyAppsMachines(ctx)
 	if err != nil {
 		return err
-	}
-
-	if app.PlatformVersion != appconfig.MachinesPlatform {
-		return flyerr.GenericErr{
-			Err: "secrets deploy is only supported for machine apps",
-		}
 	}
 
 	if !(app.Deployed && len(machines) > 0) {

--- a/internal/command/secrets/secrets.go
+++ b/internal/command/secrets/secrets.go
@@ -45,6 +45,7 @@ func New() *cobra.Command {
 		newSet(),
 		newUnset(),
 		newImport(),
+		newDeploy(),
 	)
 
 	return secrets

--- a/internal/flyerr/flyerr.go
+++ b/internal/flyerr/flyerr.go
@@ -90,8 +90,7 @@ func PrintCLIOutput(err error) {
 	suggestion := GetErrorSuggestion(err)
 
 	if description != "" {
-		fmt.Println()
-		fmt.Printf("\n%s", description)
+		fmt.Printf("\n\n%s", description)
 	}
 
 	if suggestion != "" {

--- a/internal/flyerr/flyerr.go
+++ b/internal/flyerr/flyerr.go
@@ -90,6 +90,7 @@ func PrintCLIOutput(err error) {
 	suggestion := GetErrorSuggestion(err)
 
 	if description != "" {
+		fmt.Println()
 		fmt.Printf("\n%s", description)
 	}
 


### PR DESCRIPTION

## Change Summary

### What and Why:

A `fly secrets deploy` command to deploy staged secrets. It would be useful to have a way to deploy secrets using the current deployed app config (i.e: without having to cut a new release which requires the code, etc.). There are some follow up features that I'm exploring (in the UI) that would use this command.

To explain a bit more, it's possible to stage secrets (for machine apps) using `fly secrets set --staging FOO=BAR` but the only way to deploy them is using `fly deploy` which cuts a new release. It would be useful to have a way to deploy secrets _without having to create a new release_, which is exactly what `fly secrets set FOO=BAR` does already when it's not staged:

https://github.com/superfly/flyctl/blob/b61fe0fa4ef70f2a97aac8abf0d23cb5a3d4c50e/internal/command/secrets/secrets.go#L105-L111

### How:

This PR doesn't reinvent the wheel. It simply uses the existing [`DeploySecrets`](https://github.com/superfly/flyctl/blob/b61fe0fa4ef70f2a97aac8abf0d23cb5a3d4c50e/internal/command/secrets/secrets.go#L81) function, which is normally called _after_ unsetting/setting secrets. 

### Caveats:

- only works with machine apps
- requires that at least one deploy has been run prior

## Testing

I've omitted my app name, machine id's, etc. 

```bash
> fly secrets set --stage -a lonely-secret TEST=FOO

Secrets have been staged, but not set on VMs. Deploy or update machines in this app for the secrets to take effect.

> go run . secrets deploy -a [app name]
INFO Using wait timeout: 2m0s lease timeout: 13s delay between lease refreshes: 4s

Updating existing machines in '[app name]' with rolling strategy
  [1/2] Machine ******************* [app] update finished: success
  [2/2] Machine ******************* [app] update finished: success
  Finished deploying

> fly ssh console -a [app name]
Connecting to fdaa:1:***:***:***:****:****:*... complete
root@******************:/usr/src/app# env | grep TEST
TEST=FOO
```

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
