### PR TITLE
Try to catch flaps status codes

### DIFF
--- a/flaps/flaps_error.go
+++ b/flaps/flaps_error.go
@@ -1,10 +1,26 @@
 package flaps
 
-import "net/http"
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
 
 var (
 	FlapsErrorNotFound = &FlapsError{ResponseStatusCode: http.StatusNotFound}
 )
+
+type StatusCode string
+
+const (
+	unknown          StatusCode = "unknown"
+	regionOOCapacity StatusCode = "insufficient_capacity"
+)
+
+type errorResponse struct {
+	Error      string     `json:"error"`
+	StatusCode StatusCode `json:"status"`
+}
 
 type FlapsError struct {
 	OriginalError      error
@@ -18,6 +34,64 @@ func (fe *FlapsError) Error() string {
 		return ""
 	}
 	return fe.OriginalError.Error()
+}
+
+func (fe *FlapsError) Suggestion() string {
+	statusCode := fe.StatusCode()
+	if statusCode == nil {
+		return ""
+	}
+
+	switch *statusCode {
+	case unknown:
+		return ""
+	case regionOOCapacity:
+		// TODO(billy): once we have support for 'backup regions', suggest creating adding those (or eveven better, just do it automatically)
+		return "Try choosing a different region for machine creation"
+	}
+
+	return ""
+}
+
+type ErrorStatusCode interface {
+	error
+	StatusCode() *StatusCode
+}
+
+func GetErrorStatusCode(err error) *StatusCode {
+	var ferr ErrorStatusCode
+	if errors.As(err, &ferr) {
+		return ferr.StatusCode()
+	}
+	return nil
+}
+
+// TODO: we might not actually need an interface type here
+type ErrorRequestID interface {
+	ErrRequestID() string
+}
+
+func GetErrorRequestID(err error) string {
+	var ferr ErrorRequestID
+	if errors.As(err, &ferr) {
+		return ferr.ErrRequestID()
+	}
+	return ""
+}
+
+func (fe *FlapsError) StatusCode() *StatusCode {
+	var errResp errorResponse
+	unmarshalErr := json.Unmarshal(fe.ResponseBody, &errResp)
+
+	if unmarshalErr != nil {
+		return nil
+	}
+
+	return &errResp.StatusCode
+}
+
+func (fe *FlapsError) ErrRequestID() string {
+	return fe.FlyRequestId
 }
 
 func (fe *FlapsError) Is(target error) bool {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kr/text"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/internal/metrics"
@@ -120,7 +121,13 @@ func isUnchangedError(err error) bool {
 }
 
 func printError(io *iostreams.IOStreams, cs *iostreams.ColorScheme, cmd *cobra.Command, err error) {
-	fmt.Fprint(io.ErrOut, cs.Red("Error: "), err.Error(), "\n")
+	var requestId string
+
+	if requestId = flaps.GetErrorRequestID(err); requestId != "" {
+		requestId = fmt.Sprintf(" (Request ID: %s)", requestId)
+	}
+
+	fmt.Fprint(io.ErrOut, cs.Red("Error: "), err.Error(), requestId, "\n")
 
 	if description := flyerr.GetErrorDescription(err); description != "" && err.Error() != description {
 		fmt.Fprintln(io.ErrOut, description)


### PR DESCRIPTION
### Change Summary

What and Why:

We can use this information to better inform the user as to how to procede, as well as letting Flyctl perform actions to get around issues.

In a future PR, I want to add a `backup_regions` feature to flyctl that allows us to automatically select a region in case  creating a machine in said region fails.

How:

Take advantage of flaps sending a `statusCode`

Related to:

https://github.com/superfly/nomad-firecracker/pull/1592

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
