### PR TITLE
Remove . from `flyctl launch` long desc

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -19,7 +19,7 @@ import (
 
 func New() (cmd *cobra.Command) {
 	const (
-		long  = `Create and configure a new app from source code or a Docker image.`
+		long  = `Create and configure a new app from source code or a Docker image`
 		short = long
 	)
 


### PR DESCRIPTION
### Change Summary

What and Why:
This might be the smallest change ever,
but I happened to notice the other commands in "Here's a few commands to get you started" didn't have a . in the end.