### PR TITLE
fly ssh console: select/filter by process group

### DIFF
--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -66,6 +66,7 @@ func stdArgsSSH(cmd *cobra.Command) {
 			Description: "Unix username to connect as",
 			Default:     DefaultSshUsername,
 		},
+		flag.ProcessGroup(),
 	)
 }
 
@@ -229,8 +230,22 @@ func addrForMachines(ctx context.Context, app *api.AppCompact, console bool) (ad
 		return "", fmt.Errorf("app %s has no started VMs", app.Name)
 	}
 
-	if err != nil {
-		return "", err
+	if region := flag.GetRegion(ctx); region != "" {
+		machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
+			return m.Region == region
+		})
+		if len(machines) < 1 {
+			return "", fmt.Errorf("app %s has no VMs in region %s", app.Name, region)
+		}
+	}
+
+	if group := flag.GetProcessGroup(ctx); group != "" {
+		machines = lo.Filter(machines, func(m *api.Machine, _ int) bool {
+			return m.ProcessGroup() == group
+		})
+		if len(machines) < 1 {
+			return "", fmt.Errorf("app %s has no VMs in process group %s", app.Name, group)
+		}
 	}
 
 	var namesWithRegion []string

--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -235,6 +235,7 @@ func addrForMachines(ctx context.Context, app *api.AppCompact, console bool) (ad
 
 	var namesWithRegion []string
 	var selectedMachine *api.Machine
+	multipleGroups := len(lo.UniqBy(machines, func(m *api.Machine) string { return m.ProcessGroup() })) > 1
 
 	for _, machine := range machines {
 		nameWithRegion := fmt.Sprintf("%s: %s %s %s", machine.Region, machine.ID, machine.PrivateIP, machine.Name)
@@ -254,6 +255,9 @@ func addrForMachines(ctx context.Context, app *api.AppCompact, console bool) (ad
 			nameWithRegion += fmt.Sprintf(" (%s)", role)
 		}
 
+		if multipleGroups {
+			nameWithRegion += fmt.Sprintf(" (%s)", machine.ProcessGroup())
+		}
 		namesWithRegion = append(namesWithRegion, nameWithRegion)
 	}
 

--- a/internal/flag/context.go
+++ b/internal/flag/context.go
@@ -166,3 +166,7 @@ func GetFlagsName(ctx context.Context, ignoreFlags []string) []string {
 
 	return flagsName
 }
+
+func GetProcessGroup(ctx context.Context) string {
+	return GetString(ctx, flagnames.ProcessGroup)
+}

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -528,3 +528,10 @@ func JSONOutput() Bool {
 		Default:     false,
 	}
 }
+
+func ProcessGroup() String {
+	return String{
+		Name:        flagnames.ProcessGroup,
+		Description: "The target process group",
+	}
+}

--- a/internal/flag/flagnames/constants.go
+++ b/internal/flag/flagnames/constants.go
@@ -48,4 +48,7 @@ const (
 
 	// BindAddr denotes the name of the local bind address flag.
 	BindAddr = "bind-addr"
+
+	// ProcessGroup denotes the name of the process group flag.
+	ProcessGroup = "group"
 )


### PR DESCRIPTION
### Change Summary

- Appends a process group field to the end of `fly ssh console --select`, if there is more than one process group set on the machines:

```
$ fly ssh console --select
? Select VM:  [Use arrows to move, type to filter]
> lax: aaaaaaaaaaaaaa fdaa:0:aaaa:aaa:aaaa:aaaa:aaaa:a crimson-shadow-1234 (process1)
  lax: bbbbbbbbbbbbbb fdaa:0:bbbb:bbb:bbbb:bbbb:bbbb:b lingering-morning-5678 (process2)
```

- Add `--group` flag to `fly ssh console` to filter target machines by the specified process group.
- Make `--region` flag actually filter target machines by the specified region.