### PR TITLE
reset files if none are passed in

### DIFF
--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -191,6 +191,7 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 	c.tomachineSetStopConfig(mConfig)
 
 	// Files
+	mConfig.Files = nil
 	machine.MergeFiles(mConfig, c.MergedFiles)
 
 	return mConfig, nil

--- a/internal/command/deploy/machines_launchinput_test.go
+++ b/internal/command/deploy/machines_launchinput_test.go
@@ -296,9 +296,6 @@ func Test_launchInputForUpdate_Files(t *testing.T) {
 				SecretName: api.StringPointer("SECRET_CONFIG"),
 			},
 			{
-				GuestPath: "/path/to/be/deleted",
-			},
-			{
 				GuestPath: "/path/to/hello.txt",
 				RawValue:  api.StringPointer("Z29vZGJ5ZQo="),
 			},
@@ -321,14 +318,8 @@ func Test_launchInputForUpdate_Files(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []*api.File{
-		{
-			GuestPath: "/path/to/hello.txt",
-			RawValue:  api.StringPointer("Z29vZGJ5ZQo="),
-		},
-		{
-			GuestPath:  "/path/to/config/yaml",
-			SecretName: api.StringPointer("SECRET_CONFIG"),
-		},
-	}, li.Config.Files)
+	assert.Equal(t, "/path/to/config/yaml", li.Config.Files[0].GuestPath)
+	assert.Equal(t, "SECRET_CONFIG", *li.Config.Files[0].SecretName)
+	assert.Equal(t, "/path/to/hello.txt", li.Config.Files[1].GuestPath)
+	assert.Equal(t, "Z29vZGJ5ZQo=", *li.Config.Files[1].RawValue)
 }

--- a/internal/machine/config.go
+++ b/internal/machine/config.go
@@ -117,6 +117,11 @@ func configCompare(ctx context.Context, original api.MachineConfig, new api.Mach
 
 // MergeFiles merges the files parsed from the command line or fly.toml into the machine configuration.
 func MergeFiles(machineConf *api.MachineConfig, files []*api.File) {
+	if len(files) == 0 {
+		machineConf.Files = []*api.File{}
+		return
+	}
+
 	for _, f := range files {
 		idx := slices.IndexFunc(machineConf.Files, func(i *api.File) bool {
 			return i.GuestPath == f.GuestPath

--- a/internal/machine/config.go
+++ b/internal/machine/config.go
@@ -118,7 +118,7 @@ func configCompare(ctx context.Context, original api.MachineConfig, new api.Mach
 // MergeFiles merges the files parsed from the command line or fly.toml into the machine configuration.
 func MergeFiles(machineConf *api.MachineConfig, files []*api.File) {
 	if len(files) == 0 {
-		machineConf.Files = []*api.File{}
+		machineConf.Files = nil
 		return
 	}
 

--- a/internal/machine/config.go
+++ b/internal/machine/config.go
@@ -117,11 +117,6 @@ func configCompare(ctx context.Context, original api.MachineConfig, new api.Mach
 
 // MergeFiles merges the files parsed from the command line or fly.toml into the machine configuration.
 func MergeFiles(machineConf *api.MachineConfig, files []*api.File) {
-	if len(files) == 0 {
-		machineConf.Files = nil
-		return
-	}
-
 	for _, f := range files {
 		idx := slices.IndexFunc(machineConf.Files, func(i *api.File) bool {
 			return i.GuestPath == f.GuestPath


### PR DESCRIPTION
### Change Summary

What and Why:

See #2851

How:

Just sets the `Files` var to an empty list if no files are passed in

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
