### PR TITLE
Show regions with GPU capabilities as part of `fly platform regions`

### DIFF
--- a/internal/command/platform/regions.go
+++ b/internal/command/platform/regions.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
 
 	"github.com/superfly/flyctl/iostreams"
 
@@ -15,6 +16,10 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 )
+
+// Hardcoded list of regions with GPUs
+// TODO: fetch this list from the graphql endpoint once it is there
+var gpuRegions = []string{"iad", "sjc", "syd", "ams"}
 
 func newRegions() (cmd *cobra.Command) {
 	const (
@@ -58,13 +63,19 @@ func runRegions(ctx context.Context) error {
 		if region.RequiresPaidPlan {
 			paidPlan = "✓"
 		}
+		gpuAvailable := ""
+		if slices.Contains(gpuRegions, region.Code) {
+			gpuAvailable = "✓"
+		}
+
 		rows = append(rows, []string{
 			region.Name,
 			region.Code,
 			gateway,
 			paidPlan,
+			gpuAvailable,
 		})
 	}
 
-	return render.Table(out, "", rows, "Name", "Code", "Gateway", "Paid Plan Only")
+	return render.Table(out, "", rows, "Name", "Code", "Gateway", "Paid-Only", "GPUs")
 }


### PR DESCRIPTION
### Change Summary

What and Why: Provide users a way to know what regions can run GPU machines.

How: Show them as a column in `fly platform regions` output

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
