### PR TITLE
`migrate-to-v2`: migrate volumes from maa to bom

### DIFF
--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -84,11 +84,18 @@ func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 			}
 		}
 
+		// maa is deprecated. see migrate_to_v2/machines.go:createMachines
+		region := vol.Region
+		if region == "maa" {
+			region = "bom"
+		}
+
 		newVol, err := m.flapsClient.CreateVolume(ctx, api.CreateVolumeRequest{
 			SourceVolumeID:      &vol.ID,
 			MachinesOnly:        api.Pointer(true),
 			Name:                vol.Name,
 			ComputeRequirements: m.machineGuests[processGroup],
+			Region:              region,
 		})
 		if err != nil && strings.HasSuffix(err.Error(), " is not a valid candidate") {
 			return fmt.Errorf("unfortunately the worker hosting your volume %s (%s) does not have capacity for another volume to support the migration; some other options: 1) try again later and there might be more space on the worker, 2) run a manual migration https://community.fly.io/t/manual-migration-to-apps-v2/11870, or 3) wait until we support volume migrations across workers (we're working on it!)", vol.ID, vol.Name)


### PR DESCRIPTION
### Change Summary

What and Why: `maa` is deprecated. machines are moved to `bom`, but if they use volumes, those are not, which prevents migration from succeeding.

How: Migrate volumes remotely from `maa` -> `bom`

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
