### PR TITLE
Minor updates to some machine error message text

### DIFF
--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -182,7 +182,7 @@ func (lm *leasableMachine) WaitForState(ctx context.Context, desiredState string
 		case errors.Is(waitCtx.Err(), context.Canceled):
 			return err
 		case errors.Is(waitCtx.Err(), context.DeadlineExceeded):
-			return fmt.Errorf("timeout reached waiting for machine to %s %w", desiredState, err)
+			return fmt.Errorf("timeout reached waiting for machine to reach %s state: %w", desiredState, err)
 		case notFoundResponse && desiredState != api.MachineStateDestroyed:
 			return err
 		case !notFoundResponse && err != nil:
@@ -290,7 +290,7 @@ func (lm *leasableMachine) WaitForHealthchecksToPass(ctx context.Context, timeou
 		case errors.Is(waitCtx.Err(), context.Canceled):
 			return err
 		case errors.Is(waitCtx.Err(), context.DeadlineExceeded):
-			return fmt.Errorf("timeout reached waiting for healthchecks to pass for machine %s %w", lm.Machine().ID, err)
+			return fmt.Errorf("timeout reached waiting for health checks to pass for machine %s: %w", lm.Machine().ID, err)
 		case err != nil:
 			return fmt.Errorf("error getting machine %s from api: %w", lm.Machine().ID, err)
 		case !updateMachine.AllHealthChecks().AllPassing():
@@ -327,7 +327,7 @@ func (lm *leasableMachine) WaitForEventTypeAfterType(ctx context.Context, eventT
 		case errors.Is(waitCtx.Err(), context.Canceled):
 			return nil, err
 		case errors.Is(waitCtx.Err(), context.DeadlineExceeded):
-			return nil, fmt.Errorf("timeout reached waiting for healthchecks to pass for machine %s %w", lm.Machine().ID, err)
+			return nil, fmt.Errorf("timeout reached waiting for health checks to pass for machine %s: %w", lm.Machine().ID, err)
 		case err != nil:
 			return nil, fmt.Errorf("error getting machine %s from api: %w", lm.Machine().ID, err)
 		}

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -182,7 +182,7 @@ func (lm *leasableMachine) WaitForState(ctx context.Context, desiredState string
 		case errors.Is(waitCtx.Err(), context.Canceled):
 			return err
 		case errors.Is(waitCtx.Err(), context.DeadlineExceeded):
-			return fmt.Errorf("timeout reached waiting for machine to reach %s state: %w", desiredState, err)
+			return fmt.Errorf("timed out waiting for machine to reach %s state: %w", desiredState, err)
 		case notFoundResponse && desiredState != api.MachineStateDestroyed:
 			return err
 		case !notFoundResponse && err != nil:


### PR DESCRIPTION
### Change Summary

What and Why:

Error message example: `Error: timeout reached waiting for machine to started `, where `started` is the machine state. Updated for slightly better readability to `timed out waiting for machine to reach started state:`.

Plus a few other changes for consistency.

How:
edited error messages

Related to:
n/a

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
