### PR TITLE
Only create releases from v0.* tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
   release:
     needs: test
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'dev-')
+    if: startsWith(github.ref, 'refs/tags/v0.') && !contains(github.ref, 'dev-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
   sync_docs:
     needs: release
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.ref, 'pre') }}
+    if: startsWith(github.ref, 'refs/tags/v0.') && !contains(github.ref, 'pre') && !contains(github.ref, 'dev-')
     steps:
       - name: Checkout flyctl
         uses: actions/checkout@v4
@@ -106,7 +106,7 @@ jobs:
         run: scripts/publish_docs.sh ${{ github.ref_name }}
 
   dev_release:
-    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, 'dev-')
+    if: startsWith(github.ref, 'refs/tags/v0.') && contains(github.ref, 'dev-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -141,7 +141,7 @@ jobs:
   aur-publish:
     name: Build & publish to AUR
     needs: release
-    if: ${{ !contains(github.ref, 'pre') }}
+    if: startsWith(github.ref, 'refs/tags/v0.') && !contains(github.ref, 'pre') && !contains(github.ref, 'dev-')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I'm working on version numbers and release scripts and don't want any of my test garbage getting released by accident. This change limits releases to only `v0.*` formatted tags, which I am not using. 