### PR TITLE
Skip Barman Machines in PG config updates

### DIFF
--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -233,6 +233,10 @@ func updateFlexConfig(ctx context.Context, app *api.AppCompact, leaderIP string)
 
 	// Sync configuration settings for each node. This should be safe to apply out-of-order.
 	for _, machine := range machines {
+		if machine.Config.Env["IS_BARMAN"] != "" {
+			continue
+		}
+
 		client := flypg.NewFromInstance(machine.PrivateIP, dialer)
 
 		// Pull configuration settings down from Consul for each node and reload the config.


### PR DESCRIPTION
### Change Summary

What and Why:

Don't attempt to update the config for Barman machine when running `fly postgres config update`

How:

In the `updateFlexConfig` function, only update Machines with an empty `IS_BARMAN` var.

Related to:

Internal discussion #3747

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
