### PR TITLE
bluegreen: gracefully tear down blue machines

### DIFF
--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -503,7 +503,7 @@ func (bg *blueGreen) Rollback(ctx context.Context, err error) error {
 	if strings.Contains(err.Error(), ErrDestroyBlueMachines.Error()) {
 		hangingBlueMachines := lo.Keys(bg.hangingBlueMachines)
 		fmt.Fprintf(bg.io.ErrOut, "\nFailed to destroy blue machines (%s)\n", strings.Join(hangingBlueMachines, ","))
-		fmt.Fprintf(bg.io.ErrOut, "\nYou can destroy them using `fly machines destroy --force <id>`")
+		fmt.Fprintln(bg.io.ErrOut, "\nYou can destroy them using `fly machines destroy --force <id>`")
 		return nil
 	}
 

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -491,6 +491,8 @@ func (bg *blueGreen) Deploy(ctx context.Context) error {
 	fmt.Fprintf(bg.io.ErrOut, "\nDestroying all blue machines\n")
 	if err := bg.DestroyBlueMachines(ctx); err != nil {
 		return errors.Wrap(err, ErrDestroyBlueMachines.Error())
+	} else if len(bg.hangingBlueMachines) > 0 {
+		return ErrDestroyBlueMachines
 	}
 
 	fmt.Fprintf(bg.io.ErrOut, "\nDeployment Complete\n")

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -101,7 +101,7 @@ func (bg *blueGreen) CreateGreenMachines(ctx context.Context) error {
 	return nil
 }
 
-func (bg *blueGreen) renderMachineStates(state map[string]int) func() {
+func (bg *blueGreen) renderMachineStates(state map[string]int, fromState, toState string) func() {
 	firstRun := true
 
 	previousView := map[string]string{}
@@ -111,9 +111,9 @@ func (bg *blueGreen) renderMachineStates(state map[string]int) func() {
 		rows := []string{}
 		bg.stateLock.RLock()
 		for id, value := range state {
-			status := "created"
+			status := fromState
 			if value == 1 {
-				status = "started"
+				status = toState
 			}
 
 			currentView[id] = status
@@ -150,7 +150,7 @@ func (bg *blueGreen) allMachinesStarted(stateMap map[string]int) bool {
 func (bg *blueGreen) WaitForGreenMachinesToBeStarted(ctx context.Context) error {
 	wait := time.NewTicker(bg.timeout)
 	machineIDToState := map[string]int{}
-	render := bg.renderMachineStates(machineIDToState)
+	render := bg.renderMachineStates(machineIDToState, "created", "started")
 	errChan := make(chan error)
 
 	for _, gm := range bg.greenMachines {

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -136,7 +136,7 @@ func (bg *blueGreen) renderMachineStates(state map[string]int, fromState, toStat
 	}
 }
 
-func (bg *blueGreen) allMachinesStarted(stateMap map[string]int) bool {
+func (bg *blueGreen) allMachinesChangedState(stateMap map[string]int) bool {
 	started := 0
 	bg.stateLock.RLock()
 	for _, v := range stateMap {
@@ -179,7 +179,7 @@ func (bg *blueGreen) WaitForGreenMachinesToBeStarted(ctx context.Context) error 
 	}
 
 	for {
-		if bg.allMachinesStarted(machineIDToState) {
+		if bg.allMachinesChangedState(machineIDToState) {
 			return nil
 		}
 


### PR DESCRIPTION
### Change Summary

**What and Why:**

Currently blue (old) machines are torn down at the end of a blue-green deployment by force-destroying them. This gives only 5 seconds before the machine is abruptly terminated. For users who rely on an explicitly specified `kill_timeout` to allow for graceful shutdowns, this is unexpected and can break their apps (see the forum post linked below). It's also inconsistent with rolling deployments, which do respect the `kill_timeout`.

This PR implements graceful tear-down of blue machines (and fixes an existing case where the hanging-machines message isn't shown).

**How:**

This inserts two steps immediately before destroying blue machines: (1) signaling them to stop and (2) waiting for them to stop. If either step fails for a machine, it's marked as "hanging" (as is done in the existing destruction code), and it's ignored in the subsequent steps.

**Related to:**

* https://community.fly.io/t/sigterm-sent-twice-not-respecting-kill-timeout-then-virtual-machine-exited-abruptly/15720

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
