### PR TITLE
Fix extra line in docs output for image commands

### DIFF
--- a/internal/command/image/show.go
+++ b/internal/command/image/show.go
@@ -21,7 +21,7 @@ import (
 
 func newShow() *cobra.Command {
 	const (
-		short  = "Show image details."
+		short = "Show image details."
 		long = short + "\n"
 
 		usage = "show"

--- a/internal/command/image/show.go
+++ b/internal/command/image/show.go
@@ -22,7 +22,7 @@ import (
 func newShow() *cobra.Command {
 	const (
 		short = "Show image details."
-		long = short + "\n"
+		long  = short + "\n"
 
 		usage = "show"
 	)

--- a/internal/command/image/show.go
+++ b/internal/command/image/show.go
@@ -21,8 +21,8 @@ import (
 
 func newShow() *cobra.Command {
 	const (
-		long  = "Show image details."
-		short = long + "\n"
+		short  = "Show image details."
+		long = short + "\n"
 
 		usage = "show"
 	)


### PR DESCRIPTION
### Change Summary

What and Why: The output for the available commands for `image` has extra spacing in the list.  
![Screenshot 2023-08-30 at 9 10 15 PM](https://github.com/superfly/flyctl/assets/13827355/01febfd2-85e8-4a65-a542-06accd1517c4)

How:
Reversed the pattern for the `long` and `short` descriptions. The `short` description had a newline. If we only have one desc we usually do the `short` one and then `long = short + \n`.

Related to:
Noticed by a user and flagged in this docs repo PR: https://github.com/superfly/docs/issues/743

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
