### PR TITLE
Cleanup PG Fork output

### DIFF
--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -193,13 +193,11 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 			machineConf.Env["FLY_RESTORED_FROM"] = config.ForkFrom
 
 			action = "fork"
-
 			volInput.SourceVolumeID = &config.ForkFrom
 			volInput.MachinesOnly = api.Pointer(true)
 			volInput.Name = "pg_data"
 		} else {
 			action = "create"
-
 			volInput.Region = config.Region
 			volInput.SizeGb = config.VolumeSize
 		}
@@ -224,15 +222,10 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 			return err
 		}
 
-		if config.ForkFrom != "" {
-			fmt.Fprintf(io.Out, "Waiting for volume fork process to complete...\n")
-			fmt.Fprintf(io.Out, "This may take a while...\n")
-		} else {
-			fmt.Fprintf(io.Out, "Waiting for machine to start...\n")
-		}
+		fmt.Fprintf(io.Out, "Waiting for machine to start...\n")
 
 		waitTimeout := time.Minute * 5
-		if snapshot != nil || config.ForkFrom != "" {
+		if snapshot != nil {
 			waitTimeout = time.Hour
 		}
 


### PR DESCRIPTION
### Change Summary

Forks now take just a hair longer than a normal provision, so this removes the extended timeout and logs that pertain to how we used to perform forks. 