### PR TITLE
Use positional arg for cluster name for 'lfsc clusters destroy'

### DIFF
--- a/internal/command/lfsc/clusters_destroy.go
+++ b/internal/command/lfsc/clusters_destroy.go
@@ -25,11 +25,10 @@ func newClustersDestroy() *cobra.Command {
 		command.LoadAppNameIfPresentNoFlag,
 	)
 
-	cmd.Args = cobra.NoArgs
+	cmd.Args = cobra.RangeArgs(0, 1)
 
 	flag.Add(cmd,
 		urlFlag(),
-		clusterFlag(),
 		flag.Org(),
 		flag.JSONOutput(),
 	)
@@ -38,9 +37,9 @@ func newClustersDestroy() *cobra.Command {
 }
 
 func runClustersDestroy(ctx context.Context) error {
-	clusterName := flag.GetString(ctx, "cluster")
+	clusterName := flag.FirstArg(ctx)
 	if clusterName == "" {
-		return errors.New("required: --cluster NAME")
+		return errors.New("cluster name required as first argument")
 	}
 
 	lfscClient, err := newLFSCClient(ctx, "")


### PR DESCRIPTION
### Change Summary

What and Why: Changes `fly lfsc clusters destroy` command to use a positional argument for cluster name rather than a flag. This matches the functionality in `fly lfsc clusters create`.

Related to: https://github.com/superfly/flyctl/pull/2786

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
