### PR TITLE
Feat/ssh/win32 poll console size completed

### DIFF
--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -186,14 +186,6 @@ func runConsole(ctx context.Context) error {
 }
 
 func Console(ctx context.Context, sshClient *ssh.Client, cmd string, allocPTY bool) error {
-	sessIO := &ssh.SessionIO{
-		Stdin:    os.Stdin,
-		Stdout:   ioutils.NewWriteCloserWrapper(colorable.NewColorableStdout(), func() error { return nil }),
-		Stderr:   ioutils.NewWriteCloserWrapper(colorable.NewColorableStderr(), func() error { return nil }),
-		AllocPTY: allocPTY,
-		TermEnv:  determineTermEnv(),
-	}
-
 	currentStdin, currentStdout, currentStderr, err := setupConsole()
 	defer func() error {
 		if err := cleanupConsole(currentStdin, currentStdout, currentStderr); err != nil {
@@ -201,6 +193,18 @@ func Console(ctx context.Context, sshClient *ssh.Client, cmd string, allocPTY bo
 		}
 		return nil
 	}()
+
+	sessIO := &ssh.SessionIO{
+		Stdin:    os.Stdin,
+		// "colorable" package should be used after the console setup performed above.
+		// Otherwise, virtual terminal emulation provided by the package will break UTF-8 encoding.
+		// If flyctl targets Windows 10+ only then we can avoid using this package at all
+		// because Windows 10+ already provides virtual terminal support.
+		Stdout:   ioutils.NewWriteCloserWrapper(colorable.NewColorableStdout(), func() error { return nil }),
+		Stderr:   ioutils.NewWriteCloserWrapper(colorable.NewColorableStderr(), func() error { return nil }),
+		AllocPTY: allocPTY,
+		TermEnv:  determineTermEnv(),
+	}
 
 	if err := sshClient.Shell(ctx, sessIO, cmd); err != nil {
 		return errors.Wrap(err, "ssh shell")

--- a/ssh/terminal_windows.go
+++ b/ssh/terminal_windows.go
@@ -11,16 +11,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func getConsoleSize(fd windows.Handle) (int, int, error) {
-	var csbi windows.ConsoleScreenBufferInfo;
-	err := windows.GetConsoleScreenBufferInfo(fd, &csbi)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	return int(csbi.Size.X), int(csbi.Size.Y), nil
-}
-
 func (s *SessionIO) getAndWatchSize(ctx context.Context, sess *ssh.Session) (int, int, error) {
 
 	// TODO(Ali): Hardcoded stdout instead of pulling it from the SessionIO because it's
@@ -73,4 +63,20 @@ func watchWindowSize(ctx context.Context, fd windows.Handle, sess *ssh.Session, 
 	}
 
 	return nil
+}
+
+func getConsoleSize(fd windows.Handle) (int, int, error) {
+	var csbi windows.ConsoleScreenBufferInfo;
+	err := windows.GetConsoleScreenBufferInfo(fd, &csbi)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// Cannot use csbi.Size here because it represents a size of
+	// the buffer (which includes scrollback) but not the size of
+	// the window. 
+	width := csbi.Window.Right - csbi.Window.Left + 1
+	height := csbi.Window.Bottom - csbi.Window.Top + 1
+
+	return int(width), int(height), nil
 }

--- a/ssh/terminal_windows.go
+++ b/ssh/terminal_windows.go
@@ -8,10 +8,39 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/term"
+	"golang.org/x/sys/windows"
 )
 
-func watchWindowSize(ctx context.Context, fd int, sess *ssh.Session) error {
+func getConsoleSize(fd windows.Handle) (int, int, error) {
+	var csbi windows.ConsoleScreenBufferInfo;
+	err := windows.GetConsoleScreenBufferInfo(fd, &csbi)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	width := csbi.Window.Right - csbi.Window.Left + 1
+	height := csbi.Window.Bottom - csbi.Window.Top + 1
+
+	return int(width), int(height), nil
+}
+
+func (s *SessionIO) getAndWatchSize(ctx context.Context, sess *ssh.Session) (int, int, error) {
+
+	// TODO(Ali): Hardcoded stdout instead of pulling it from the SessionIO because it's
+	//            wrapped in multiple wrapper types.
+	fd := windows.Stdout;
+
+	width, height, err := getConsoleSize(fd)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	go watchWindowSize(ctx, fd, sess, width, height)
+
+	return width, height, nil
+}
+
+func watchWindowSize(ctx context.Context, fd windows.Handle, sess *ssh.Session, width int, height int) error {
 
 	// NOTE(Ali): Windows doesn't support SIGWINCH. The closest it has is WINDOW_BUFFER_SIZE_EVENT,
 	// which you only seem to be able to receive if *all* of your console input is read with ReadConsoleInput.
@@ -22,11 +51,6 @@ func watchWindowSize(ctx context.Context, fd int, sess *ssh.Session) error {
 	//
 	// Because of this, we resort to the oldest trick in the book: polling! Sorry.
 
-	width, height, err := term.GetSize(fd)
-	if err != nil {
-		return err
-	}
-
 	for {
 		select {
 		case <-ctx.Done():
@@ -34,7 +58,7 @@ func watchWindowSize(ctx context.Context, fd int, sess *ssh.Session) error {
 		case <-time.After(200 * time.Millisecond):
 		}
 
-		newWidth, newHeight, err := term.GetSize(fd)
+		newWidth, newHeight, err := getConsoleSize(fd)
 		if err != nil {
 			return err
 		}

--- a/ssh/terminal_windows.go
+++ b/ssh/terminal_windows.go
@@ -18,10 +18,7 @@ func getConsoleSize(fd windows.Handle) (int, int, error) {
 		return 0, 0, err
 	}
 
-	width := csbi.Window.Right - csbi.Window.Left + 1
-	height := csbi.Window.Bottom - csbi.Window.Top + 1
-
-	return int(width), int(height), nil
+	return int(csbi.Size.X), int(csbi.Size.Y), nil
 }
 
 func (s *SessionIO) getAndWatchSize(ctx context.Context, sess *ssh.Session) (int, int, error) {


### PR DESCRIPTION
### Change Summary

What and Why:

- Completed SSH console resize support for Windows OS

How:

- By using the right console APIs on Windows
- By Implementing a workaround for a UTF-8 encoding bug caused by the https://github.com/mattn/go-colorable package that stood in the way of implementing the feature

Related to: #1458, #2726, https://github.com/superfly/flyctl/pull/2745

(Implementation is validated and tested)

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
