### PR TITLE
audit tool

### DIFF
--- a/cmd/audit/audit.go
+++ b/cmd/audit/audit.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "audit",
+		Short: "Tool for auditing flyctl commands",
+	}
+
+	rootCmd.AddCommand(newListCmd())
+	rootCmd.AddCommand(newStatsCmd())
+	rootCmd.AddCommand(newLintCmd())
+
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatalln(err)
+	}
+}
+
+type walkFn func(cmd *cobra.Command, depth int)
+
+func walkInternal(cmd *cobra.Command, maxDepth int, depth int, fn walkFn) {
+	if maxDepth > -1 && depth > maxDepth {
+		return
+	}
+
+	fn(cmd, depth)
+
+	for _, childCmd := range cmd.Commands() {
+		walkInternal(childCmd, maxDepth, depth+1, fn)
+	}
+}
+
+func walk(cmd *cobra.Command, fn walkFn) {
+	walkInternal(cmd, -1, 0, fn)
+}
+
+func walkMaxDepth(cmd *cobra.Command, maxDepth int, fn walkFn) {
+	walkInternal(cmd, maxDepth, 0, fn)
+}

--- a/cmd/audit/lint.go
+++ b/cmd/audit/lint.go
@@ -1,0 +1,317 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"unicode"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/superfly/flyctl/internal/command/root"
+	"golang.org/x/exp/slices"
+)
+
+func newLintCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "lint",
+		Short: "Run checks against flyctl commands and flags",
+		Run: func(cmd *cobra.Command, args []string) {
+			root := root.New()
+			run := NewCheckRun(root)
+
+			table := tablewriter.NewWriter(os.Stdout)
+			table.SetBorder(false)
+			table.SetAutoWrapText(false)
+			table.SetHeader([]string{"Path", "Check", "Failure Reason"})
+
+			errors := run.Run()
+			for _, err := range errors {
+				table.Append([]string{
+					err.command,
+					err.check,
+					err.Error(),
+				})
+			}
+
+			table.Render()
+
+			fmt.Println()
+			fmt.Printf("%d checks failed\n", len(errors))
+
+			if len(errors) > 0 {
+				os.Exit(1)
+			}
+		},
+	}
+	return cmd
+}
+
+// add more to this list as needed. Just make sure they are actually common (in flyctl and other well known CLIs)!
+var commonFlagShorthands = map[string]string{
+	"app":          "a",
+	"org":          "o",
+	"config":       "c",
+	"access-token": "t",
+	"help":         "h",
+	"json":         "j",
+}
+
+type run struct {
+	rootCmd        *cobra.Command
+	commandsByName map[string][]*cobra.Command
+	flagsByName    map[string][]*pflag.Flag
+}
+
+func (r *run) Run() (errors []checkError) {
+	walk(r.rootCmd, func(cmd *cobra.Command, depth int) {
+		for name, fn := range commandChecks {
+			if err := fn(r, cmd); err != nil {
+				errors = append(errors, checkError{
+					command: cmd.CommandPath(),
+					check:   name,
+					err:     err,
+				})
+			}
+		}
+
+		cmd.Flags().VisitAll(func(f *pflag.Flag) {
+			for name, fn := range flagChecks {
+				if err := fn(r, cmd, f); err != nil {
+					errors = append(errors, checkError{
+						command: cmd.CommandPath() + " --" + f.Name,
+						check:   name,
+						err:     err,
+					})
+				}
+			}
+		})
+	})
+
+	return
+}
+
+func NewCheckRun(root *cobra.Command) *run {
+	r := &run{
+		rootCmd:        root,
+		commandsByName: make(map[string][]*cobra.Command),
+		flagsByName:    make(map[string][]*pflag.Flag),
+	}
+
+	walk(root, func(cmd *cobra.Command, depth int) {
+		r.commandsByName[cmd.Name()] = append(r.commandsByName[cmd.Name()], cmd)
+
+		cmd.Flags().VisitAll(func(f *pflag.Flag) {
+			r.flagsByName[f.Name] = append(r.flagsByName[f.Name], f)
+		})
+	})
+
+	return r
+}
+
+type checkError struct {
+	command string
+	check   string
+	err     error
+}
+
+func (e *checkError) Error() string {
+	return e.err.Error()
+}
+
+type cmdCheckFn func(run *run, cmd *cobra.Command) error
+
+var commandChecks = map[string]cmdCheckFn{
+	"flags-in-usage":         redundantUsageCheck,
+	"duplicate-description":  duplicateDescription,
+	"description-too-long":   shortDescriptionTooLong,
+	"inconsistent-aliases":   inconsistentAliases,
+	"usage-punctuation":      usagePunctuation,
+	"newline-in-description": newlineInDescription,
+	"missing-descriptions":   missingDescriptions,
+	"short-description-case": shortDescriptionCasing,
+	"poor-command-name":      poorCommandName,
+	"too-many-subcommands":   tooManySubcommands,
+	"invalid-group":          invalidGroup,
+}
+
+type flagCheckFn func(run *run, cmd *cobra.Command, flag *pflag.Flag) error
+
+var flagChecks = map[string]flagCheckFn{
+	// disabled for now because there are a lot of these
+	// "flag-punctuation": flagPunctuation,
+	"misused-shorthand":            misusedShorthand,
+	"inconsistent-flag-shorthands": inconsistentFlagShorthands,
+}
+
+func redundantUsageCheck(run *run, cmd *cobra.Command) error {
+	if strings.Contains(cmd.Use, "[flags]") {
+		return fmt.Errorf("redundant \"[flags]\" in usage string: \"%s\"; remove \"[flags]\"", cmd.Use)
+	}
+	return nil
+}
+
+func duplicateDescription(run *run, cmd *cobra.Command) error {
+	if cmd.Long == cmd.Short {
+		return fmt.Errorf("duplicate cmd.Long and cmd.Short; remove cmd.long")
+	}
+	return nil
+}
+
+func shortDescriptionCasing(run *run, cmd *cobra.Command) error {
+	if cmd.Short != "" && !unicode.IsUpper([]rune(cmd.Short)[0]) {
+		return fmt.Errorf("cmd.Short should be capitalized")
+	}
+	return nil
+}
+
+func newlineInDescription(run *run, cmd *cobra.Command) error {
+	if strings.Contains(cmd.Short, "\n") {
+		return fmt.Errorf("cmd.Short cannot contain newlines")
+	}
+	return nil
+}
+
+func missingDescriptions(run *run, cmd *cobra.Command) error {
+	if cmd.Short == "" && cmd.Long == "" {
+		return fmt.Errorf("no description; add cmd.Short and ideally cmd.Long")
+	} else if cmd.Short == "" {
+		return fmt.Errorf("has cmd.Long but not cmd.Short; add cmd.Short")
+	}
+	return nil
+}
+
+func shortDescriptionTooLong(run *run, cmd *cobra.Command) error {
+	if len(cmd.Short) > 80 {
+		return fmt.Errorf("cmd.Short is too long and risks wrapping; should be 80 characters or less")
+	}
+	return nil
+}
+
+func usagePunctuation(run *run, cmd *cobra.Command) error {
+	if strings.HasSuffix(cmd.Use, ".") {
+		return fmt.Errorf("cmd.Use should not end with a period")
+	}
+	return nil
+}
+
+func inconsistentAliases(run *run, cmd *cobra.Command) error {
+	aliases := map[string]int{}
+	cmdCount := len(run.commandsByName[cmd.Name()])
+	for _, otherCmd := range run.commandsByName[cmd.Name()] {
+		for _, alias := range otherCmd.Aliases {
+			aliases[alias]++
+		}
+	}
+
+	uncommon := []string{}
+	missing := []string{}
+
+	for alias, count := range aliases {
+		if float64(count)/float64(cmdCount) > 0.5 {
+			if !slices.Contains(cmd.Aliases, alias) {
+				missing = append(missing, alias)
+			}
+		} else {
+			if slices.Contains(cmd.Aliases, alias) {
+				uncommon = append(uncommon, alias)
+			}
+		}
+	}
+
+	if len(uncommon) > 0 {
+		return fmt.Errorf("has aliases not used by other commands with the same name: %s", encodeForMessage(uncommon))
+	}
+
+	if len(missing) > 0 {
+		return fmt.Errorf("missing aliases used by other commands with the same name: %s", encodeForMessage(missing))
+	}
+
+	return nil
+}
+
+func poorCommandName(run *run, cmd *cobra.Command) error {
+	var msg string
+	switch cmd.Name() {
+	case "destroy":
+		msg = "is too agro. consider renaming to \"delete\""
+	}
+
+	if msg != "" {
+		return fmt.Errorf("command name \"%s\" %s", cmd.Name(), msg)
+	}
+	return nil
+}
+
+func tooManySubcommands(run *run, cmd *cobra.Command) error {
+	var count int
+	for _, c := range cmd.Commands() {
+		if !c.Hidden {
+			count++
+		}
+	}
+
+	if count > 10 && len(cmd.Groups()) > 0 {
+		return fmt.Errorf("too many non-hidden subcommands (%d); consider using groups to organze them", count)
+	}
+
+	return nil
+}
+
+func invalidGroup(run *run, cmd *cobra.Command) error {
+	if cmd.GroupID != "" && !cmd.Parent().ContainsGroup(cmd.GroupID) {
+		groupIDs := []string{}
+		for _, g := range cmd.Parent().Groups() {
+			groupIDs = append(groupIDs, g.ID)
+		}
+		return fmt.Errorf("group \"%s\" is not registered on the parent command: %v", cmd.GroupID, groupIDs)
+	}
+	return nil
+}
+
+func flagPunctuation(run *run, cmd *cobra.Command, flag *pflag.Flag) error {
+	if !strings.HasSuffix(flag.Usage, ".") {
+		return fmt.Errorf("flag.Usage should end with a period")
+	}
+	return nil
+}
+
+func misusedShorthand(run *run, cmd *cobra.Command, flag *pflag.Flag) error {
+	if flag.Shorthand != "" {
+		for name, shorthand := range commonFlagShorthands {
+			if flag.Shorthand == shorthand && flag.Name != name {
+				return fmt.Errorf("shorthand \"%s\" should only be used with flags named \"%s\"", shorthand, name)
+			}
+		}
+	}
+
+	return nil
+}
+
+func inconsistentFlagShorthands(run *run, cmd *cobra.Command, flag *pflag.Flag) error {
+	shorthandCounts := map[string]int{}
+	flagCount := len(run.flagsByName[flag.Name])
+	for _, otherFlags := range run.flagsByName[flag.Name] {
+		shorthandCounts[otherFlags.Shorthand]++
+	}
+
+	for shorthand, count := range shorthandCounts {
+		if float64(count)/float64(flagCount) > 0.5 {
+			if flag.Shorthand != shorthand {
+				return fmt.Errorf("shorthand \"%s\" is inconsistent with other flags with the same name: %v", flag.Shorthand, encodeForMessage(shorthandCounts))
+			}
+		}
+	}
+
+	return nil
+}
+
+func encodeForMessage(x any) string {
+	b, err := json.Marshal(x)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}

