### PR TITLE
`migrate-to-v2`: run GetVolume for each vol to get attached alloc

### DIFF
--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -134,6 +134,14 @@ func (m *v2PlatformMigrator) resolveOldVolumes(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// GetVolumes doesn't return attached allocations or machines.
+	for i := range vols {
+		fullVol, err := m.flapsClient.GetVolume(ctx, vols[i].ID)
+		if err != nil {
+			return err
+		}
+		vols[i] = *fullVol
+	}
 	m.oldAttachedVolumes = lo.Filter(vols, func(v api.Volume, _ int) bool {
 		if v.AttachedAllocation != nil {
 			for _, a := range m.oldAllocs {


### PR DESCRIPTION
### Change Summary

What and Why: We stopped returning attached vms in the list-all-volumes endpoint. This works around that by calling the GetVolume endpoint on each returned volume.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
