### PR TITLE
Fixed UTF-8 console encoding setup for Windows OS

### DIFF
--- a/internal/cli/cli_windows.go
+++ b/internal/cli/cli_windows.go
@@ -3,10 +3,14 @@ package cli
 import "golang.org/x/sys/windows"
 
 func init() {
-
 	kernel32 := windows.NewLazySystemDLL("kernel32.dll")
+
 	setConsoleCP := kernel32.NewProc("SetConsoleCP")
-	// Set codepage to UTF-8
+	// Set console input codepage to UTF-8
 	// https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers#:~:text=Unicode%20(UTF%2D7)-,65001,-utf%2D8
 	setConsoleCP.Call(uintptr(65001))
+
+	setConsoleOutputCP := kernel32.NewProc("SetConsoleOutputCP")
+	// Set console ouput codepage to UTF-8
+	setConsoleOutputCP.Call(uintptr(65001))
 }


### PR DESCRIPTION
Not only the input console encoding should be set to UTF-8 on Windows, but also the output console encoding.

### Change Summary

What and Why:

- When setting console encoding on Windows, it should be done for both input and output streams

How:

- `SetConsoleCP` Windows API function had already been used to set the input encoding
- `SetConsoleOutputCP` Windows API function is now used to set the output encoding as well

Related to: https://github.com/superfly/flyctl/pull/2726, https://github.com/superfly/flyctl/pull/2887

(Implementation is validated and tested)

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