--- a/cmd/audit/lint.go
+++ b/cmd/audit/lint.go
@@ -271,12 +271,12 @@ func invalidGroup(run *run, cmd *cobra.Command) error {
 	return nil
 }
 
-func flagPunctuation(run *run, cmd *cobra.Command, flag *pflag.Flag) error {
-	if !strings.HasSuffix(flag.Usage, ".") {
-		return fmt.Errorf("flag.Usage should end with a period")
-	}
-	return nil
-}
+// func flagPunctuation(run *run, cmd *cobra.Command, flag *pflag.Flag) error {
+// 	if !strings.HasSuffix(flag.Usage, ".") {
+// 		return fmt.Errorf("flag.Usage should end with a period")
+// 	}
+// 	return nil
+// }
 
 func misusedShorthand(run *run, cmd *cobra.Command, flag *pflag.Flag) error {
 	if flag.Shorthand != "" {

--- a/cmd/audit/list.go
+++ b/cmd/audit/list.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/superfly/flyctl/internal/command/root"
+	"golang.org/x/exp/slices"
+)
+
+func formatRawText(desc string) string {
+	return strings.ReplaceAll(desc, "\n", "⏎")
+}
+
+func newListCmd() *cobra.Command {
+	var maxDepth int
+	var printUsage bool
+	var printDescription bool
+	var outputFormat string
+	var flags bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List flyctl commands",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			output := newOutput(os.Stdout, outputFormat)
+			root := root.New()
+
+			header := []string{"Command", "Aliases", "Flags", "Details"}
+			if flags {
+				header = slices.Insert(header, 1, "Flag")
+			}
+			if printUsage {
+				header = append(header, "Usage")
+			}
+			if printDescription {
+				header = append(header, "Description")
+			}
+			output.SetHeader(header)
+
+			walkMaxDepth(root, maxDepth, func(cmd *cobra.Command, depth int) {
+				cols := []string{
+					cmd.CommandPath(),
+					strings.Join(cmd.Aliases, ", "),
+					strconv.Itoa(countFlags(cmd)),
+					commandAttrs(cmd),
+				}
+
+				if flags {
+					cols = slices.Insert(cols, 1, "")
+				}
+
+				if printUsage {
+					cols = append(cols, formatRawText(cmd.UseLine()))
+				}
+				if printDescription {
+					cols = append(cols, formatRawText(cmd.Short))
+				}
+
+				output.Append(cols)
+
+				if flags {
+					cmd.Flags().VisitAll(func(f *pflag.Flag) {
+						cols = []string{
+							cmd.CommandPath(),
+							"--" + f.Name,
+							f.Shorthand,
+							"",
+							flagAttrs(f),
+						}
+						if printUsage {
+							cols = append(cols, f.Usage)
+						}
+						if printDescription {
+							cols = append(cols, "")
+						}
+
+						output.Append(cols)
+					})
+				}
+			})
+
+			return output.Flush()
+		},
+	}
+	cmd.Flags().IntVar(&maxDepth, "max-depth", -1, "Maximum depth to walk the command tree")
+	cmd.Flags().BoolVar(&printUsage, "usage", false, "Print usage for each command")
+	cmd.Flags().BoolVar(&printDescription, "description", false, "Print description for each command")
+	cmd.Flags().StringVar(&outputFormat, "output", "table", "Output format (table, csv, json)")
+	cmd.Flags().BoolVar(&flags, "flags", false, "Include flags for each command")
+
+	return cmd
+}
+
+func commandAttrs(cmd *cobra.Command) string {
+	attrs := []string{}
+	if cmd.GroupID != "" {
+		attrs = append(attrs, "group:"+cmd.GroupID)
+	}
+	if cmd.Deprecated != "" {
+		attrs = append(attrs, "deprecated")
+	}
+	if cmd.Hidden {
+		attrs = append(attrs, "hidden")
+	}
+	if !cmd.Runnable() {
+		attrs = append(attrs, "not_runnable")
+	}
+	if cmd.HasExample() {
+		attrs = append(attrs, "has_example")
+	}
+	slices.Sort(attrs)
+	return strings.Join(attrs, ", ")
+}
+
+func flagAttrs(f *pflag.Flag) string {
+	attrs := []string{}
+	if f.Deprecated != "" {
+		attrs = append(attrs, "deprecated")
+	}
+	if f.Hidden {
+		attrs = append(attrs, "hidden")
+	}
+	if f.ShorthandDeprecated != "" {
+		attrs = append(attrs, "shorthand_deprecated")
+	}
+	slices.Sort(attrs)
+	return strings.Join(attrs, ", ")
+}
+
+func countFlags(cmd *cobra.Command) (count int) {
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		count++
+	})
+	return
+}

