### PR TITLE
use source machine to set host dedication id

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -244,11 +244,6 @@ func runMachineClone(ctx context.Context) (err error) {
 				fmt.Fprintf(io.Out, "Creating new volume from snapshot: %s\n", colorize.Bold(*snapshotID))
 			}
 
-			var hostDedicationID string
-			if vol != nil {
-				hostDedicationID = vol.HostDedicationID
-			}
-
 			volInput := api.CreateVolumeRequest{
 				Name:              mnt.Name,
 				Region:            region,
@@ -256,7 +251,7 @@ func runMachineClone(ctx context.Context) (err error) {
 				Encrypted:         &mnt.Encrypted,
 				SnapshotID:        snapshotID,
 				RequireUniqueZone: api.Pointer(flag.GetBool(ctx, "volume-requires-unique-zone")),
-				HostDedicationId:  hostDedicationID,
+				HostDedicationId:  source.HostDedicationID,
 			}
 			vol, err = flapsClient.CreateVolume(ctx, volInput)
 			if err != nil {

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -244,6 +244,11 @@ func runMachineClone(ctx context.Context) (err error) {
 				fmt.Fprintf(io.Out, "Creating new volume from snapshot: %s\n", colorize.Bold(*snapshotID))
 			}
 
+			var hostDedicationID string
+			if vol != nil {
+				hostDedicationID = vol.HostDedicationID
+			}
+
 			volInput := api.CreateVolumeRequest{
 				Name:              mnt.Name,
 				Region:            region,
@@ -251,7 +256,7 @@ func runMachineClone(ctx context.Context) (err error) {
 				Encrypted:         &mnt.Encrypted,
 				SnapshotID:        snapshotID,
 				RequireUniqueZone: api.Pointer(flag.GetBool(ctx, "volume-requires-unique-zone")),
-				HostDedicationId:  vol.HostDedicationID,
+				HostDedicationId:  hostDedicationID,
 			}
 			vol, err = flapsClient.CreateVolume(ctx, volInput)
 			if err != nil {


### PR DESCRIPTION
### Change Summary

What and Why:

If a new volume is created, `vol == nil` and the call to `vol.HostDedicationID` would segfault. This fixes it.

How:

Set `HostDedicationID` using the value in the source machine 

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
