### PR TITLE
Update docs to say that --remote-only is the default

### DIFF
--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -390,7 +390,7 @@ const remoteOnlyName = "remote-only"
 func RemoteOnly(defaultValue bool) Bool {
 	return Bool{
 		Name:        remoteOnlyName,
-		Description: "Perform builds on a remote builder instance instead of using the local docker daemon",
+		Description: "Perform builds on a remote builder instance instead of using the local docker daemon. This is the default. Use --local-only to build locally.",
 		Default:     defaultValue,
 	}
 }
@@ -405,7 +405,7 @@ const localOnlyName = "local-only"
 func LocalOnly() Bool {
 	return Bool{
 		Name:        localOnlyName,
-		Description: "Only perform builds locally using the local docker daemon",
+		Description: "Perform builds locally using the local docker daemon. The default is --remote-only.",
 	}
 }
 


### PR DESCRIPTION
### Change Summary

What and Why: 
`--remote-only` is the default way to build, so added that to the docs.

How:
docs

Related to:
n/a

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
