### PR TITLE
Show machine selection menu automatically

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -28,7 +28,7 @@ func newClone() *cobra.Command {
 		short = "Clone a Fly machine"
 		long  = short + "\n"
 
-		usage = "clone <machine_id>"
+		usage = "clone [machine_id]"
 	)
 
 	cmd := command.New(usage, short, long, runMachineClone,

--- a/internal/command/machine/cordon.go
+++ b/internal/command/machine/cordon.go
@@ -15,7 +15,7 @@ func newMachineCordon() *cobra.Command {
 	const (
 		short = "Reactive all services on a machine"
 		long  = short + "\n"
-		usage = "cordon <id> [<id>...]"
+		usage = "cordon [<id>...]"
 	)
 
 	cmd := command.New(usage, short, long, runMachineCordon,

--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -20,7 +20,7 @@ func newDestroy() *cobra.Command {
 		long  = `Destroy a Fly machine.
 This command requires a machine to be in a stopped state unless the force flag is used.
 `
-		usage = "destroy <id>"
+		usage = "destroy [id]"
 	)
 
 	cmd := command.New(usage, short, long, runMachineDestroy,

--- a/internal/command/machine/exec.go
+++ b/internal/command/machine/exec.go
@@ -19,7 +19,7 @@ func newMachineExec() *cobra.Command {
 	const (
 		short = "Execute a command on a machine"
 		long  = short + "\n"
-		usage = "exec <machine-id> <command>"
+		usage = "exec [machine-id] <command>"
 	)
 
 	cmd := command.New(usage, short, long, runMachineExec,

--- a/internal/command/machine/kill.go
+++ b/internal/command/machine/kill.go
@@ -16,7 +16,7 @@ func newKill() *cobra.Command {
 		short = "Kill (SIGKILL) a Fly machine"
 		long  = short + "\n"
 
-		usage = "kill <id>"
+		usage = "kill [id]"
 	)
 
 	cmd := command.New(usage, short, long, runMachineKill,

--- a/internal/command/machine/leases.go
+++ b/internal/command/machine/leases.go
@@ -41,7 +41,7 @@ func newLeaseView() *cobra.Command {
 	const (
 		short = "View machine leases"
 		long  = short + "\n"
-		usage = "view <machine-id>"
+		usage = "view [machine-id]"
 	)
 
 	cmd := command.New(usage, short, long, runLeaseView,
@@ -66,7 +66,7 @@ func newLeaseClear() *cobra.Command {
 	const (
 		short = "Clear machine leases"
 		long  = short + "\n"
-		usage = "clear <machine-id>"
+		usage = "clear [machine-id]"
 	)
 
 	cmd := command.New(usage, short, long, runLeaseClear,

--- a/internal/command/machine/restart.go
+++ b/internal/command/machine/restart.go
@@ -18,7 +18,7 @@ func newRestart() *cobra.Command {
 		short = "Restart one or more Fly machines"
 		long  = short + "\n"
 
-		usage = "restart <id> [<id>...]"
+		usage = "restart [<id>...]"
 	)
 
 	cmd := command.New(usage, short, long, runMachineRestart,

--- a/internal/command/machine/start.go
+++ b/internal/command/machine/start.go
@@ -16,7 +16,7 @@ func newStart() *cobra.Command {
 		short = "Start one or more Fly machines"
 		long  = short + "\n"
 
-		usage = "start <id> [<id>...]"
+		usage = "start [<id>...]"
 	)
 
 	cmd := command.New(usage, short, long, runMachineStart,

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -18,7 +18,7 @@ func newStatus() *cobra.Command {
 		short = "Show current status of a running machine"
 		long  = short + "\n"
 
-		usage = "status <id>"
+		usage = "status [id]"
 	)
 
 	cmd := command.New(usage, short, long, runMachineStatus,

--- a/internal/command/machine/stop.go
+++ b/internal/command/machine/stop.go
@@ -19,7 +19,7 @@ func newStop() *cobra.Command {
 		short = "Stop one or more Fly machines"
 		long  = short + "\n"
 
-		usage = "stop <id> [<id>...]"
+		usage = "stop [<id>...]"
 	)
 
 	cmd := command.New(usage, short, long, runMachineStop,

--- a/internal/command/machine/uncordon.go
+++ b/internal/command/machine/uncordon.go
@@ -15,7 +15,7 @@ func newMachineUncordon() *cobra.Command {
 	const (
 		short = "Deactivate all services on a machine"
 		long  = short + "\n"
-		usage = "uncordon <id> [<id>...]"
+		usage = "uncordon [<id>...]"
 	)
 
 	cmd := command.New(usage, short, long, runMachineUncordon,

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -23,7 +23,7 @@ func newUpdate() *cobra.Command {
 		short = "Update a machine"
 		long  = short + "\n"
 
-		usage = "update <machine_id>"
+		usage = "update [machine_id]"
 	)
 
 	cmd := command.New(usage, short, long, runUpdate,


### PR DESCRIPTION
### Change Summary

It's tedious to type out `--select` for `fly machines` commands. As suggested in #2752 (selection prompts for volumes), show a selection menu automatically when there is no machine ID from the command line and we're running interactively.

The `--select` flag is now hidden, but it still exists for backward compatibility.

---

### Documentation

There are a few uses of `--select` in the docs that can be updated after merging, but in the meantime they won't stop working.
