### PR TITLE
Add `--yes` flag and autoconfirm if present

### DIFF
--- a/internal/command/apps/set_platform_version.go
+++ b/internal/command/apps/set_platform_version.go
@@ -34,6 +34,7 @@ Please use caution when using this command.`
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.Yes(),
 	)
 
 	cmd.ValidArgs = []string{"nomad", "detached", "machines"}

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -109,13 +109,17 @@ func run(ctx context.Context) (err error) {
 	)
 
 	confirm := false
-	prompt := &survey.Confirm{
-		Message: "Do you want to tweak these settings before proceeding?",
-	}
-	err = survey.AskOne(prompt, &confirm)
-	if err != nil {
-		// TODO(allison): This should probably not just return the error
-		return err
+	if !flag.GetYes(ctx) {
+		prompt := &survey.Confirm{
+			Message: "Do you want to tweak these settings before proceeding?",
+		}
+		err = survey.AskOne(prompt, &confirm)
+		if err != nil {
+			// TODO(allison): This should probably not just return the error
+			return err
+		}
+	} else {
+		confirm = true
 	}
 
 	if confirm {

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -195,6 +195,7 @@ func newRun() *cobra.Command {
 			Name: "host-dedication-id",
 		},
 		sharedFlags,
+		flag.Yes(),
 	)
 
 	cmd.Args = cobra.MinimumNArgs(1)

--- a/internal/command/postgres/add_flycast.go
+++ b/internal/command/postgres/add_flycast.go
@@ -33,6 +33,7 @@ func newAddFlycast() *cobra.Command {
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.Yes(),
 	)
 
 	cmd.Hidden = true
@@ -92,12 +93,16 @@ func doAddFlycast(ctx context.Context) error {
 		}
 
 		confirm := false
-		prompt := &survey.Confirm{
-			Message: "This will overwrite existing services you have manually added. Continue?",
-			Default: true,
-		}
-		if err := survey.AskOne(prompt, &confirm); err != nil {
-			return err
+		if !flag.GetYes(ctx) {
+			prompt := &survey.Confirm{
+				Message: "This will overwrite existing services you have manually added. Continue?",
+				Default: true,
+			}
+			if err := survey.AskOne(prompt, &confirm); err != nil {
+				return err
+			}
+		} else {
+			confirm = true
 		}
 
 		if !confirm {

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -86,6 +86,7 @@ func newCreate() *cobra.Command {
 			Description: "Automatically start a stopped Postgres app when a network request is received",
 			Default:     false,
 		},
+		flag.Yes(),
 	)
 
 	return cmd

--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -52,6 +52,7 @@ func newCreate() (cmd *cobra.Command) {
 			Name:        "plan",
 			Description: "Upstash Redis plan",
 		},
+		flag.Yes(),
 	)
 
 	return cmd

--- a/internal/command/redis/update.go
+++ b/internal/command/redis/update.go
@@ -29,6 +29,7 @@ func newUpdate() (cmd *cobra.Command) {
 		flag.Org(),
 		flag.Region(),
 		flag.ReplicaRegions(),
+		flag.Yes(),
 	)
 	cmd.Args = cobra.ExactArgs(1)
 	return cmd

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -132,6 +132,10 @@ func Confirmf(ctx context.Context, format string, a ...interface{}) (bool, error
 }
 
 func Confirm(ctx context.Context, message string) (confirm bool, err error) {
+	if flag.GetYes(ctx) {
+		return true, nil
+	}
+
 	var opt survey.AskOpt
 	if opt, err = newSurveyIO(ctx); err != nil {
 		return
@@ -147,6 +151,10 @@ func Confirm(ctx context.Context, message string) (confirm bool, err error) {
 }
 
 func ConfirmOverwrite(ctx context.Context, filename string) (confirm bool, err error) {
+	if flag.GetYes(ctx) {
+		return true, nil
+	}
+
 	prompt := &survey.Confirm{
 		Message: fmt.Sprintf(`Overwrite "%s"?`, filename),
 	}


### PR DESCRIPTION
### Change Summary

What and Why:
All commands should override their prompts based on a `--yes` flag.

How:
On `--yes` flag, autoconfirm on `prompt.Confirm`, `prompt.Confirmf` and `prompt.ConfirmOverride`.

Related to: #933 
