### PR TITLE
Fix cordon commands messages.

### DIFF
--- a/internal/command/machine/cordon.go
+++ b/internal/command/machine/cordon.go
@@ -13,7 +13,7 @@ import (
 
 func newMachineCordon() *cobra.Command {
 	const (
-		short = "Reactive all services on a machine"
+		short = "Deactivate all services on a machine"
 		long  = short + "\n"
 		usage = "cordon <id> [<id>...]"
 	)

--- a/internal/command/machine/uncordon.go
+++ b/internal/command/machine/uncordon.go
@@ -13,7 +13,7 @@ import (
 
 func newMachineUncordon() *cobra.Command {
 	const (
-		short = "Deactivate all services on a machine"
+		short = "Reactive all services on a machine"
 		long  = short + "\n"
 		usage = "uncordon <id> [<id>...]"
 	)


### PR DESCRIPTION
### Change Summary

What and Why: #2790 Introduces the cordon and uncordon commands, but the messages indicate the opposite of what the commands do.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
