### PR TITLE
Allow changing CLI configuration directory

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,18 +1,19 @@
 package agent
 
 import (
-	"os"
 	"path/filepath"
+
+	"github.com/superfly/flyctl/helpers"
 )
 
 // TODO: deprecate
 func PathToSocket() string {
-	dir, err := os.UserHomeDir()
+	dir, err := helpers.GetConfigDirectory()
 	if err != nil {
 		panic(err)
 	}
 
-	return filepath.Join(dir, ".fly", "fly-agent.sock")
+	return filepath.Join(dir, "fly-agent.sock")
 }
 
 type Instances struct {

--- a/flyctl/flyctl.go
+++ b/flyctl/flyctl.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"path/filepath"
 
 	"github.com/spf13/viper"
 	"github.com/superfly/flyctl/api"
@@ -18,8 +17,19 @@ var configDir string
 
 // InitConfig - Initialises config file for Viper
 func InitConfig() {
-	if err := initConfigDir(); err != nil {
-		fmt.Println("Error accessing config directory at $HOME/.fly", err)
+	var dir string
+
+	dir, err := helpers.GetConfigDirectory()
+	if err != nil {
+		fmt.Println("Error accessing home directory", err)
+		return
+	}
+
+	if err = initConfigDir(dir); err != nil {
+		fmt.Println(
+			fmt.Sprintf("Error accessing config directory at %s", dir),
+			err,
+		)
 		return
 	}
 
@@ -36,14 +46,7 @@ func ConfigFilePath() string {
 	return path.Join(configDir, "config.yml")
 }
 
-func initConfigDir() error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
-	dir := filepath.Join(homeDir, ".fly")
-
+func initConfigDir(dir string) error {
 	if !helpers.DirectoryExists(dir) {
 		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return err

--- a/helpers/config.go
+++ b/helpers/config.go
@@ -1,0 +1,25 @@
+package helpers
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// GetConfigDirectory will return where config and state files should be
+// stored, either respecting `FLY_CONFIG_DIR` or defaulting to the user's home
+// directory at `~/.fly`.
+func GetConfigDirectory() (string, error) {
+	var dir string
+
+	if value, isSet := os.LookupEnv("FLY_CONFIG_DIR"); isSet {
+		dir = value
+	} else {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		dir = filepath.Join(homeDir, ".fly")
+	}
+
+	return dir, nil
+}

--- a/helpers/config.go
+++ b/helpers/config.go
@@ -9,17 +9,12 @@ import (
 // stored, either respecting `FLY_CONFIG_DIR` or defaulting to the user's home
 // directory at `~/.fly`.
 func GetConfigDirectory() (string, error) {
-	var dir string
-
 	if value, isSet := os.LookupEnv("FLY_CONFIG_DIR"); isSet {
-		dir = value
-	} else {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		dir = filepath.Join(homeDir, ".fly")
+		return value, nil
 	}
-
-	return dir, nil
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".fly"), nil
 }

--- a/helpers/config_test.go
+++ b/helpers/config_test.go
@@ -1,0 +1,47 @@
+package helpers
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetConfigDirectoryWithEnv(t *testing.T) {
+	var previousEnv string
+	if v, isSet := os.LookupEnv("FLY_CONFIG_DIR"); isSet {
+		previousEnv = v
+	}
+
+	os.Setenv("FLY_CONFIG_DIR", "/var/db/flyctl")
+
+	value, err := GetConfigDirectory()
+	assert.NoError(t, err)
+	assert.Equal(t, "/var/db/flyctl", value)
+
+	if previousEnv != "" {
+		os.Setenv("FLY_CONFIG_DIR", previousEnv)
+	}
+}
+
+func TestGetConfigDirectoryDefault(t *testing.T) {
+	var previousEnv string
+	if v, isSet := os.LookupEnv("FLY_CONFIG_DIR"); isSet {
+		previousEnv = v
+	}
+
+	os.Unsetenv("FLY_CONFIG_DIR")
+
+	value, err := GetConfigDirectory()
+	assert.NoError(t, err)
+
+	homeDir, err := os.UserHomeDir()
+	assert.NoError(t, err)
+
+	assert.Equal(t, path.Join(homeDir, ".fly"), value)
+
+	if previousEnv != "" {
+		os.Setenv("FLY_CONFIG_DIR", previousEnv)
+	}
+}

--- a/helpers/config_test.go
+++ b/helpers/config_test.go
@@ -2,7 +2,7 @@ package helpers
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,7 +39,7 @@ func TestGetConfigDirectoryDefault(t *testing.T) {
 	homeDir, err := os.UserHomeDir()
 	assert.NoError(t, err)
 
-	assert.Equal(t, path.Join(homeDir, ".fly"), value)
+	assert.Equal(t, filepath.Join(homeDir, ".fly"), value)
 
 	if previousEnv != "" {
 		os.Setenv("FLY_CONFIG_DIR", previousEnv)

--- a/internal/appconfig/validation_test.go
+++ b/internal/appconfig/validation_test.go
@@ -15,9 +15,7 @@ import (
 func _getValidationContext(t *testing.T) context.Context {
 	ctx := logger.NewContext(context.Background(), logger.New(os.Stderr, logger.Info, false))
 	ctx = flag.NewContext(ctx, &pflag.FlagSet{})
-	ctx, err := preparers.DetermineUserHomeDir(ctx)
-	require.NoError(t, err)
-	ctx, err = preparers.DetermineConfigDir(ctx)
+	ctx, err := preparers.DetermineConfigDir(ctx)
 	require.NoError(t, err)
 	ctx, err = preparers.LoadConfig(ctx)
 	require.NoError(t, err)

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/pflag"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag/flagctx"
 	"github.com/superfly/flyctl/internal/httptracing"
@@ -68,24 +68,15 @@ func InitClient(ctx context.Context) (context.Context, error) {
 }
 
 func DetermineConfigDir(ctx context.Context) (context.Context, error) {
-	dir := filepath.Join(state.UserHomeDirectory(ctx), ".fly")
+	dir, err := helpers.GetConfigDirectory()
+	if err != nil {
+		return ctx, err
+	}
 
 	logger.FromContext(ctx).
 		Debugf("determined config directory: %q", dir)
 
 	return state.WithConfigDirectory(ctx, dir), nil
-}
-
-func DetermineUserHomeDir(ctx context.Context) (context.Context, error) {
-	wd, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("failed determining user home directory: %w", err)
-	}
-
-	logger.FromContext(ctx).
-		Debugf("determined user home directory: %q", wd)
-
-	return state.WithUserHomeDirectory(ctx, wd), nil
 }
 
 // ApplyAliases consolidates flags with aliases into a single source-of-truth flag.

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -53,7 +53,6 @@ var commonPreparers = []preparers.Preparer{
 	preparers.ApplyAliases,
 	determineHostname,
 	determineWorkingDir,
-	preparers.DetermineUserHomeDir,
 	preparers.DetermineConfigDir,
 	ensureConfigDirExists,
 	ensureConfigDirPerms,

--- a/internal/flag/completion/completion_preparers.go
+++ b/internal/flag/completion/completion_preparers.go
@@ -21,10 +21,6 @@ func prepareInitialCtx(cmd *cobra.Command) (context.Context, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctx, err = preparers.DetermineUserHomeDir(ctx)
-	if err != nil {
-		return nil, err
-	}
 	ctx, err = preparers.DetermineConfigDir(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/logger/logfile/fs.go
+++ b/internal/logger/logfile/fs.go
@@ -7,15 +7,17 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/superfly/flyctl/helpers"
 )
 
 func logDir() (string, error) {
-	homeDir, err := os.UserHomeDir()
+	configDir, err := helpers.GetConfigDirectory()
 	if err != nil {
 		return "", err
 	}
 
-	dir := filepath.Join(homeDir, ".fly", "logs")
+	dir := filepath.Join(configDir, "logs")
 
 	dirStat, err := os.Stat(dir)
 	if err == nil && !dirStat.IsDir() {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -14,7 +14,6 @@ const (
 	_ contextKeyType = iota
 	hostnameKey
 	workDirKey
-	userHomeDirKey
 	configDirKey
 )
 
@@ -39,18 +38,6 @@ func WithWorkingDirectory(ctx context.Context, wd string) context.Context {
 // ctx carries no working directory.
 func WorkingDirectory(ctx context.Context) string {
 	return get(ctx, workDirKey).(string)
-}
-
-// WithUserHomeDirectory derives a Context that carries the given user home
-// directory from ctx.
-func WithUserHomeDirectory(ctx context.Context, uhd string) context.Context {
-	return set(ctx, userHomeDirKey, uhd)
-}
-
-// UserHomeDirectory returns the user home directory ctx carries. It panics in
-// case ctx carries no user home directory.
-func UserHomeDirectory(ctx context.Context) string {
-	return get(ctx, userHomeDirKey).(string)
 }
 
 // WithConfigDir derives a Context that carries the given config directory from

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -15,7 +15,6 @@ func TestStrings(t *testing.T) {
 	}{
 		"Hostname":          {Hostname, WithHostname},
 		"WorkingDirectory":  {WorkingDirectory, WithWorkingDirectory},
-		"UserHomeDirectory": {UserHomeDirectory, WithUserHomeDirectory},
 		"ConfigDirectory":   {ConfigDirectory, WithConfigDirectory},
 	}
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -13,9 +13,9 @@ func TestStrings(t *testing.T) {
 		getter func(context.Context) string
 		setter func(context.Context, string) context.Context
 	}{
-		"Hostname":          {Hostname, WithHostname},
-		"WorkingDirectory":  {WorkingDirectory, WithWorkingDirectory},
-		"ConfigDirectory":   {ConfigDirectory, WithConfigDirectory},
+		"Hostname":         {Hostname, WithHostname},
+		"WorkingDirectory": {WorkingDirectory, WithWorkingDirectory},
+		"ConfigDirectory":  {ConfigDirectory, WithConfigDirectory},
 	}
 
 	for name := range cases {


### PR DESCRIPTION
### Change Summary

We should introduce an environment variable that, if set, will be used instead of hardcoding `~/.fly` everywhere. This allows for the user to use the CLI in non-standard environments, or in more advanced ways (for example, by swapping the config dir to isolate separate accounts).

This is pretty common for infrastructure tools; eg., the Azure CLI allows setting `AZURE_CONFIG_DIR` to do this.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
