### PR TITLE
"flyctl" to "fly" in suggested command messages

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -276,7 +276,7 @@ func newRemoteDockerClient(ctx context.Context, apiClient *api.Client, appName s
 	case !up:
 		streams.StopProgressIndicator()
 
-		terminal.Warnf("Remote builder did not start in time. Check remote builder logs with `flyctl logs -a %s`\n", remoteBuilderAppName)
+		terminal.Warnf("Remote builder did not start in time. Check remote builder logs with `fly logs -a %s`\n", remoteBuilderAppName)
 
 		return nil, errors.New("remote builder app unavailable")
 	default:

--- a/internal/command/doctor/app_checks.go
+++ b/internal/command/doctor/app_checks.go
@@ -63,7 +63,7 @@ func NewAppChecker(ctx context.Context, jsonOutput bool, color *iostreams.ColorS
 	}
 
 	if !appCompact.Deployed && appCompact.PlatformVersion != "machines" {
-		ac.lprint(color.Yellow, "%s app has not been deployed yet. Skipping app checks. Deploy using `flyctl deploy`.\n", appName)
+		ac.lprint(color.Yellow, "%s app has not been deployed yet. Skipping app checks. Deploy using `fly deploy`.\n", appName)
 		return nil, nil
 	}
 

--- a/internal/command/history/history.go
+++ b/internal/command/history/history.go
@@ -30,7 +30,7 @@ events and their results.
 		command.RequireSession,
 		command.RequireAppName,
 	)
-	cmd.Deprecated = "Use `flyctl apps releases` instead"
+	cmd.Deprecated = "Use `fly apps releases` instead"
 	cmd.Hidden = true
 
 	cmd.Args = cobra.NoArgs

--- a/internal/command/image/show.go
+++ b/internal/command/image/show.go
@@ -110,7 +110,7 @@ func showNomadImage(ctx context.Context, app *api.AppCompact) error {
 		}
 
 		message := fmt.Sprintf("Update available! (%s -> %s)\n", current, latest)
-		message += "Run `flyctl image update` to migrate to the latest image version.\n"
+		message += "Run `fly image update` to migrate to the latest image version.\n"
 
 		fmt.Fprintln(io.ErrOut, colorize.Yellow(message))
 	}
@@ -250,7 +250,7 @@ func showMachineImage(ctx context.Context, app *api.AppCompact) error {
 		}
 
 		fmt.Fprintln(io.ErrOut, colorize.Yellow(strings.Join(msgs, "")))
-		fmt.Fprintln(io.ErrOut, colorize.Yellow("Run `flyctl image update` to migrate to the latest image version."))
+		fmt.Fprintln(io.ErrOut, colorize.Yellow("Run `fly image update` to migrate to the latest image version."))
 	}
 
 	var rows [][]string

--- a/internal/command/launch/deploy.go
+++ b/internal/command/launch/deploy.go
@@ -90,7 +90,7 @@ func (state *launchState) firstDeploy(ctx context.Context) error {
 	if state.sourceInfo.DeployDocs != "" {
 		fmt.Fprintln(io.Out, state.sourceInfo.DeployDocs)
 	} else {
-		fmt.Fprintln(io.Out, "Your app is ready! Deploy with `flyctl deploy`")
+		fmt.Fprintln(io.Out, "Your app is ready! Deploy with `fly deploy`")
 	}
 
 	return nil

--- a/internal/command/launch/legacy/launch.go
+++ b/internal/command/launch/legacy/launch.go
@@ -304,7 +304,7 @@ func Run(ctx context.Context) (err error) {
 	if srcInfo.DeployDocs != "" {
 		fmt.Fprintln(io.Out, srcInfo.DeployDocs)
 	} else {
-		fmt.Fprintln(io.Out, "Your app is ready! Deploy with `flyctl deploy`")
+		fmt.Fprintln(io.Out, "Your app is ready! Deploy with `fly deploy`")
 	}
 
 	return nil

--- a/internal/command/ssh/connect.go
+++ b/internal/command/ssh/connect.go
@@ -63,7 +63,7 @@ func Connect(p *ConnectParams, addr string) (*ssh.Client, error) {
 
 	cert, pk, err := singleUseSSHCertificate(p.Ctx, p.Org)
 	if err != nil {
-		return nil, fmt.Errorf("create ssh certificate: %w (if you haven't created a key for your org yet, try `flyctl ssh issue`)", err)
+		return nil, fmt.Errorf("create ssh certificate: %w (if you haven't created a key for your org yet, try `fly ssh issue`)", err)
 	}
 
 	pemkey := ssh.MarshalED25519PrivateKey(pk, "single-use certificate")

--- a/internal/command/ssh/ssh_terminal.go
+++ b/internal/command/ssh/ssh_terminal.go
@@ -67,7 +67,7 @@ func SSHConnect(p *SSHParams, addr string) error {
 
 	cert, pk, err := singleUseSSHCertificate(p.Ctx, p.Org)
 	if err != nil {
-		return fmt.Errorf("create ssh certificate: %w (if you haven't created a key for your org yet, try `flyctl ssh issue`)", err)
+		return fmt.Errorf("create ssh certificate: %w (if you haven't created a key for your org yet, try `fly ssh issue`)", err)
 	}
 
 	pemkey := ssh.MarshalED25519PrivateKey(pk, "single-use certificate")

--- a/internal/command/status/machines.go
+++ b/internal/command/status/machines.go
@@ -139,7 +139,7 @@ func RenderMachineStatus(ctx context.Context, app *api.AppCompact, out io.Writer
 		}
 
 		fmt.Fprintln(out, colorize.Yellow(strings.Join(msgs, "")))
-		fmt.Fprintln(out, colorize.Yellow("Run `flyctl image update` to migrate to the latest image version."))
+		fmt.Fprintln(out, colorize.Yellow("Run `fly image update` to migrate to the latest image version."))
 	}
 
 	managed, unmanaged := []*api.Machine{}, []*api.Machine{}
@@ -320,7 +320,7 @@ func renderPGStatus(ctx context.Context, app *api.AppCompact, machines []*api.Ma
 		}
 
 		fmt.Fprintln(out, colorize.Yellow(strings.Join(msgs, "")))
-		fmt.Fprintln(out, colorize.Yellow("Run `flyctl image update` to migrate to the latest image version."))
+		fmt.Fprintln(out, colorize.Yellow("Run `fly image update` to migrate to the latest image version."))
 	}
 
 	rows := [][]string{}

--- a/internal/command/wireguard/wireguard.go
+++ b/internal/command/wireguard/wireguard.go
@@ -87,7 +87,7 @@ func runWireguardWebsockets(ctx context.Context) error {
 	// kill the agent if necessary, if that fails print manual instructions
 	if err := tryKillingAgent(); err != nil {
 		terminal.Debugf("error stopping the agent: %s", err)
-		fmt.Fprintf(io.Out, "Run `flyctl agent restart` to make changes take effect.\n")
+		fmt.Fprintf(io.Out, "Run `fly agent restart` to make changes take effect.\n")
 	}
 
 	return nil


### PR DESCRIPTION
### Change Summary

What and Why:
I am not sure about this change, but I think most people use "fly" so leading in that direction would be okay?