### PR TITLE
legacy pg: don't try parsing plaintext str as json

### DIFF
--- a/flypg/pg.go
+++ b/flypg/pg.go
@@ -140,8 +140,7 @@ func (c *Client) NodeRole(ctx context.Context) (string, error) {
 
 func (c *Client) legacyNodeRole(ctx context.Context) (string, error) {
 	endpoint := "/flycheck/role"
-	var out string
-	err := c.Do(ctx, http.MethodGet, endpoint, nil, &out)
+	out, err := c.DoPlaintext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
### Change Summary

What and Why: when migrating, we need to know a node's role. For some reason, the primary endpoint (`commands/admin/role`) returns errors for some people (404, `{"error":"no rows in result set"}`).

The fallback path is to use `flycheck/role`, but flyctl attempts to parse its plaintext response as a JSON-encoded string.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
