### PR TITLE
add trailing newline to usage template

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -209,4 +209,5 @@ Global Flags:
 Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
   {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
 
-Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}`
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`


### PR DESCRIPTION
Followup fix for #2733 for proper `fly help` output.

Note the original the default cobra `UsageTemplate` we used as a source includes a trailing newline:
https://github.com/spf13/cobra/blob/fd865a44e3c48afeb6a6dbddadb8a5519173e029/command.go#L567-L568