### PR TITLE
Add `fly m (un)cordon` commands

### DIFF
--- a/flaps/flaps_machines.go
+++ b/flaps/flaps_machines.go
@@ -382,7 +382,7 @@ func (f *Client) Cordon(ctx context.Context, machineID string) (err error) {
 	return nil
 }
 
-func (f *Client) UnCordon(ctx context.Context, machineID string) (err error) {
+func (f *Client) Uncordon(ctx context.Context, machineID string) (err error) {
 	metrics.Started(ctx, "machine_uncordon")
 	sendUpdateMetrics := metrics.StartTiming(ctx, "machine_uncordon/duration")
 	defer func() {

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -67,7 +67,6 @@ func BlueGreenStrategy(md *machineDeployment, blueMachines []*machineUpdateEntry
 	})
 
 	return bg
-
 }
 
 func (bg *blueGreen) CreateGreenMachines(ctx context.Context) error {
@@ -313,7 +312,6 @@ func (bg *blueGreen) WaitForGreenMachinesToBeHealthy(ctx context.Context) error 
 
 				time.Sleep(interval)
 			}
-
 		}(gm)
 	}
 
@@ -346,7 +344,7 @@ func (bg *blueGreen) MarkGreenMachinesAsReadyForTraffic(ctx context.Context) err
 		if bg.aborted.Load() {
 			return ErrAborted
 		}
-		err := bg.flaps.UnCordon(ctx, gm.Machine().ID)
+		err := bg.flaps.Uncordon(ctx, gm.Machine().ID)
 		if err != nil {
 			return err
 		}
@@ -411,7 +409,6 @@ func (bg *blueGreen) attachCustomTopLevelChecks() {
 }
 
 func (bg *blueGreen) Deploy(ctx context.Context) error {
-
 	defer bg.ctrlcHook.Done()
 
 	if bg.aborted.Load() {
@@ -484,7 +481,6 @@ func (bg *blueGreen) Deploy(ctx context.Context) error {
 }
 
 func (bg *blueGreen) Rollback(ctx context.Context, err error) error {
-
 	if strings.Contains(err.Error(), ErrDestroyBlueMachines.Error()) {
 		fmt.Fprintf(bg.io.ErrOut, "\nFailed to destroy blue machines (%s)\n", strings.Join(bg.hangingBlueMachines, ","))
 		fmt.Fprintf(bg.io.ErrOut, "\nYou can destroy them using `fly machines destroy --force <id>`")

--- a/internal/command/machine/cordon.go
+++ b/internal/command/machine/cordon.go
@@ -1,0 +1,58 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newMachineCordon() *cobra.Command {
+	const (
+		short = "Reactive all services on a machine"
+		long  = short + "\n"
+		usage = "cordon <id> [<id>...]"
+	)
+
+	cmd := command.New(usage, short, long, runMachineCordon,
+		command.RequireSession,
+		command.LoadAppNameIfPresent,
+	)
+
+	flag.Add(
+		cmd,
+		flag.App(),
+		flag.AppConfig(),
+		selectFlag,
+	)
+
+	cmd.Args = cobra.ArbitraryArgs
+	return cmd
+}
+
+func runMachineCordon(ctx context.Context) (err error) {
+	var (
+		io   = iostreams.FromContext(ctx)
+		args = flag.Args(ctx)
+	)
+
+	machineIDs, ctx, err := selectManyMachineIDs(ctx, args)
+	if err != nil {
+		return err
+	}
+
+	flapsClient := flaps.FromContext(ctx)
+
+	for _, machineID := range machineIDs {
+		fmt.Fprintf(io.Out, "Activating cordon on machine %s...\n", machineID)
+		if err = flapsClient.Cordon(ctx, machineID); err != nil {
+			return err
+		}
+		fmt.Fprintf(io.Out, "done!\n")
+	}
+	return
+}

--- a/internal/command/machine/machine.go
+++ b/internal/command/machine/machine.go
@@ -32,6 +32,8 @@ func New() *cobra.Command {
 		newRestart(),
 		newLeases(),
 		newMachineExec(),
+		newMachineCordon(),
+		newMachineUncordon(),
 	)
 
 	return cmd

--- a/internal/command/machine/uncordon.go
+++ b/internal/command/machine/uncordon.go
@@ -1,0 +1,58 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newMachineUncordon() *cobra.Command {
+	const (
+		short = "Deactivate all services on a machine"
+		long  = short + "\n"
+		usage = "uncordon <id> [<id>...]"
+	)
+
+	cmd := command.New(usage, short, long, runMachineUncordon,
+		command.RequireSession,
+		command.LoadAppNameIfPresent,
+	)
+
+	flag.Add(
+		cmd,
+		flag.App(),
+		flag.AppConfig(),
+		selectFlag,
+	)
+
+	cmd.Args = cobra.ArbitraryArgs
+	return cmd
+}
+
+func runMachineUncordon(ctx context.Context) (err error) {
+	var (
+		io   = iostreams.FromContext(ctx)
+		args = flag.Args(ctx)
+	)
+
+	machineIDs, ctx, err := selectManyMachineIDs(ctx, args)
+	if err != nil {
+		return err
+	}
+
+	flapsClient := flaps.FromContext(ctx)
+
+	for _, machineID := range machineIDs {
+		fmt.Fprintf(io.Out, "Deactivating cordon on machine %s...\n", machineID)
+		if err = flapsClient.Uncordon(ctx, machineID); err != nil {
+			return err
+		}
+		fmt.Fprintf(io.Out, "done!\n")
+	}
+	return
+}


### PR DESCRIPTION
### Change Summary

What and Why: Expose Machine's APIs for Cordon and Uncordon

How: 

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
