### PR TITLE
Fix scaling up from zero when group has mounted volumes

### DIFF
--- a/internal/command/machine/list.go
+++ b/internal/command/machine/list.go
@@ -64,15 +64,15 @@ func runMachineList(ctx context.Context) (err error) {
 		return fmt.Errorf("machines could not be retrieved")
 	}
 
+	if cfg.JSONOutput {
+		return render.JSON(io.Out, machines)
+	}
+
 	if len(machines) == 0 {
 		if !silence {
 			fmt.Fprintf(io.Out, "No machines are available on this app %s\n", appName)
 		}
 		return nil
-	}
-
-	if cfg.JSONOutput {
-		return render.JSON(io.Out, machines)
 	}
 
 	rows := [][]string{}
@@ -81,7 +81,6 @@ func runMachineList(ctx context.Context) (err error) {
 
 	if !silence {
 		fmt.Fprintf(io.Out, "%d machines have been retrieved from app %s.\n%s\n\n", len(machines), appName, listOfMachinesLink)
-
 	}
 	if silence {
 		for _, machine := range machines {
@@ -102,12 +101,10 @@ func runMachineList(ctx context.Context) (err error) {
 			if machine.Config != nil {
 				if platformVersion, ok := machine.Config.Metadata[api.MachineConfigMetadataKeyFlyPlatformVersion]; ok {
 					appPlatform = platformVersion
-
 				}
 
 				if processGroup := machine.ProcessGroup(); processGroup != "" {
 					machineProcessGroup = processGroup
-
 				}
 
 				if machine.Config.Guest != nil {

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -70,7 +70,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 		}
 	})
 
-	defaults := newDefaults(appConfig, latestCompleteRelease, machines)
+	defaults := newDefaults(appConfig, latestCompleteRelease, machines, volumes)
 
 	actions, err := computeActions(machines, expectedGroupCounts, availableVols, regions, maxPerRegion, defaults)
 	if err != nil {

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -63,7 +63,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 	if err != nil {
 		return err
 	}
-	defaults := newDefaults(appConfig, latestCompleteRelease, machines, volumes)
+	defaults := newDefaults(appConfig, latestCompleteRelease, machines, volumes, flag.GetBool(ctx, "with-new-volumes"))
 
 	actions, err := computeActions(machines, expectedGroupCounts, regions, maxPerRegion, defaults)
 	if err != nil {
@@ -85,9 +85,9 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 		volumesToCreate := action.VolumesDelta()
 		switch {
 		case volumesToReuse > 0 && volumesToCreate > 0:
-			fmt.Fprintf(io.Out, "%+4d volumes and using %d existing volumes for group '%s' in region '%s'\n", volumesToCreate, volumesToReuse, action.GroupName, action.Region)
+			fmt.Fprintf(io.Out, "%+4d volumes and %d unattached volumes assigned to group '%s' in region '%s'\n", volumesToCreate, volumesToReuse, action.GroupName, action.Region)
 		case volumesToReuse > 0:
-			fmt.Fprintf(io.Out, "  Using %d existing volumes for group '%s' in region '%s'\n", volumesToReuse, action.GroupName, action.Region)
+			fmt.Fprintf(io.Out, "% 4d unattached volumes to be assigned to group '%s' in region '%s'\n", volumesToReuse, action.GroupName, action.Region)
 		case volumesToCreate > 0:
 			fmt.Fprintf(io.Out, "%+4d volumes for group '%s' in region '%s'\n", volumesToCreate, action.GroupName, action.Region)
 		}

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -65,14 +65,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 	}
 	defaults := newDefaults(appConfig, latestCompleteRelease, machines, volumes)
 
-	var availableVols []*api.Volume
-	if !flag.GetBool(ctx, "with-new-volumes") {
-		availableVols = lo.FilterMap(volumes, func(v api.Volume, _ int) (*api.Volume, bool) {
-			return &v, !v.IsAttached()
-		})
-	}
-
-	actions, err := computeActions(machines, expectedGroupCounts, availableVols, regions, maxPerRegion, defaults)
+	actions, err := computeActions(machines, expectedGroupCounts, regions, maxPerRegion, defaults)
 	if err != nil {
 		return err
 	}
@@ -250,7 +243,7 @@ func (pi *planItem) MachineSize() string {
 	return ""
 }
 
-func computeActions(machines []*api.Machine, expectedGroupCounts map[string]int, volumes []*api.Volume, regions []string, maxPerRegion int, defaults *defaultValues) ([]*planItem, error) {
+func computeActions(machines []*api.Machine, expectedGroupCounts map[string]int, regions []string, maxPerRegion int, defaults *defaultValues) ([]*planItem, error) {
 	actions := make([]*planItem, 0)
 	seenGroups := make(map[string]bool)
 	machineGroups := lo.GroupBy(machines, func(m *api.Machine) string {

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -30,16 +30,13 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 	}
 
 	var latestCompleteRelease api.Release
-
-	releases, err := apiClient.GetAppReleasesMachines(ctx, appName, "complete", 1)
-	if err != nil {
+	switch releases, err := apiClient.GetAppReleasesMachines(ctx, appName, "complete", 1); {
+	case err != nil:
 		return err
-	}
-
-	if len(releases) > 0 {
-		latestCompleteRelease = releases[0]
-	} else {
+	case len(releases) == 0:
 		return fmt.Errorf("this app has no complete releases. Run `fly deploy` to create one and rerun this command")
+	default:
+		latestCompleteRelease = releases[0]
 	}
 
 	var regions []string

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -218,28 +218,11 @@ func pickOrCreateVolume(ctx context.Context, mount api.MachineMount, volumes []*
 		fmt.Fprintf(io.Out, "  Creating new volume from snapshot: %s\n", colorize.Bold(*snapshotID))
 	}
 
-	sizeGb := mount.SizeGb
-	encrypted := mount.Encrypted
-	if sizeGb == 0 {
-		if len(volumes) > 0 {
-			sizeGb = volumes[0].Volume.SizeGb
-			encrypted = volumes[0].Volume.Encrypted
-		} else {
-			fmt.Fprintf(
-				io.Out,
-				"  Using 1GB encrypted volume for '%s'. Run `fly vol extend` to increase the size\n",
-				colorize.Bold(mount.Name),
-			)
-			sizeGb = 1
-			encrypted = true
-		}
-	}
-
 	volInput := api.CreateVolumeRequest{
 		Name:              mount.Name,
 		Region:            region,
-		SizeGb:            &sizeGb,
-		Encrypted:         api.Pointer(encrypted),
+		SizeGb:            &mount.SizeGb,
+		Encrypted:         api.Pointer(mount.Encrypted),
 		SnapshotID:        snapshotID,
 		RequireUniqueZone: api.Pointer(false),
 	}

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -257,8 +257,9 @@ func destroyMachine(ctx context.Context, machine *api.Machine) error {
 }
 
 type planItem struct {
-	GroupName     string
-	Region        string
+	GroupName string
+	Region    string
+	// The number of machines to add or remove
 	Delta         int
 	Machines      []*api.Machine
 	MachineConfig *api.MachineConfig

--- a/internal/command/scale/machine_defaults.go
+++ b/internal/command/scale/machine_defaults.go
@@ -19,9 +19,10 @@ type defaultValues struct {
 	releaseVersion  string
 	appConfig       *appconfig.Config
 	existingVolumes map[string]map[string][]*api.Volume
+	snapshotID      *string
 }
 
-func newDefaults(appConfig *appconfig.Config, latest api.Release, machines []*api.Machine, volumes []api.Volume, withNewVolumes bool) *defaultValues {
+func newDefaults(appConfig *appconfig.Config, latest api.Release, machines []*api.Machine, volumes []api.Volume, snapshotID string, withNewVolumes bool) *defaultValues {
 	guestPerGroup := lo.Associate(
 		lo.Filter(machines, func(m *api.Machine, _ int) bool {
 			return m.Config.Guest != nil
@@ -51,6 +52,10 @@ func newDefaults(appConfig *appconfig.Config, latest api.Release, machines []*ap
 		releaseId:      latest.ID,
 		releaseVersion: strconv.Itoa(latest.Version),
 		appConfig:      appConfig,
+	}
+
+	if snapshotID != "" {
+		defaults.snapshotID = &snapshotID
 	}
 
 	defaults.volsizeByName = lo.Reduce(volumes, func(agg map[string]int, v api.Volume, _ int) map[string]int {
@@ -120,5 +125,6 @@ func (d *defaultValues) CreateVolumeRequest(mConfig *api.MachineConfig, region s
 		SizeGb:            &mount.SizeGb,
 		Encrypted:         api.Pointer(mount.Encrypted),
 		RequireUniqueZone: api.Pointer(false),
+		SnapshotID:        d.snapshotID,
 	}
 }

--- a/internal/command/scale/machine_defaults.go
+++ b/internal/command/scale/machine_defaults.go
@@ -42,9 +42,10 @@ func newDefaults(appConfig *appconfig.Config, latest api.Release, machines []*ap
 		}
 	}
 
-	volsizeByName := lo.Associate(volumes, func(v api.Volume) (string, int) {
-		return v.Name, v.SizeGb
-	})
+	volsizeByName := lo.Reduce(volumes, func(agg map[string]int, v api.Volume, _ int) map[string]int {
+		agg[v.Name] = lo.Max([]int{agg[v.Name], v.SizeGb})
+		return agg
+	}, make(map[string]int))
 
 	return &defaultValues{
 		image:          latest.ImageRef,

--- a/test/preflight/fly_scale_count.go
+++ b/test/preflight/fly_scale_count.go
@@ -1,0 +1,35 @@
+//go:build integration
+// +build integration
+
+package preflight
+
+import (
+	"testing"
+
+	"github.com/superfly/flyctl/test/preflight/testlib"
+)
+
+func TestFlyScaleCount(t *testing.T) {
+	t.Parallel()
+
+	f := testlib.NewTestEnvFromEnv(t)
+	appName := f.CreateRandomAppName()
+
+	f.WriteFlyToml(`
+app = "%s"
+primary_region = "%s"
+
+[build]
+	image = "nginx"
+
+[mounts]
+	source = "data"
+	destination = "/data"
+	`, appName, f.PrimaryRegion())
+
+	f.Fly("deploy --ha=false")
+	f.Fly("scale count -y 2")
+	f.Fly("scale count -y 1 --region %s", f.SecondaryRegion())
+	f.Fly("scale count -y 0")
+	f.Fly("scale count -y 2")
+}

--- a/test/preflight/fly_scale_test.go
+++ b/test/preflight/fly_scale_test.go
@@ -5,6 +5,7 @@ package preflight
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/superfly/flyctl/test/preflight/testlib"
@@ -33,18 +34,22 @@ primary_region = "%s"
 	require.Equal(f, 1, len(ml))
 
 	f.Fly("scale count -y 2")
+	time.Sleep(2 * time.Second)
 	ml = f.MachinesList(appName)
 	require.Equal(f, 2, len(ml))
 
 	f.Fly("scale count -y 1 --region %s", f.SecondaryRegion())
+	time.Sleep(2 * time.Second)
 	ml = f.MachinesList(appName)
 	require.Equal(f, 3, len(ml))
 
 	f.Fly("scale count -y 0")
+	time.Sleep(2 * time.Second)
 	ml = f.MachinesList(appName)
 	require.Equal(f, 0, len(ml))
 
 	f.Fly("scale count -y 2")
+	time.Sleep(2 * time.Second)
 	ml = f.MachinesList(appName)
 	require.Equal(f, 2, len(ml))
 }

--- a/test/preflight/fly_scale_test.go
+++ b/test/preflight/fly_scale_test.go
@@ -33,6 +33,9 @@ primary_region = "%s"
 	ml := f.MachinesList(appName)
 	require.Equal(f, 1, len(ml))
 
+	// Extend the volume because if not found, scaling will default to 1GB.
+	f.Fly("vol extend -s 2 %s", ml[0].Config.Mounts[0].Volume)
+
 	f.Fly("scale count -y 2")
 	time.Sleep(2 * time.Second)
 	ml = f.MachinesList(appName)
@@ -52,4 +55,9 @@ primary_region = "%s"
 	time.Sleep(2 * time.Second)
 	ml = f.MachinesList(appName)
 	require.Equal(f, 2, len(ml))
+
+	vl := f.VolumeList(appName)
+	for _, v := range vl {
+		require.Equal(f, v.SizeGb, 2)
+	}
 }

--- a/test/preflight/fly_scale_test.go
+++ b/test/preflight/fly_scale_test.go
@@ -6,6 +6,7 @@ package preflight
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/superfly/flyctl/test/preflight/testlib"
 )
 
@@ -13,7 +14,7 @@ func TestFlyScaleCount(t *testing.T) {
 	t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
-	appName := f.CreateRandomAppName()
+	appName := f.CreateRandomAppMachines()
 
 	f.WriteFlyToml(`
 app = "%s"
@@ -28,8 +29,22 @@ primary_region = "%s"
 	`, appName, f.PrimaryRegion())
 
 	f.Fly("deploy --ha=false")
+	ml := f.MachinesList(appName)
+	require.Equal(f, 1, len(ml))
+
 	f.Fly("scale count -y 2")
+	ml = f.MachinesList(appName)
+	require.Equal(f, 2, len(ml))
+
 	f.Fly("scale count -y 1 --region %s", f.SecondaryRegion())
+	ml = f.MachinesList(appName)
+	require.Equal(f, 3, len(ml))
+
 	f.Fly("scale count -y 0")
+	ml = f.MachinesList(appName)
+	require.Equal(f, 0, len(ml))
+
 	f.Fly("scale count -y 2")
+	ml = f.MachinesList(appName)
+	require.Equal(f, 2, len(ml))
 }


### PR DESCRIPTION
### Change Summary

What and Why: Scaling up from zero fails due to lack of volume size information

How: Infer size from available volumes or fallback to 1GB+encrypted if none found

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
