### PR TITLE
Extension provisioning updates

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -286,30 +286,87 @@ func (v *AppData) GetOrganization() AppDataOrganization { return v.Organization 
 
 // AppDataOrganization includes the requested fields of the GraphQL type Organization.
 type AppDataOrganization struct {
-	Id string `json:"id"`
-	// Unique organization slug
-	Slug string `json:"slug"`
-	// Unmodified unique org slug
-	RawSlug  string `json:"rawSlug"`
-	PaidPlan bool   `json:"paidPlan"`
-	// Whether the organization can provision beta extensions
-	ProvisionsBetaExtensions bool `json:"provisionsBetaExtensions"`
+	OrganizationData `json:"-"`
 }
 
 // GetId returns AppDataOrganization.Id, and is useful for accessing the field via an interface.
-func (v *AppDataOrganization) GetId() string { return v.Id }
+func (v *AppDataOrganization) GetId() string { return v.OrganizationData.Id }
 
 // GetSlug returns AppDataOrganization.Slug, and is useful for accessing the field via an interface.
-func (v *AppDataOrganization) GetSlug() string { return v.Slug }
+func (v *AppDataOrganization) GetSlug() string { return v.OrganizationData.Slug }
 
 // GetRawSlug returns AppDataOrganization.RawSlug, and is useful for accessing the field via an interface.
-func (v *AppDataOrganization) GetRawSlug() string { return v.RawSlug }
+func (v *AppDataOrganization) GetRawSlug() string { return v.OrganizationData.RawSlug }
 
 // GetPaidPlan returns AppDataOrganization.PaidPlan, and is useful for accessing the field via an interface.
-func (v *AppDataOrganization) GetPaidPlan() bool { return v.PaidPlan }
+func (v *AppDataOrganization) GetPaidPlan() bool { return v.OrganizationData.PaidPlan }
+
+// GetAddOnSsoLink returns AppDataOrganization.AddOnSsoLink, and is useful for accessing the field via an interface.
+func (v *AppDataOrganization) GetAddOnSsoLink() string { return v.OrganizationData.AddOnSsoLink }
 
 // GetProvisionsBetaExtensions returns AppDataOrganization.ProvisionsBetaExtensions, and is useful for accessing the field via an interface.
-func (v *AppDataOrganization) GetProvisionsBetaExtensions() bool { return v.ProvisionsBetaExtensions }
+func (v *AppDataOrganization) GetProvisionsBetaExtensions() bool {
+	return v.OrganizationData.ProvisionsBetaExtensions
+}
+
+func (v *AppDataOrganization) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*AppDataOrganization
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.AppDataOrganization = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.OrganizationData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalAppDataOrganization struct {
+	Id string `json:"id"`
+
+	Slug string `json:"slug"`
+
+	RawSlug string `json:"rawSlug"`
+
+	PaidPlan bool `json:"paidPlan"`
+
+	AddOnSsoLink string `json:"addOnSsoLink"`
+
+	ProvisionsBetaExtensions bool `json:"provisionsBetaExtensions"`
+}
+
+func (v *AppDataOrganization) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *AppDataOrganization) __premarshalJSON() (*__premarshalAppDataOrganization, error) {
+	var retval __premarshalAppDataOrganization
+
+	retval.Id = v.OrganizationData.Id
+	retval.Slug = v.OrganizationData.Slug
+	retval.RawSlug = v.OrganizationData.RawSlug
+	retval.PaidPlan = v.OrganizationData.PaidPlan
+	retval.AddOnSsoLink = v.OrganizationData.AddOnSsoLink
+	retval.ProvisionsBetaExtensions = v.OrganizationData.ProvisionsBetaExtensions
+	return &retval, nil
+}
 
 type BuildFinalImageInput struct {
 	// Sha256 id of docker image
@@ -2167,26 +2224,89 @@ func (v *GetNearestRegionResponse) GetNearestRegion() GetNearestRegionNearestReg
 
 // GetOrganizationOrganization includes the requested fields of the GraphQL type Organization.
 type GetOrganizationOrganization struct {
-	Id string `json:"id"`
-	// Organization name
-	Name string `json:"name"`
-	// Unique organization slug
-	Slug string `json:"slug"`
-	// Single sign-on link for the given integration type
-	AddOnSsoLink string `json:"addOnSsoLink"`
+	OrganizationData `json:"-"`
 }
 
 // GetId returns GetOrganizationOrganization.Id, and is useful for accessing the field via an interface.
-func (v *GetOrganizationOrganization) GetId() string { return v.Id }
-
-// GetName returns GetOrganizationOrganization.Name, and is useful for accessing the field via an interface.
-func (v *GetOrganizationOrganization) GetName() string { return v.Name }
+func (v *GetOrganizationOrganization) GetId() string { return v.OrganizationData.Id }
 
 // GetSlug returns GetOrganizationOrganization.Slug, and is useful for accessing the field via an interface.
-func (v *GetOrganizationOrganization) GetSlug() string { return v.Slug }
+func (v *GetOrganizationOrganization) GetSlug() string { return v.OrganizationData.Slug }
+
+// GetRawSlug returns GetOrganizationOrganization.RawSlug, and is useful for accessing the field via an interface.
+func (v *GetOrganizationOrganization) GetRawSlug() string { return v.OrganizationData.RawSlug }
+
+// GetPaidPlan returns GetOrganizationOrganization.PaidPlan, and is useful for accessing the field via an interface.
+func (v *GetOrganizationOrganization) GetPaidPlan() bool { return v.OrganizationData.PaidPlan }
 
 // GetAddOnSsoLink returns GetOrganizationOrganization.AddOnSsoLink, and is useful for accessing the field via an interface.
-func (v *GetOrganizationOrganization) GetAddOnSsoLink() string { return v.AddOnSsoLink }
+func (v *GetOrganizationOrganization) GetAddOnSsoLink() string {
+	return v.OrganizationData.AddOnSsoLink
+}
+
+// GetProvisionsBetaExtensions returns GetOrganizationOrganization.ProvisionsBetaExtensions, and is useful for accessing the field via an interface.
+func (v *GetOrganizationOrganization) GetProvisionsBetaExtensions() bool {
+	return v.OrganizationData.ProvisionsBetaExtensions
+}
+
+func (v *GetOrganizationOrganization) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*GetOrganizationOrganization
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.GetOrganizationOrganization = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.OrganizationData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalGetOrganizationOrganization struct {
+	Id string `json:"id"`
+
+	Slug string `json:"slug"`
+
+	RawSlug string `json:"rawSlug"`
+
+	PaidPlan bool `json:"paidPlan"`
+
+	AddOnSsoLink string `json:"addOnSsoLink"`
+
+	ProvisionsBetaExtensions bool `json:"provisionsBetaExtensions"`
+}
+
+func (v *GetOrganizationOrganization) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *GetOrganizationOrganization) __premarshalJSON() (*__premarshalGetOrganizationOrganization, error) {
+	var retval __premarshalGetOrganizationOrganization
+
+	retval.Id = v.OrganizationData.Id
+	retval.Slug = v.OrganizationData.Slug
+	retval.RawSlug = v.OrganizationData.RawSlug
+	retval.PaidPlan = v.OrganizationData.PaidPlan
+	retval.AddOnSsoLink = v.OrganizationData.AddOnSsoLink
+	retval.ProvisionsBetaExtensions = v.OrganizationData.ProvisionsBetaExtensions
+	return &retval, nil
+}
 
 // GetOrganizationResponse is returned by GetOrganization on success.
 type GetOrganizationResponse struct {
@@ -2493,6 +2613,38 @@ type MigrateMachinesCreateReleaseResponse struct {
 func (v *MigrateMachinesCreateReleaseResponse) GetCreateRelease() MigrateMachinesCreateReleaseCreateReleaseCreateReleasePayload {
 	return v.CreateRelease
 }
+
+// OrganizationData includes the GraphQL fields of Organization requested by the fragment OrganizationData.
+type OrganizationData struct {
+	Id string `json:"id"`
+	// Unique organization slug
+	Slug string `json:"slug"`
+	// Unmodified unique org slug
+	RawSlug  string `json:"rawSlug"`
+	PaidPlan bool   `json:"paidPlan"`
+	// Single sign-on link for the given integration type
+	AddOnSsoLink string `json:"addOnSsoLink"`
+	// Whether the organization can provision beta extensions
+	ProvisionsBetaExtensions bool `json:"provisionsBetaExtensions"`
+}
+
+// GetId returns OrganizationData.Id, and is useful for accessing the field via an interface.
+func (v *OrganizationData) GetId() string { return v.Id }
+
+// GetSlug returns OrganizationData.Slug, and is useful for accessing the field via an interface.
+func (v *OrganizationData) GetSlug() string { return v.Slug }
+
+// GetRawSlug returns OrganizationData.RawSlug, and is useful for accessing the field via an interface.
+func (v *OrganizationData) GetRawSlug() string { return v.RawSlug }
+
+// GetPaidPlan returns OrganizationData.PaidPlan, and is useful for accessing the field via an interface.
+func (v *OrganizationData) GetPaidPlan() bool { return v.PaidPlan }
+
+// GetAddOnSsoLink returns OrganizationData.AddOnSsoLink, and is useful for accessing the field via an interface.
+func (v *OrganizationData) GetAddOnSsoLink() string { return v.AddOnSsoLink }
+
+// GetProvisionsBetaExtensions returns OrganizationData.ProvisionsBetaExtensions, and is useful for accessing the field via an interface.
+func (v *OrganizationData) GetProvisionsBetaExtensions() bool { return v.ProvisionsBetaExtensions }
 
 type PlatformVersionEnum string
 
@@ -3561,12 +3713,16 @@ fragment AppData on App {
 	deployed
 	platformVersion
 	organization {
-		id
-		slug
-		rawSlug
-		paidPlan
-		provisionsBetaExtensions
+		... OrganizationData
 	}
+}
+fragment OrganizationData on Organization {
+	id
+	slug
+	rawSlug
+	paidPlan
+	addOnSsoLink
+	provisionsBetaExtensions
 }
 `
 
@@ -3871,12 +4027,16 @@ fragment AppData on App {
 	deployed
 	platformVersion
 	organization {
-		id
-		slug
-		rawSlug
-		paidPlan
-		provisionsBetaExtensions
+		... OrganizationData
 	}
+}
+fragment OrganizationData on Organization {
+	id
+	slug
+	rawSlug
+	paidPlan
+	addOnSsoLink
+	provisionsBetaExtensions
 }
 `
 
@@ -3974,12 +4134,16 @@ fragment AppData on App {
 	deployed
 	platformVersion
 	organization {
-		id
-		slug
-		rawSlug
-		paidPlan
-		provisionsBetaExtensions
+		... OrganizationData
 	}
+}
+fragment OrganizationData on Organization {
+	id
+	slug
+	rawSlug
+	paidPlan
+	addOnSsoLink
+	provisionsBetaExtensions
 }
 `
 
@@ -4067,11 +4231,7 @@ fragment AppData on App {
 	deployed
 	platformVersion
 	organization {
-		id
-		slug
-		rawSlug
-		paidPlan
-		provisionsBetaExtensions
+		... OrganizationData
 	}
 }
 fragment AddOnData on AddOn {
@@ -4079,6 +4239,14 @@ fragment AddOnData on AddOn {
 	name
 	primaryRegion
 	status
+}
+fragment OrganizationData on Organization {
+	id
+	slug
+	rawSlug
+	paidPlan
+	addOnSsoLink
+	provisionsBetaExtensions
 }
 `
 
@@ -4125,12 +4293,16 @@ fragment AppData on App {
 	deployed
 	platformVersion
 	organization {
-		id
-		slug
-		rawSlug
-		paidPlan
-		provisionsBetaExtensions
+		... OrganizationData
 	}
+}
+fragment OrganizationData on Organization {
+	id
+	slug
+	rawSlug
+	paidPlan
+	addOnSsoLink
+	provisionsBetaExtensions
 }
 `
 
@@ -4199,11 +4371,16 @@ func GetNearestRegion(
 const GetOrganization_Operation = `
 query GetOrganization ($slug: String!) {
 	organization(slug: $slug) {
-		id
-		name
-		slug
-		addOnSsoLink
+		... OrganizationData
 	}
+}
+fragment OrganizationData on Organization {
+	id
+	slug
+	rawSlug
+	paidPlan
+	addOnSsoLink
+	provisionsBetaExtensions
 }
 `
 

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -88,10 +88,7 @@ query AgreedToProviderTos($addOnProviderName: String!, $organizationId: ID!) {
 
 query GetOrganization($slug: String!) {
 	organization(slug: $slug) {
-		id
-		name
-		slug
-		addOnSsoLink
+		...OrganizationData
 	}
 }
 
@@ -120,17 +117,22 @@ query GetAppsByRole($role: String!, $organizationId: ID!) {
 	}
 }
 
+fragment OrganizationData on Organization {
+	id
+	slug
+	rawSlug
+	paidPlan
+	addOnSsoLink
+	provisionsBetaExtensions
+}
+
 fragment AppData on App {
 	id
 	name
 	deployed
 	platformVersion
 	organization {
-		id
-		slug
-		rawSlug
-		paidPlan
-		provisionsBetaExtensions
+		...OrganizationData
 	}
 }
 

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -50,11 +50,6 @@ var CommonFlags = flag.Set{
 		Name:        "provision-extensions",
 		Description: "Provision any extensions assigned as a default to first deployments",
 	},
-	flag.Bool{
-		Name:        "no-extensions",
-		Description: "Do not provision Sentry nor other auto-provisioned extensions",
-		Default:     true,
-	},
 	flag.StringArray{
 		Name:        "env",
 		Shorthand:   "e",
@@ -327,7 +322,6 @@ func deployToMachines(
 		UpdateOnly:             flag.GetBool(ctx, "update-only"),
 		Files:                  files,
 		ExcludeRegions:         excludeRegions,
-		NoExtensions:           flag.GetBool(ctx, "no-extensions"),
 		OnlyRegions:            onlyRegions,
 		ImmediateMaxConcurrent: flag.GetInt(ctx, "immediate-max-concurrent"),
 	})

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
-	"github.com/superfly/flyctl/gql"
-	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/prompt"
 )
 
@@ -20,14 +18,6 @@ func (md *machineDeployment) provisionFirstDeploy(ctx context.Context, allocPubl
 	}
 	if err := md.provisionVolumesOnFirstDeploy(ctx); err != nil {
 		return fmt.Errorf("failed to provision seed volumes: %w", err)
-	}
-
-	// Provision Sentry on first deployment unless explicitly prevented by the --no-extensions option
-	if !md.noExtensions {
-		_, err := extensions_core.ProvisionExtension(ctx, md.app.Name, "sentry", true, gql.AddOnOptions{})
-		if err != nil {
-			fmt.Fprintf(md.io.ErrOut, "Failed to provision a Sentry project for this app. Use `fly ext sentry create` to try again.\nERROR: %s", err)
-		}
 	}
 	return nil
 }

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -51,8 +51,6 @@ type MachineDeploymentArgs struct {
 	AllocPublicIP          bool
 	UpdateOnly             bool
 	Files                  []*api.File
-	ProvisionExtensions    bool
-	NoExtensions           bool
 	ExcludeRegions         map[string]interface{}
 	OnlyRegions            map[string]interface{}
 	ImmediateMaxConcurrent int
@@ -86,7 +84,6 @@ type machineDeployment struct {
 	increasedAvailability  bool
 	listenAddressChecked   map[string]struct{}
 	updateOnly             bool
-	noExtensions           bool
 	excludeRegions         map[string]interface{}
 	onlyRegions            map[string]interface{}
 	immediateMaxConcurrent int
@@ -172,7 +169,6 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		listenAddressChecked:   make(map[string]struct{}),
 		updateOnly:             args.UpdateOnly,
 		machineGuest:           args.Guest,
-		noExtensions:           args.NoExtensions,
 		excludeRegions:         args.ExcludeRegions,
 		onlyRegions:            args.OnlyRegions,
 		immediateMaxConcurrent: immedateMaxConcurrent,

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/skratchdot/open-golang/open"
+	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -24,20 +25,22 @@ type Extension struct {
 	App  gql.AppData
 }
 
-func ProvisionExtension(ctx context.Context, appName string, providerName string, auto bool, options map[string]interface{}) (extension Extension, err error) {
+type ExtensionParams struct {
+	AppName      string
+	Organization *api.Organization
+	Provider     string
+	Options      map[string]interface{}
+}
+
+func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension Extension, err error) {
 	client := client.FromContext(ctx).API().GenqClient
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
-	// Fetch the target organization from the app
-	appResponse, err := gql.GetAppWithAddons(ctx, client, appName, gql.AddOnType(providerName))
 
-	if err != nil {
-		return
-	}
+	var targetApp gql.AppData
+	var targetOrg gql.OrganizationData
 
-	targetApp := appResponse.App.AppData
-	targetOrg := targetApp.Organization
-	resp, err := gql.GetAddOnProvider(ctx, client, providerName)
+	resp, err := gql.GetAddOnProvider(ctx, client, params.Provider)
 
 	if err != nil {
 		return
@@ -45,48 +48,46 @@ func ProvisionExtension(ctx context.Context, appName string, providerName string
 
 	provider := resp.AddOnProvider.ExtensionProviderData
 
-	// Stop provisioning if being provisioned automatically, but the provider has auto-provisioning disabled
-
-	if auto && !provider.AutoProvision {
-		return extension, nil
-	}
-
-	// Stop auto-provisioning if this provider is in beta and the target org does is not allowed to provision beta extensions.\
-	// Standard provisioning will be stopped by the backend for the same reason, but there, we'll supply a better error message.
-
-	if auto && provider.Beta && !targetOrg.ProvisionsBetaExtensions {
-		return extension, nil
-	}
-
-	// Stop provisioning if this app already has an extension of this type, but only display an error for
-	// extensions that weren't automatically provisioned
-
-	if len(appResponse.App.AddOns.Nodes) > 0 {
-		existsError := fmt.Errorf("A %s %s named %s already exists for app %s", provider.DisplayName, provider.ResourceName, colorize.Green(appResponse.App.AddOns.Nodes[0].Name), colorize.Green(appName))
-
-		if auto {
-			existsError = nil
+	if params.AppName != "" {
+		appResponse, err := gql.GetAppWithAddons(ctx, client, params.AppName, gql.AddOnType(params.Provider))
+		if err != nil {
+			return extension, err
 		}
 
-		return extension, existsError
+		targetApp = appResponse.App.AppData
+		targetOrg = appResponse.App.Organization.OrganizationData
+
+		if len(appResponse.App.AddOns.Nodes) > 0 {
+			existsError := fmt.Errorf("A %s %s named %s already exists for app %s", provider.DisplayName, provider.ResourceName, colorize.Green(appResponse.App.AddOns.Nodes[0].Name), colorize.Green(params.AppName))
+
+			return extension, existsError
+		}
+
+	} else {
+		resp, err := gql.GetOrganization(ctx, client, params.Organization.Slug)
+
+		if err != nil {
+			return extension, err
+		}
+
+		targetOrg = resp.Organization.OrganizationData
 	}
 
-	// Display ToS implicit agreement only once per org. Viewing makes the agreement official.
-
-	err = DisplayTosAgreement(ctx, provider, targetOrg, auto)
+	// Ensure orgs have agreed to the provider terms of service
+	err = AgreeToProviderTos(ctx, provider, targetOrg)
 
 	if err != nil {
 		return extension, err
 	}
 
-	// Pick a name for the extension unless we want it to be the same as the app, like in Sentry's case
 	var name string
 
+	// Prompt to name the provisioned resource, or use the target app name like in Sentry's case
 	if provider.SelectName {
 		name = flag.GetString(ctx, "name")
 
 		if name == "" {
-			if provider.NameSuffix != "" {
+			if provider.NameSuffix != "" && targetApp.Name != "" {
 				name = targetApp.Name + "-" + provider.NameSuffix
 			}
 			err = prompt.String(ctx, &name, "Choose a name, use the default, or leave blank to generate one:", name, false)
@@ -103,7 +104,7 @@ func ProvisionExtension(ctx context.Context, appName string, providerName string
 		OrganizationId: targetOrg.Id,
 		Name:           name,
 		AppId:          targetApp.Id,
-		Type:           gql.AddOnType(providerName),
+		Type:           gql.AddOnType(provider.Name),
 	}
 
 	var inExcludedRegion bool
@@ -147,7 +148,6 @@ func ProvisionExtension(ctx context.Context, appName string, providerName string
 	var detectedPlatform *scanner.SourceInfo
 
 	// Pass the detected platform family to the API
-
 	if provider.DetectPlatform {
 		absDir, err := filepath.Abs(".")
 
@@ -162,15 +162,14 @@ func ProvisionExtension(ctx context.Context, appName string, providerName string
 		}
 
 		if detectedPlatform != nil && PlatformMap[detectedPlatform.Family] != "" {
-			if options == nil {
-				options = gql.AddOnOptions{}
+			if params.Options == nil {
+				params.Options = gql.AddOnOptions{}
 			}
-			options["platform"] = PlatformMap[detectedPlatform.Family]
+			params.Options["platform"] = PlatformMap[detectedPlatform.Family]
 		}
-
 	}
 
-	input.Options = options
+	input.Options = params.Options
 	createResp, err := gql.CreateExtension(ctx, client, input)
 
 	if err != nil {
@@ -212,31 +211,33 @@ func ProvisionExtension(ctx context.Context, appName string, providerName string
 	return extension, nil
 }
 
-func DisplayTosAgreement(ctx context.Context, provider gql.ExtensionProviderData, org gql.AppDataOrganization, auto bool) error {
-	io := iostreams.FromContext(ctx)
-	colorize := io.ColorScheme()
+func AgreeToProviderTos(ctx context.Context, provider gql.ExtensionProviderData, org gql.OrganizationData) error {
 	client := client.FromContext(ctx).API().GenqClient
 
+	// Internal providers like kubernetes don't need ToS agreement
+	if provider.TosAgreement == "" {
+		return nil
+	}
+
+	// Check if the provider ToS was agreed to already
 	agreed, err := AgreedToProviderTos(ctx, provider.Name, org.Id)
 
 	if err != nil {
 		return err
 	}
 
-	var tosMsgPrefix string
-
-	// Display different ToS copy if an extension was automatically provisioned at deploy time
-	if auto {
-		tosMsgPrefix = "By deploying this app"
-	} else {
-		tosMsgPrefix = fmt.Sprintf("By provisioning this %s", provider.ResourceName)
+	if agreed {
+		return nil
 	}
 
-	tosSuffix := "you agree to the %s Terms of Service: https://fly.io/legal/supplemental-terms"
-	tosMessage := colorize.Green("* ") + provider.TosAgreement + " " + tosMsgPrefix + ", " + tosSuffix
+	// Prompt the user to agree to the provider ToS
+	confirmTos, err := prompt.Confirm(ctx, fmt.Sprintf("To provision this %s, you must agree on behalf of your organization to the %s Terms Of Service at %s. Do you agree?", provider.ResourceName, provider.DisplayName, provider.TosUrl))
 
-	if !agreed {
-		fmt.Fprintf(io.Out, tosMessage+"\n\n", provider.DisplayName)
+	if err != nil {
+		return err
+	}
+
+	if confirmTos {
 		_, err = gql.CreateTosAgreement(ctx, client, gql.CreateExtensionTosAgreementInput{
 			AddOnProviderName: provider.Name,
 			OrganizationId:    org.Id,

--- a/internal/command/extensions/planetscale/create.go
+++ b/internal/command/extensions/planetscale/create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
+	"github.com/superfly/flyctl/internal/command/orgs"
 	"github.com/superfly/flyctl/internal/command/secrets"
 	"github.com/superfly/flyctl/internal/flag"
 )
@@ -19,7 +20,7 @@ func create() (cmd *cobra.Command) {
 		long  = short + "\n"
 	)
 
-	cmd = command.New("create", short, long, runPlanetscaleCreate, command.RequireSession, command.RequireAppName)
+	cmd = command.New("create", short, long, runPlanetscaleCreate, command.RequireSession, command.LoadAppNameIfPresent)
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
@@ -36,8 +37,13 @@ func create() (cmd *cobra.Command) {
 
 func runPlanetscaleCreate(ctx context.Context) (err error) {
 	appName := appconfig.NameFromContext(ctx)
+	org, err := orgs.OrgFromFlagOrSelect(ctx)
 
-	extension, err := extensions_core.ProvisionExtension(ctx, appName, "planetscale", false, gql.AddOnOptions{})
+	extension, err := extensions_core.ProvisionExtension(ctx, extensions_core.ExtensionParams{
+		AppName:      appName,
+		Provider:     "planetscale",
+		Organization: org,
+	})
 
 	if err != nil {
 		return err

--- a/internal/command/extensions/sentry/create.go
+++ b/internal/command/extensions/sentry/create.go
@@ -30,7 +30,10 @@ func create() (cmd *cobra.Command) {
 func runSentryCreate(ctx context.Context) (err error) {
 	appName := appconfig.NameFromContext(ctx)
 
-	extension, err := extensions_core.ProvisionExtension(ctx, appName, "sentry", false, gql.AddOnOptions{})
+	extension, err := extensions_core.ProvisionExtension(ctx, extensions_core.ExtensionParams{
+		AppName:  appName,
+		Provider: "sentry",
+	})
 	secrets.DeploySecrets(ctx, gql.ToAppCompact(extension.App), false, false)
 	return
 }


### PR DESCRIPTION
Redis users currently provision databases independently from apps. We want to support this behavior for all extensions, but we should default to associating an app should one be in the context of an app directory or have passed `-a`.

This PR also: 

* Removes extension auto-provisioning related code, since we don't plan to reintroduce that behavior
* Ensures that customers accept provider ToS agreements explicitly when provisioning

Note: normally these changes might be split into separate PRs, but the behavior across them would be too coupled to make it worthwhile. Also, the changes here are important for continued work from @ndarilek on FKS.