### PR TITLE
Remove debugging output

### DIFF
--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -55,7 +55,6 @@ func ProvisionExtension(ctx context.Context, appName string, providerName string
 	// Standard provisioning will be stopped by the backend for the same reason, but there, we'll supply a better error message.
 
 	if auto && provider.Beta && !targetOrg.ProvisionsBetaExtensions {
-		fmt.Println("skipping provisioning")
 		return extension, nil
 	}
 


### PR DESCRIPTION
This PR simply removes annoying debugging output that shows up on every new, first deployment.