### PR TITLE
Switch GPU selection to model instead of counts

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -25,6 +25,7 @@ const (
 	MachineStateStopped                        = "stopped"
 	MachineStateCreated                        = "created"
 	DefaultVMSize                              = "shared-cpu-1x"
+	DefaultGPUVMSize                           = "performance-8x"
 )
 
 type Machine struct {
@@ -321,7 +322,7 @@ type MachineGuest struct {
 	CPUKind  string `json:"cpu_kind,omitempty"`
 	CPUs     int    `json:"cpus,omitempty"`
 	MemoryMB int    `json:"memory_mb,omitempty"`
-	GPUs     int    `json:"gpus,omitempty"`
+	GPUModel string `json:"gpu_model,omitempty"`
 
 	KernelArgs []string `json:"kernel_args,omitempty"`
 }

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -322,7 +322,7 @@ type MachineGuest struct {
 	CPUKind  string `json:"cpu_kind,omitempty"`
 	CPUs     int    `json:"cpus,omitempty"`
 	MemoryMB int    `json:"memory_mb,omitempty"`
-	GPUModel string `json:"gpu_model,omitempty"`
+	GPUKind  string `json:"gpu_kind,omitempty"`
 
 	KernelArgs []string `json:"kernel_args,omitempty"`
 }

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -240,7 +240,7 @@ func determineEphemeralConsoleMachineGuest(ctx context.Context) (*api.MachineGue
 		}
 	}
 
-	if cpuKind := flag.GetString(ctx, "vm-cpukind"); cpuKind != "" {
+	if cpuKind := flag.GetString(ctx, "vm-cpu-kind"); cpuKind != "" {
 		desiredGuest.CPUKind = cpuKind
 	}
 

--- a/internal/flag/machines.go
+++ b/internal/flag/machines.go
@@ -3,9 +3,13 @@ package flag
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/superfly/flyctl/api"
 )
+
+var validGPUModels = []string{"a100-pcie-40gb", "a100-sxm4-80gb"}
 
 // Returns a MachineGuest based on the flags provided overwriting a default VM
 func GetMachineGuest(ctx context.Context, guest *api.MachineGuest) (*api.MachineGuest, error) {
@@ -48,8 +52,8 @@ func GetMachineGuest(ctx context.Context, guest *api.MachineGuest) (*api.Machine
 
 	if IsSpecified(ctx, "vm-gpu-model") {
 		m := GetString(ctx, "vm-gpu-model")
-		if m != "a100-40gb-pci" && m != "a100-80gb-sxm" {
-			return nil, fmt.Errorf("--vm-gpu-model must be set to 'a100-40gb-pci' or 'a100-80gb-sxm'")
+		if !slices.Contains(validGPUModels, m) {
+			return nil, fmt.Errorf("--vm-gpu-model must be set to one of: %v", strings.Join(validGPUModels, ", "))
 		}
 		guest.GPUModel = m
 	}
@@ -79,6 +83,6 @@ var VMSizeFlags = Set{
 	},
 	String{
 		Name:        "vm-gpu-model",
-		Description: "If set, the GPU model to attach ('a100-40gb-pci' or 'a100-80gb-sxm')",
+		Description: fmt.Sprintf("If set, the GPU model to attach (%v)", strings.Join(validGPUModels, ", ")),
 	},
 }

--- a/internal/flag/machines.go
+++ b/internal/flag/machines.go
@@ -9,12 +9,12 @@ import (
 	"github.com/superfly/flyctl/api"
 )
 
-var validGPUModels = []string{"a100-pcie-40gb", "a100-sxm4-80gb"}
+var validGPUKinds = []string{"a100-pcie-40gb", "a100-sxm4-80gb"}
 
 // Returns a MachineGuest based on the flags provided overwriting a default VM
 func GetMachineGuest(ctx context.Context, guest *api.MachineGuest) (*api.MachineGuest, error) {
 	defaultVMSize := api.DefaultVMSize
-	if IsSpecified(ctx, "vm-gpu-model") {
+	if IsSpecified(ctx, "vm-gpu-kind") {
 		defaultVMSize = api.DefaultGPUVMSize
 	}
 
@@ -43,19 +43,19 @@ func GetMachineGuest(ctx context.Context, guest *api.MachineGuest) (*api.Machine
 		}
 	}
 
-	if IsSpecified(ctx, "vm-cpukind") {
-		guest.CPUKind = GetString(ctx, "vm-cpukind")
+	if IsSpecified(ctx, "vm-cpu-kind") {
+		guest.CPUKind = GetString(ctx, "vm-cpu-kind")
 		if k := guest.CPUKind; k != "shared" && k != "performance" {
-			return nil, fmt.Errorf("--vm-cpukind must be set to 'shared' or 'performance'")
+			return nil, fmt.Errorf("--vm-cpu-kind must be set to 'shared' or 'performance'")
 		}
 	}
 
-	if IsSpecified(ctx, "vm-gpu-model") {
-		m := GetString(ctx, "vm-gpu-model")
-		if !slices.Contains(validGPUModels, m) {
-			return nil, fmt.Errorf("--vm-gpu-model must be set to one of: %v", strings.Join(validGPUModels, ", "))
+	if IsSpecified(ctx, "vm-gpu-kind") {
+		m := GetString(ctx, "vm-gpu-kind")
+		if !slices.Contains(validGPUKinds, m) {
+			return nil, fmt.Errorf("--vm-gpu-kind must be set to one of: %v", strings.Join(validGPUKinds, ", "))
 		}
-		guest.GPUModel = m
+		guest.GPUKind = m
 	}
 
 	return guest, nil
@@ -73,8 +73,9 @@ var VMSizeFlags = Set{
 		Aliases:     []string{"cpus"},
 	},
 	String{
-		Name:        "vm-cpukind",
+		Name:        "vm-cpu-kind",
 		Description: "The kind of CPU to use ('shared' or 'performance')",
+		Aliases:     []string{"vm-cpukind"},
 	},
 	Int{
 		Name:        "vm-memory",
@@ -82,7 +83,8 @@ var VMSizeFlags = Set{
 		Aliases:     []string{"memory"},
 	},
 	String{
-		Name:        "vm-gpu-model",
-		Description: fmt.Sprintf("If set, the GPU model to attach (%v)", strings.Join(validGPUModels, ", ")),
+		Name:        "vm-gpu-kind",
+		Description: fmt.Sprintf("If set, the GPU model to attach (%v)", strings.Join(validGPUKinds, ", ")),
+		Aliases:     []string{"vm-gpukind"},
 	},
 }

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -487,7 +487,7 @@ func TestLaunchCpusMem(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
-	f.Fly("launch --org %s --name %s --region %s --now --internal-port 80 --image nginx --auto-confirm --vm-cpus 4 --vm-memory 8192 --vm-cpukind performance", f.OrgSlug(), appName, f.PrimaryRegion())
+	f.Fly("launch --org %s --name %s --region %s --now --internal-port 80 --image nginx --auto-confirm --vm-cpus 4 --vm-memory 8192 --vm-cpu-kind performance", f.OrgSlug(), appName, f.PrimaryRegion())
 	machines := f.MachinesList(appName)
 	firstMachineGuest := machines[0].Config.Guest
 


### PR DESCRIPTION
With the advent of SXM gpu devices, it doesn't make sense to expose multi gpus, those are going to be combined into a single GPU and it simplifies scheduling and accounting if we keep it simple as a single device.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
