### PR TITLE
`migrate-to-v2`: Query app volumes from Flaps

### DIFF
--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -159,15 +159,6 @@ func (client *Client) GetApp(ctx context.Context, appName string) (*App, error) 
 					digest
 					version
 				}
-				volumes {
-					nodes {
-						id
-						sizeGb
-						name
-						region
-						attached_alloc_id: attachedAllocationId
-					}
-				}
 				machines{
 					nodes {
 						id

--- a/api/types.go
+++ b/api/types.go
@@ -323,12 +323,9 @@ type App struct {
 	VMSize           VMSize
 	Regions          *[]Region
 	BackupRegions    *[]Region
-	Volumes          struct {
-		Nodes []Volume
-	}
-	TaskGroupCounts []TaskGroupCount
-	ProcessGroups   []ProcessGroup
-	HealthChecks    *struct {
+	TaskGroupCounts  []TaskGroupCount
+	ProcessGroups    []ProcessGroup
+	HealthChecks     *struct {
 		Nodes []CheckState
 	}
 	PostgresAppRole *struct {

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -352,7 +352,10 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 	if err != nil {
 		return nil, err
 	}
-	migrator.resolveOldVolumes()
+	err = migrator.resolveOldVolumes(ctx)
+	if err != nil {
+		return nil, err
+	}
 	err = migrator.validateVolumes(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/command/migrate_to_v2/pg.go
+++ b/internal/command/migrate_to_v2/pg.go
@@ -77,10 +77,9 @@ func (m *v2PlatformMigrator) updateNomadPostgresImage(ctx context.Context) error
 }
 
 func (m *v2PlatformMigrator) migratePgVolumes(ctx context.Context) error {
-	app := m.appFull
 	regionsToVols := map[string][]api.Volume{}
 	// Find all volumes
-	for _, vol := range app.Volumes.Nodes {
+	for _, vol := range m.oldAttachedVolumes {
 		if strings.Contains(vol.Name, "machines") || vol.AttachedAllocation == nil {
 			continue
 		}

--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -112,8 +112,12 @@ func (m *v2PlatformMigrator) nomadVolPath(v *api.Volume, group string) string {
 }
 
 // Must run *after* allocs are filtered
-func (m *v2PlatformMigrator) resolveOldVolumes() {
-	m.oldAttachedVolumes = lo.Filter(m.appFull.Volumes.Nodes, func(v api.Volume, _ int) bool {
+func (m *v2PlatformMigrator) resolveOldVolumes(ctx context.Context) error {
+	vols, err := m.flapsClient.GetAllVolumes(ctx)
+	if err != nil {
+		return err
+	}
+	m.oldAttachedVolumes = lo.Filter(vols, func(v api.Volume, _ int) bool {
 		if v.AttachedAllocation != nil {
 			for _, a := range m.oldAllocs {
 				if a.ID == *v.AttachedAllocation {
@@ -123,6 +127,7 @@ func (m *v2PlatformMigrator) resolveOldVolumes() {
 		}
 		return false
 	})
+	return nil
 }
 
 func (m *v2PlatformMigrator) printReplacedVolumes() {


### PR DESCRIPTION
### Change Summary

What and Why: Query volumes with the Flaps API for volumes instead of including them in the GraphQL "App" query. Also removes the field from that query, to prevent accidental usage of the old API.

Related to: https://community.fly.io/t/fly-migrate-to-v2-apps-with-volumes-support/12316/44?u=allison (shouldn't fix this problem, but helps narrow down the causes)

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
