### PR TITLE
If only 1 machine found, msg should be in singular

### DIFF
--- a/internal/command/machine/list.go
+++ b/internal/command/machine/list.go
@@ -80,7 +80,11 @@ func runMachineList(ctx context.Context) (err error) {
 	listOfMachinesLink := io.CreateLink("View them in the UI here", fmt.Sprintf("https://fly.io/apps/%s/machines/", appName))
 
 	if !silence {
-		fmt.Fprintf(io.Out, "%d machines have been retrieved from app %s.\n%s\n\n", len(machines), appName, listOfMachinesLink)
+		if len(machines) == 1 {
+			fmt.Fprintf(io.Out, "1 machine has been retrieved from app %s.\n%s\n\n", appName, listOfMachinesLink)
+		} else {
+			fmt.Fprintf(io.Out, "%d machines have been retrieved from app %s.\n%s\n\n", len(machines), appName, listOfMachinesLink)
+		}
 	}
 	if silence {
 		for _, machine := range machines {


### PR DESCRIPTION
### Change Summary

What and Why:
I saw "1 machines found" in the docs and I immediately came here to fix that.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
