### PR TITLE
Add LiteFS Cloud commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/superfly/flyctl/api v0.0.0-20230714194642-3abf5055f01a
 	github.com/superfly/graphql v0.2.4
-	github.com/superfly/lfsc-go v0.1.0
+	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.0.5
 	github.com/superfly/tokenizer v0.0.2
 	github.com/vektah/gqlparser v1.3.1
@@ -235,6 +235,6 @@ require (
 
 replace github.com/superfly/flyctl/api => ./api
 
-//replace github.com/superfly/lfsc-go => ../lfsc-go
+// replace github.com/superfly/lfsc-go => ../lfsc-go
 
 replace github.com/loadsmart/calver-go => github.com/ndarilek/calver-go v0.0.0-20230710153822-893bbd83a936

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/superfly/flyctl
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
@@ -58,6 +58,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/superfly/flyctl/api v0.0.0-20230714194642-3abf5055f01a
 	github.com/superfly/graphql v0.2.4
+	github.com/superfly/lfsc-go v0.1.0
 	github.com/superfly/macaroon v0.0.5
 	github.com/superfly/tokenizer v0.0.2
 	github.com/vektah/gqlparser v1.3.1
@@ -144,6 +145,7 @@ require (
 	github.com/moby/term v0.5.0 // indirect
 	github.com/opencontainers/selinux v1.11.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
+	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/rivo/tview v0.0.0-20220307222120-9994674d60a8 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
@@ -152,6 +154,7 @@ require (
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/skeema/knownhosts v1.2.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
+	github.com/superfly/ltx v0.3.12 // indirect
 	github.com/vbatts/tar-split v0.11.3 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
@@ -231,5 +234,7 @@ require (
 )
 
 replace github.com/superfly/flyctl/api => ./api
+
+//replace github.com/superfly/lfsc-go => ../lfsc-go
 
 replace github.com/loadsmart/calver-go => github.com/ndarilek/calver-go v0.0.0-20230710153822-893bbd83a936

--- a/go.sum
+++ b/go.sum
@@ -646,6 +646,8 @@ github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3v
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
+github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=
+github.com/pierrec/lz4/v4 v4.1.17/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
@@ -738,6 +740,10 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
+github.com/superfly/lfsc-go v0.1.0 h1:jXxla4ns3EjLOS+4ZVgHTfvmNPBKs+iUlbHyBAVttrM=
+github.com/superfly/lfsc-go v0.1.0/go.mod h1:zVb0VENz/Il8Nmvvd4XAsX2bWhQ+sr0nK8vv9PeezcE=
+github.com/superfly/ltx v0.3.12 h1:Z7z1sc4g34/jUi3XO84+zBlIsbaoh2RJ3b4zTQpBK/M=
+github.com/superfly/ltx v0.3.12/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/superfly/macaroon v0.0.5 h1:Rw48kdYc2k0PHccGnNWO0Byc5TQoJBjbQtzGZJPFKcU=
 github.com/superfly/macaroon v0.0.5/go.mod h1:5DZuLe1e3EiEDs9R7snKQJVslVjgBhlJ9jbnOmKasRg=
 github.com/superfly/tokenizer v0.0.2 h1:gBREpm08sPWUHsqKHKHFy/AIKwrqpg+VBD/wtJ6x5Jk=

--- a/go.sum
+++ b/go.sum
@@ -740,8 +740,6 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
-github.com/superfly/lfsc-go v0.1.0 h1:jXxla4ns3EjLOS+4ZVgHTfvmNPBKs+iUlbHyBAVttrM=
-github.com/superfly/lfsc-go v0.1.0/go.mod h1:zVb0VENz/Il8Nmvvd4XAsX2bWhQ+sr0nK8vv9PeezcE=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=
 github.com/superfly/lfsc-go v0.1.1/go.mod h1:zVb0VENz/Il8Nmvvd4XAsX2bWhQ+sr0nK8vv9PeezcE=
 github.com/superfly/ltx v0.3.12 h1:Z7z1sc4g34/jUi3XO84+zBlIsbaoh2RJ3b4zTQpBK/M=

--- a/go.sum
+++ b/go.sum
@@ -742,6 +742,8 @@ github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3P
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.0 h1:jXxla4ns3EjLOS+4ZVgHTfvmNPBKs+iUlbHyBAVttrM=
 github.com/superfly/lfsc-go v0.1.0/go.mod h1:zVb0VENz/Il8Nmvvd4XAsX2bWhQ+sr0nK8vv9PeezcE=
+github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=
+github.com/superfly/lfsc-go v0.1.1/go.mod h1:zVb0VENz/Il8Nmvvd4XAsX2bWhQ+sr0nK8vv9PeezcE=
 github.com/superfly/ltx v0.3.12 h1:Z7z1sc4g34/jUi3XO84+zBlIsbaoh2RJ3b4zTQpBK/M=
 github.com/superfly/ltx v0.3.12/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
 github.com/superfly/macaroon v0.0.5 h1:Rw48kdYc2k0PHccGnNWO0Byc5TQoJBjbQtzGZJPFKcU=

--- a/internal/command/lfsc/clusters.go
+++ b/internal/command/lfsc/clusters.go
@@ -1,0 +1,28 @@
+package lfsc
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/superfly/flyctl/internal/command"
+)
+
+func newClusters() *cobra.Command {
+	const (
+		long = `"Commands for managing LiteFS Cloud clusters"
+`
+		short = "Manage LiteFS Cloud clusters"
+		usage = "clusters <command>"
+	)
+
+	cmd := command.New(usage, short, long, nil,
+		command.RequireSession,
+	)
+
+	cmd.Aliases = []string{"clusters"}
+
+	cmd.AddCommand(
+		newClustersList(),
+	)
+
+	return cmd
+}

--- a/internal/command/lfsc/clusters.go
+++ b/internal/command/lfsc/clusters.go
@@ -21,6 +21,7 @@ func newClusters() *cobra.Command {
 	cmd.Aliases = []string{"clusters"}
 
 	cmd.AddCommand(
+		newClustersCreate(),
 		newClustersDestroy(),
 		newClustersList(),
 	)

--- a/internal/command/lfsc/clusters.go
+++ b/internal/command/lfsc/clusters.go
@@ -21,6 +21,7 @@ func newClusters() *cobra.Command {
 	cmd.Aliases = []string{"clusters"}
 
 	cmd.AddCommand(
+		newClustersDestroy(),
 		newClustersList(),
 	)
 

--- a/internal/command/lfsc/clusters.go
+++ b/internal/command/lfsc/clusters.go
@@ -18,8 +18,6 @@ func newClusters() *cobra.Command {
 		command.RequireSession,
 	)
 
-	cmd.Aliases = []string{"clusters"}
-
 	cmd.AddCommand(
 		newClustersCreate(),
 		newClustersDestroy(),

--- a/internal/command/lfsc/clusters_create.go
+++ b/internal/command/lfsc/clusters_create.go
@@ -1,0 +1,86 @@
+package lfsc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/gql"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newClustersCreate() *cobra.Command {
+	const (
+		long = `Creates a new LiteFS Cloud cluster.`
+
+		short = "Creates a LiteFS Cloud cluster"
+
+		usage = "create CLUSTERNAME"
+	)
+
+	cmd := command.New(usage, short, long, runClustersCreate,
+		command.RequireSession,
+		command.LoadAppNameIfPresentNoFlag,
+	)
+
+	cmd.Args = cobra.RangeArgs(0, 1)
+
+	flag.Add(cmd,
+		urlFlag(),
+		regionFlag(),
+		flag.Org(),
+		flag.JSONOutput(),
+	)
+
+	return cmd
+}
+
+func runClustersCreate(ctx context.Context) error {
+	apiClient := client.FromContext(ctx).API()
+
+	orgID, err := getOrgID(ctx)
+	if err != nil {
+		return err
+	}
+
+	clusterName := flag.FirstArg(ctx)
+	if clusterName == "" {
+		return errors.New("cluster name required as first argument")
+	}
+	region := flag.GetString(ctx, "region")
+	if region == "" {
+		return errors.New("required: --region CODE")
+	}
+
+	lfscClient, err := newLFSCClient(ctx, "")
+	if err != nil {
+		return err
+	}
+
+	cluster, err := lfscClient.CreateCluster(ctx, clusterName, region)
+	if err != nil {
+		return err
+	}
+
+	resp, err := gql.CreateLimitedAccessToken(ctx, apiClient.GenqClient, clusterName, orgID, "litefs_cloud",
+		&gql.LimitedAccessTokenOptions{
+			"cluster": clusterName,
+		},
+		"",
+	)
+	if err != nil {
+		return fmt.Errorf("failed creating cluster token: %w", err)
+	}
+
+	out := iostreams.FromContext(ctx).Out
+	fmt.Fprintf(out, "Cluster %q successfully created in %s.\n\n", cluster.Name, cluster.Region)
+	fmt.Fprintf(out, "Run the following to set the auth token on your application:\n\n")
+	fmt.Fprintf(out, "fly secrets set LFSC_AUTH_TOKEN=%q\n\n",
+		resp.CreateLimitedAccessToken.LimitedAccessToken.TokenHeader)
+
+	return nil
+}

--- a/internal/command/lfsc/clusters_destroy.go
+++ b/internal/command/lfsc/clusters_destroy.go
@@ -1,0 +1,59 @@
+package lfsc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newClustersDestroy() *cobra.Command {
+	const (
+		long = `Permanently deletes a LiteFS Cloud cluster.`
+
+		short = "Delete a LiteFS Cloud cluster"
+
+		usage = "destroy"
+	)
+
+	cmd := command.New(usage, short, long, runClustersDestroy,
+		command.RequireSession,
+		command.LoadAppNameIfPresentNoFlag,
+	)
+
+	cmd.Args = cobra.NoArgs
+
+	flag.Add(cmd,
+		urlFlag(),
+		clusterFlag(),
+		flag.Org(),
+		flag.JSONOutput(),
+	)
+
+	return cmd
+}
+
+func runClustersDestroy(ctx context.Context) error {
+	clusterName := flag.GetString(ctx, "cluster")
+	if clusterName == "" {
+		return errors.New("required: --cluster NAME")
+	}
+
+	lfscClient, err := newLFSCClient(ctx, "")
+	if err != nil {
+		return err
+	}
+
+	if err := lfscClient.DeleteCluster(ctx, clusterName); err != nil {
+		return err
+	}
+
+	out := iostreams.FromContext(ctx).Out
+	fmt.Fprintf(out, "Cluster %q successfully deleted.\n", clusterName)
+
+	return nil
+}

--- a/internal/command/lfsc/clusters_list.go
+++ b/internal/command/lfsc/clusters_list.go
@@ -1,0 +1,71 @@
+package lfsc
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/format"
+	"github.com/superfly/flyctl/internal/render"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newClustersList() *cobra.Command {
+	const (
+		long = `Lists the LiteFS Cloud clusters in the organization.`
+
+		short = "Show LiteFS Cloud clusters"
+
+		usage = "list <clustername>"
+	)
+
+	cmd := command.New(usage, short, long, runClustersList,
+		command.RequireSession,
+		command.LoadAppNameIfPresentNoFlag,
+	)
+
+	cmd.Args = cobra.NoArgs
+
+	flag.Add(cmd,
+		urlFlag(),
+		flag.Org(),
+		flag.JSONOutput(),
+	)
+
+	return cmd
+}
+
+func runClustersList(ctx context.Context) error {
+	cfg := config.FromContext(ctx)
+
+	lfscClient, err := newLFSCClient(ctx, "")
+	if err != nil {
+		return err
+	}
+
+	output, err := lfscClient.ListClusters(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	out := iostreams.FromContext(ctx).Out
+	if cfg.JSONOutput {
+		_ = render.JSON(out, output)
+		return nil
+	}
+
+	rows := make([][]string, 0, len(output.Clusters))
+	for _, cluster := range output.Clusters {
+		rows = append(rows, []string{
+			cluster.Name,
+			cluster.Region,
+			format.RelativeTime(cluster.CreatedAt),
+		})
+	}
+
+	_ = render.Table(out, "", rows, "Name", "Region", "Created")
+
+	return nil
+}

--- a/internal/command/lfsc/clusters_list.go
+++ b/internal/command/lfsc/clusters_list.go
@@ -18,7 +18,7 @@ func newClustersList() *cobra.Command {
 
 		short = "Show LiteFS Cloud clusters"
 
-		usage = "list <clustername>"
+		usage = "list"
 	)
 
 	cmd := command.New(usage, short, long, runClustersList,

--- a/internal/command/lfsc/clusters_list.go
+++ b/internal/command/lfsc/clusters_list.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superfly/flyctl/internal/format"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
+	"github.com/superfly/lfsc-go"
 )
 
 func newClustersList() *cobra.Command {
@@ -31,6 +32,16 @@ func newClustersList() *cobra.Command {
 	flag.Add(cmd,
 		urlFlag(),
 		flag.Org(),
+		flag.Int{
+			Name:        "offset",
+			Description: "Index of results to return from",
+			Default:     0,
+		},
+		flag.Int{
+			Name:        "limit",
+			Description: "Number of results to return",
+			Default:     50,
+		},
 		flag.JSONOutput(),
 	)
 
@@ -45,7 +56,11 @@ func runClustersList(ctx context.Context) error {
 		return err
 	}
 
-	output, err := lfscClient.ListClusters(ctx, nil)
+	var input lfsc.ListClustersInput
+	input.Offset = flag.GetInt(ctx, "offset")
+	input.Limit = flag.GetInt(ctx, "limit")
+
+	output, err := lfscClient.ListClusters(ctx, &input)
 	if err != nil {
 		return err
 	}

--- a/internal/command/lfsc/export.go
+++ b/internal/command/lfsc/export.go
@@ -1,0 +1,107 @@
+package lfsc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newExport() *cobra.Command {
+	const (
+		long = `Exports the current state of the database to a file.`
+
+		short = "Export LiteFS Cloud database"
+
+		usage = "export"
+	)
+
+	cmd := command.New(usage, short, long, runExport,
+		command.RequireSession,
+		command.LoadAppNameIfPresentNoFlag,
+	)
+
+	cmd.Args = cobra.NoArgs
+
+	flag.Add(cmd,
+		flag.String{
+			Name:        "output",
+			Description: "Output filename",
+		},
+		flag.Bool{
+			Name:        "force",
+			Shorthand:   "f",
+			Description: "Overwrite output file if it already exists",
+		},
+		urlFlag(),
+		clusterFlag(),
+		databaseFlag(),
+		flag.Org(),
+		flag.JSONOutput(),
+	)
+
+	return cmd
+}
+
+func runExport(ctx context.Context) error {
+	out := iostreams.FromContext(ctx).Out
+	output := flag.GetString(ctx, "output")
+
+	clusterName := flag.GetString(ctx, "cluster")
+	if clusterName == "" {
+		return errors.New("required: --cluster NAME")
+	}
+	databaseName := flag.GetString(ctx, "database")
+	if databaseName == "" {
+		return errors.New("required: --database NAME")
+	}
+
+	if output == "" {
+		return errors.New("required: --output PATH")
+	}
+	force := flag.GetBool(ctx, "force")
+
+	if !force {
+		if _, err := os.Stat(output); err == nil {
+			return errors.New("output file already exists, use --force to overwrite")
+		}
+	}
+
+	lfscClient, err := newLFSCClient(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	startTime := time.Now()
+
+	rc, err := lfscClient.ExportDatabase(ctx, databaseName)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rc.Close() }()
+
+	f, err := os.Create(output)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := io.Copy(f, rc); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Database exported to %s in %s\n",
+		output, time.Since(startTime).Truncate(time.Millisecond))
+
+	return nil
+}

--- a/internal/command/lfsc/import.go
+++ b/internal/command/lfsc/import.go
@@ -1,0 +1,85 @@
+package lfsc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newImport() *cobra.Command {
+	const (
+		long = `Imports a local SQLite database into a LiteFS Cloud cluster.`
+
+		short = "Import SQLite database into LiteFS Cloud"
+
+		usage = "import"
+	)
+
+	cmd := command.New(usage, short, long, runImport,
+		command.RequireSession,
+		command.LoadAppNameIfPresentNoFlag,
+	)
+
+	cmd.Args = cobra.NoArgs
+
+	flag.Add(cmd,
+		flag.String{
+			Name:        "input",
+			Description: "Input filename",
+		},
+		urlFlag(),
+		clusterFlag(),
+		databaseFlag(),
+		flag.Org(),
+		flag.JSONOutput(),
+	)
+
+	return cmd
+}
+
+func runImport(ctx context.Context) error {
+	out := iostreams.FromContext(ctx).Out
+
+	clusterName := flag.GetString(ctx, "cluster")
+	if clusterName == "" {
+		return errors.New("required: --cluster NAME")
+	}
+	databaseName := flag.GetString(ctx, "database")
+	if databaseName == "" {
+		return errors.New("required: --database NAME")
+	}
+
+	input := flag.GetString(ctx, "input")
+	if input == "" {
+		return errors.New("required: --input PATH")
+	}
+
+	lfscClient, err := newLFSCClient(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(input)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	startTime := time.Now()
+
+	if _, err := lfscClient.ImportDatabase(ctx, databaseName, f); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Database imported to %s in %s\n",
+		databaseName, time.Since(startTime).Truncate(time.Millisecond))
+
+	return nil
+}

--- a/internal/command/lfsc/lfsc.go
+++ b/internal/command/lfsc/lfsc.go
@@ -1,0 +1,122 @@
+// Package lfsc implements the LiteFS Cloud command chain.
+package lfsc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/gql"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/lfsc-go"
+)
+
+const (
+	tokenExpiry = 1 * time.Minute
+)
+
+// New initializes and returns a new apps Command.
+func New() *cobra.Command {
+	const (
+		long = `Commands for managing LiteFS Cloud databases`
+
+		short = "LiteFS Cloud management commands"
+
+		usage = "litefs-cloud <command>"
+	)
+
+	cmd := command.New("usage", short, long, nil)
+	cmd.Aliases = []string{"litefs-cloud", "lfsc"}
+
+	cmd.AddCommand(
+		newClusters(),
+		newExport(),
+		newImport(),
+		newRestore(),
+		newStatus(),
+	)
+
+	return cmd
+}
+
+// urlFlag is a hidden flag for setting the LiteFS Cloud API URL for testing.
+func urlFlag() flag.String {
+	return flag.String{
+		Name:        "url",
+		Description: "LiteFS Cloud URL",
+		Hidden:      true,
+		Default:     lfsc.DefaultURL,
+	}
+}
+
+func clusterFlag() flag.String {
+	return flag.String{
+		Name:        "cluster",
+		Shorthand:   "c",
+		Description: "LiteFS Cloud cluster name",
+	}
+}
+
+func databaseFlag() flag.String {
+	return flag.String{
+		Name:        "database",
+		Shorthand:   "d",
+		Description: "LiteFS Cloud database name",
+	}
+}
+
+// newLFSCClient returns an lfsc.Client with a temporary auth token.
+func newLFSCClient(ctx context.Context, clusterName string) (*lfsc.Client, error) {
+	apiClient := client.FromContext(ctx).API()
+
+	// Determine the org via flag or environment variable first.
+	// If neither is available, use the local app's org, if available.
+	var orgID string
+	if slug := flag.GetOrg(ctx); slug != "" {
+		org, err := apiClient.GetOrganizationBySlug(ctx, slug)
+		if err != nil {
+			return nil, fmt.Errorf("failed retrieving organization with slug %s: %w", slug, err)
+		}
+		orgID = org.ID
+
+	} else {
+		appName := appconfig.NameFromContext(ctx)
+		if appName == "" {
+			return nil, errors.New("no org was provided, and none is available from the environment or fly.toml")
+		}
+
+		app, err := apiClient.GetAppCompact(ctx, appName)
+		if err != nil {
+			return nil, err
+		}
+		orgID = app.Organization.ID
+	}
+
+	// Acquire a temporary auth token to access LiteFS Cloud.
+	resp, err := gql.CreateLimitedAccessToken(
+		ctx,
+		apiClient.GenqClient,
+		"flyctl-lfsc",
+		orgID,
+		"litefs_cloud",
+		&gql.LimitedAccessTokenOptions{
+			"cluster": clusterName,
+		},
+		tokenExpiry.String(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating litefs-cloud token: %w", err)
+	}
+
+	client := lfsc.NewClient()
+	client.URL = flag.GetString(ctx, "url")
+	client.Token = resp.CreateLimitedAccessToken.LimitedAccessToken.TokenHeader
+
+	return client, nil
+}

--- a/internal/command/lfsc/lfsc.go
+++ b/internal/command/lfsc/lfsc.go
@@ -32,7 +32,7 @@ func New() *cobra.Command {
 	)
 
 	cmd := command.New(usage, short, long, nil)
-	cmd.Aliases = []string{"litefs-cloud", "lfsc"}
+	cmd.Aliases = []string{"lfsc"}
 
 	cmd.AddCommand(
 		newClusters(),

--- a/internal/command/lfsc/regions.go
+++ b/internal/command/lfsc/regions.go
@@ -1,0 +1,71 @@
+package lfsc
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/render"
+	"github.com/superfly/flyctl/iostreams"
+	"github.com/superfly/lfsc-go"
+)
+
+func newRegions() (cmd *cobra.Command) {
+	const (
+		long  = `View a list of LiteFS Cloud regions`
+		short = "List LiteFS Cloud regions"
+	)
+
+	cmd = command.New("regions", short, long, runRegions,
+		command.RequireSession,
+	)
+
+	cmd.Args = cobra.NoArgs
+	flag.Add(cmd,
+		urlFlag(),
+		flag.JSONOutput())
+	return
+}
+
+func runRegions(ctx context.Context) error {
+	client := client.FromContext(ctx).API()
+
+	flyRegions, _, err := client.PlatformRegions(ctx)
+	if err != nil {
+		return fmt.Errorf("failed retrieving regions: %w", err)
+	}
+
+	lfscClient := lfsc.NewClient()
+	lfscClient.URL = flag.GetString(ctx, "url")
+
+	regions, err := lfscClient.Regions(ctx)
+	if err != nil {
+		return fmt.Errorf("failed retrieving litefs cloud regions: %w", err)
+	}
+	sort.Slice(regions, func(i, j int) bool {
+		return regions[i] < regions[j]
+	})
+
+	out := iostreams.FromContext(ctx).Out
+	if config.FromContext(ctx).JSONOutput {
+		return render.JSON(out, regions)
+	}
+
+	var rows [][]string
+	for _, region := range regions {
+		var regionName string
+		for _, flyRegion := range flyRegions {
+			if flyRegion.Code == region {
+				regionName = flyRegion.Name
+			}
+		}
+
+		rows = append(rows, []string{regionName, region})
+	}
+	return render.Table(out, "", rows, "Name", "Code")
+}

--- a/internal/command/lfsc/restore.go
+++ b/internal/command/lfsc/restore.go
@@ -1,0 +1,82 @@
+package lfsc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newRestore() *cobra.Command {
+	const (
+		long = `Restores a LiteFS Cloud database to a previous state.`
+
+		short = "Restore LiteFS Cloud database"
+
+		usage = "restore"
+	)
+
+	cmd := command.New(usage, short, long, runRestore,
+		command.RequireSession,
+		command.LoadAppNameIfPresentNoFlag,
+	)
+
+	cmd.Args = cobra.NoArgs
+
+	flag.Add(cmd,
+		flag.String{
+			Name:        "timestamp",
+			Description: "Time to restore to (ISO 8601)",
+		},
+		urlFlag(),
+		clusterFlag(),
+		databaseFlag(),
+		flag.Org(),
+		flag.JSONOutput(),
+	)
+
+	return cmd
+}
+
+func runRestore(ctx context.Context) error {
+	out := iostreams.FromContext(ctx).Out
+
+	clusterName := flag.GetString(ctx, "cluster")
+	if clusterName == "" {
+		return errors.New("required: --cluster NAME")
+	}
+	databaseName := flag.GetString(ctx, "database")
+	if databaseName == "" {
+		return errors.New("required: --database NAME")
+	}
+
+	timestampStr := flag.GetString(ctx, "timestamp")
+	if timestampStr == "" {
+		return errors.New("required: --timestamp YYYY-MM-DDTHH:MM:SSZ")
+	}
+	timestamp, err := time.Parse(time.RFC3339, timestampStr)
+	if err != nil {
+		return errors.New("invalid timestamp format, please use ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ)")
+	}
+
+	lfscClient, err := newLFSCClient(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	startTime := time.Now()
+
+	if _, err := lfscClient.RestoreDatabaseToTimestamp(ctx, databaseName, timestamp); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Database restored to previous state in %s\n",
+		time.Since(startTime).Truncate(time.Millisecond))
+
+	return nil
+}

--- a/internal/command/lfsc/status.go
+++ b/internal/command/lfsc/status.go
@@ -1,0 +1,79 @@
+package lfsc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/render"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newStatus() *cobra.Command {
+	const (
+		long = `Lists the databases in the cluster with their replication position.`
+
+		short = "Show LiteFS Cloud cluster status"
+
+		usage = "status"
+	)
+
+	cmd := command.New(usage, short, long, runStatus,
+		command.RequireSession,
+		command.LoadAppNameIfPresentNoFlag,
+	)
+
+	cmd.Args = cobra.NoArgs
+
+	flag.Add(cmd,
+		urlFlag(),
+		clusterFlag(),
+		flag.Org(),
+		flag.JSONOutput(),
+	)
+
+	return cmd
+}
+
+func runStatus(ctx context.Context) error {
+	cfg := config.FromContext(ctx)
+	clusterName := flag.GetString(ctx, "cluster")
+	if clusterName == "" {
+		return errors.New("required: --cluster NAME")
+	}
+
+	lfscClient, err := newLFSCClient(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	posMap, err := lfscClient.Pos(ctx)
+	if err != nil {
+		return err
+	}
+
+	out := iostreams.FromContext(ctx).Out
+	if cfg.JSONOutput {
+		_ = render.JSON(out, posMap)
+		return nil
+	}
+
+	rows := make([][]string, 0, len(posMap))
+	for name, pos := range posMap {
+		rows = append(rows, []string{
+			name,
+			pos.TXID.String(),
+			fmt.Sprintf("%016x", pos.PostApplyChecksum),
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i][0] < rows[j][0] })
+
+	_ = render.Table(out, "", rows, "Name", "TXID", "Checksum")
+
+	return nil
+}

--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -37,6 +37,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/ips"
 	"github.com/superfly/flyctl/internal/command/jobs"
 	"github.com/superfly/flyctl/internal/command/launch"
+	"github.com/superfly/flyctl/internal/command/lfsc"
 	"github.com/superfly/flyctl/internal/command/logs"
 	"github.com/superfly/flyctl/internal/command/machine"
 	"github.com/superfly/flyctl/internal/command/migrate_to_v2"
@@ -105,6 +106,7 @@ func New() *cobra.Command {
 		group(doctor.New(), "more_help"),
 		group(dig.New(), "upkeep"),
 		group(volumes.New(), "configuring"),
+		group(lfsc.New(), "dbs_and_extensions"),
 		agent.New(),
 		group(image.New(), "configuring"),
 		group(ping.New(), "upkeep"),


### PR DESCRIPTION
### Change Summary

What and Why: This pull request adds CLI commands for managing LiteFS Cloud clusters. These commands include listing clusters, listing databases, import/exporting databases, & restoring databases.

How: Added a subcommand called `litefs-cloud` which is also aliased to `lfsc` for brevity.

Related to: Users have requested CLI access to LiteFS Cloud (https://github.com/superfly/litefs/issues/392).

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team