### PR TITLE
fix scale memory typo

### DIFF
--- a/internal/machine/update.go
+++ b/internal/machine/update.go
@@ -165,7 +165,7 @@ func (e InvalidConfigErr) Suggestion() string {
 			suggestedSize = incrementSize
 		}
 
-		return fmt.Sprintf("Memory size must be in %d a MiB increment (%dMiB would work)", incrementSize, suggestedSize)
+		return fmt.Sprintf("Memory size must be in a %d MiB increment (%dMiB would work)", incrementSize, suggestedSize)
 	case memoryTooLow:
 		var min_memory_size int
 


### PR DESCRIPTION
Fix `Memory size must be in 1024 a MiB increment` typo in error text