### PR TITLE
Add the ability to deploy to backup regions

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -671,10 +671,11 @@ type LaunchMachineInput struct {
 	LeaseTTL int `json:"lease_ttl,omitempty"`
 
 	// Client side only
-	ID                  string `json:"-"`
-	SkipHealthChecks    bool   `json:"-"`
-	RequiresReplacement bool   `json:"-"`
-	Timeout             int    `json:"-"`
+	ID                  string   `json:"-"`
+	SkipHealthChecks    bool     `json:"-"`
+	RequiresReplacement bool     `json:"-"`
+	Timeout             int      `json:"-"`
+	BackupRegions       []string `json:"-"`
 }
 
 type MachineProcess struct {


### PR DESCRIPTION
Specifying the flag --launch-backup-regions will deploy a machine to one of the specified regions if there's capacity issues in the region selected

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
