### PR TITLE
`migrate-to-v2` hacks: only use postgres migration for 'flyio/postgres'

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -308,6 +308,7 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 	}
 	leaseTimeout := 13 * time.Second
 	leaseDelayBetween := (leaseTimeout - 1*time.Second) / 3
+	isPostgres := appCompact.IsPostgresApp() && appFull.ImageDetails.Repository == "flyio/postgres"
 	migrator := &v2PlatformMigrator{
 		apiClient:               apiClient,
 		flapsClient:             flapsClient,
@@ -324,7 +325,7 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 		img:                     img,
 		oldAllocs:               allocs,
 		machineGuests:           machineGuests,
-		isPostgres:              appCompact.IsPostgresApp(),
+		isPostgres:              isPostgres,
 		replacedVolumes:         map[string][]string{},
 		verbose:                 flag.GetBool(ctx, "verbose"),
 		recovery: recoveryState{


### PR DESCRIPTION
### Change Summary

What and Why: The migration process makes assumptions that we can only guarantee for `flyio/postgres`. For everyone else, use standard apps-with-volumes migration procedure.

(we were calling admin/monitoring endpoints that don't exist outside of `flyio/postgres`)

Thanks, Shaun, for figuring this out.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
