### PR TITLE
Rename `group` to `process-group` to make consistent with `scale count`

### DIFF
--- a/internal/command/scale/machines.go
+++ b/internal/command/scale/machines.go
@@ -29,7 +29,7 @@ func v2ScaleVM(ctx context.Context, appName, group, sizeName string, memoryMB in
 			return nil, err
 		}
 		if len(appConfig.Processes) > 1 {
-			return nil, fmt.Errorf("scaling an app with multiple process groups requires specifying a group with '--group <name>'\n * this app has the following process groups: %v", appConfig.FormatProcessNames())
+			return nil, fmt.Errorf("scaling an app with multiple process groups requires specifying a group with '--process-group <name>'\n * this app has the following process groups: %v", appConfig.FormatProcessNames())
 		}
 		group = appConfig.DefaultProcessName()
 	}

--- a/internal/command/scale/memory.go
+++ b/internal/command/scale/memory.go
@@ -23,7 +23,11 @@ func newScaleMemory() *cobra.Command {
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
-		flag.String{Name: "process-group", Description: "The process group to apply the VM size to"},
+		flag.String{
+			Name:        "process-group",
+			Description: "The process group to apply the VM size to",
+			Aliases:     []string{"group"},
+		},
 	)
 	return cmd
 }

--- a/internal/command/scale/memory.go
+++ b/internal/command/scale/memory.go
@@ -23,13 +23,13 @@ func newScaleMemory() *cobra.Command {
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
-		flag.String{Name: "group", Description: "The process group to apply the VM size to"},
+		flag.String{Name: "process-group", Description: "The process group to apply the VM size to"},
 	)
 	return cmd
 }
 
 func runScaleMemory(ctx context.Context) error {
-	group := flag.GetString(ctx, "group")
+	group := flag.GetString(ctx, "process-group")
 
 	memoryMB, err := helpers.ParseSize(flag.FirstArg(ctx), units.RAMInBytes, units.MiB)
 	if err != nil {

--- a/internal/command/scale/vm.go
+++ b/internal/command/scale/vm.go
@@ -39,7 +39,7 @@ For pricing, see https://fly.io/docs/about/pricing/`
 			Default:     0,
 			Aliases:     []string{"memory"},
 		},
-		flag.String{Name: "group", Description: "The process group to apply the VM size to"},
+		flag.String{Name: "process-group", Description: "The process group to apply the VM size to"},
 	)
 	return cmd
 }
@@ -47,7 +47,7 @@ For pricing, see https://fly.io/docs/about/pricing/`
 func runScaleVM(ctx context.Context) error {
 	sizeName := flag.FirstArg(ctx)
 	memoryMB := flag.GetInt(ctx, "vm-memory")
-	group := flag.GetString(ctx, "group")
+	group := flag.GetString(ctx, "process-group")
 	return scaleVertically(ctx, group, sizeName, memoryMB)
 }
 

--- a/internal/command/scale/vm.go
+++ b/internal/command/scale/vm.go
@@ -39,7 +39,11 @@ For pricing, see https://fly.io/docs/about/pricing/`
 			Default:     0,
 			Aliases:     []string{"memory"},
 		},
-		flag.String{Name: "process-group", Description: "The process group to apply the VM size to"},
+		flag.String{
+			Name:        "process-group",
+			Description: "The process group to apply the VM size to",
+			Aliases:     []string{"group"},
+		},
 	)
 	return cmd
 }


### PR DESCRIPTION
### Change Summary

What and Why: 

Renamed `--group` parameter to `--process-group` to make consistent with `fly scale count`.

It annoys me that sometimes I have to write `--group` and sometimes I have to write `--process-group`. This PR makes them consistent across `fly scale` commands.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
