### PR TITLE
Update Python Procfile

### DIFF
--- a/scanner/templates/python/Procfile
+++ b/scanner/templates/python/Procfile
@@ -1,2 +1,2 @@
-# Modify this Procfile to fit your needs
-web: gunicorn server:app
+# TODO: Modify this Procfile to fit your needs
+web: gunicorn app:app


### PR DESCRIPTION
### Change Summary

Update the Python `Procfile` to use `app:app` as the default for multiple Python frameworks. The docs will be updated to cover the most popular frameworks like Flask, FastAPI, etc. `server:app` is not a good fit based on most of the examples for those frameworks.

Related to: https://github.com/superfly/docs/pull/940

[x] Updated Python docs: https://fly.io/docs/languages-and-frameworks/python/#launch-your-fly-app

---

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a