### PR TITLE
Support Dockerfile in a parent directory

### DIFF
--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -221,7 +221,7 @@ func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 
 	build.SetBuilderMetaPart2(buildkitEnabled, serverInfo.ServerVersion, fmt.Sprintf("%s/%s/%s", serverInfo.OSType, serverInfo.Architecture, serverInfo.OSVersion))
 	if buildkitEnabled {
-		imageID, err = runBuildKitBuild(ctx, docker, opts, relDockerfile, buildArgs)
+		imageID, err = runBuildKitBuild(ctx, docker, opts, dockerfile, buildArgs)
 		if err != nil {
 			if dockerFactory.IsRemote() {
 				metrics.SendNoData(ctx, "remote_builder_failure")


### PR DESCRIPTION
Having a Dockerfile in a parent directory, like below should work, but it didn't.

```
[build]
dockerfile = "../Dockerfile"
```

### Change Summary

What and Why: The example above doesn't work without this change.

How: By removing relDockerfile. It was copied from the original code without much thoughts.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
