### PR TITLE
Bump golangci-lint on pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
 # because goalngci-lint github action is much more useful than the pre-commit action.
 # The trick is to run github action only for "manual" hook stage
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.52.2
+    rev: v1.54.2
     hooks:
     -   id: golangci-lint
         stages: [commit]


### PR DESCRIPTION
Match golangci-lint version is used in GH actions.