### PR TITLE
support separate metrics config per process group

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -33,6 +33,11 @@ func NewConfig() *Config {
 	}
 }
 
+type Metrics struct {
+	*api.MachineMetrics
+	Processes []string `json:"processes,omitempty" toml:"processes,omitempty"`
+}
+
 // Config wraps the properties of app configuration.
 // NOTE: If you any new setting here, please also add a value for it at testdata/rull-reference.toml
 type Config struct {
@@ -61,8 +66,8 @@ type Config struct {
 	MergedFiles []*api.File `toml:"-" json:"-"`
 
 	// Others, less important.
-	Statics []Static            `toml:"statics,omitempty" json:"statics,omitempty"`
-	Metrics *api.MachineMetrics `toml:"metrics,omitempty" json:"metrics,omitempty"`
+	Statics []Static   `toml:"statics,omitempty" json:"statics,omitempty"`
+	Metrics []*Metrics `toml:"metrics,omitempty" json:"metrics,omitempty"`
 
 	// RawDefinition contains fly.toml parsed as-is
 	// If you add any config field that is v2 specific, be sure to remove it in SanitizeDefinition()

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -243,9 +243,16 @@ func TestToDefinition(t *testing.T) {
 		"env": map[string]any{
 			"FOO": "BAR",
 		},
-		"metrics": map[string]any{
-			"port": int64(9999),
-			"path": "/metrics",
+		"metrics": []map[string]any{
+			{
+				"port": int64(9999),
+				"path": "/metrics",
+			},
+			{
+				"port":      int64(9998),
+				"path":      "/metrics",
+				"processes": []any{"web"},
+			},
 		},
 		"statics": []map[string]any{
 			{

--- a/internal/appconfig/from_machine_set.go
+++ b/internal/appconfig/from_machine_set.go
@@ -132,7 +132,9 @@ fly.toml only supports one mount per machine at this time. These mounts will be 
 	cfg.AppName = appCompact.Name
 	cfg.PrimaryRegion = primaryRegion
 	cfg.Env = m.Machine().Config.Env
-	cfg.Metrics = m.Machine().Config.Metrics
+	cfg.Metrics = []*Metrics{
+		{MachineMetrics: m.Machine().Config.Metrics},
+	}
 	cfg.Statics = statics
 	cfg.Mounts = mounts
 	cfg.Processes = processGroups.processes

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -105,7 +105,10 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 	}
 
 	// Metrics
-	mConfig.Metrics = c.Metrics
+	mConfig.Metrics = nil
+	if c.Metrics[0] != nil {
+		mConfig.Metrics = c.Metrics[0].MachineMetrics
+	}
 
 	// Init
 	cmd, err := c.InitCmd(processGroup)

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -106,7 +106,7 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 
 	// Metrics
 	mConfig.Metrics = nil
-	if c.Metrics != nil && len(c.Metrics) >= 1 {
+	if len(c.Metrics) > 0 {
 		mConfig.Metrics = c.Metrics[0].MachineMetrics
 	}
 

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -106,7 +106,7 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 
 	// Metrics
 	mConfig.Metrics = nil
-	if c.Metrics[0] != nil {
+	if c.Metrics != nil && len(c.Metrics) >= 1 {
 		mConfig.Metrics = c.Metrics[0].MachineMetrics
 	}
 

--- a/internal/appconfig/patches.go
+++ b/internal/appconfig/patches.go
@@ -17,6 +17,7 @@ var configPatches = []patchFuncType{
 	patchExperimental,
 	patchTopLevelChecks,
 	patchMounts,
+	patchMetrics,
 	patchTopFields,
 	patchBuild,
 }
@@ -232,6 +233,21 @@ func patchMounts(cfg map[string]any) (map[string]any, error) {
 		}
 	}
 	cfg["mounts"] = mounts
+	return cfg, nil
+}
+
+func patchMetrics(cfg map[string]any) (map[string]any, error) {
+	var metrics []map[string]any
+	for _, k := range []string{"metric", "metrics"} {
+		if raw, ok := cfg[k]; ok {
+			cast, err := ensureArrayOfMap(raw)
+			if err != nil {
+				return nil, fmt.Errorf("Error processing mounts: %w", err)
+			}
+			metrics = append(metrics, cast...)
+		}
+	}
+	cfg["metrics"] = metrics
 	return cfg, nil
 }
 

--- a/internal/appconfig/processgroups.go
+++ b/internal/appconfig/processgroups.go
@@ -81,7 +81,7 @@ func (c *Config) DefaultProcessName() string {
 
 // Flatten generates a machine config specific to a process_group.
 //
-// Only services, mounts, checks & files specific to the provided progress group will be in the returned config.
+// Only services, mounts, checks, metrics & files specific to the provided progress group will be in the returned config.
 func (c *Config) Flatten(groupName string) (*Config, error) {
 	if err := c.SetMachinesPlatform(); err != nil {
 		return nil, fmt.Errorf("can not flatten an invalid v2 application config: %w", err)
@@ -151,6 +151,11 @@ func (c *Config) Flatten(groupName string) (*Config, error) {
 
 	// [[Files]]
 	dst.Files = lo.Filter(c.Files, func(x File, _ int) bool {
+		return matchesGroups(x.Processes)
+	})
+
+	// [[metrics]]
+	dst.Metrics = lo.Filter(c.Metrics, func(x *Metrics, _ int) bool {
 		return matchesGroups(x.Processes)
 	})
 

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -467,12 +467,21 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 			"FOO": "BAR",
 		},
 
-		Metrics: []*Metrics{{
-			MachineMetrics: &api.MachineMetrics{
-				Port: 9999,
-				Path: "/metrics",
+		Metrics: []*Metrics{
+			{
+				MachineMetrics: &api.MachineMetrics{
+					Port: 9999,
+					Path: "/metrics",
+				},
 			},
-		}},
+			{
+				MachineMetrics: &api.MachineMetrics{
+					Port: 9998,
+					Path: "/metrics",
+				},
+				Processes: []string{"web"},
+			},
+		},
 
 		HTTPService: &HTTPService{
 			InternalPort: 8080,

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -268,6 +268,12 @@ func TestLoadTOMLAppConfigOldFormat(t *testing.T) {
 			Source:      "data",
 			Destination: "/data",
 		}},
+		Metrics: []*Metrics{{
+			MachineMetrics: &api.MachineMetrics{
+				Port: 9999,
+				Path: "/metrics",
+			},
+		}},
 		Services: []Service{
 			{
 				InternalPort: 8080,
@@ -325,6 +331,10 @@ func TestLoadTOMLAppConfigOldFormat(t *testing.T) {
 			"mount": map[string]any{
 				"source":      "data",
 				"destination": "/data",
+			},
+			"metrics": map[string]any{
+				"port": int64(9999),
+				"path": "/metrics",
 			},
 			"processes": []map[string]any{{}},
 			"services": []map[string]any{{

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -189,10 +189,12 @@ func TestLoadTOMLAppConfigExperimental(t *testing.T) {
 		defaultGroupName: "app",
 		AppName:          "foo",
 		KillTimeout:      api.MustParseDuration("3s"),
-		Metrics: &api.MachineMetrics{
-			Path: "/foo",
-			Port: 9000,
-		},
+		Metrics: []*Metrics{{
+			MachineMetrics: &api.MachineMetrics{
+				Path: "/foo",
+				Port: 9000,
+			},
+		}},
 		Experimental: &Experimental{
 			Cmd:        []string{"cmd"},
 			Entrypoint: []string{"entrypoint"},
@@ -465,10 +467,12 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 			"FOO": "BAR",
 		},
 
-		Metrics: &api.MachineMetrics{
-			Port: 9999,
-			Path: "/metrics",
-		},
+		Metrics: []*Metrics{{
+			MachineMetrics: &api.MachineMetrics{
+				Port: 9999,
+				Path: "/metrics",
+			},
+		}},
 
 		HTTPService: &HTTPService{
 			InternalPort: 8080,

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -39,9 +39,14 @@ host_dedication_id = "06031957"
 [env]
   FOO = "BAR"
 
-[metrics]
+[[metrics]]
   port = 9999
   path = "/metrics"
+
+[[metrics]]
+  port = 9998
+  path = "/metrics"
+  processes = ["web"]
 
 [http_service]
   internal_port = 8080

--- a/internal/appconfig/testdata/old-format.toml
+++ b/internal/appconfig/testdata/old-format.toml
@@ -59,3 +59,8 @@ build_target = "thalayer"
   # singular mount
   source = "data"
   destination = "/data"
+
+[metrics]
+  # singular metrics
+  port = 9999
+  path = "/metrics"

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -66,9 +66,11 @@ func Test_resolveUpdatedMachineConfig_ReleaseCommand(t *testing.T) {
 			"PRIMARY_REGION": "scl",
 			"OTHER":          "value",
 		},
-		Metrics: &api.MachineMetrics{
-			Port: 9000,
-			Path: "/prometheus",
+		Metrics: []*appconfig.Metrics{{
+			MachineMetrics: &api.MachineMetrics{
+				Port: 9000,
+				Path: "/prometheus",
+			}},
 		},
 		Deploy: &appconfig.Deploy{
 			ReleaseCommand: "touch sky",


### PR DESCRIPTION
Similar to other app-config constructs (e.g., #2086), this change allows specifying a separate Metrics config per process group with a `processes` field:

```toml
[[metrics]]
  port = 9998
  path = "/metrics"
  processes = ["web"]
```

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs (superfly/docs#1028)