### PR TITLE
More places to consider compute requirements on volume creation

### DIFF
--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -120,11 +120,12 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 			fmt.Fprintf(md.io.Out, "Creating 1GB volume '%s' for process group '%s'. Use 'fly vol extend' to increase its size\n", m.Source, groupName)
 
 			input := api.CreateVolumeRequest{
-				Name:             m.Source,
-				Region:           groupConfig.PrimaryRegion,
-				SizeGb:           api.Pointer(1),
-				Encrypted:        api.Pointer(true),
-				HostDedicationId: md.appConfig.HostDedicationID,
+				Name:                m.Source,
+				Region:              groupConfig.PrimaryRegion,
+				SizeGb:              api.Pointer(1),
+				Encrypted:           api.Pointer(true),
+				HostDedicationId:    md.appConfig.HostDedicationID,
+				ComputeRequirements: md.machineGuest,
 			}
 
 			vol, err := md.flapsClient.CreateVolume(ctx, input)

--- a/internal/command/launch/launch_frameworks.go
+++ b/internal/command/launch/launch_frameworks.go
@@ -136,11 +136,12 @@ func (state *launchState) scannerCreateVolumes(ctx context.Context) error {
 
 	for _, vol := range state.sourceInfo.Volumes {
 		volume, err := flapsClient.CreateVolume(ctx, api.CreateVolumeRequest{
-			Name:             vol.Source,
-			Region:           state.Plan.RegionCode,
-			SizeGb:           api.Pointer(1),
-			Encrypted:        api.Pointer(true),
-			HostDedicationId: state.appConfig.HostDedicationID,
+			Name:                vol.Source,
+			Region:              state.Plan.RegionCode,
+			SizeGb:              api.Pointer(1),
+			Encrypted:           api.Pointer(true),
+			HostDedicationId:    state.appConfig.HostDedicationID,
+			ComputeRequirements: state.Plan.Guest(),
 		})
 		if err != nil {
 			return err
@@ -219,7 +220,6 @@ func execInitCommand(ctx context.Context, command scanner.InitCommand) (err erro
 }
 
 func (state *launchState) scannerSetAppconfig(ctx context.Context) error {
-
 	srcInfo := state.sourceInfo
 	appConfig := state.appConfig
 

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -245,13 +245,14 @@ func runMachineClone(ctx context.Context) (err error) {
 			}
 
 			volInput := api.CreateVolumeRequest{
-				Name:              mnt.Name,
-				Region:            region,
-				SizeGb:            &mnt.SizeGb,
-				Encrypted:         &mnt.Encrypted,
-				SnapshotID:        snapshotID,
-				RequireUniqueZone: api.Pointer(flag.GetBool(ctx, "volume-requires-unique-zone")),
-				HostDedicationId:  source.HostDedicationID,
+				Name:                mnt.Name,
+				Region:              region,
+				SizeGb:              &mnt.SizeGb,
+				Encrypted:           &mnt.Encrypted,
+				SnapshotID:          snapshotID,
+				RequireUniqueZone:   api.Pointer(flag.GetBool(ctx, "volume-requires-unique-zone")),
+				HostDedicationId:    source.HostDedicationID,
+				ComputeRequirements: targetConfig.Guest,
 			}
 			vol, err = flapsClient.CreateVolume(ctx, volInput)
 			if err != nil {

--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -60,37 +60,45 @@ func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 		return v
 	}))
 
+	allocMap := lo.KeyBy(m.oldAllocs, func(a *api.AllocationStatus) string {
+		return a.IDShort
+	})
+
 	for _, vol := range m.oldAttachedVolumes {
+		// We have to search for the full alloc ID, because the volume only has the short-form alloc ID
+		path := ""
+		allocId := ""
+		processGroup := ""
+
+		if shortAllocId := vol.AttachedAllocation; shortAllocId != nil {
+			alloc, ok := allocMap[*shortAllocId]
+			if !ok {
+				return fmt.Errorf("volume %s[%s] is attached to alloc %s, but that alloc is not running", vol.Name, vol.ID, *shortAllocId)
+			}
+			allocId = alloc.ID
+			processGroup = alloc.TaskName
+
+			path = m.nomadVolPath(&vol, alloc.TaskName)
+			if path == "" {
+				return fmt.Errorf("volume %s[%s] is mounted on alloc %s, but has no mountpoint", vol.Name, vol.ID, allocId)
+			}
+		}
+
 		newVol, err := m.flapsClient.CreateVolume(ctx, api.CreateVolumeRequest{
-			SourceVolumeID: &vol.ID,
-			MachinesOnly:   api.Pointer(true),
-			Name:           vol.Name,
+			SourceVolumeID:      &vol.ID,
+			MachinesOnly:        api.Pointer(true),
+			Name:                vol.Name,
+			ComputeRequirements: m.machineGuests[processGroup],
 		})
 		if err != nil && strings.HasSuffix(err.Error(), " is not a valid candidate") {
 			return fmt.Errorf("unfortunately the worker hosting your volume %s (%s) does not have capacity for another volume to support the migration; some other options: 1) try again later and there might be more space on the worker, 2) run a manual migration https://community.fly.io/t/manual-migration-to-apps-v2/11870, or 3) wait until we support volume migrations across workers (we're working on it!)", vol.ID, vol.Name)
 		} else if err != nil {
 			return err
 		}
-
-		// We have to search for the full alloc ID, because the volume only has the short-form alloc ID
-		allocId := ""
-		path := ""
-		if shortAllocId := vol.AttachedAllocation; shortAllocId != nil {
-			alloc, ok := lo.Find(m.oldAllocs, func(a *api.AllocationStatus) bool {
-				return a.IDShort == *shortAllocId
-			})
-			if !ok {
-				return fmt.Errorf("volume %s[%s] is attached to alloc %s, but that alloc is not running", vol.Name, vol.ID, *shortAllocId)
-			}
-			allocId = alloc.ID
-			path = m.nomadVolPath(&vol, alloc.TaskName)
-			if path == "" {
-				return fmt.Errorf("volume %s[%s] is mounted on alloc %s, but has no mountpoint", vol.Name, vol.ID, allocId)
-			}
-		}
 		if m.verbose {
 			fmt.Fprintf(m.io.Out, "Forked volume %s[%s] into %s[%s]\n", vol.Name, vol.ID, newVol.Name, newVol.ID)
 		}
+
 		m.createdVolumes = append(m.createdVolumes, &NewVolume{
 			vol:             newVol,
 			previousAllocId: allocId,

--- a/internal/command/scale/machine_defaults.go
+++ b/internal/command/scale/machine_defaults.go
@@ -121,12 +121,13 @@ func (d *defaultValues) CreateVolumeRequest(mConfig *api.MachineConfig, region s
 	}
 	mount := mConfig.Mounts[0]
 	return &api.CreateVolumeRequest{
-		Name:              mount.Name,
-		Region:            region,
-		SizeGb:            &mount.SizeGb,
-		Encrypted:         api.Pointer(mount.Encrypted),
-		RequireUniqueZone: api.Pointer(false),
-		SnapshotID:        d.snapshotID,
-		HostDedicationId:  mConfig.HostDedicationId,
+		Name:                mount.Name,
+		Region:              region,
+		SizeGb:              &mount.SizeGb,
+		Encrypted:           api.Pointer(mount.Encrypted),
+		RequireUniqueZone:   api.Pointer(false),
+		SnapshotID:          d.snapshotID,
+		HostDedicationId:    mConfig.HostDedicationId,
+		ComputeRequirements: mConfig.Guest,
 	}
 }


### PR DESCRIPTION
### Change Summary

What and Why: The volume creation API accepts hints on the future machine that will be launched to use the volume, but right now this info is not passed on multiple places like first deploy.

How: 

Add compute resource hints to:

* First `fly deploy` and `fly launch --ui`
* `fly machine clone`
* `fly scale count`

Related to: #2839

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
