### PR TITLE
`migrate-to-v2`: finish `--force-standard-migration` for PG

### DIFF
--- a/internal/command/migrate_to_v2/machines.go
+++ b/internal/command/migrate_to_v2/machines.go
@@ -45,7 +45,9 @@ func (m *v2PlatformMigrator) createLaunchMachineInput(oldAllocID string, skipLau
 		mConfig.Metadata[api.MachineConfigMetadataKeyFlyPreviousAlloc] = oldAllocID
 	}
 
-	if m.isPostgres {
+	// Intentionally not checking m.isPostgres here because we need to support
+	// standard "app"-style migrations for PG apps
+	if m.pgConsulUrl != "" {
 		mConfig.Env["FLY_CONSUL_URL"] = m.pgConsulUrl
 		mConfig.Metadata[api.MachineConfigMetadataKeyFlyManagedPostgres] = "true"
 	}


### PR DESCRIPTION
### Change Summary

What and Why: ensures that even when `--force-standard-migration` is passed, the machines are passed the consul url from the nomad config. after this, clusters are able to successfully migrate (although it takes a minute or so of downtime when you combine vol forking, machine startup, and leader election)

This could be a viable path for people having trouble migrating.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
