### PR TITLE
Prep for Rails 7.1 by always running the dockerfile generator.

### DIFF
--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -221,7 +221,8 @@ func RailsCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan) e
 		}
 	}
 
-	// ensure fly.toml exists
+	// ensure fly.toml exists.  If present, the rails dockerfile generator will
+	// add volumes, processes, release command and potentailly other configuration.
 	flyToml := "fly.toml"
 	_, err = os.Stat(flyToml)
 	if os.IsNotExist(err) {


### PR DESCRIPTION
Starting with Rails 7.1, a Dockerfile will be produced.  The policy has been, and remains, to leave this Dockerfile alone at launch.  Originally the dockerfile generator focused on generating a dockerfile, so it was skipped.  Over time the dockerfile generator got other responsibilities: set up sentry, define processes for sidekiq, define volumes for sqlite, etc.  So the new approach will be to always run the dockerfile generator and pass in a `--skip` option if the dockerfile already exists so that existing files will be left alone and only things that are missing will be filled in.