### PR TITLE
[bluegreen] don't re-render bluegreen deployment status state hasn't changed

### DIFF
--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -97,7 +97,10 @@ func (bg *blueGreen) CreateGreenMachines(ctx context.Context) error {
 func (bg *blueGreen) renderMachineStates(state map[string]int) func() {
 	firstRun := true
 
+	previousView := map[string]string{}
+
 	return func() {
+		currentView := map[string]string{}
 		rows := []string{}
 		bg.stateLock.RLock()
 		for id, value := range state {
@@ -105,17 +108,23 @@ func (bg *blueGreen) renderMachineStates(state map[string]int) func() {
 			if value == 1 {
 				status = "started"
 			}
+
+			currentView[id] = status
 			rows = append(rows, fmt.Sprintf("  Machine %s - %s", bg.colorize.Bold(id), bg.colorize.Green(status)))
 		}
 		bg.stateLock.RUnlock()
 
-		if !firstRun {
+		if !firstRun && bg.changeDetected(currentView, previousView) {
 			bg.clearLinesAbove(len(rows))
 		}
 
 		sort.Strings(rows)
 
-		fmt.Fprintf(bg.io.ErrOut, "%s\n", strings.Join(rows, "\n"))
+		if bg.changeDetected(currentView, previousView) {
+			fmt.Fprintf(bg.io.ErrOut, "%s\n", strings.Join(rows, "\n"))
+			previousView = currentView
+		}
+
 		firstRun = false
 	}
 }
@@ -183,10 +192,22 @@ func (bg *blueGreen) WaitForGreenMachinesToBeStarted(ctx context.Context) error 
 	}
 }
 
+func (bg *blueGreen) changeDetected(a, b map[string]string) bool {
+	for key := range a {
+		if a[key] != b[key] {
+			return true
+		}
+	}
+	return false
+}
+
 func (bg *blueGreen) renderMachineHealthchecks(state map[string]*api.HealthCheckStatus) func() {
 	firstRun := true
 
+	previousView := map[string]string{}
+
 	return func() {
+		currentView := map[string]string{}
 		rows := []string{}
 		bg.healthLock.RLock()
 		for id, value := range state {
@@ -194,17 +215,23 @@ func (bg *blueGreen) renderMachineHealthchecks(state map[string]*api.HealthCheck
 			if value.Total != 0 {
 				status = fmt.Sprintf("%d/%d passing", value.Passing, value.Total)
 			}
+
+			currentView[id] = status
 			rows = append(rows, fmt.Sprintf("  Machine %s - %s", bg.colorize.Bold(id), bg.colorize.Green(status)))
 		}
 		bg.healthLock.RUnlock()
 
-		if !firstRun {
+		if !firstRun && bg.changeDetected(currentView, previousView) {
 			bg.clearLinesAbove(len(rows))
 		}
 
 		sort.Strings(rows)
 
-		fmt.Fprintf(bg.io.ErrOut, "%s\n", strings.Join(rows, "\n"))
+		if bg.changeDetected(currentView, previousView) {
+			fmt.Fprintf(bg.io.ErrOut, "%s\n", strings.Join(rows, "\n"))
+			previousView = currentView
+		}
+
 		firstRun = false
 	}
 }


### PR DESCRIPTION
### Change Summary
Cache previous view and compare it with current view. 

This is to prevent re-rendering if state hasn't changed from previous render. 
Our aggressive rendering is apparently causing spam LOGS in CI's. It's an improvement on https://github.com/superfly/flyctl/pull/2666.

https://github.com/superfly/flyctl/pull/2666 works fine for 1 machine deployment. With multiple machine deployments it doesn't display the right state.