### PR TITLE
Groups without mounts don't need volumes

### DIFF
--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -200,6 +200,9 @@ type planItem struct {
 }
 
 func (pi *planItem) VolumesDelta() int {
+	if pi.CreateVolumeRequest == nil {
+		return 0
+	}
 	return pi.Delta - len(pi.Volumes)
 }
 


### PR DESCRIPTION
What and Why:
`fly scale count` says it will create volumes for groups that don't use them. At the end, it doesn't create any volume but the summary says it will.

i.e.:
```
...
[processes]
  app = ""
  disk = ""
 
[[mounts]]
  source = "my_vol"
  destination = "/data"
  processes = ["disk"]
...
```

For disk group it says it will create a new volume and it does
```
$ fly scale count disk=2
App 'scaleapp' is going to be scaled according to this plan:
  +1 machines for group 'disk' on region 'ord' of size 'shared-cpu-1x'
  +1 volumes  for group 'disk' in region 'ord'
? Scale app scaleapp? Yes
Executing scale plan
  Creating volume my_vol region:ord size:1GiB
  Created 080e074c137598 group:disk region:ord size:shared-cpu-1x volume:vol_zrenqyy2zw56dmlr
```

For _app_ group, it says it will but it doesn't. *it shouldn't say anything* as _app_ group has no mounts.
```
$ fly scale count app=3
App 'scaleapp' is going to be scaled according to this plan:
  +1 machines for group 'app' on region 'ord' of size 'shared-cpu-1x'
  +1 volumes  for group 'app' in region 'ord'
? Scale app scaleapp? Yes
Executing scale plan
  Created d89172ef4707e8 group:app region:ord size:shared-cpu-1x
```

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
