### PR TITLE
Warn if "fly scale count 0" resets the VM size

### DIFF
--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command/deploy"
 	"github.com/superfly/flyctl/internal/flag"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
@@ -79,6 +80,9 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 	for _, action := range actions {
 		fmt.Fprintf(io.Out, "%+4d machines for group '%s' on region '%s' of size '%s'\n",
 			action.Delta, action.GroupName, action.Region, action.MachineSize())
+		if action.MachineSize() != deploy.DefaultVMSize && len(action.Machines)+action.Delta == 0 {
+			fmt.Fprintf(io.Out, "  Scaling to zero resets the size of the machines to '%s'\n", deploy.DefaultVMSize)
+		}
 
 		volumesToReuse := len(action.Volumes)
 		volumesToCreate := action.VolumesDelta()


### PR DESCRIPTION
If a VM is not shared-cpu-1x, "fly scale count 0" shows a warning to avoid surprises.

### Change Summary

What and Why:

`fly scale count 0` is having a bit of surprising behavior. While we might need to change the behavior someday, this change at least tells customers about potential surprises.

How:

```
% ../flyctl/bin/flyctl scale count 0
App 'withered-wildflower-5588' is going to be scaled according to this plan:
  -2 machines for group 'app' on region 'sea' with size 'shared-cpu-2x'
  Scaling to zero resets the size of the machines to 'shared-cpu-1x'
? Scale app withered-wildflower-5588? No
```

No warnings if the machine is shared-cpu-1x.

```
% ../flyctl/bin/flyctl scale count 0
App 'withered-wildflower-5588' is going to be scaled according to this plan:
  -2 machines for group 'app' on region 'sea' with size 'shared-cpu-1x'
? Scale app withered-wildflower-5588? No
```


Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
