### PR TITLE
Add a note to help text that vm commands are V1 only

### DIFF
--- a/internal/command/vm/restart.go
+++ b/internal/command/vm/restart.go
@@ -14,8 +14,8 @@ import (
 
 func newRestart() *cobra.Command {
 	const (
-		short = "Restart a VM"
-		long  = "Request for a VM to be asynchronously restarted."
+		short = "V1 APPS ONLY: Restart a VM"
+		long  = "V1 APPS ONLY: Request for a VM to be asynchronously restarted."
 		usage = "restart <vm-id>"
 	)
 

--- a/internal/command/vm/status.go
+++ b/internal/command/vm/status.go
@@ -16,7 +16,7 @@ import (
 
 func newStatus() *cobra.Command {
 	const (
-		short = "Show a VM's status"
+		short = "V1 APPS ONLY: Show a VM's status"
 		long  = short + "\t" + "including logs, checks, and events." + "\n"
 		usage = "status <vm-id>"
 	)

--- a/internal/command/vm/stop.go
+++ b/internal/command/vm/stop.go
@@ -14,8 +14,8 @@ import (
 
 func newStop() *cobra.Command {
 	const (
-		short = "Stop a VM"
-		long  = "Request for a VM to be asynchronously stopped"
+		short = "V1 APPS ONLY: Stop a VM"
+		long  = "V1 APPS ONLY: Request for a VM to be asynchronously stopped"
 		usage = "stop <vm-id>"
 	)
 


### PR DESCRIPTION
### Change Summary

What and Why: 
`vm` commands are for V1 apps only but you don't know that until you run them and get an error.

How:
Added the same note that we include for the V1-only `region` commands: https://github.com/superfly/flyctl/tree/master/internal/command/regions

Related to:
n/a

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
