### PR TITLE
Reduce flaky tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   test_build:
     runs-on:
-      group: ubuntu-latest-m
+      labels: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,7 @@ env:
 
 jobs:
   test_build:
-    runs-on:
-      labels: ubuntu-latest-m
+    runs-on: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
 env:
   go_version: 1.21
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   test_build:
     runs-on: ubuntu-latest-m

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,8 @@ env:
 
 jobs:
   test_build:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest-m, macos-latest-xl, windows-latest-l ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        parallelism: [10]
+        parallelism: [1]
         index: [0,1,2,3,4,5,6,7,8,9]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -17,10 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # parallelism: [10]
-        # index: [0,1,2,3,4,5,6,7,8,9]
-        parallelism: [1]
-        index: [0]
+        parallelism: [10]
+        index: [0,1,2,3,4,5,6,7,8,9]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        parallelism: [10]
-        index: [0,1,2,3,4,5,6,7,8,9]
+        parallelism: [20]
+        index: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -28,7 +28,7 @@ jobs:
       - name: Get go version
         id: go-version
         run: echo "name=version::$(go env GOVERSION)" >> $GITHUB_OUTPUT
-      - name: Install gotesplit, set FLY_PREFLIGHT_TEST_APP_PREFIX and build flyctl
+      - name: Install gotesplit, set FLY_PREFLIGHT_TEST_APP_PREFIX
         run: |
           curl -sfL https://raw.githubusercontent.com/Songmu/gotesplit/v0.2.1/install.sh | sh -s
           echo "FLY_PREFLIGHT_TEST_APP_PREFIX=pf-gha-$(openssl rand -hex 4)" >> "$GITHUB_ENV"

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -17,8 +17,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # parallelism: [10]
+        # index: [0,1,2,3,4,5,6,7,8,9]
         parallelism: [1]
