### PR TITLE
Use `require.Eventually` instead of `require.EventuallyWithT`

### DIFF
--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -39,10 +39,9 @@ func TestAppsV2Example(t *testing.T) {
 	require.Contains(f, result.StdOutString(), fmt.Sprintf("Created app '%s' in organization '%s'", appName, f.OrgSlug()))
 	require.Contains(f, result.StdOutString(), "Wrote config file fly.toml")
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.Eventually(t, func() bool {
 		resp, err := http.Get(appUrl)
-		assert.NoError(c, err)
-		assert.Equal(c, http.StatusOK, resp.StatusCode)
+		return err == nil && resp.StatusCode == http.StatusOK
 	}, 20*time.Second, 1*time.Second, "GET %s never returned 200 OK response 20 seconds", appUrl)
 
 	machList := f.MachinesList(appName)


### PR DESCRIPTION
It seems that some assertions will call `FailNow()` which panics when called on `assert.CollectT`.

See:
- https://github.com/stretchr/testify/issues/1396
- https://github.com/stretchr/testify/issues/1457
