### PR TITLE
Add --vm-gpus flag to command that accepts sizing the machines

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -279,7 +279,10 @@ func deployToMachines(
 	}
 
 	if guest == nil {
-		guest = flag.GetMachineGuest(ctx)
+		guest, err = flag.GetMachineGuest(ctx, nil)
+		if err != nil {
+			return err
+		}
 	}
 
 	excludeRegions := make(map[string]interface{})

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -21,7 +21,6 @@ import (
 // v2BuildPlan creates a launchState from command line flags.
 // It shouldn't have any filesystem side effects.
 func v2BuildPlan(ctx context.Context) (*launchState, error) {
-
 	var (
 		io        = iostreams.FromContext(ctx)
 		client    = client.FromContext(ctx)
@@ -178,7 +177,6 @@ func v2DetermineBaseAppConfig(ctx context.Context) (*appconfig.Config, bool, err
 
 // v2DetermineAppName determines the app name from the config file or directory name
 func v2DetermineAppName(ctx context.Context, configPath string) (string, string, error) {
-
 	appName := flag.GetString(ctx, "name")
 	if appName == "" {
 		appName = filepath.Base(filepath.Dir(configPath))
@@ -220,7 +218,6 @@ func v2DetermineOrg(ctx context.Context) (*api.Organization, string, error) {
 //  2. the region specified on the command line, if specified
 //  3. the nearest region to the user
 func v2DetermineRegion(ctx context.Context, config *appconfig.Config, paidPlan bool) (*api.Region, string, error) {
-
 	client := client.FromContext(ctx)
 	regionCode := flag.GetRegion(ctx)
 	explanation := "specified on the command line"
@@ -264,7 +261,11 @@ func v2DetermineGuest(ctx context.Context, config *appconfig.Config, srcInfo *sc
 	shared1x := api.MachinePresets["shared-cpu-1x"]
 	reason := "most apps need about 1GB of RAM"
 
-	guest := flag.GetMachineGuest(ctx)
+	guest, err := flag.GetMachineGuest(ctx, nil)
+	if err != nil {
+		return nil, reason, err
+	}
+
 	if shared1x != guest {
 		reason = "specified on the command line"
 	}

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -242,12 +242,6 @@ func runMachineRun(ctx context.Context) error {
 	}
 
 	machineConf := &api.MachineConfig{
-		Guest: &api.MachineGuest{
-			CPUKind:    "shared",
-			CPUs:       1,
-			MemoryMB:   256,
-			KernelArgs: flag.GetStringArray(ctx, "kernel-arg"),
-		},
 		AutoDestroy: flag.GetBool(ctx, "rm"),
 		DNS: &api.DNSConfig{
 			SkipRegistration: flag.GetBool(ctx, "skip-dns-registration"),
@@ -714,30 +708,10 @@ type determineMachineConfigInput struct {
 func determineMachineConfig(ctx context.Context, input *determineMachineConfigInput) (*api.MachineConfig, error) {
 	machineConf := mach.CloneConfig(&input.initialMachineConf)
 
-	if guestSize := flag.GetString(ctx, "vm-size"); guestSize != "" {
-		err := machineConf.Guest.SetSize(guestSize)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Potential overrides for Guest
-	if cpus := flag.GetInt(ctx, "vm-cpus"); cpus != 0 {
-		machineConf.Guest.CPUs = cpus
-	} else if flag.IsSpecified(ctx, "vm-cpus") {
-		return nil, fmt.Errorf("cannot have zero cpus")
-	}
-
-	if memory := flag.GetInt(ctx, "vm-memory"); memory != 0 {
-		machineConf.Guest.MemoryMB = memory
-	} else if flag.IsSpecified(ctx, "vm-memory") {
-		return nil, fmt.Errorf("memory cannot be zero")
-	}
-
-	if cpuKind := flag.GetString(ctx, "vm-cpukind"); cpuKind == "shared" || cpuKind == "performance" {
-		machineConf.Guest.CPUKind = cpuKind
-	} else if flag.IsSpecified(ctx, "vm-cpukind") {
-		return nil, fmt.Errorf("cpukind must be set to 'shared' or 'performance'")
+	var err error
+	machineConf.Guest, err = flag.GetMachineGuest(ctx, machineConf.Guest)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(flag.GetStringArray(ctx, "kernel-arg")) != 0 {

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -61,7 +61,11 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 		return err
 	}
 
-	defaultGuest := flag.GetMachineGuest(ctx)
+	defaultGuest, err := flag.GetMachineGuest(ctx, nil)
+	if err != nil {
+		return err
+	}
+
 	defaults := newDefaults(appConfig, latestCompleteRelease, machines, volumes,
 		flag.GetString(ctx, "from-snapshot"), flag.GetBool(ctx, "with-new-volumes"), defaultGuest)
 


### PR DESCRIPTION
### Change Summary

What and Why: Add `--vm-gpus` flag to all commands that accepts maching sizing 

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
