### PR TITLE
Ensure that disagreeing to provider ToS will abort provisioning

### DIFF
--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -231,7 +231,7 @@ func AgreeToProviderTos(ctx context.Context, provider gql.ExtensionProviderData,
 	}
 
 	// Prompt the user to agree to the provider ToS
-	confirmTos, err := prompt.Confirm(ctx, fmt.Sprintf("To provision this %s, you must agree on behalf of your organization to the %s Terms Of Service at %s. Do you agree?", provider.ResourceName, provider.DisplayName, provider.TosUrl))
+	confirmTos, err := prompt.Confirm(ctx, fmt.Sprintf("To provision %s %ss, you must agree on behalf of your organization to the %s Terms Of Service at %s. Do you agree?", provider.DisplayName, provider.ResourceName, provider.DisplayName, provider.TosUrl))
 
 	if err != nil {
 		return err
@@ -242,6 +242,8 @@ func AgreeToProviderTos(ctx context.Context, provider gql.ExtensionProviderData,
 			AddOnProviderName: provider.Name,
 			OrganizationId:    org.Id,
 		})
+	} else {
+		return errors.New(fmt.Sprintf("%s provisioning stopped.", provider.DisplayName))
 	}
 
 	return err

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -243,7 +243,7 @@ func AgreeToProviderTos(ctx context.Context, provider gql.ExtensionProviderData,
 			OrganizationId:    org.Id,
 		})
 	} else {
-		return errors.New(fmt.Sprintf("%s provisioning stopped.", provider.DisplayName))
+		return fmt.Errorf("%s provisioning stopped.", provider.DisplayName)
 	}
 
 	return err


### PR DESCRIPTION
This PR fixes a bug that allowed extension provisioning to proceed even when disagreeing to terms of service.