### PR TITLE
Smoke checks: use uptime to more quickly pass test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: "Place wintun.dll"
         run: cp deps/wintun/bin/amd64/wintun.dll ./
       - name: Run tests
-        run: make test
+        run: make test test-api
 
   release:
     needs: test

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ build: generate
 test: FORCE
 	go test ./... -ldflags="-X 'github.com/superfly/flyctl/internal/buildinfo.buildDate=$(NOW_RFC3339)'" --run=$(T)
 
+test-api: FORCE
+	cd ./api && go test ./... -ldflags="-X 'github.com/superfly/flyctl/internal/buildinfo.buildDate=$(NOW_RFC3339)'" --run=$(T)
+
 raw-preflight-test:
 	if [ -r .direnv/preflight ]; then . .direnv/preflight; fi; \
 	go test ./test/preflight --tags=integration -v -timeout 10m --run="$(T)"

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -176,6 +176,40 @@ func (m *Machine) GetLatestEventOfTypeAfterType(latestEventType, firstEventType 
 	return nil
 }
 
+func (m *Machine) MostRecentStartTimeAfterLaunch() (time.Time, error) {
+	if m == nil {
+		return time.Time{}, fmt.Errorf("machine is nil")
+	}
+	var (
+		firstStart  = -1
+		firstLaunch = -1
+		firstExit   = -1
+	)
+	for i, e := range m.Events {
+		switch e.Type {
+		case "start":
+			firstStart = i
+		case "launch":
+			firstLaunch = i
+		case "exit":
+			firstExit = i
+		}
+		if firstStart != -1 && firstLaunch != -1 {
+			break
+		}
+	}
+	switch {
+	case firstStart == -1:
+		return time.Time{}, fmt.Errorf("no start event found")
+	case firstStart >= firstLaunch:
+		return time.Time{}, fmt.Errorf("no start event found after launch")
+	case firstExit != -1 && firstExit <= firstStart:
+		return time.Time{}, fmt.Errorf("no start event found after most recent exit")
+	default:
+		return m.Events[firstStart].Time(), nil
+	}
+}
+
 func (m *Machine) IsReleaseCommandMachine() bool {
 	return m.HasProcessGroup(MachineProcessGroupFlyAppReleaseCommand) || m.Config.Metadata["process_group"] == "release_command"
 }
@@ -194,6 +228,10 @@ type MachineEvent struct {
 	Request   *MachineRequest `json:"request,omitempty"`
 	Source    string          `json:"source,omitempty"`
 	Timestamp int64           `json:"timestamp,omitempty"`
+}
+
+func (e *MachineEvent) Time() time.Time {
+	return time.Unix(e.Timestamp/1000, e.Timestamp%1000)
 }
 
 type MachineRequest struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -231,7 +231,7 @@ type MachineEvent struct {
 }
 
 func (e *MachineEvent) Time() time.Time {
-	return time.Unix(e.Timestamp/1000, e.Timestamp%1000)
+	return time.Unix(e.Timestamp/1000, e.Timestamp%1000*1000000)
 }
 
 type MachineRequest struct {

--- a/api/machine_types_test.go
+++ b/api/machine_types_test.go
@@ -230,7 +230,7 @@ func TestMachineMostRecentStartTimeAfterLaunch(t *testing.T) {
 				t.Error(testCase.name, "unexpected error:", err)
 			} else {
 				delta := testCase.expected.Sub(actual)
-				if delta < -1*time.Second || delta > 1*time.Second {
+				if delta < -1*time.Millisecond || delta > 1*time.Millisecond {
 					t.Error(testCase.name, "expected", testCase.expected, "got", actual)
 				}
 			}

--- a/api/machine_types_test.go
+++ b/api/machine_types_test.go
@@ -3,8 +3,6 @@ package api
 import (
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestIsReleaseCommandMachine(t *testing.T) {
@@ -224,10 +222,18 @@ func TestMachineMostRecentStartTimeAfterLaunch(t *testing.T) {
 	for _, testCase := range cases {
 		actual, err := testCase.machine.MostRecentStartTimeAfterLaunch()
 		if testCase.expectedErr {
-			require.Error(t, err, testCase.name)
+			if err == nil {
+				t.Error(testCase.name, "expected error, got nil")
+			}
 		} else {
-			require.NoError(t, err, testCase.name)
-			require.WithinDuration(t, testCase.expected, actual, 1*time.Second, testCase.name)
+			if err != nil {
+				t.Error(testCase.name, "unexpected error:", err)
+			} else {
+				delta := testCase.expected.Sub(actual)
+				if delta < -1*time.Second || delta > 1*time.Second {
+					t.Error(testCase.name, "expected", testCase.expected, "got", actual)
+				}
+			}
 		}
 	}
 }

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -257,7 +257,14 @@ func (lm *leasableMachine) WaitForSmokeChecksToPass(ctx context.Context, logPref
 
 	for {
 		machine, err := lm.flapsClient.Get(waitCtx, lm.Machine().ID)
+		startedAt, startedAtErr := machine.MostRecentStartTimeAfterLaunch()
+		uptime := 0 * time.Second
+		if startedAtErr == nil {
+			uptime = time.Since(startedAt)
+		}
 		switch {
+		case uptime > 10*time.Second && !lm.isConstantlyRestarting(machine):
+			return nil
 		case errors.Is(waitCtx.Err(), context.Canceled):
 			return err
 		case errors.Is(waitCtx.Err(), context.DeadlineExceeded):


### PR DESCRIPTION
Clusters over a handful of machines will see faster `fly deploy` times with this change.

Previously, the smoke checks started a 10 second timer and ran a series of checks over those 10 seconds. The intent was to ensure that the machine stayed up and didn't repeatedly exit over that time.

Since we added smoke checks we started batching updates for machines, and then run the smoke checks sequentially. This means the smoke test may run multiple minutes after a machine was updated. For example, with an app with 36 machine it will get updated in batches of 12. Then the smoke check will be run on each machine sequentially. It takes ~110 seconds to get to the 12th machine. At that point, it doesn't make sense to wait another 10 seconds observing the machine.

This change updates the smoke check to look for the most recent start event, and then use that to calculate the uptime. We pass the smoke check when the machine has an uptime greater than 10 seconds. For the batch deployment example above, this means the first machine will wait ~10 seconds for the smoke to complete, then the 2nd through 12th machines will pass the smoke checks nearly immediately—assuming they are up and not constantly restarting.

`fly deploy` dropped from 6.5 minutes down to a little under 2 minutes on a 36 machine app I tested.🏎️

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
