### PR TITLE
`pg import`: explicitly set all migration command flags

### DIFF
--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -202,19 +202,8 @@ func resolveImportCommand(ctx context.Context) string {
 		dataOnly = flag.GetBool(ctx, "data-only")
 	)
 
-	importCmd := "migrate "
-	if noOwner {
-		importCmd = importCmd + " -no-owner"
-	}
-	if clean {
-		importCmd = importCmd + " -clean"
-	}
-	if create {
-		importCmd = importCmd + " -create"
-	}
-	if dataOnly {
-		importCmd = importCmd + " -data-only"
-	}
-
-	return importCmd
+	return fmt.Sprintf(
+		"migrate -no-owner=%v -create=%v -clean=%v -data-only=%v",
+		noOwner, create, clean, dataOnly,
+	)
 }


### PR DESCRIPTION
### Change Summary

#### What and Why:

Some of the PG importer image's `migrate` command's flags are [true by default](https://github.com/fly-apps/postgres-importer/blob/5138f66c891748ad42b0d92e5994e03e18086b5a/cmd/migrate/main.go#L30-L32). When `fly pg import` transcribes its own flags into flags for the `migrate` command, it includes them only if they are true, which makes it impossible to disable flags that are true-by-default on the `migrate` side. E.g. using `fly pg import --create=false` does not work, since `flyctl` does not include `-create` in the `migrate` flags and migrate's `-create` is true by default.

#### How:

To fix this, make `flyctl` specify the value of each flag explicitly.

⚠️ `migrate`'s `-clean` is true by default but `flyctl`'s `--clean` is false by default. Therefore, as it stands, this PR will change the effective behavior when `--clean` is not specified from "true" to "false".

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