-        index: [0,1,2,3,4,5,6,7,8,9]
+        index: [0]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        parallelism: [20]
-        index: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
+        parallelism: [25]
+        index: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -27,7 +27,6 @@ func TestAppsV2Example(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	// t.Parallel()
 
 	var (
 		err    error
@@ -121,7 +120,6 @@ ENV BUILT_BY_DOCKERFILE=true
 }
 
 func TestAppsV2ConfigChanges(t *testing.T) {
-	// t.Parallel()
 
 	var (
 		err            error
@@ -162,7 +160,6 @@ func TestAppsV2ConfigChanges(t *testing.T) {
 }
 
 func TestAppsV2ConfigSave_ProcessGroups(t *testing.T) {
-	// t.Parallel()
 
 	var (
 		err            error
@@ -213,7 +210,6 @@ func TestAppsV2ConfigSave_OneMachineNoAppConfig(t *testing.T) {
 }
 
 func TestAppsV2Config_ParseExperimental(t *testing.T) {
-	// t.Parallel()
 
 	var (
 		err            error
@@ -239,7 +235,6 @@ func TestAppsV2Config_ParseExperimental(t *testing.T) {
 }
 
 func TestAppsV2Config_ProcessGroups(t *testing.T) {
-	// t.Parallel()
 
 	var (
 		f              = testlib.NewTestEnvFromEnv(t)
@@ -432,7 +427,6 @@ web = "nginx -g 'daemon off;'"
 }
 
 func TestAppsV2MigrateToV2(t *testing.T) {
-	// t.Parallel()
 
 	var (
 		err     error
@@ -455,7 +449,6 @@ func TestAppsV2MigrateToV2(t *testing.T) {
 
 // This test takes forever. I'm sorry.
 func TestAppsV2MigrateToV2_Volumes(t *testing.T) {
-	// t.Parallel()
 
 	if testing.Short() {
 		t.Skip()
@@ -523,7 +516,6 @@ primary_region = "%s"
 
 // this test is really slow :(
 func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
-	// t.Parallel()
 
 	var (
 		err     error
@@ -564,7 +556,6 @@ func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
 }
 
 func TestNoPublicIPDeployMachines(t *testing.T) {
-	// t.Parallel()
 
 	var (
 		result *testlib.FlyctlResult
@@ -580,7 +571,6 @@ func TestNoPublicIPDeployMachines(t *testing.T) {
 }
 
 func TestLaunchCpusMem(t *testing.T) {
-	// t.Parallel()
 
 	var (
 		f       = testlib.NewTestEnvFromEnv(t)
@@ -597,7 +587,6 @@ func TestLaunchCpusMem(t *testing.T) {
 }
 
 func TestLaunchDetach(t *testing.T) {
-	// t.Parallel()
 
 	var (
 		f       = testlib.NewTestEnvFromEnv(t)
@@ -614,7 +603,6 @@ func TestLaunchDetach(t *testing.T) {
 }
 
 func TestDeployDetach(t *testing.T) {
-	// t.Parallel()
 
 	var (
 		f       = testlib.NewTestEnvFromEnv(t)
@@ -631,7 +619,6 @@ func TestDeployDetach(t *testing.T) {
 }
 
 func TestDeployDetachBatching(t *testing.T) {
-	// t.Parallel()
 
 	var (
 		f       = testlib.NewTestEnvFromEnv(t)
@@ -649,7 +636,6 @@ func TestDeployDetachBatching(t *testing.T) {
 }
 
 func TestErrOutput(t *testing.T) {
-	// t.Parallel()
 
 	var (
 		f       = testlib.NewTestEnvFromEnv(t)

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -523,7 +523,7 @@ func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
 		appName = f.CreateRandomAppName()
 	)
 
-	ctx, cancel := context.WithTimeoutCause(context.Background(), 4*time.Minute, errors.New("test timed out"))
+	ctx, cancel := context.WithTimeoutCause(context.Background(), 6*time.Minute, errors.New("test timed out"))
 	defer cancel()
 
 	f.FlyC(ctx, "launch --org %s --name %s --region %s --now --internal-port 80 --force-nomad --image nginx", f.OrgSlug(), appName, f.PrimaryRegion())

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -523,7 +523,7 @@ func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
 		appName = f.CreateRandomAppName()
 	)
 
-	ctx, cancel := context.WithTimeoutCause(context.Background(), 2*time.Minute, errors.New("test timed out"))
+	ctx, cancel := context.WithTimeoutCause(context.Background(), 4*time.Minute, errors.New("test timed out"))
 	defer cancel()
 
 	f.FlyC(ctx, "launch --org %s --name %s --region %s --now --internal-port 80 --force-nomad --image nginx", f.OrgSlug(), appName, f.PrimaryRegion())

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -27,7 +27,7 @@ func TestAppsV2Example(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	t.Parallel()
+	// t.Parallel()
 
 	var (
 		err    error
@@ -121,7 +121,7 @@ ENV BUILT_BY_DOCKERFILE=true
 }
 
 func TestAppsV2ConfigChanges(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	var (
 		err            error
@@ -162,7 +162,7 @@ func TestAppsV2ConfigChanges(t *testing.T) {
 }
 
 func TestAppsV2ConfigSave_ProcessGroups(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	var (
 		err            error
@@ -213,7 +213,7 @@ func TestAppsV2ConfigSave_OneMachineNoAppConfig(t *testing.T) {
 }
 
 func TestAppsV2Config_ParseExperimental(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	var (
 		err            error
@@ -239,7 +239,7 @@ func TestAppsV2Config_ParseExperimental(t *testing.T) {
 }
 
 func TestAppsV2Config_ProcessGroups(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	var (
 		f              = testlib.NewTestEnvFromEnv(t)
@@ -432,7 +432,7 @@ web = "nginx -g 'daemon off;'"
 }
 
 func TestAppsV2MigrateToV2(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	var (
 		err     error
@@ -455,7 +455,7 @@ func TestAppsV2MigrateToV2(t *testing.T) {
 
 // This test takes forever. I'm sorry.
 func TestAppsV2MigrateToV2_Volumes(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	if testing.Short() {
 		t.Skip()
@@ -523,7 +523,7 @@ primary_region = "%s"
 
 // this test is really slow :(
 func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	var (
 		err     error
@@ -564,7 +564,7 @@ func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
 }
 
 func TestNoPublicIPDeployMachines(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	var (
 		result *testlib.FlyctlResult
@@ -580,7 +580,7 @@ func TestNoPublicIPDeployMachines(t *testing.T) {
 }
 
 func TestLaunchCpusMem(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	var (
 		f       = testlib.NewTestEnvFromEnv(t)
@@ -597,7 +597,7 @@ func TestLaunchCpusMem(t *testing.T) {
 }
 
 func TestLaunchDetach(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	var (
 		f       = testlib.NewTestEnvFromEnv(t)
@@ -614,7 +614,7 @@ func TestLaunchDetach(t *testing.T) {
 }
 
 func TestDeployDetach(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	var (
 		f       = testlib.NewTestEnvFromEnv(t)
@@ -631,7 +631,7 @@ func TestDeployDetach(t *testing.T) {
 }
 
 func TestDeployDetachBatching(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	var (
 		f       = testlib.NewTestEnvFromEnv(t)
@@ -649,7 +649,7 @@ func TestDeployDetachBatching(t *testing.T) {
 }
 
 func TestErrOutput(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	var (
 		f       = testlib.NewTestEnvFromEnv(t)

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -516,7 +516,6 @@ primary_region = "%s"
 
 // this test is really slow :(
 func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
-
 	var (
 		err     error
 		f       = testlib.NewTestEnvFromEnv(t)
@@ -535,6 +534,9 @@ func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
 	}
 	platformVersion, _ := statusMap["PlatformVersion"].(string)
 	require.Equal(f, "machines", platformVersion)
+
+	// give time for the request to process
+	time.Sleep(5 * time.Second)
 
 	machines := f.MachinesList(appName)
 	require.Equal(f, 4, len(machines))

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -528,7 +528,7 @@ func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
 
 	f.FlyC(ctx, "launch --org %s --name %s --region %s --now --internal-port 80 --force-nomad --image nginx", f.OrgSlug(), appName, f.PrimaryRegion())
 	time.Sleep(3 * time.Second)
-	f.FlyC(ctx, "autoscale set min=2 max=4")
+	f.FlyC(ctx, "autoscale set min=2 max=3")
 	f.FlyC(ctx, "migrate-to-v2 --primary-region %s --yes", f.PrimaryRegion())
 	result := f.FlyC(ctx, "status --json")
 
@@ -544,7 +544,7 @@ func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	machines := f.MachinesList(appName)
-	require.Equal(f, 4, len(machines))
+	require.Equal(f, 3, len(machines))
 
 	for _, machine := range machines {
 		services := machine.Config.Services
@@ -559,7 +559,6 @@ func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
 	require.Contains(f, result.StdOut().String(), `"min_machines_running": 2,`)
 	require.Contains(f, result.StdOut().String(), `"auto_start_machines": true,`)
 	require.Contains(f, result.StdOut().String(), `"auto_stop_machines": true,`)
-
 }
 
 func TestNoPublicIPDeployMachines(t *testing.T) {

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -523,7 +523,7 @@ func TestAppsV2MigrateToV2_Autoscaling(t *testing.T) {
 		appName = f.CreateRandomAppName()
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeoutCause(context.Background(), 2*time.Minute, errors.New("test timed out"))
 	defer cancel()
 
 	f.FlyC(ctx, "launch --org %s --name %s --region %s --now --internal-port 80 --force-nomad --image nginx", f.OrgSlug(), appName, f.PrimaryRegion())

--- a/test/preflight/fly_console_test.go
+++ b/test/preflight/fly_console_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestFlyConsole(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()

--- a/test/preflight/fly_console_test.go
+++ b/test/preflight/fly_console_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestFlyConsole(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
 	targetOutput := "console test in " + appName

--- a/test/preflight/fly_deploy_fixtures_test.go
+++ b/test/preflight/fly_deploy_fixtures_test.go
@@ -25,8 +25,6 @@ func copyFixtureIntoWorkDir(workDir, name string, exclusion []string) error {
 }
 
 func TestFlyDeployBuildpackNodeAppWithRemoteBuilder(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node", []string{})
 	require.NoError(t, err)
@@ -77,8 +75,6 @@ func TestFlyDeployBuildpackNodeAppWithRemoteBuilder(t *testing.T) {
 }
 
 func TestFlyDeployBasicNodeWithWGEnabled(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node", []string{})
 	require.NoError(t, err)

--- a/test/preflight/fly_deploy_fixtures_test.go
+++ b/test/preflight/fly_deploy_fixtures_test.go
@@ -25,7 +25,7 @@ func copyFixtureIntoWorkDir(workDir, name string, exclusion []string) error {
 }
 
 func TestFlyDeployBuildpackNodeAppWithRemoteBuilder(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node", []string{})
@@ -77,7 +77,7 @@ func TestFlyDeployBuildpackNodeAppWithRemoteBuilder(t *testing.T) {
 }
 
 func TestFlyDeployBasicNodeWithWGEnabled(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node", []string{})

--- a/test/preflight/fly_deploy_test.go
+++ b/test/preflight/fly_deploy_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestFlyDeployHA(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -41,7 +41,7 @@ func TestFlyDeployHA(t *testing.T) {
 }
 
 func TestFlyDeploy_DeployToken_Simple(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -51,7 +51,7 @@ func TestFlyDeploy_DeployToken_Simple(t *testing.T) {
 }
 
 func TestFlyDeploy_DeployToken_FailingSmokeCheck(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -70,7 +70,7 @@ func TestFlyDeploy_DeployToken_FailingSmokeCheck(t *testing.T) {
 }
 
 func TestFlyDeploy_DeployToken_FailingReleaseCommand(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -89,7 +89,7 @@ func TestFlyDeploy_DeployToken_FailingReleaseCommand(t *testing.T) {
 }
 
 func TestFlyDeploy_Dockerfile(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -102,7 +102,7 @@ ENV PREFLIGHT_TEST=true`)
 
 // If this test passes at all, that means that a slow metrics server isn't affecting flyctl
 func TestFlyDeploySlowMetrics(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	env := make(map[string]string)
 	env["FLY_METRICS_BASE_URL"] = "https://flyctl-metrics-slow.fly.dev"

--- a/test/preflight/fly_deploy_test.go
+++ b/test/preflight/fly_deploy_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestFlyDeployHA(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -41,8 +39,6 @@ func TestFlyDeployHA(t *testing.T) {
 }
 
 func TestFlyDeploy_DeployToken_Simple(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 	f.Fly("launch --org %s --name %s --region %s --image nginx --internal-port 80 --force-machines --ha=false", f.OrgSlug(), appName, f.PrimaryRegion())
@@ -51,8 +47,6 @@ func TestFlyDeploy_DeployToken_Simple(t *testing.T) {
 }
 
 func TestFlyDeploy_DeployToken_FailingSmokeCheck(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 	f.Fly("launch --org %s --name %s --region %s --image nginx --internal-port 80 --force-machines --ha=false", f.OrgSlug(), appName, f.PrimaryRegion())
@@ -70,8 +64,6 @@ func TestFlyDeploy_DeployToken_FailingSmokeCheck(t *testing.T) {
 }
 
 func TestFlyDeploy_DeployToken_FailingReleaseCommand(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 	f.Fly("launch --org %s --name %s --region %s --image nginx --internal-port 80 --force-machines --ha=false", f.OrgSlug(), appName, f.PrimaryRegion())
@@ -89,8 +81,6 @@ func TestFlyDeploy_DeployToken_FailingReleaseCommand(t *testing.T) {
 }
 
 func TestFlyDeploy_Dockerfile(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 	f.WriteFile("Dockerfile", `FROM nginx
@@ -102,8 +92,6 @@ ENV PREFLIGHT_TEST=true`)
 
 // If this test passes at all, that means that a slow metrics server isn't affecting flyctl
 func TestFlyDeploySlowMetrics(t *testing.T) {
-	// t.Parallel()
-
 	env := make(map[string]string)
 	env["FLY_METRICS_BASE_URL"] = "https://flyctl-metrics-slow.fly.dev"
 	env["FLY_SEND_METRICS"] = "1"

--- a/test/preflight/fly_deploy_test.go
+++ b/test/preflight/fly_deploy_test.go
@@ -6,6 +6,7 @@ package preflight
 import (
 	"strings"
 	"testing"
+	"time"
 
 	//"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
@@ -86,6 +87,9 @@ func TestFlyDeploy_Dockerfile(t *testing.T) {
 	f.WriteFile("Dockerfile", `FROM nginx
 ENV PREFLIGHT_TEST=true`)
 	f.Fly("launch --org %s --name %s --region %s --internal-port 80 --force-machines --ha=false --now", f.OrgSlug(), appName, f.PrimaryRegion())
+
+	time.Sleep(3 * time.Second)
+
 	sshResult := f.Fly("ssh console -C 'printenv PREFLIGHT_TEST'")
 	require.Equal(f, "true", strings.TrimSpace(sshResult.StdOut().String()), "expected PREFLIGHT_TEST env var to be set in machine")
 }

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -356,6 +356,7 @@ RUN --mount=type=secret,id=secret1 cat /run/secrets/secret1 > /tmp/secrets.txt
 
 	f.Fly("launch --org %s --name %s --region %s --internal-port 80 --force-machines --ha=false --now --build-secret secret1=SECRET1 --remote-only", f.OrgSlug(), appName, f.PrimaryRegion())
 	ssh := f.Fly("ssh console -C 'cat /tmp/secrets.txt'")
+	time.Sleep(5 * time.Second)
 	assert.Equal(f, "SECRET1", ssh.StdOut().String())
 }
 

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -30,7 +30,7 @@ import (
 // - Primary region found in imported fly.toml must be reused if set and no --region is passed
 // - As we are reusing an existing app, the --org param is not needed after the first call
 func TestFlyLaunchV2(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -72,7 +72,7 @@ func TestFlyLaunchV2(t *testing.T) {
 
 // Same as case01 but for Nomad apps
 func TestFlyLaunchV1(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -129,7 +129,7 @@ func TestFlyLaunchV1(t *testing.T) {
 
 // Run fly launch from a template Fly App directory (fly.toml without app name)
 func TestFlyLaunchWithTOML(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -167,7 +167,7 @@ func TestFlyLaunchWithTOML(t *testing.T) {
 
 // Trying to import an invalid fly.toml should fail before creating the app
 func TestFlyLaunchWithInvalidTOML(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -187,7 +187,7 @@ app = "foo"
 // Fail if the existing app doesn't match the forced platform version
 // V2 app forced as V1
 func TestFlyLaunchForceV1(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 
@@ -199,7 +199,7 @@ func TestFlyLaunchForceV1(t *testing.T) {
 
 // test --generate-name, --name and reuse imported name
 func TestFlyLaunchReuseName(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 
@@ -232,7 +232,7 @@ primary_region = "%s"
 
 // test volumes are created on first launch
 func TestFlyLaunchWithVolumes(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -262,7 +262,7 @@ func TestFlyLaunchWithVolumes(t *testing.T) {
 
 // test --vm-size sets the machine guest on first deploy
 func TestFlyLaunchWithSize(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -279,7 +279,7 @@ func TestFlyLaunchWithSize(t *testing.T) {
 
 // test default HA setup
 func TestFlyLaunchHA(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -338,7 +338,7 @@ func TestFlyLaunchHA(t *testing.T) {
 
 // test first deploy with single mount for multiple processes
 func TestFlyLaunchSigleMount(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -380,7 +380,7 @@ RUN --mount=type=secret,id=secret1 cat /run/secrets/secret1 > /tmp/secrets.txt
 }
 
 func TestFlyLaunchBasicNodeApp(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node", []string{})

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -355,8 +355,8 @@ RUN --mount=type=secret,id=secret1 cat /run/secrets/secret1 > /tmp/secrets.txt
 `)
 
 	f.Fly("launch --org %s --name %s --region %s --internal-port 80 --force-machines --ha=false --now --build-secret secret1=SECRET1 --remote-only", f.OrgSlug(), appName, f.PrimaryRegion())
+	time.Sleep(3 * time.Second)
 	ssh := f.Fly("ssh console -C 'cat /tmp/secrets.txt'")
-	time.Sleep(5 * time.Second)
 	assert.Equal(f, "SECRET1", ssh.StdOut().String())
 }
 

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -30,8 +30,6 @@ import (
 // - Primary region found in imported fly.toml must be reused if set and no --region is passed
 // - As we are reusing an existing app, the --org param is not needed after the first call
 func TestFlyLaunchV2(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -72,8 +70,6 @@ func TestFlyLaunchV2(t *testing.T) {
 
 // Same as case01 but for Nomad apps
 func TestFlyLaunchV1(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -129,8 +125,6 @@ func TestFlyLaunchV1(t *testing.T) {
 
 // Run fly launch from a template Fly App directory (fly.toml without app name)
 func TestFlyLaunchWithTOML(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -167,8 +161,6 @@ func TestFlyLaunchWithTOML(t *testing.T) {
 
 // Trying to import an invalid fly.toml should fail before creating the app
 func TestFlyLaunchWithInvalidTOML(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -187,8 +179,6 @@ app = "foo"
 // Fail if the existing app doesn't match the forced platform version
 // V2 app forced as V1
 func TestFlyLaunchForceV1(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 
 	appName := f.CreateRandomAppName()
@@ -199,8 +189,6 @@ func TestFlyLaunchForceV1(t *testing.T) {
 
 // test --generate-name, --name and reuse imported name
 func TestFlyLaunchReuseName(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 
 	// V2 app forced as V1
@@ -232,8 +220,6 @@ primary_region = "%s"
 
 // test volumes are created on first launch
 func TestFlyLaunchWithVolumes(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -262,8 +248,6 @@ func TestFlyLaunchWithVolumes(t *testing.T) {
 
 // test --vm-size sets the machine guest on first deploy
 func TestFlyLaunchWithSize(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -279,8 +263,6 @@ func TestFlyLaunchWithSize(t *testing.T) {
 
 // test default HA setup
 func TestFlyLaunchHA(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -338,8 +320,6 @@ func TestFlyLaunchHA(t *testing.T) {
 
 // test first deploy with single mount for multiple processes
 func TestFlyLaunchSigleMount(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -380,8 +360,6 @@ RUN --mount=type=secret,id=secret1 cat /run/secrets/secret1 > /tmp/secrets.txt
 }
 
 func TestFlyLaunchBasicNodeApp(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node", []string{})
 	require.NoError(t, err)

--- a/test/preflight/fly_machine_test.go
+++ b/test/preflight/fly_machine_test.go
@@ -14,8 +14,6 @@ import (
 
 // test --port and --autostart --autostop flags
 func TestFlyMachineRun_autoStartStop(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
 
@@ -69,8 +67,6 @@ func TestFlyMachineRun_autoStartStop(t *testing.T) {
 
 // test --standby-for
 func TestFlyMachineRun_standbyFor(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
 
@@ -133,8 +129,6 @@ func TestFlyMachineRun_standbyFor(t *testing.T) {
 
 // test --port (add, update, remove services and ports)
 func TestFlyMachineRun_port(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
 

--- a/test/preflight/fly_machine_test.go
+++ b/test/preflight/fly_machine_test.go
@@ -14,7 +14,7 @@ import (
 
 // test --port and --autostart --autostop flags
 func TestFlyMachineRun_autoStartStop(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
@@ -69,7 +69,7 @@ func TestFlyMachineRun_autoStartStop(t *testing.T) {
 
 // test --standby-for
 func TestFlyMachineRun_standbyFor(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
@@ -133,7 +133,7 @@ func TestFlyMachineRun_standbyFor(t *testing.T) {
 
 // test --port (add, update, remove services and ports)
 func TestFlyMachineRun_port(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()

--- a/test/preflight/fly_postgres_test.go
+++ b/test/preflight/fly_postgres_test.go
@@ -148,7 +148,9 @@ func TestPostgres_ImportSuccess(t *testing.T) {
 	output := result.StdOut().String()
 	require.Contains(f, output, firstAppName)
 
-	// The importer machine should have been destroyed.
+	// Wait for the importer machine to be destroyed.
+	time.Sleep(5 * time.Second)
+
 	ml := f.MachinesList(secondAppName)
 	require.Equal(f, 1, len(ml))
 }

--- a/test/preflight/fly_postgres_test.go
+++ b/test/preflight/fly_postgres_test.go
@@ -4,6 +4,7 @@
 package preflight
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"

--- a/test/preflight/fly_postgres_test.go
+++ b/test/preflight/fly_postgres_test.go
@@ -185,5 +185,9 @@ func TestPostgres_ImportFailure(t *testing.T) {
 	// Even with the error, the importer machine should have been
 	// destroyed.
 	ml := f.MachinesList(appName)
+
+	for _, m := range ml {
+		fmt.Println("found machine", m.ID, m.Name, m.State)
+	}
 	require.Equal(f, 1, len(ml))
 }

--- a/test/preflight/fly_postgres_test.go
+++ b/test/preflight/fly_postgres_test.go
@@ -6,6 +6,7 @@ package preflight
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/superfly/flyctl/api"
@@ -182,6 +183,9 @@ func TestPostgres_ImportFailure(t *testing.T) {
 	)
 	require.NotEqual(f, 0, result.ExitCode())
 	require.Contains(f, result.StdOut().String(), "database \"test\" does not exist")
+
+	// Wait for the importer machine to be destroyed.
+	time.Sleep(5 * time.Second)
 
 	// Even with the error, the importer machine should have been
 	// destroyed.

--- a/test/preflight/fly_postgres_test.go
+++ b/test/preflight/fly_postgres_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPostgres_singleNode(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -27,7 +27,7 @@ func TestPostgres_singleNode(t *testing.T) {
 }
 
 func TestPostgres_autostart(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -56,7 +56,7 @@ func TestPostgres_autostart(t *testing.T) {
 }
 
 func TestPostgres_FlexFailover(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	if testing.Short() {
 		t.Skip()
@@ -89,7 +89,7 @@ func TestPostgres_FlexFailover(t *testing.T) {
 }
 
 func TestPostgres_NoMachines(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -105,7 +105,7 @@ func TestPostgres_NoMachines(t *testing.T) {
 }
 
 func TestPostgres_haConfigSave(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
@@ -123,7 +123,7 @@ func TestPostgres_haConfigSave(t *testing.T) {
 }
 
 func TestPostgres_ImportSuccess(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	firstAppName := f.CreateRandomAppName()
@@ -165,7 +165,7 @@ func TestPostgres_ImportSuccess(t *testing.T) {
 }
 
 func TestPostgres_ImportFailure(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()

--- a/test/preflight/fly_postgres_test.go
+++ b/test/preflight/fly_postgres_test.go
@@ -4,7 +4,6 @@
 package preflight
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -176,9 +175,5 @@ func TestPostgres_ImportFailure(t *testing.T) {
 	// Even with the error, the importer machine should have been
 	// destroyed.
 	ml := f.MachinesList(appName)
-
-	for _, m := range ml {
-		fmt.Println("found machine", m.ID, m.Name, m.State)
-	}
 	require.Equal(f, 1, len(ml))
 }

--- a/test/preflight/fly_postgres_test.go
+++ b/test/preflight/fly_postgres_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestPostgres_singleNode(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -29,8 +27,6 @@ func TestPostgres_singleNode(t *testing.T) {
 }
 
 func TestPostgres_autostart(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -58,8 +54,6 @@ func TestPostgres_autostart(t *testing.T) {
 }
 
 func TestPostgres_FlexFailover(t *testing.T) {
-	// t.Parallel()
-
 	if testing.Short() {
 		t.Skip()
 	}
@@ -91,8 +85,6 @@ func TestPostgres_FlexFailover(t *testing.T) {
 }
 
 func TestPostgres_NoMachines(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -107,8 +99,6 @@ func TestPostgres_NoMachines(t *testing.T) {
 }
 
 func TestPostgres_haConfigSave(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -125,8 +115,6 @@ func TestPostgres_haConfigSave(t *testing.T) {
 }
 
 func TestPostgres_ImportSuccess(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	firstAppName := f.CreateRandomAppName()
 	secondAppName := f.CreateRandomAppName()
@@ -167,8 +155,6 @@ func TestPostgres_ImportSuccess(t *testing.T) {
 }
 
 func TestPostgres_ImportFailure(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 

--- a/test/preflight/fly_scale_test.go
+++ b/test/preflight/fly_scale_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestFlyScaleCount(t *testing.T) {
-	t.Parallel()
+	// t.Parallel()
 
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()

--- a/test/preflight/fly_scale_test.go
+++ b/test/preflight/fly_scale_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestFlyScaleCount(t *testing.T) {
-	// t.Parallel()
-
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
 

--- a/test/preflight/testlib/test_env.go
+++ b/test/preflight/testlib/test_env.go
@@ -183,6 +183,14 @@ func (f *FlyctlTestEnv) FlyAllowExitFailure(flyctlCmd string, vals ...interface{
 	return f.FlyContextAndConfig(context.TODO(), FlyCmdConfig{NoAssertSuccessfulExit: true}, flyctlCmd, vals...)
 }
 
+func (f *FlyctlTestEnv) FlyC(ctx context.Context, flyctlCmd string, vals ...interface{}) *FlyctlResult {
+	return f.FlyContextAndConfig(ctx, FlyCmdConfig{}, flyctlCmd, vals...)
+}
+
+// func (f *FlyctlTestEnv) FlyAllowExitFailure(ctx context.Context, flyctlCmd string, vals ...interface{}) *FlyctlResult {
+// 	return f.FlyContextAndConfig(ctx, FlyCmdConfig{NoAssertSuccessfulExit: true}, flyctlCmd, vals...)
+// }
+
 type FlyCmdConfig struct {
 	NoAssertSuccessfulExit bool
 }


### PR DESCRIPTION
- no longer runs preflight tests in parallel on the same worker. This was causing hard to debug race issues, and ended up being slower anyway.
- increases the number of runners from 10 to 25. More parallel runners each handling fewer tests ran serially is much faster.
- build and CI workflows are now ran on larger GH action runners. 
- solved several intermittent failures (waiting a few seconds between api calls so the backend has time to process, reducing the number of machines created in a test, etc)
- cancels in-progress runs when a commit on the same PR/branch triggers a build
- support for passing a context.Context to the fly binary runner for cancelation