### PR TITLE
Create volume and configure LITESTACK_DATA_PATH if `litestack` gem is present

### DIFF
--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -78,9 +78,20 @@ func configureRails(sourceDir string, config *ScannerConfig) (*SourceInfo, error
 	}
 
 	if checksPass(sourceDir, dirContains("Gemfile", "litestack")) {
-		// don't prompt for pg, redis if litestack is in the Gemfile
+		// Don't prompt for pg, redis if litestack is in the Gemfile
 		s.DatabaseDesired = DatabaseKindSqlite
 		s.SkipDatabase = true
+		// Create a persistent volume where sqlite databases will be stored.
+		s.Volumes = []Volume{
+		  {
+		    Source:      "data",
+		    Destination: "/data",
+		  },
+		}
+		// Configure Litestack ENV vars to point to the persisten volume.
+		s.Env = map[string]string{
+			"LITESTACK_DATA_PATH":   "/data",
+		}
 	} else if checksPass(sourceDir, dirContains("Gemfile", "mysql")) {
 		// mysql
 		s.DatabaseDesired = DatabaseKindMySQL


### PR DESCRIPTION
When a Rails application is deployed with Litestack enabled, it would assume Sqlite and configure the application accordingly.

### Change Summary

What and Why: Litestack makes it possible to deploy Rails applications that only need Sqlite (not Redis or database servers). This scanner streamlines the deployment by detecting the presence of the gem and configuring the application accordingly.

Related to: Rails Sqlite production deployments

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