--- a/cmd/audit/output.go
+++ b/cmd/audit/output.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+func newOutput(w io.Writer, format string) output {
+	switch format {
+	case "csv":
+		return NewCSVOutput(w)
+	default:
+		return NewTableOutput(w)
+	}
+}
+
+type output interface {
+	SetHeader([]string)
+	Append([]string)
+	Flush() error
+}
+
+func NewTableOutput(w io.Writer) *tableOutput {
+	t := tablewriter.NewWriter(w)
+	t.SetBorder(false)
+	t.SetAutoWrapText(false)
+	return &tableOutput{
+		Table: t,
+	}
+}
+
+type tableOutput struct {
+	*tablewriter.Table
+}
+
+func (t *tableOutput) Flush() error {
+	t.Table.Render()
+	return nil
+}
+
+func NewCSVOutput(w io.Writer) *csvOutput {
+	return &csvOutput{
+		w: csv.NewWriter(w),
+	}
+}
+
+type csvOutput struct {
+	w *csv.Writer
+}
+
+func (t *csvOutput) SetHeader(header []string) {
+	t.Append(header)
+}
+
+func (t *csvOutput) Append(row []string) {
+	if err := t.w.Write(row); err != nil {
+		panic(err)
+	}
+}
+
+func (t *csvOutput) Flush() error {
+	t.w.Flush()
+	return t.w.Error()
+}
+
+func prettyPrintJSON(v any) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(b))
+}

