### PR TITLE
Validate machine limits before performing b/g deployment

### DIFF
--- a/api/resource_deploy.go
+++ b/api/resource_deploy.go
@@ -121,3 +121,22 @@ func (c *Client) GetReleaseCommand(ctx context.Context, id string) (*ReleaseComm
 
 	return data.ReleaseCommandNode, nil
 }
+
+func (c *Client) CanPerformBluegreenDeployment(ctx context.Context, appName string) (bool, error) {
+	query := `
+		query ($appName: String!) {
+			canPerformBluegreenDeployment(name: $appName)
+		}
+	`
+
+	req := c.NewRequest(query)
+
+	req.Var("appName", appName)
+
+	data, err := c.RunWithContext(ctx, req)
+	if err != nil {
+		return false, err
+	}
+
+	return data.CanPerformBluegreenDeployment, nil
+}

--- a/api/types.go
+++ b/api/types.go
@@ -215,6 +215,8 @@ type Query struct {
 	UpdateRemoteBuilder struct {
 		Organization Organization
 	}
+
+	CanPerformBluegreenDeployment bool
 }
 
 type CreatedWireGuardPeer struct {

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -6292,7 +6292,7 @@ input MigrateVolumeInput {
   """
   The target Volume ID to be migrated
   """
-  targetVolumeId: Int!
+  targetVolumeId: String!
 
   """
   Use the latest snapshot instead of creating a new one.
@@ -8223,6 +8223,16 @@ type Queries {
   ): AppConnection!
 
   """
+  Verifies if an app can undergo a bluegreen deployment
+  """
+  canPerformBluegreenDeployment(
+    """
+    The name of the app
+    """
+    name: String!
+  ): Boolean!
+
+  """
   Find a certificate by ID
   """
   certificate(id: ID!): AppCertificate
@@ -8674,7 +8684,7 @@ input RegisterVolumeInput {
   """
   The application to attach the new volume to
   """
-  appId: ID!
+  appId: Int!
   autoBackupEnabled: Boolean!
 
   """
@@ -8702,7 +8712,7 @@ input RegisterVolumeInput {
   Desired volume size, in GB
   """
   sizeGb: Int!
-  snapshotId: ID
+  snapshot: ID
   volumeId: String!
 }
 


### PR DESCRIPTION
### Change Summary
This PR adds machine limit validation to bluegreen deployments. It will allow us fail fast & reduce chances of creating zombie machines when a user hits their org limits in the middle of a deployment.