### PR TITLE
`win32`: Set console codepage to UTF-8

### DIFF
--- a/internal/cli/cli_windows.go
+++ b/internal/cli/cli_windows.go
@@ -1,0 +1,12 @@
+package cli
+
+import "golang.org/x/sys/windows"
+
+func init() {
+
+	kernel32 := windows.NewLazySystemDLL("kernel32.dll")
+	setConsoleCP := kernel32.NewProc("SetConsoleCP")
+	// Set codepage to UTF-8
+	// https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers#:~:text=Unicode%20(UTF%2D7)-,65001,-utf%2D8
+	setConsoleCP.Call(uintptr(65001))
+}


### PR DESCRIPTION
### Change Summary

What and Why: Sets the Windows console codepage to UTF-8, hopefully making SSH and interactive sessions more reliable on Windows builds.

Related to: https://github.com/superfly/flyctl/issues/1458

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
