### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ You can run these tests by running `make test` from the `flyctl/` directory.
 
 The integration tests, called preflight, are different. They exist to test flyctl functionality on production infra, in order to make sure that entire commands and workflows don&rsquo;t break. Those are located in the `test/preflight` directory.
 
-For outside contributors, please be warned that running preflight tests creates real apps and machines and will cost real money. We already run preflight by default on all pull requests, so we recommend just opening up a draft PR instead. If you work at Fly and want to work on preflight tests, go ahead and continue reading.
+For outside contributors, **please be warned that running preflight tests creates real apps and machines and will cost real money**. We already run preflight by default on all pull requests, so we recommend just opening up a draft PR instead. If you work at Fly and want to work on preflight tests, go ahead and continue reading.
 
 Before running any preflight test, you must first set some specific environment variables. It&rsquo;s recommended to set them up using [direnv](https://direnv.net/docs/installation.html). First, copy the `.direnv/preflight-example` file to `.direnv/preflight`. Next, modify `FLY_PREFLIGHT_TEST_FLY_ORG` to an organization you make specifically for testing. Don&rsquo;t use your `personal` org. Modify `FLY_PREFLIGHT_TEST_FLY_REGIONS` to have two regions, ideally ones not the closest ones. For example, `"iad sin"`. Finally, set `FLY_PREFLIGHT_TEST_ACCESS_TOKEN` to whatever `fly auth token` outputs.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+
+
+# Development flow
+
+
+## Building
+
+To build `flyctl`, all you need to do is to run `make build` from the `flyctl/` directory. This will build a binary in the `bin/` directory. Alternatively, you can run `go build .`
+
+To run `flyctl`, you can run `go run .`, followed by whatever sub-command you want to run. So for example, to update a machine, you can run =go run . m update -a <app<sub>name</sub>> <machine<sub>id</sub>>
+
+
+## Testing
+
+We have two different kinds of tests in `flyctl`, unit tests and integration tests (preflight). It&rsquo;s recommend to write a test for any features added or bug fixes, in order to prevent regressions in the future.
+
+
+## Linting
+
+With the trifecta of the development process nearly complete, let&rsquo;s talk about linting. The linter we run is [golangci-lint](https://golangci-lint.run/). It helps with finding potential bugs in programs, as well as helping you follow standard go convetions. To run it locally, just run `golangci-lint --path-prefix=. run`.
+
+
+# Testing
+
+
+## Integration tests
+
+Unit tests are stored in individual files next to the functionality they&rsquo;re testing. For example
+
+`internal/command/secrets/parser_test.go`
+is a test for the secrets parsing code
+
+`internal/command/secrets/parser_test.go`.
+You can run these tests by running `make test` from the `flyctl/` directory.
+
+
+## Preflight
+
+The integration tests, called preflight, are different. They exist to test flyctl functionality on production infra, in order to make sure that entire commands and workflows don&rsquo;t break. Those are located in the `test/preflight` directory.
+
+For outside contributors, please be warned that running preflight tests creates real apps and machines and will cost real money. We already run preflight by default on all pull requests, so we recommend just opening up a draft PR instead. If you work at Fly and want to work on preflight tests, go ahead and continue reading.
+
+Before running any preflight test, you must first set some specific environment variables. It&rsquo;s recommended to set them up using [direnv](https://direnv.net/docs/installation.html). First, copy the `.direnv/preflight-example` file to `.direnv/preflight`. Next, modify `FLY_PREFLIGHT_TEST_FLY_ORG` to an organization you make specifically for testing. Don&rsquo;t use your `personal` org. Modify `FLY_PREFLIGHT_TEST_FLY_REGIONS` to have two regions, ideally ones not the closest ones. For example, `"iad sin"`. Finally, set `FLY_PREFLIGHT_TEST_ACCESS_TOKEN` to whatever `fly auth token` outputs.
+
+To run preflight tests, you can just run `make preflight-test`. If you want to run a specific preflight test, run `make preflight-test T=<test_name>`
+
+If you&rsquo;re trying to decide whether to write a unit test, or an integration test for your change, I recommend just writing a preflight test. They&rsquo;re usually simpler to write, and there&rsquo;s a lot more examples of how to write them.
+
+
+# Generating the GraphQL Schema
+
+As of writing this, we host our GraphQL schema on `web`, an internal repo that hosts our GQL based API. Unfortunately, that means that outside contributors can&rsquo;t updated the GraphQL schema used by `flyctl`. While there isn&rsquo;t much of a reason why you may want to do so, we&rsquo;re working on automating update the GQL schema in `flyctl`.
+
+Updating the GraphQL schema from web is a manual process at the moment. To do so, `cd` into `web/`, and run `bundle exec rails graphql:schema:idl && cp ./schema.graphql ../flyctl/gql/schema.graphql`, assuming that `flyctl/` is in the same directory as `web/`
+
+
+# Cutting a release
+
+If you have write access to this repo, you can ship a prerelease with:
+
+`scripts/bump_version.sh prerel`
+
+or a full release with:
+
+`scripts/bump_version.sh`
+
+
+# Committing to flyctl
+
+When committing to `flyctl`, there are a few important things to keep in mind:
+
+-   Keep commits small and focused, it helps greatly when reviewing larger PRs
+-   Make sure to use descriptive messages in your commit messages, since we use those to generate changelogs. It also helps future people understand why a change was made.
+-   PRs are squash merged, so please make sure to use descriptive titles
+
+
+## Examples
+
+[This is a bad example of a commit](https://github.com/superfly/flyctl/pull/1809/commits/6f167c858dbd7ae1324632dda9e29072ddde8ad7), it has a large diff and no explanation as to why this change is being made. [This is a great one](https://github.com/superfly/flyctl/commit/2636f47fe91cbe37018926cb0d7d2227a6887086), since it&rsquo;s a small commit, and it&rsquo;s reasoning as well as the context behind the change. Good commit messages also help contributors in the future to understand <span class="underline">why</span> we did something a certain way.
+
+
+# Further Go reading
+
+Go is a weird language full of a million different pitfalls. If you haven&rsquo;t already, I strongly recommend reading through these articles:
+
+-   <https://go.dev/doc/effective_go> (just a generally great resource)
+-   <https://go.dev/blog/go1.13-errors> (error wrapping specifically is useful for a lot of the functionality we use)
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,4 +85,3 @@ Go is a weird language full of a million different pitfalls. If you haven&rsquo;
 
 -   <https://go.dev/doc/effective_go> (just a generally great resource)
 -   <https://go.dev/blog/go1.13-errors> (error wrapping specifically is useful for a lot of the functionality we use)
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,21 @@
-
-
 # Development flow
 
 
 ## Building
 
-To build `flyctl`, all you need to do is to run `make build` from the `flyctl/` directory. This will build a binary in the `bin/` directory. Alternatively, you can run `go build .`
+To build `flyctl`, all you need to do is to run `make build` from the root directory. This will build a binary in the `bin/` directory. Alternatively, you can run `go build .`
 
-To run `flyctl`, you can run `go run .`, followed by whatever sub-command you want to run. So for example, to update a machine, you can run `go run . m update -a <app_name> <machine_id>`
+To run `flyctl`, you can just run the binary you built using `make build`: `./bin/flyctl`. So for example, to update a machine, you can run `go run . m update -a <app_name> <machine_id>`. Alternatively, you can build and run in the same command by running `go run .`, followed by whatever sub-command you want to run. Just note that this will have a slower startup.
 
 
 ## Testing
 
-We have two different kinds of tests in `flyctl`, unit tests and integration tests (preflight). It&rsquo;s recommend to write a test for any features added or bug fixes, in order to prevent regressions in the future.
+We have two different kinds of tests in `flyctl`, unit tests and integration tests (preflight). It's recommend to write a test for any features added or bug fixes, in order to prevent regressions in the future.
 
 
 ## Linting
 
-With the trifecta of the development process nearly complete, let&rsquo;s talk about linting. The linter we run is [golangci-lint](https://golangci-lint.run/). It helps with finding potential bugs in programs, as well as helping you follow standard go convetions. To run it locally, just run `golangci-lint --path-prefix=. run`. If you&rsquo;d like to run all of our [pre-commit lints](https://pre-commit.com/), then run `pre-commit run --all-files`
+With the trifecta of the development process nearly complete, let's talk about linting. The linter we run is [golangci-lint](https://golangci-lint.run/). It helps with finding potential bugs in programs, as well as helping you follow standard go conventions. To run it locally, just run `golangci-lint --path-prefix=. run`. If you'd like to run all of our [pre-commit lints](https://pre-commit.com/), then run `pre-commit run --all-files`
 
 
 # Testing
@@ -25,7 +23,7 @@ With the trifecta of the development process nearly complete, let&rsquo;s talk a
 
 ## Integration tests
 
-Unit tests are stored in individual files next to the functionality they&rsquo;re testing. For example
+Unit tests are stored in individual files next to the functionality they're testing. For example
 
 `internal/command/secrets/parser_test.go`
 is a test for the secrets parsing code
@@ -36,20 +34,20 @@ You can run these tests by running `make test` from the `flyctl/` directory.
 
 ## Preflight
 
-The integration tests, called preflight, are different. They exist to test flyctl functionality on production infra, in order to make sure that entire commands and workflows don&rsquo;t break. Those are located in the `test/preflight` directory.
+The integration tests, called preflight, are different. They exist to test flyctl functionality on production infra, in order to make sure that entire commands and workflows don't break. Those are located in the `test/preflight` directory.
 
 For outside contributors, **please be warned that running preflight tests creates real apps and machines and will cost real money**. We already run preflight by default on all pull requests, so we recommend just opening up a draft PR instead. If you work at Fly and want to work on preflight tests, go ahead and continue reading.
 
-Before running any preflight test, you must first set some specific environment variables. It&rsquo;s recommended to set them up using [direnv](https://direnv.net/docs/installation.html). First, copy the `.direnv/preflight-example` file to `.direnv/preflight`. Next, modify `FLY_PREFLIGHT_TEST_FLY_ORG` to an organization you make specifically for testing. Don&rsquo;t use your `personal` org. Modify `FLY_PREFLIGHT_TEST_FLY_REGIONS` to have two regions, ideally ones not the closest ones. For example, `"iad sin"`. Finally, set `FLY_PREFLIGHT_TEST_ACCESS_TOKEN` to whatever `fly auth token` outputs.
+Before running any preflight test, you must first set some specific environment variables. It's recommended to set them up using [direnv](https://direnv.net/docs/installation.html). First, copy the `.direnv/preflight-example` file to `.direnv/preflight`. Next, modify `FLY_PREFLIGHT_TEST_FLY_ORG` to an organization you make specifically for testing. Don't use your `personal` org. Modify `FLY_PREFLIGHT_TEST_FLY_REGIONS` to have two regions, ideally ones not the closest ones. For example, `"iad sin"`. Finally, set `FLY_PREFLIGHT_TEST_ACCESS_TOKEN` to whatever `fly auth token` outputs.
 
 To run preflight tests, you can just run `make preflight-test`. If you want to run a specific preflight test, run `make preflight-test T=<test_name>`
 
-If you&rsquo;re trying to decide whether to write a unit test, or an integration test for your change, I recommend just writing a preflight test. They&rsquo;re usually simpler to write, and there&rsquo;s a lot more examples of how to write them.
+If you're trying to decide whether to write a unit test, or an integration test for your change, I recommend just writing a preflight test. They're usually simpler to write, and there's a lot more examples of how to write them.
 
 
 # Generating the GraphQL Schema
 
-As of writing this, we host our GraphQL schema on `web`, an internal repo that hosts our GQL based API. Unfortunately, that means that outside contributors can&rsquo;t updated the GraphQL schema used by `flyctl`. While there isn&rsquo;t much of a reason why you may want to do so, we&rsquo;re working on automating update the GQL schema in `flyctl`.
+As of writing this, we host our GraphQL schema on `web`, an internal repo that hosts our GQL based API. Unfortunately, that means that outside contributors can't updated the GraphQL schema used by `flyctl`. While there isn't much of a reason why you may want to do so, we're working on automating update the GQL schema in `flyctl`.
 
 Updating the GraphQL schema from web is a manual process at the moment. To do so, `cd` into `web/`, and run `bundle exec rails graphql:schema:idl && cp ./schema.graphql ../flyctl/gql/schema.graphql`, assuming that `flyctl/` is in the same directory as `web/`
 
@@ -70,18 +68,18 @@ or a full release with:
 When committing to `flyctl`, there are a few important things to keep in mind:
 
 -   Keep commits small and focused, it helps greatly when reviewing larger PRs
--   Make sure to use descriptive messages in your commit messages, since we use those to generate changelogs. It also helps future people understand why a change was made.
--   PRs are squash merged, so please make sure to use descriptive titles
+-   Make sure to use descriptive messages in your commit messages, it helps future people understand why a change was made
+-   PRs are squash merged and used to generate changelogs, so please make sure to use descriptive titles
 
 
 ## Examples
 
-[This is a bad example of a commit](https://github.com/superfly/flyctl/pull/1809/commits/6f167c858dbd7ae1324632dda9e29072ddde8ad7), it has a large diff and no explanation as to why this change is being made. [This is a great one](https://github.com/superfly/flyctl/commit/2636f47fe91cbe37018926cb0d7d2227a6887086), since it&rsquo;s a small commit, and it&rsquo;s reasoning as well as the context behind the change. Good commit messages also help contributors in the future to understand <span class="underline">why</span> we did something a certain way.
+[This is a bad example of a commit](https://github.com/superfly/flyctl/pull/1809/commits/6f167c858dbd7ae1324632dda9e29072ddde8ad7), it has a large diff and no explanation as to why this change is being made. [This is a great one](https://github.com/superfly/flyctl/commit/2636f47fe91cbe37018926cb0d7d2227a6887086), since it's a small commit, and it's reasoning as well as the context behind the change. Good commit messages also help contributors in the future to understand *why* we did something a certain way.
 
 
 # Further Go reading
 
-Go is a weird language full of a million different pitfalls. If you haven&rsquo;t already, I strongly recommend reading through these articles:
+Go is a weird language full of a million different pitfalls. If you haven't already, I strongly recommend reading through these articles:
 
 -   <https://go.dev/doc/effective_go> (just a generally great resource)
 -   <https://go.dev/blog/go1.13-errors> (error wrapping specifically is useful for a lot of the functionality we use)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ We have two different kinds of tests in `flyctl`, unit tests and integration tes
 
 ## Linting
 
-With the trifecta of the development process nearly complete, let&rsquo;s talk about linting. The linter we run is [golangci-lint](https://golangci-lint.run/). It helps with finding potential bugs in programs, as well as helping you follow standard go convetions. To run it locally, just run `golangci-lint --path-prefix=. run`.
+With the trifecta of the development process nearly complete, let&rsquo;s talk about linting. The linter we run is [golangci-lint](https://golangci-lint.run/). It helps with finding potential bugs in programs, as well as helping you follow standard go convetions. To run it locally, just run `golangci-lint --path-prefix=. run`. If you&rsquo;d like to run all of our [pre-commit lints](https://pre-commit.com/), then run `pre-commit run --all-files`
 
 
 # Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,23 +5,15 @@
 
 To build `flyctl`, all you need to do is to run `make build` from the root directory. This will build a binary in the `bin/` directory. Alternatively, you can run `go build .`
 
-To run `flyctl`, you can just run the binary you built using `make build`: `./bin/flyctl`. So for example, to update a machine, you can run `./bin/flyctl m update -a <app_name> <machine_id>`. Alternatively, you can build and run in the same command by running `go run .`, followed by whatever sub-command you want to run. Just note that this will have a slower startup.
+To run `flyctl`, you can just run the binary you built using `make build`: `./bin/flyctl`. So for example, to update a machine, you can run `go run . m update -a <app_name> <machine_id>`. Alternatively, you can build and run in the same command by running `go run .`, followed by whatever sub-command you want to run. Just note that this will have a slower startup.
 
 
 ## Testing
 
-We have two different kinds of tests in `flyctl`, unit tests and integration tests (preflight). It's recommended to write a test for any features added or bug fixes, in order to prevent regressions in the future.
+We have two different kinds of tests in `flyctl`, unit tests and integration tests (preflight). It's recommend to write a test for any features added or bug fixes, in order to prevent regressions in the future.
 
 
-## Linting
-
-With the trifecta of the development process nearly complete, let's talk about linting. The linter we run is [golangci-lint](https://golangci-lint.run/). It helps with finding potential bugs in programs, as well as helping you follow standard go conventions. To run it locally, just run `golangci-lint --path-prefix=. run`. If you'd like to run all of our [pre-commit lints](https://pre-commit.com/), then run `pre-commit run --all-files`
-
-
-# Testing
-
-
-## Integration tests
+### Integration tests
 
 Unit tests are stored in individual files next to the functionality they're testing. For example
 
@@ -29,10 +21,10 @@ Unit tests are stored in individual files next to the functionality they're test
 is a test for the secrets parsing code
 
 `internal/command/secrets/parser_test.go`.
-You can run these tests by running `make test` from the `flyctl/` directory.
+You can run these tests by running `make test` from the root directory.
 
 
-## Preflight
+### Preflight
 
 The integration tests, called preflight, are different. They exist to test flyctl functionality on production infra, in order to make sure that entire commands and workflows don't break. Those are located in the `test/preflight` directory.
 
@@ -44,6 +36,11 @@ To run preflight tests, you can just run `make preflight-test`. If you want to r
 
 If you're trying to decide whether to write a unit test, or an integration test for your change, I recommend just writing a preflight test. They're usually simpler to write, and there's a lot more examples of how to write them.
 
+
+
+## Linting
+
+With the trifecta of the development process nearly complete, let's talk about linting. The linter we run is [golangci-lint](https://golangci-lint.run/). It helps with finding potential bugs in programs, as well as helping you follow standard go conventions. To run it locally, just run `golangci-lint --path-prefix=. run`. If you'd like to run all of our [pre-commit lints](https://pre-commit.com/), then run `pre-commit run --all-files`
 
 # Generating the GraphQL Schema
 
@@ -68,13 +65,13 @@ or a full release with:
 When committing to `flyctl`, there are a few important things to keep in mind:
 
 -   Keep commits small and focused, it helps greatly when reviewing larger PRs
--   Make sure to use descriptive messages in your commit messages, it helps future people understand why a change was made
--   PRs are squash merged and used to generate changelogs, so please make sure to use descriptive titles
+-   Make sure to use descriptive messages in your commit messages, it also helps future people understand why a change was made.
+-   PRs are squash merged, so please make sure to use descriptive titles
 
 
 ## Examples
 
-[This is a bad example of a commit](https://github.com/superfly/flyctl/pull/1809/commits/6f167c858dbd7ae1324632dda9e29072ddde8ad7), it has a large diff and no explanation as to why this change is being made. [This is a great one](https://github.com/superfly/flyctl/commit/2636f47fe91cbe37018926cb0d7d2227a6887086), since it's a small commit, and its reasoning as well as the context behind the change. Good commit messages also help contributors in the future to understand *why* we did something a certain way.
+[This is a bad example of a commit](https://github.com/superfly/flyctl/pull/1809/commits/6f167c858dbd7ae1324632dda9e29072ddde8ad7), it has a large diff and no explanation as to why this change is being made. [This is a great one](https://github.com/superfly/flyctl/commit/2636f47fe91cbe37018926cb0d7d2227a6887086), since it's a small commit, and it's reasoning as well as the context behind the change. Good commit messages also help contributors in the future to understand *why* we did something a certain way.
 
 
 # Further Go reading

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,12 @@
 
 To build `flyctl`, all you need to do is to run `make build` from the root directory. This will build a binary in the `bin/` directory. Alternatively, you can run `go build .`
 
-To run `flyctl`, you can just run the binary you built using `make build`: `./bin/flyctl`. So for example, to update a machine, you can run `go run . m update -a <app_name> <machine_id>`. Alternatively, you can build and run in the same command by running `go run .`, followed by whatever sub-command you want to run. Just note that this will have a slower startup.
+To run `flyctl`, you can just run the binary you built using `make build`: `./bin/flyctl`. So for example, to update a machine, you can run `./bin/flyctl m update -a <app_name> <machine_id>`. Alternatively, you can build and run in the same command by running `go run .`, followed by whatever sub-command you want to run. Just note that this will have a slower startup.
 
 
 ## Testing
 
-We have two different kinds of tests in `flyctl`, unit tests and integration tests (preflight). It's recommend to write a test for any features added or bug fixes, in order to prevent regressions in the future.
+We have two different kinds of tests in `flyctl`, unit tests and integration tests (preflight). It's recommended to write a test for any features added or bug fixes, in order to prevent regressions in the future.
 
 
 ## Linting
@@ -74,7 +74,7 @@ When committing to `flyctl`, there are a few important things to keep in mind:
 
 ## Examples
 
-[This is a bad example of a commit](https://github.com/superfly/flyctl/pull/1809/commits/6f167c858dbd7ae1324632dda9e29072ddde8ad7), it has a large diff and no explanation as to why this change is being made. [This is a great one](https://github.com/superfly/flyctl/commit/2636f47fe91cbe37018926cb0d7d2227a6887086), since it's a small commit, and it's reasoning as well as the context behind the change. Good commit messages also help contributors in the future to understand *why* we did something a certain way.
+[This is a bad example of a commit](https://github.com/superfly/flyctl/pull/1809/commits/6f167c858dbd7ae1324632dda9e29072ddde8ad7), it has a large diff and no explanation as to why this change is being made. [This is a great one](https://github.com/superfly/flyctl/commit/2636f47fe91cbe37018926cb0d7d2227a6887086), since it's a small commit, and its reasoning as well as the context behind the change. Good commit messages also help contributors in the future to understand *why* we did something a certain way.
 
 
 # Further Go reading

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 
 To build `flyctl`, all you need to do is to run `make build` from the `flyctl/` directory. This will build a binary in the `bin/` directory. Alternatively, you can run `go build .`
 
-To run `flyctl`, you can run `go run .`, followed by whatever sub-command you want to run. So for example, to update a machine, you can run =go run . m update -a <app<sub>name</sub>> <machine<sub>id</sub>>
+To run `flyctl`, you can run `go run .`, followed by whatever sub-command you want to run. So for example, to update a machine, you can run `go run . m update -a <app_name> <machine_id>`
 
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -98,42 +98,5 @@ There is a simple Powershell script, `winbuild.ps1`, which will run the code gen
 Run `scripts/build-dfly` to build a Docker image from the current branch. Then, use `scripts/dfly` to run it. This assumes you are already
 authenticated to Fly in your local environment.
 
-## Cutting a release
-
-If you have write access to this repo, you can ship a prerelease or full release with:
-
-`scripts/bump_version.sh prerel`
-
-or
-
-`scripts/bump_version.sh`
-
-## Running preflight tests
-
-A preflight suite of integration tests is located under the test/preflight/ directory. It uses a flyctl binary and runs real user scenarios, including deploying apps and dbs, and validates expected behavior.
-
-**Warning**: Real apps will be deployed that cost real money. The test fixture does its best to destroy resources it creates, but sometimes it may fail to delete a resource.
-
-The easiest way to run the preflight tests is:
-
-Copy `.direnv/preflight-example` to `.direnv/preflight` and edit following these guidelines:
-
-* Grab your auth token from `~/.fly/config.yml`
-* Do not use your "personal" org, create an new org (i.e. `flyctl-tests-YOURNAME`)
-* Set 2 regions, ideally not your closest region because it leads
-  to false positives when --region or primary region handling is buggy.
-	Run `fly platform regions` for valid ids.
-
-Finally run the tests:
-
-	make preflight-test
-
-That builds a flyctl binary (just like running `make`), then runs the preflight tests against that binary.
-
-To run a single test:
-
-```
-make preflight-test T=TestAppsV2Example
-```
-
-Oh, add more preflight tests at `tests/preflight/*`
+## Development/Contributing guide
+See [CONTRIBUTING.md](./CONTRIBUTING.mdl)

--- a/README.md
+++ b/README.md
@@ -98,5 +98,5 @@ There is a simple Powershell script, `winbuild.ps1`, which will run the code gen
 Run `scripts/build-dfly` to build a Docker image from the current branch. Then, use `scripts/dfly` to run it. This assumes you are already
 authenticated to Fly in your local environment.
 
-## Development/Contributing guide
+## Contributing guide
 See [CONTRIBUTING.md](./CONTRIBUTING.mdl)


### PR DESCRIPTION
### Change Summary

What and Why:
People new to the flyctl repo struggle to get around sometimes, so adding a file that explains basic things like building and runnning flyctl, as well as testing, creating a new release, etc. is something useful to share

How:
Create a CONTRIBUTING.md file with some relevant info on contributing to flyctl.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
