### PR TITLE
LSVD support

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -666,6 +666,7 @@ type LaunchMachineInput struct {
 	SkipLaunch              bool           `json:"skip_launch,omitempty"`
 	SkipServiceRegistration bool           `json:"skip_service_registration,omitempty"`
 	HostDedicationID        string         `json:"host_dedication_id,omitempty"`
+	LSVD                    bool           `json:"lsvd,omitempty"`
 
 	LeaseTTL int `json:"lease_ttl,omitempty"`
 

--- a/internal/command/lsvd/lsvd.go
+++ b/internal/command/lsvd/lsvd.go
@@ -6,7 +6,8 @@ import (
 )
 
 func New() *cobra.Command {
-	cmd := command.New("lsvd", "", "", nil)
+	const help = "Manage log-structured virtual disks (LSVD) on an app"
+	cmd := command.New("lsvd", help, help, nil)
 	cmd.Hidden = true
 	cmd.AddCommand(newSetup())
 	return cmd

--- a/internal/command/lsvd/lsvd.go
+++ b/internal/command/lsvd/lsvd.go
@@ -1,0 +1,13 @@
+package lsvd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/command"
+)
+
+func New() *cobra.Command {
+	cmd := command.New("lsvd", "", "", nil)
+	cmd.Hidden = true
+	cmd.AddCommand(newSetup())
+	return cmd
+}

--- a/internal/command/lsvd/setup.go
+++ b/internal/command/lsvd/setup.go
@@ -19,7 +19,8 @@ import (
 )
 
 func newSetup() *cobra.Command {
-	cmd := command.New("setup", "", "", runSetup, command.RequireAppName)
+	const help = "Configure an app for log-structured virtual disks (LSVD)"
+	cmd := command.New("setup", help, help, runSetup, command.RequireAppName)
 	cmd.Args = cobra.NoArgs
 	flag.Add(
 		cmd,

--- a/internal/command/lsvd/setup.go
+++ b/internal/command/lsvd/setup.go
@@ -1,0 +1,209 @@
+package lsvd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyerr"
+	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func newSetup() *cobra.Command {
+	cmd := command.New("setup", "", "", runSetup, command.RequireAppName)
+	cmd.Args = cobra.NoArgs
+	flag.Add(
+		cmd,
+		flag.App(),
+	)
+	return cmd
+}
+
+func runSetup(ctx context.Context) error {
+	appName := appconfig.NameFromContext(ctx)
+	client := client.FromContext(ctx).API()
+	io := iostreams.FromContext(ctx)
+
+	app, err := client.GetAppCompact(ctx, appName)
+	if err != nil {
+		return err
+	} else if app.PlatformVersion != "machines" {
+		return errors.New("LSVD is supported only for Machines apps")
+	}
+
+	secrets, err := client.GetAppSecrets(ctx, appName)
+	if err != nil {
+		return err
+	}
+
+	var (
+		haveKeyID = false
+		haveKey   = true
+
+		newSecrets      = make(map[string]string)
+		existingSecrets []string
+		deletedSecrets  []string
+
+		keyID       string
+		key         string
+		serviceType int
+		endpoint    string
+		region      string
+		bucket      string
+		deviceSize  int
+		mountPoint  string
+	)
+
+	for _, secret := range secrets {
+		switch secret.Name {
+		case "AWS_ACCESS_KEY_ID":
+			haveKeyID = true
+			existingSecrets = append(existingSecrets, secret.Name)
+		case "AWS_SECRET_ACCESS_KEY":
+			haveKey = true
+			existingSecrets = append(existingSecrets, secret.Name)
+		case "AWS_REGION", "FLY_LSVD_S3_ENDPOINT", "FLY_LSVD_S3_BUCKET", "FLY_LSVD_DEVICE_SIZE", "FLY_LSVD_MOUNT_POINT":
+			existingSecrets = append(existingSecrets, secret.Name)
+		}
+	}
+
+	if len(existingSecrets) > 0 {
+		fmt.Fprintf(io.Out, "Found existing LSVD secrets: %s\n", strings.Join(existingSecrets, ", "))
+		overwrite, err := prompt.Confirm(ctx, "Reconfigure overwriting existing secrets?")
+		if err != nil {
+			return err
+		} else if !overwrite {
+			return errors.New("LSVD is already configured; not reconfiguring")
+		}
+		fmt.Fprintln(io.Out)
+	}
+
+	fmt.Fprintln(
+		io.Out,
+		"This will configure S3-backed log-structured virtual disks for your app\n"+
+			"by setting several secrets on it.\n\n"+
+			"THIS IS AN EXPERIMENTAL FEATURE. Using it may lead to data loss or\n"+
+			"corruption. There is no official support for this feature, nor can we\n"+
+			"guarantee that it will continue to be available. Do not use this for\n"+
+			"production workloads.",
+	)
+	cont, err := prompt.Confirm(ctx, "Do you wish to continue?")
+	if err != nil {
+		return err
+	} else if !cont {
+		return errors.New("not continuing")
+	}
+
+	fmt.Fprint(
+		io.Out,
+		"\nTo begin, you'll need to have a bucket on an S3-compatible object\n"+
+			"storage service and an access key ID/secret access key pair that can\n"+
+			"access it. One these are ready, enter the required information here.\n\n",
+	)
+
+	reuseCreds := false
+	if haveKeyID && haveKey {
+		fmt.Fprintln(io.Out, "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY secrets already exist.")
+		reuseCreds, err = prompt.Confirm(ctx, "Reuse these existing credentials?")
+		if err != nil {
+			return err
+		}
+	}
+	if !reuseCreds {
+		if err := prompt.String(ctx, &keyID, "Enter your access key ID:", "", true); err != nil {
+			return err
+		}
+		if err := prompt.Password(ctx, &key, "Enter your secret access key:", true); err != nil {
+			return err
+		}
+		newSecrets["AWS_ACCESS_KEY_ID"] = keyID
+		newSecrets["AWS_SECRET_ACCESS_KEY"] = key
+	}
+
+	serviceTypeOptions := []string{"Amazon S3", "Another S3-compatible service"}
+	if err := prompt.Select(ctx, &serviceType, "Which service are you using?", serviceTypeOptions[0], serviceTypeOptions...); err != nil {
+		return err
+	}
+
+	switch serviceType {
+	case 0: // Amazon S3
+		if err := prompt.String(ctx, &region, "Enter your bucket's region:", "", true); err != nil {
+			return err
+		}
+		newSecrets["AWS_REGION"] = region
+		deletedSecrets = append(deletedSecrets, "FLY_LSVD_S3_ENDPOINT")
+	case 1: // Another S3-compatible service
+		if err := prompt.String(ctx, &endpoint, "Enter your S3-compatible service's endpoint URL:", "", true); err != nil {
+			return err
+		}
+		newSecrets["FLY_LSVD_S3_ENDPOINT"] = endpoint
+		deletedSecrets = append(deletedSecrets, "AWS_REGION")
+	default:
+		return &flyerr.GenericErr{
+			Err:     "invalid option selected",
+			Suggest: "This is a bug. Please report this at https://github.com/superfly/flyctl/issues/new/choose",
+		}
+	}
+
+	if err := prompt.String(ctx, &bucket, "Enter your bucket's name:", "", true); err != nil {
+		return err
+	}
+	newSecrets["FLY_LSVD_S3_BUCKET"] = bucket
+
+	fmt.Fprintln(
+		io.Out,
+		"\nNext you'll need to specify the size of your device. (Be aware that the\n"+
+			"LSVD process currently requires 2 MiB of RAM per gigabyte for in-memory\n"+
+			"sector mappings, so larger devices will require larger machines to run.)",
+	)
+	for {
+		if err := prompt.Int(ctx, &deviceSize, "Enter the device's size (GiB):", 1, true); err != nil {
+			return err
+		} else if deviceSize > 0 {
+			break
+		}
+		fmt.Fprintln(io.Out, "The device size must be positive.")
+	}
+	newSecrets["FLY_LSVD_DEVICE_SIZE"] = strconv.Itoa(deviceSize * 1024 * 1024 * 1024)
+
+	fmt.Fprintln(
+		io.Out,
+		"\nOptionally, we can automatically create an ext4 filesystem on the device\n"+
+			"and mount it at a specified path. To make use of this, your image must\n"+
+			"contain the `mkfs.ext4` binary, which will be executed on the first run.",
+	)
+	if err := prompt.String(ctx, &mountPoint, "Enter a mount point for the device (or leave empty to disable):", "", false); err != nil {
+		return err
+	}
+	if mountPoint != "" {
+		newSecrets["FLY_LSVD_MOUNT_POINT"] = mountPoint
+	} else {
+		deletedSecrets = append(deletedSecrets, "FLY_LSVD_MOUNT_POINT")
+	}
+
+	_, err = client.UnsetSecrets(ctx, appName, deletedSecrets)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.SetSecrets(ctx, appName, newSecrets)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(
+		io.Out,
+		"\nLSVD is configured! Now use the `--lsvd` flag with `fly machines run` to\n"+
+			"create an LSVD-enabled machine.",
+	)
+	return nil
+}

--- a/internal/command/lsvd/setup.go
+++ b/internal/command/lsvd/setup.go
@@ -91,10 +91,9 @@ func runSetup(ctx context.Context) error {
 		io.Out,
 		"This will configure S3-backed log-structured virtual disks for your app\n"+
 			"by setting several secrets on it.\n\n"+
-			"THIS IS AN EXPERIMENTAL FEATURE. Using it may lead to data loss or\n"+
-			"corruption. There is no official support for this feature, nor can we\n"+
-			"guarantee that it will continue to be available. Do not use this for\n"+
-			"production workloads.",
+			"THIS IS AN EXPERIMENTAL FEATURE. It's not ready for production use, and\n" +
+			"it's not officially supported. If you run into problems, please get in\n" +
+			"touch with us at https://community.fly.io.",
 	)
 	cont, err := prompt.Confirm(ctx, "Do you wish to continue?")
 	if err != nil {
@@ -107,7 +106,7 @@ func runSetup(ctx context.Context) error {
 		io.Out,
 		"\nTo begin, you'll need to have a bucket on an S3-compatible object\n"+
 			"storage service and an access key ID/secret access key pair that can\n"+
-			"access it. One these are ready, enter the required information here.\n\n",
+			"access it. Once these are ready, enter the required information here.\n\n",
 	)
 
 	reuseCreds := false
@@ -161,27 +160,27 @@ func runSetup(ctx context.Context) error {
 
 	fmt.Fprintln(
 		io.Out,
-		"\nNext you'll need to specify the size of your device. (Be aware that the\n"+
-			"LSVD process currently requires 2 MiB of RAM per gigabyte for in-memory\n"+
-			"sector mappings, so larger devices will require larger machines to run.)",
+		"\nNext, you'll need to specify the size of your volume. (Be aware that the\n"+
+			"LSVD background daemon currently requires 2 MiB of RAM per gigabyte of\n"+
+			"volume, so larger volumes will require larger Machines to run.)",
 	)
 	for {
-		if err := prompt.Int(ctx, &deviceSize, "Enter the device's size (GiB):", 1, true); err != nil {
+		if err := prompt.Int(ctx, &deviceSize, "Enter the volume's size (GiB):", 1, true); err != nil {
 			return err
 		} else if deviceSize > 0 {
 			break
 		}
-		fmt.Fprintln(io.Out, "The device size must be positive.")
+		fmt.Fprintln(io.Out, "The volume size must be positive.")
 	}
 	newSecrets["FLY_LSVD_DEVICE_SIZE"] = strconv.Itoa(deviceSize * 1024 * 1024 * 1024)
 
 	fmt.Fprintln(
 		io.Out,
-		"\nOptionally, we can automatically create an ext4 filesystem on the device\n"+
+		"\nOptionally, we can automatically create an ext4 filesystem on the volume\n"+
 			"and mount it at a specified path. To make use of this, your image must\n"+
 			"contain the `mkfs.ext4` binary, which will be executed on the first run.",
 	)
-	if err := prompt.String(ctx, &mountPoint, "Enter a mount point for the device (or leave empty to disable):", "", false); err != nil {
+	if err := prompt.String(ctx, &mountPoint, "Enter a mount point for the volume (or leave empty to disable):", "", false); err != nil {
 		return err
 	}
 	if mountPoint != "" {

--- a/internal/command/lsvd/setup.go
+++ b/internal/command/lsvd/setup.go
@@ -92,8 +92,8 @@ func runSetup(ctx context.Context) error {
 		io.Out,
 		"This will configure S3-backed log-structured virtual disks for your app\n"+
 			"by setting several secrets on it.\n\n"+
-			"THIS IS AN EXPERIMENTAL FEATURE. It's not ready for production use, and\n" +
-			"it's not officially supported. If you run into problems, please get in\n" +
+			"THIS IS AN EXPERIMENTAL FEATURE. It's not ready for production use, and\n"+
+			"it's not officially supported. If you run into problems, please get in\n"+
 			"touch with us at https://community.fly.io.",
 	)
 	cont, err := prompt.Confirm(ctx, "Do you wish to continue?")

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -194,6 +194,11 @@ func newRun() *cobra.Command {
 		flag.String{
 			Name: "host-dedication-id",
 		},
+		flag.Bool{
+			Name:        "lsvd",
+			Description: "Enable LSVD for this machine",
+			Hidden:      true,
+		},
 		sharedFlags,
 	)
 
@@ -252,6 +257,7 @@ func runMachineRun(ctx context.Context) error {
 		Name:             flag.GetString(ctx, "name"),
 		Region:           flag.GetString(ctx, "region"),
 		HostDedicationID: flag.GetString(ctx, "host-dedication-id"),
+		LSVD:   flag.GetBool(ctx, "lsvd"),
 	}
 
 	flapsClient, err := flaps.New(ctx, app)

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -257,7 +257,7 @@ func runMachineRun(ctx context.Context) error {
 		Name:             flag.GetString(ctx, "name"),
 		Region:           flag.GetString(ctx, "region"),
 		HostDedicationID: flag.GetString(ctx, "host-dedication-id"),
-		LSVD:   flag.GetBool(ctx, "lsvd"),
+		LSVD:             flag.GetBool(ctx, "lsvd"),
 	}
 
 	flapsClient, err := flaps.New(ctx, app)

--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -38,6 +38,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/jobs"
 	"github.com/superfly/flyctl/internal/command/launch"
 	"github.com/superfly/flyctl/internal/command/logs"
+	"github.com/superfly/flyctl/internal/command/lsvd"
 	"github.com/superfly/flyctl/internal/command/machine"
 	"github.com/superfly/flyctl/internal/command/migrate_to_v2"
 	"github.com/superfly/flyctl/internal/command/monitor"
@@ -146,6 +147,7 @@ func New() *cobra.Command {
 		suspend.New(),    // TODO: deprecate
 		resume.New(),     // TODO: deprecate
 		dnsrecords.New(), // TODO: deprecate
+		lsvd.New(),
 	)
 
 	// if os.Getenv("DEV") != "" {


### PR DESCRIPTION
### Change Summary

This adds support for the experimental [LSVD](https://doi.org/10.1145/3492321.3524271)/S3-backed volume implementation that we are about to Fresh Produce. There are two parts:

1. It provides a guided/interactive command, `fly lsvd setup`, to configure an app to use the feature. The `lsvd` daemon that's injected into a Machine and provides the block device is configured via environment variables; this command sets them (as secrets). The goal is to make it easy for a user with a spare hour or two for experimentation to get this up and running.
2. It provides an `--lsvd` flag for `fly machines run`, which actually enables LSVD for a Machine (i.e., gets the `lsvd` daemon injected and started).

If the setup command should be called something else (e.g. if it should be placed under `fly ext`), just say the word.

---

### Documentation

- [x] Fresh Produce (once this is merged)
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
