### PR TITLE
Add --volume-initial-size flag to set volume sizes on first fly deploy

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -131,6 +131,11 @@ var CommonFlags = flag.Set{
 		Description: "Maximum number of machines to update concurrently when using the immediate deployment strategy.",
 		Default:     16,
 	},
+	flag.Int{
+		Name:        "volume-initial-size",
+		Description: "The initial size in GB for volumes created on first deploy",
+		Default:     1,
+	},
 	flag.VMSizeFlags,
 }
 
@@ -324,6 +329,7 @@ func deployToMachines(
 		ExcludeRegions:         excludeRegions,
 		OnlyRegions:            onlyRegions,
 		ImmediateMaxConcurrent: flag.GetInt(ctx, "immediate-max-concurrent"),
+		VolumeInitialSize:      flag.GetInt(ctx, "volume-initial-size"),
 	})
 	if err != nil {
 		sentry.CaptureExceptionWithAppInfo(err, "deploy", appCompact)

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -107,12 +107,17 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 				continue
 			}
 
-			fmt.Fprintf(md.io.Out, "Creating 1GB volume '%s' for process group '%s'. Use 'fly vol extend' to increase its size\n", m.Source, groupName)
+			fmt.Fprintf(
+				md.io.Out,
+				"Creating a %d GB volume named '%s' for process group '%s'. "+
+					"Use 'fly vol extend' to increase its size\n",
+				md.volumeInitialSize, m.Source, groupName,
+			)
 
 			input := api.CreateVolumeRequest{
 				Name:                m.Source,
 				Region:              groupConfig.PrimaryRegion,
-				SizeGb:              api.Pointer(1),
+				SizeGb:              api.Pointer(md.volumeInitialSize),
 				Encrypted:           api.Pointer(true),
 				HostDedicationId:    md.appConfig.HostDedicationID,
 				ComputeRequirements: md.machineGuest,

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -54,6 +54,7 @@ type MachineDeploymentArgs struct {
 	ExcludeRegions         map[string]interface{}
 	OnlyRegions            map[string]interface{}
 	ImmediateMaxConcurrent int
+	VolumeInitialSize      int
 }
 
 type machineDeployment struct {
@@ -87,6 +88,7 @@ type machineDeployment struct {
 	excludeRegions         map[string]interface{}
 	onlyRegions            map[string]interface{}
 	immediateMaxConcurrent int
+	volumeInitialSize      int
 }
 
 func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (MachineDeployment, error) {
@@ -147,6 +149,10 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	if immedateMaxConcurrent < 1 {
 		immedateMaxConcurrent = 1
 	}
+	volumeInitialSize := 1
+	if args.VolumeInitialSize > 0 {
+		volumeInitialSize = args.VolumeInitialSize
+	}
 
 	md := &machineDeployment{
 		apiClient:              apiClient,
@@ -172,6 +178,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		excludeRegions:         args.ExcludeRegions,
 		onlyRegions:            args.OnlyRegions,
 		immediateMaxConcurrent: immedateMaxConcurrent,
+		volumeInitialSize:      volumeInitialSize,
 	}
 	if err := md.setStrategy(); err != nil {
 		return nil, err


### PR DESCRIPTION
### Change Summary

What and Why: When deploying an app for the first time, there are some initial resources size that can't be set in fly.toml, yet we offer a way to pass them as flags (--vm-size, --vm-cpus, ...). Until now it wasn't possible to set the volume size created on first deploy and it always defaulted to 1GB.

How: Adds `fly deploy --volume-initial-size=N` 
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
