### PR TITLE
`migrate-to-v2`: improve postgres debug info

### DIFF
--- a/flypg/pg.go
+++ b/flypg/pg.go
@@ -2,8 +2,10 @@ package flypg
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/superfly/flyctl/terminal"
 )
@@ -143,6 +145,12 @@ func (c *Client) legacyNodeRole(ctx context.Context) (string, error) {
 	out, err := c.DoPlaintext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return "", err
+	}
+	if len(out) > 0 && out[0] == '"' {
+		// Parse as JSON-encoded string
+		var jsonOut string
+		err := json.NewDecoder(strings.NewReader(out)).Decode(&jsonOut)
+		return jsonOut, err
 	}
 	return out, nil
 }

--- a/internal/command/migrate_to_v2/pg.go
+++ b/internal/command/migrate_to_v2/pg.go
@@ -17,6 +17,7 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/internal/watch"
+	"github.com/superfly/flyctl/terminal"
 )
 
 func (m *v2PlatformMigrator) updateNomadPostgresImage(ctx context.Context) error {
@@ -154,7 +155,7 @@ func leaderIpFromInstances(ctx context.Context, addrs []string) (string, error) 
 		if err != nil {
 			return "", fmt.Errorf("can't get role for %s: %w", addr, err)
 		}
-
+		terminal.Debugf("role for %s: %s\n", addr, role)
 		if role == "leader" || role == "primary" {
 			return addr, nil
 		}


### PR DESCRIPTION
### Change Summary

* Add debug logging to postgres migration to troubleshoot "no instances found with leader role"
    * In debug builds, it'll log each 6pn address and their role.
* In `legacyNodeRole`, we [recently changed it from reading JSON strings to plaintext strings](https://github.com/superfly/flyctl/pull/2833). Just in case we were using JSON somewhere, re-add the JSON string parsing, but only if the output starts with quotes.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
