### PR TITLE
Treat HostDedicationID as a compute requirement

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -38,14 +38,13 @@ type Machine struct {
 	InstanceID string `json:"instance_id,omitempty"`
 	Version    string `json:"version,omitempty"`
 	// PrivateIP is the internal 6PN address of the machine.
-	PrivateIP        string                `json:"private_ip,omitempty"`
-	CreatedAt        string                `json:"created_at,omitempty"`
-	UpdatedAt        string                `json:"updated_at,omitempty"`
-	Config           *MachineConfig        `json:"config,omitempty"`
-	Events           []*MachineEvent       `json:"events,omitempty"`
-	Checks           []*MachineCheckStatus `json:"checks,omitempty"`
-	LeaseNonce       string                `json:"nonce,omitempty"`
-	HostDedicationID string                `json:"host_dedication_id,omitempty"`
+	PrivateIP  string                `json:"private_ip,omitempty"`
+	CreatedAt  string                `json:"created_at,omitempty"`
+	UpdatedAt  string                `json:"updated_at,omitempty"`
+	Config     *MachineConfig        `json:"config,omitempty"`
+	Events     []*MachineEvent       `json:"events,omitempty"`
+	Checks     []*MachineCheckStatus `json:"checks,omitempty"`
+	LeaseNonce string                `json:"nonce,omitempty"`
 }
 
 func (m *Machine) FullImageRef() string {
@@ -319,10 +318,11 @@ type MachineMount struct {
 }
 
 type MachineGuest struct {
-	CPUKind  string `json:"cpu_kind,omitempty"`
-	CPUs     int    `json:"cpus,omitempty"`
-	MemoryMB int    `json:"memory_mb,omitempty"`
-	GPUKind  string `json:"gpu_kind,omitempty"`
+	CPUKind          string `json:"cpu_kind,omitempty"`
+	CPUs             int    `json:"cpus,omitempty"`
+	MemoryMB         int    `json:"memory_mb,omitempty"`
+	GPUKind          string `json:"gpu_kind,omitempty"`
+	HostDedicationID string `json:"host_dedication_id,omitempty"`
 
 	KernelArgs []string `json:"kernel_args,omitempty"`
 }
@@ -579,8 +579,6 @@ type MachineConfig struct {
 	VMSize string `json:"size,omitempty"`
 	// Deprecated: use Service.Autostart instead
 	DisableMachineAutostart *bool `json:"disable_machine_autostart,omitempty"`
-
-	HostDedicationId string `json:"host_dedication_id,omitempty"`
 }
 
 func (c *MachineConfig) ProcessGroup() string {
@@ -665,7 +663,6 @@ type LaunchMachineInput struct {
 	Name                    string         `json:"name,omitempty"`
 	SkipLaunch              bool           `json:"skip_launch,omitempty"`
 	SkipServiceRegistration bool           `json:"skip_service_registration,omitempty"`
-	HostDedicationID        string         `json:"host_dedication_id,omitempty"`
 	LSVD                    bool           `json:"lsvd,omitempty"`
 
 	LeaseTTL int `json:"lease_ttl,omitempty"`

--- a/api/volume_types.go
+++ b/api/volume_types.go
@@ -34,8 +34,6 @@ type CreateVolumeRequest struct {
 	SourceVolumeID *string `json:"source_volume_id"`
 
 	ComputeRequirements *MachineGuest `json:"compute"`
-
-	HostDedicationId string `json:"host_dedication_id"`
 }
 
 type VolumeSnapshot struct {

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -359,11 +359,14 @@ func makeEphemeralConsoleMachine(ctx context.Context, app *api.AppCompact, appCo
 		machConfig.Init.Entrypoint = splitted
 	}
 
+	if hdid := appConfig.HostDedicationID; hdid != "" {
+		machConfig.Guest.HostDedicationID = hdid
+	}
+
 	input := &machine.EphemeralInput{
 		LaunchInput: api.LaunchMachineInput{
-			Config:           machConfig,
-			Region:           config.FromContext(ctx).Region,
-			HostDedicationID: appConfig.HostDedicationID,
+			Config: machConfig,
+			Region: config.FromContext(ctx).Region,
 		},
 		What: "to run the console",
 	}

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -119,7 +119,6 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 				Region:              groupConfig.PrimaryRegion,
 				SizeGb:              api.Pointer(md.volumeInitialSize),
 				Encrypted:           api.Pointer(true),
-				HostDedicationId:    md.appConfig.HostDedicationID,
 				ComputeRequirements: md.machineGuest,
 			}
 

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -16,10 +16,9 @@ func (md *machineDeployment) launchInputForRestart(origMachineRaw *api.Machine) 
 	md.setMachineReleaseData(Config)
 
 	return &api.LaunchMachineInput{
-		ID:               origMachineRaw.ID,
-		Config:           Config,
-		Region:           origMachineRaw.Region,
-		HostDedicationID: md.appConfig.HostDedicationID,
+		ID:     origMachineRaw.ID,
+		Config: Config,
+		Region: origMachineRaw.Region,
 	}
 }
 
@@ -48,11 +47,14 @@ func (md *machineDeployment) launchInputForLaunch(processGroup string, guest *ap
 		mConfig.Standbys = standbyFor
 	}
 
+	if hdid := md.appConfig.HostDedicationID; hdid != "" {
+		mConfig.Guest.HostDedicationID = hdid
+	}
+
 	return &api.LaunchMachineInput{
-		Region:           region,
-		Config:           mConfig,
-		SkipLaunch:       len(standbyFor) > 0,
-		HostDedicationID: md.appConfig.HostDedicationID,
+		Region:     region,
+		Config:     mConfig,
+		SkipLaunch: len(standbyFor) > 0,
 	}, nil
 }
 
@@ -130,13 +132,17 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 		mConfig.Standbys = nil
 	}
 
