### PR TITLE
Fix typo in uncordon command

### DIFF
--- a/internal/command/machine/uncordon.go
+++ b/internal/command/machine/uncordon.go
@@ -13,7 +13,7 @@ import (
 
 func newMachineUncordon() *cobra.Command {
 	const (
-		short = "Reactive all services on a machine"
+		short = "Reactivate all services on a machine"
 		long  = short + "\n"
 		usage = "uncordon <id> [<id>...]"
 	)


### PR DESCRIPTION
### Change Summary

What and Why: Missed a typo in #2803

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
