### PR TITLE
add selection prompt to volumes commands

### DIFF
--- a/internal/command/volumes/destroy.go
+++ b/internal/command/volumes/destroy.go
@@ -27,12 +27,15 @@ number to operate. This can be found through the volumes list command`
 
 	cmd := command.New("destroy <id>", short, long, runDestroy,
 		command.RequireSession,
+		command.LoadAppNameIfPresent,
 	)
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cobra.MaximumNArgs(1)
 	cmd.Aliases = []string{"delete", "rm"}
 
 	flag.Add(cmd,
 		flag.Yes(),
+		flag.App(),
+		flag.AppConfig(),
 	)
 
 	return cmd
@@ -46,6 +49,10 @@ func runDestroy(ctx context.Context) error {
 	)
 
 	appName := appconfig.NameFromContext(ctx)
+	if volID == "" && appName == "" {
+		return fmt.Errorf("volume ID or app required")
+	}
+
 	if appName == "" {
 		n, err := client.GetAppNameFromVolume(ctx, volID)
 		if err != nil {
@@ -59,6 +66,22 @@ func runDestroy(ctx context.Context) error {
 		return err
 	}
 	ctx = flaps.NewContext(ctx, flapsClient)
+
+	if volID == "" {
+		volumes, err := flapsClient.GetVolumes(ctx)
+		if err != nil {
+			return err
+		}
+		app, err := client.GetApp(ctx, appName)
+		if err != nil {
+			return err
+		}
+		volume, err := selectVolume(ctx, volumes, app)
+		if err != nil {
+			return err
+		}
+		volID = volume.ID
+	}
 
 	if confirm, err := confirmVolumeDelete(ctx, volID); err != nil {
 		return err

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -34,7 +34,7 @@ func newExtend() *cobra.Command {
 		command.RequireAppName,
 	)
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cobra.MaximumNArgs(1)
 
 	flag.Add(cmd,
 		flag.App(),
@@ -90,6 +90,18 @@ func runExtend(ctx context.Context) error {
 				return err
 			}
 		}
+	}
+
+	if volID == "" {
+		volumes, err := flapsClient.GetVolumes(ctx)
+		if err != nil {
+			return err
+		}
+		volume, err := selectVolume(ctx, volumes, app)
+		if err != nil {
+			return err
+		}
+		volID = volume.ID
 	}
 
 	volume, needsRestart, err := flapsClient.ExtendVolume(ctx, volID, flag.GetInt(ctx, "size"))

--- a/internal/command/volumes/list.go
+++ b/internal/command/volumes/list.go
@@ -3,9 +3,6 @@ package volumes
 import (
 	"context"
 	"fmt"
-	"strconv"
-
-	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/client"
@@ -69,43 +66,5 @@ func runList(ctx context.Context) error {
 		return render.JSON(out, volumes)
 	}
 
-	rows := make([][]string, 0, len(volumes))
-	for _, volume := range volumes {
-		var attachedVMID string
-
-		if app.PlatformVersion == "machines" {
-			if volume.AttachedMachine != nil {
-				attachedVMID = *volume.AttachedMachine
-			}
-		} else {
-			names, err := apiClient.GetAllocationTaskNames(ctx, appName)
-			if err != nil {
-				return err
-			}
-
-			if volume.AttachedAllocation != nil {
-				attachedVMID = *volume.AttachedAllocation
-
-				taskName, ok := names[*volume.AttachedAllocation]
-
-				if ok && taskName != "app" {
-					attachedVMID = fmt.Sprintf("%s (%s)", *volume.AttachedAllocation, taskName)
-				}
-			}
-		}
-
-		rows = append(rows, []string{
-			volume.ID,
-			volume.State,
-			volume.Name,
-			strconv.Itoa(volume.SizeGb) + "GB",
-			volume.Region,
-			volume.Zone,
-			fmt.Sprint(volume.Encrypted),
-			attachedVMID,
-			humanize.Time(volume.CreatedAt),
-		})
-	}
-
-	return render.Table(out, "", rows, "ID", "State", "Name", "Size", "Region", "Zone", "Encrypted", "Attached VM", "Created At")
+	return renderTable(ctx, volumes, app, out)
 }


### PR DESCRIPTION
### Change Summary

The `destroy`, `extend`, `fork`, and `show` subcommands of `fly volumes` will display an interactive prompt to choose from a list of existing volumes on an app, when no volume ID is specified.

The prompt reuses the table formatting from `fly volumes list` for the selection lines (which I've extracted to `renderTable` for reuse).

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
