### PR TITLE
add --count to volumes create command

### DIFF
--- a/internal/command/volumes/create.go
+++ b/internal/command/volumes/create.go
@@ -63,6 +63,12 @@ sets the size as the number of gigabytes the volume will consume.`
 			Description: "Create volume from a specified snapshot",
 		},
 		flag.Yes(),
+		flag.Int{
+			Name:        "count",
+			Shorthand:   "n",
+			Default:     1,
+			Description: "Number of volumes to create",
+		},
 	)
 
 	flag.Add(cmd, flag.JSONOutput())
@@ -76,6 +82,7 @@ func runCreate(ctx context.Context) error {
 
 		volumeName = flag.FirstArg(ctx)
 		appName    = appconfig.NameFromContext(ctx)
+		count      = flag.GetInt(ctx, "count")
 	)
 
 	flapsClient, err := flaps.NewFromAppName(ctx, appName)
@@ -123,19 +130,23 @@ func runCreate(ctx context.Context) error {
 		RequireUniqueZone: api.Pointer(flag.GetBool(ctx, "require-unique-zone")),
 		SnapshotID:        snapshotID,
 	}
-
-	volume, err := flapsClient.CreateVolume(ctx, input)
-	if err != nil {
-		return fmt.Errorf("failed creating volume: %w", err)
-	}
-
 	out := iostreams.FromContext(ctx).Out
+	for i := 0; i < count; i++ {
+		volume, err := flapsClient.CreateVolume(ctx, input)
+		if err != nil {
+			return fmt.Errorf("failed creating volume: %w", err)
+		}
 
-	if cfg.JSONOutput {
-		return render.JSON(out, volume)
+		if cfg.JSONOutput {
+			err = render.JSON(out, volume)
+		} else {
+			err = printVolume(out, volume, appName)
+		}
+		if err != nil {
+			return err
+		}
 	}
-
-	return printVolume(out, volume, appName)
+	return nil
 }
 
 func confirmVolumeCreate(ctx context.Context, appName string) (bool, error) {
@@ -147,7 +158,11 @@ func confirmVolumeCreate(ctx context.Context, appName string) (bool, error) {
 		return true, nil
 	}
 
-	// If we have more than 0 volues with this name already, return early
+	if flag.GetInt(ctx, "count") > 1 {
+		return true, nil
+	}
+
+	// If we have more than 0 volumes with this name already, return early
 	if matches, err := countVolumesMatchingName(ctx, volumeName); err != nil {
 		return false, err
 	} else if matches > 0 {


### PR DESCRIPTION
Simple change to call `CreateVolume` API `count` times instead of 1 if `--count` is specified.

This allows a simple way to avoid the "You should create two or more volumes per application" warning by specifying `--count 2` when creating volumes for an app. (You could use `--yes` and script multiple calls to `fly volumes create` in user code, but a built-in flag is slightly more convenient.)

The shorthand is `n` for consistency with `flyctl ping`'s existing `--count` flag.