### PR TITLE
`migrate-to-v2`: enable consul on non-`flyio/postgres` apps

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -314,8 +314,7 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 	leaseTimeout := 13 * time.Second
 	leaseDelayBetween := (leaseTimeout - 1*time.Second) / 3
 
-	isPostgres := appCompact.IsPostgresApp() &&
-		appFull.ImageDetails.Repository == "flyio/postgres"
+	isPostgres := appCompact.IsPostgresApp()
 
 	pgConsulUrl := ""
 	if isPostgres {
@@ -326,7 +325,7 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 		pgConsulUrl = consul.ConsulURL
 	}
 
-	if flag.GetBool(ctx, "force-standard-migration") {
+	if flag.GetBool(ctx, "force-standard-migration") || appFull.ImageDetails.Repository != "flyio/postgres" {
 		isPostgres = false
 	}
 


### PR DESCRIPTION
We reenabled consul for happy-path postgres recently, even when --force-standard-migration was passed, but forgot to add it for non-`flyio/postgres` images, which also go through the standard volapp migration path.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