+	if hdid := md.appConfig.HostDedicationID; hdid != "" && hdid != mConfig.Guest.HostDedicationID {
+		mConfig.Guest.HostDedicationID = md.appConfig.HostDedicationID
+		machineShouldBeReplaced = true
+	}
+
 	return &api.LaunchMachineInput{
 		ID:                  mID,
 		Region:              origMachineRaw.Region,
 		Config:              mConfig,
 		SkipLaunch:          len(mConfig.Standbys) > 0,
 		RequiresReplacement: machineShouldBeReplaced,
-		HostDedicationID:    md.appConfig.HostDedicationID,
 	}, nil
 }
 

--- a/internal/command/deploy/machines_releasecommand.go
+++ b/internal/command/deploy/machines_releasecommand.go
@@ -88,7 +88,7 @@ func (md *machineDeployment) runReleaseCommand(ctx context.Context) (err error) 
 // dedicatedHostIdMismatch checks if the dedicatedHostID on a machine is the same as the one set in the fly.toml
 // a mismatch will result in a delete+recreate op
 func dedicatedHostIdMismatch(m *api.Machine, ac *appconfig.Config) bool {
-	return strings.TrimSpace(ac.HostDedicationID) != "" && m.HostDedicationID != ac.HostDedicationID
+	return strings.TrimSpace(ac.HostDedicationID) != "" && m.Config.Guest.HostDedicationID != ac.HostDedicationID
 }
 
 func (md *machineDeployment) createOrUpdateReleaseCmdMachine(ctx context.Context) error {
@@ -157,10 +157,13 @@ func (md *machineDeployment) launchInputForReleaseCommand(origMachineRaw *api.Ma
 	mConfig.Image = md.img
 	md.setMachineReleaseData(mConfig)
 
+	if hdid := md.appConfig.HostDedicationID; hdid != "" {
+		mConfig.Guest.HostDedicationID = hdid
+	}
+
 	return &api.LaunchMachineInput{
-		Config:           mConfig,
-		Region:           origMachineRaw.Region,
-		HostDedicationID: md.appConfig.HostDedicationID,
+		Config: mConfig,
+		Region: origMachineRaw.Region,
 	}
 }
 

--- a/internal/command/launch/launch_frameworks.go
+++ b/internal/command/launch/launch_frameworks.go
@@ -134,20 +134,23 @@ func (state *launchState) scannerCreateVolumes(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
 	flapsClient := flaps.FromContext(ctx)
 
+	computeRequirements := state.Plan.Guest()
+	if hdid := state.appConfig.HostDedicationID; hdid != "" {
+		computeRequirements.HostDedicationID = hdid
+	}
+
 	for _, vol := range state.sourceInfo.Volumes {
 		volume, err := flapsClient.CreateVolume(ctx, api.CreateVolumeRequest{
 			Name:                vol.Source,
 			Region:              state.Plan.RegionCode,
 			SizeGb:              api.Pointer(1),
 			Encrypted:           api.Pointer(true),
-			HostDedicationId:    state.appConfig.HostDedicationID,
-			ComputeRequirements: state.Plan.Guest(),
+			ComputeRequirements: computeRequirements,
 		})
 		if err != nil {
 			return err
-		} else {
-			fmt.Fprintf(io.Out, "Created a %dGB volume %s in the %s region\n", volume.SizeGb, volume.ID, state.Plan.RegionCode)
 		}
+		fmt.Fprintf(io.Out, "Created a %dGB volume %s in the %s region\n", volume.SizeGb, volume.ID, state.Plan.RegionCode)
 	}
 	return nil
 }

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -251,7 +251,6 @@ func runMachineClone(ctx context.Context) (err error) {
 				Encrypted:           &mnt.Encrypted,
 				SnapshotID:          snapshotID,
 				RequireUniqueZone:   api.Pointer(flag.GetBool(ctx, "volume-requires-unique-zone")),
-				HostDedicationId:    source.HostDedicationID,
 				ComputeRequirements: targetConfig.Guest,
 			}
 			vol, err = flapsClient.CreateVolume(ctx, volInput)
@@ -280,11 +279,10 @@ func runMachineClone(ctx context.Context) (err error) {
 	}
 
 	input := api.LaunchMachineInput{
-		Name:             flag.GetString(ctx, "name"),
-		Region:           region,
-		Config:           targetConfig,
-		SkipLaunch:       len(targetConfig.Standbys) > 0,
-		HostDedicationID: source.HostDedicationID,
+		Name:       flag.GetString(ctx, "name"),
+		Region:     region,
+		Config:     targetConfig,
+		SkipLaunch: len(targetConfig.Standbys) > 0,
 	}
 
 	fmt.Fprintf(out, "Provisioning a new machine with image %s...\n", source.Config.Image)

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -181,9 +181,6 @@ func newRun() *cobra.Command {
 			Shorthand:   "v",
 			Description: "Volumes to mount in the form of <volume_id_or_name>:/path/inside/machine[:<options>]",
 		},
-		flag.String{
-			Name: "host-dedication-id",
-		},
 		flag.Bool{
 			Name:        "lsvd",
 			Description: "Enable LSVD for this machine",
@@ -244,10 +241,9 @@ func runMachineRun(ctx context.Context) error {
 	}
 
 	input := api.LaunchMachineInput{
-		Name:             flag.GetString(ctx, "name"),
-		Region:           flag.GetString(ctx, "region"),
-		HostDedicationID: flag.GetString(ctx, "host-dedication-id"),
-		LSVD:             flag.GetBool(ctx, "lsvd"),
+		Name:   flag.GetString(ctx, "name"),
+		Region: flag.GetString(ctx, "region"),
+		LSVD:   flag.GetBool(ctx, "lsvd"),
 	}
 
 	flapsClient, err := flaps.New(ctx, app)

--- a/internal/command/scale/machine_defaults.go
+++ b/internal/command/scale/machine_defaults.go
@@ -127,7 +127,6 @@ func (d *defaultValues) CreateVolumeRequest(mConfig *api.MachineConfig, region s
 		Encrypted:           api.Pointer(mount.Encrypted),
 		RequireUniqueZone:   api.Pointer(false),
 		SnapshotID:          d.snapshotID,
-		HostDedicationId:    mConfig.HostDedicationId,
 		ComputeRequirements: mConfig.Guest,
 	}
 }

--- a/internal/command/volumes/create.go
+++ b/internal/command/volumes/create.go
@@ -62,9 +62,6 @@ sets the size as the number of gigabytes the volume will consume.`
 			Name:        "snapshot-id",
 			Description: "Create volume from a specified snapshot",
 		},
-		flag.String{
-			Name: "host-dedication-id",
-		},
 		flag.Yes(),
 		flag.Int{
 			Name:        "count",
@@ -138,7 +135,6 @@ func runCreate(ctx context.Context) error {
 		Encrypted:           api.Pointer(!flag.GetBool(ctx, "no-encryption")),
 		RequireUniqueZone:   api.Pointer(flag.GetBool(ctx, "require-unique-zone")),
 		SnapshotID:          snapshotID,
-		HostDedicationId:    flag.GetString(ctx, "host-dedication-id"),
 		ComputeRequirements: computeRequirements,
 	}
 	out := iostreams.FromContext(ctx).Out

--- a/internal/flag/machines.go
+++ b/internal/flag/machines.go
@@ -66,6 +66,10 @@ func GetMachineGuest(ctx context.Context, guest *api.MachineGuest) (*api.Machine
 		guest.GPUKind = m
 	}
 
+	if IsSpecified(ctx, "host-dedication-id") {
+		guest.HostDedicationID = GetString(ctx, "host-dedication-id")
+	}
+
 	return guest, nil
 }
 
@@ -94,5 +98,9 @@ var VMSizeFlags = Set{
 		Description: fmt.Sprintf("If set, the GPU model to attach (%v)", strings.Join(validGPUKinds, ", ")),
 		Aliases:     []string{"vm-gpukind"},
 		Hidden:      true,
+	},
+	String{
+		Name:        "host-dedication-id",
+		Description: "The dedication id of the reserved hosts for your organization (if any)",
 	},
 }


### PR DESCRIPTION
### Change Summary

What and Why: We have a lot of cases to handle HostDedicationID when it should be treated as a compute requirement.

How: By moving it to MachineGuest type, we ensure all commands that needs to propagate the field work out without much additional work. i.e.: fly m clone, fly scale count (including volumes), fly deploy ...   

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
