### PR TITLE
Fix `fly orgs show` to correctly take a slug as advertised

### DIFF
--- a/internal/command/orgs/orgs.go
+++ b/internal/command/orgs/orgs.go
@@ -68,6 +68,10 @@ func slugFromArgOrSelect(ctx context.Context, orgSlug string, filters ...api.Org
 		return orgSlug, nil
 	}
 
+	if args := flag.Args(ctx); len(args) > 0 {
+		return args[0], nil
+	}
+
 	io := iostreams.FromContext(ctx)
 	if !io.IsInteractive() {
 		err = errSlugArgMustBeSpecified


### PR DESCRIPTION
### Change Summary

`fly orgs show` advertises that it takes a slug but always displays the select interface, even if a slug is provided.
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
