### PR TITLE
`migrate-to-v2`: add flag to force standard migration on postgres apps

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -98,6 +98,11 @@ func newMigrateToV2() *cobra.Command {
 			Description: "Use local fly.toml. Do not attempt to remotely fetch the app configuration from the latest deployed release",
 			Default:     false,
 		},
+		flag.Bool{
+			Name:        "force-standard-migration",
+			Description: "Use the standard volume fork-based migration, even for apps using the Postgres image",
+			Default:     false,
+		},
 	)
 
 	cmd.AddCommand(newTroubleshoot())
@@ -308,7 +313,11 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 	}
 	leaseTimeout := 13 * time.Second
 	leaseDelayBetween := (leaseTimeout - 1*time.Second) / 3
-	isPostgres := appCompact.IsPostgresApp() && appFull.ImageDetails.Repository == "flyio/postgres"
+
+	isPostgres := appCompact.IsPostgresApp() &&
+		appFull.ImageDetails.Repository == "flyio/postgres" &&
+		!flag.GetBool(ctx, "force-standard-migration")
+
 	migrator := &v2PlatformMigrator{
 		apiClient:               apiClient,
 		flapsClient:             flapsClient,


### PR DESCRIPTION
### Change Summary

What and Why: Adds the flag `--force-standard-migration`, which forces the migration to proceed as if the app is not a Postgres app, even if it is. This allows us to (hopefully) migrate clusters that aren't perfectly healthy.

This is a last-resort, meant to be used in the final pass of automatic migrations as we approach the deadline.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
