### PR TITLE
Fix typo in `open` command error

### DIFF
--- a/internal/command/apps/open.go
+++ b/internal/command/apps/open.go
@@ -64,7 +64,7 @@ func runOpen(ctx context.Context) error {
 
 	appURL := appConfig.URL()
 	if appURL == nil {
-		return errors.New("The app doesn't exspose a public http service")
+		return errors.New("The app doesn't expose a public http service")
 	}
 
 	if relURI := flag.FirstArg(ctx); relURI != "" {


### PR DESCRIPTION
### Change Summary

What and Why: typo

How: fixed

Related to: n/a

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
