### PR TITLE
migrate to v2 hacks: infer process names when possible

### DIFF
--- a/internal/command/migrate_to_v2/hacks.go
+++ b/internal/command/migrate_to_v2/hacks.go
@@ -1,0 +1,32 @@
+package migrate_to_v2
+
+import "context"
+
+// This all *should* work, based on the assumption that the existing app was validated and is running.
+// Essentially, we shouldn't make things up here, but extrapolate the *only* possible outcome.
+
+func (m *v2PlatformMigrator) applyHacks(ctx context.Context) {
+
+	m.hackAddProcessToServices(ctx)
+}
+
+// If there is only one process to the app, we can assume that services are all tied to that one process
+// unless they specify another process name
+func (m *v2PlatformMigrator) hackAddProcessToServices(ctx context.Context) {
+	appProcesses := m.appConfig.ProcessNames()
+
+	if len(appProcesses) != 1 {
+		// Apps typically aren't hosting services on multiple process groups, so we can't really
+		// make a good prediction here.
+		return
+	}
+
+	for idx := range m.appConfig.Services {
+		if len(m.appConfig.Services[idx].Processes) == 0 {
+			m.appConfig.Services[idx].Processes = appProcesses
+		}
+	}
+	if m.appConfig.HTTPService != nil && len(m.appConfig.HTTPService.Processes) == 0 {
+		m.appConfig.HTTPService.Processes = appProcesses
+	}
+}

--- a/internal/command/migrate_to_v2/hacks.go
+++ b/internal/command/migrate_to_v2/hacks.go
@@ -1,6 +1,11 @@
 package migrate_to_v2
 
-import "context"
+import (
+	"context"
+
+	"github.com/samber/lo"
+	"github.com/superfly/flyctl/api"
+)
 
 // This all *should* work, based on the assumption that the existing app was validated and is running.
 // Essentially, we shouldn't make things up here, but extrapolate the *only* possible outcome.
@@ -8,6 +13,7 @@ import "context"
 func (m *v2PlatformMigrator) applyHacks(ctx context.Context) {
 
 	m.hackAddProcessToServices(ctx)
+	m.hackInferProcessName(ctx)
 }
 
 // If there is only one process to the app, we can assume that services are all tied to that one process
@@ -28,5 +34,27 @@ func (m *v2PlatformMigrator) hackAddProcessToServices(ctx context.Context) {
 	}
 	if m.appConfig.HTTPService != nil && len(m.appConfig.HTTPService.Processes) == 0 {
 		m.appConfig.HTTPService.Processes = appProcesses
+	}
+}
+
+func (m *v2PlatformMigrator) hackInferProcessName(ctx context.Context) {
+
+	existingNames := m.appConfig.ProcessNames()
+	if len(existingNames) > 1 || existingNames[0] != api.MachineProcessGroupApp {
+		return
+	}
+
+	// There's a single process, and it's unnamed. See if we can infer its name from services
+	var listedNames []string
+	for _, service := range m.appConfig.AllServices() {
+		listedNames = append(listedNames, service.Processes...)
+	}
+	listedNames = lo.Uniq(listedNames)
+
+	if len(listedNames) == 1 {
+		// There's a single name listed, so we can assume that that's the only process.
+		m.appConfig.Processes = map[string]string{
+			listedNames[0]: "", // an empty cmd will inherit the CMD from the Dockerfile, or from Experimental.Cmd
+		}
 	}
 }

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -341,6 +341,9 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 		}
 		migrator.pgConsulUrl = consul.ConsulURL
 	}
+
+	migrator.applyHacks(ctx)
+
 	err = migrator.validate(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Change Summary

What and Why: unblocks a chunk of apps with strange config inconsistencies.

How:

Adds two pre-process hacks to the migration process:
1. Infers process names on services iff the service has no processes listed, and there's a single process defined for the app (this includes "app")

2. Infers unspecified app process name from service process lists iff each process only lists one process, and it's all the same process.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
