### PR TITLE
apply pg updates on barman too

### DIFF
--- a/internal/command/image/update_machines.go
+++ b/internal/command/image/update_machines.go
@@ -172,6 +172,19 @@ func updatePostgresOnMachines(ctx context.Context, app *api.AppCompact) (err err
 		}
 	}
 
+	// Update any barman nodes
+	for _, member := range members["barman"] {
+		machine := member.Machine
+		input := &api.LaunchMachineInput{
+			Region:           machine.Region,
+			Config:           &member.TargetConfig,
+			SkipHealthChecks: true,
+		}
+		if err := mach.Update(ctx, machine, input); err != nil {
+			return err
+		}
+	}
+
 	if flex {
 		if len(members["primary"]) > 0 {
 			primary := members["primary"][0]


### PR DESCRIPTION
### Change Summary

What and Why: `fly image update` ignored barman nodes

How: added those to the loop

Related to: Im releasing a new barman image version soon and it needs to be updated properly on existing customer nodes

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