--- a/cmd/audit/stats.go
+++ b/cmd/audit/stats.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/command/root"
+)
+
+func newStatsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stats",
+		Short: "Stats. Everybody loves stats.",
+		Run: func(cmd *cobra.Command, args []string) {
+			root := root.New()
+			stats := stats{}
+
+			walk(root, func(cmd *cobra.Command, depth int) {
+				stats.Commands.Total++
+
+				if cmd.Hidden {
+					stats.Commands.Hidden++
+				}
+
+				if cmd.Deprecated != "" {
+					stats.Commands.Deprecated++
+				}
+
+				if cmd.Runnable() {
+					stats.Commands.Runnable++
+				}
+
+				if cmd.HasExample() {
+					stats.Commands.WithExamples++
+				}
+
+				if command.IsAppsV1Command(cmd) {
+					stats.Commands.AppsV1++
+				}
+
+				stats.Commands.Aliases += len(cmd.Aliases)
+
+				cmd.Flags().VisitAll(func(f *pflag.Flag) {
+					stats.Flags.Total++
+
+					if f.Hidden {
+						stats.Flags.Hidden++
+					}
+
+					if f.Deprecated != "" {
+						stats.Flags.Deprecated++
+					}
+
+					if f.Shorthand != "" {
+						stats.Flags.WithShorthand++
+					}
+				})
+			})
+
+			stats.Root.Groups = len(root.Groups())
+
+			for _, cmd := range root.Commands() {
+				stats.Root.Commands++
+
+				if cmd.Hidden {
+					stats.Root.Hidden++
+				} else {
+					stats.Root.Visible++
+				}
+
+				if cmd.Deprecated != "" {
+					stats.Root.Deprecated++
+				}
+
+				if cmd.Runnable() {
+					stats.Root.Runnable++
+				}
+			}
+
+			prettyPrintJSON(stats)
+		},
+	}
+
+	return cmd
+}
+
+type stats struct {
+	Root struct {
+		Commands   int
+		Hidden     int
+		Visible    int
+		Deprecated int
+		Runnable   int
+		Groups     int
+	}
+	Commands struct {
+		Total        int
+		Runnable     int
+		Hidden       int
+		Deprecated   int
+		WithExamples int
+		Aliases      int
+		AppsV1       int
+	}
+	Flags struct {
+		Total         int
+		Hidden        int
+		Deprecated    int
+		WithShorthand int
+		AppsV1        int
+	}
+}

--- a/internal/command/options.go
+++ b/internal/command/options.go
@@ -1,0 +1,22 @@
+package command
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func AnnotateCommand(cmd *cobra.Command, key, value string) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+
+	cmd.Annotations[key] = value
+}
+
+func TagV1Command(cmd *cobra.Command) {
+	AnnotateCommand(cmd, "apps_v1", "1")
+}
+
+func IsAppsV1Command(cmd *cobra.Command) bool {
+	_, ok := cmd.Annotations["apps_v1"]
+	return ok
+}


### PR DESCRIPTION
### Change Summary

What and Why:

Tool to help us wrangle sprawling flyctl commands.

How:

`go run ./cmd/audit <lint|stats|list>`

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
