### PR TITLE
add --snapshot-retention flag to volumes

### DIFF
--- a/api/volume_types.go
+++ b/api/volume_types.go
@@ -14,6 +14,7 @@ type Volume struct {
 	AttachedAllocation *string   `json:"attached_alloc_id"`
 	CreatedAt          time.Time `json:"created_at"`
 	HostDedicationID   string    `json:"host_dedication_id"`
+	SnapshotRetention  int       `json:"snapshot_retention"`
 }
 
 func (v Volume) IsAttached() bool {
@@ -27,6 +28,7 @@ type CreateVolumeRequest struct {
 	Encrypted         *bool  `json:"encrypted"`
 	RequireUniqueZone *bool  `json:"require_unique_zone"`
 	MachinesOnly      *bool  `json:"machines_only"`
+	SnapshotRetention *int   `json:"snapshot_retention"`
 
 	// restore from snapshot
 	SnapshotID *string `json:"snapshot_id"`
@@ -34,6 +36,10 @@ type CreateVolumeRequest struct {
 	SourceVolumeID *string `json:"source_volume_id"`
 
 	ComputeRequirements *MachineGuest `json:"compute"`
+}
+
+type UpdateVolumeRequest struct {
+	SnapshotRetention *int `json:"snapshot_retention"`
 }
 
 type VolumeSnapshot struct {

--- a/flaps/flaps_volumes.go
+++ b/flaps/flaps_volumes.go
@@ -51,6 +51,18 @@ func (f *Client) CreateVolume(ctx context.Context, req api.CreateVolumeRequest) 
 	return out, nil
 }
 
+func (f *Client) UpdateVolume(ctx context.Context, volumeId string, req api.UpdateVolumeRequest) (*api.Volume, error) {
+	updateVolumeEndpoint := fmt.Sprintf("/%s", volumeId)
+
+	out := new(api.Volume)
+
+	err := f.sendRequestVolumes(ctx, http.MethodPut, updateVolumeEndpoint, req, out, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create volume: %w", err)
+	}
+	return out, nil
+}
+
 func (f *Client) GetVolume(ctx context.Context, volumeId string) (*api.Volume, error) {
 	getVolumeEndpoint := fmt.Sprintf("/%s", volumeId)
 

--- a/flaps/flaps_volumes.go
+++ b/flaps/flaps_volumes.go
@@ -58,7 +58,7 @@ func (f *Client) UpdateVolume(ctx context.Context, volumeId string, req api.Upda
 
 	err := f.sendRequestVolumes(ctx, http.MethodPut, updateVolumeEndpoint, req, out, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create volume: %w", err)
+		return nil, fmt.Errorf("failed to update volume: %w", err)
 	}
 	return out, nil
 }

--- a/internal/command/volumes/create.go
+++ b/internal/command/volumes/create.go
@@ -48,6 +48,11 @@ func newCreate() *cobra.Command {
 			Default:     3,
 			Description: "The size of volume in gigabytes. The default is 3.",
 		},
+		flag.Int{
+			Name:        "snapshot-retention",
+			Default:     5,
+			Description: "Snapshot retention in days (min 5)",
+		},
 		flag.Bool{
 			Name:        "no-encryption",
 			Description: "Do not encrypt the volume contents. Volume contents are encrypted by default.",
@@ -136,6 +141,7 @@ func runCreate(ctx context.Context) error {
 		RequireUniqueZone:   api.Pointer(flag.GetBool(ctx, "require-unique-zone")),
 		SnapshotID:          snapshotID,
 		ComputeRequirements: computeRequirements,
+		SnapshotRetention:   api.Pointer(flag.GetInt(ctx, "snapshot-retention")),
 	}
 	out := iostreams.FromContext(ctx).Out
 	for i := 0; i < count; i++ {

--- a/internal/command/volumes/update.go
+++ b/internal/command/volumes/update.go
@@ -1,0 +1,115 @@
+package volumes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/iostreams"
+
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/render"
+)
+
+func newUpdate() *cobra.Command {
+	const (
+		short = "Update a volume for an app."
+
+		long = short + ` Volumes are persistent storage for
+		Fly Machines. The default size is 3 GB. Learn how to add a volume to
+		your app: https://fly.io/docs/apps/volume-storage/`
+
+		usage = "update <volumename>"
+	)
+
+	cmd := command.New(usage, short, long, runUpdate,
+		command.RequireSession,
+		command.RequireAppName,
+	)
+
+	cmd.Args = cobra.ExactArgs(1)
+
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+		flag.Int{
+			Name:        "snapshot-retention",
+			Description: "Snapshot retention in days (min 5)",
+		},
+	)
+
+	flag.Add(cmd, flag.JSONOutput())
+	return cmd
+}
+
+func runUpdate(ctx context.Context) error {
+	var (
+		cfg      = config.FromContext(ctx)
+		client   = client.FromContext(ctx).API()
+		volumeID = flag.FirstArg(ctx)
+		// count      = flag.GetInt(ctx, "count")
+	)
+
+	appName := appconfig.NameFromContext(ctx)
+	if volumeID == "" && appName == "" {
+		return fmt.Errorf("volume ID or app required")
+	}
+
+	if appName == "" {
+		n, err := client.GetAppNameFromVolume(ctx, volumeID)
+		if err != nil {
+			return err
+		}
+		appName = *n
+	}
+
+	flapsClient, err := flaps.NewFromAppName(ctx, appName)
+	if err != nil {
+		return err
+	}
+
+	var volume *api.Volume
+	if volumeID == "" {
+		app, err := client.GetApp(ctx, appName)
+		if err != nil {
+			return err
+		}
+		volume, err = selectVolume(ctx, flapsClient, app)
+		if err != nil {
+			return err
+		}
+	} else {
+		volume, err = flapsClient.GetVolume(ctx, volumeID)
+		if err != nil {
+			return fmt.Errorf("failed retrieving volume: %w", err)
+		}
+	}
+
+	var snapshotRetention *int
+	if flag.GetInt(ctx, "snapshot-retention") != 0 {
+		snapshotRetention = api.Pointer(flag.GetInt(ctx, "snapshot-retention"))
+	}
+
+	out := iostreams.FromContext(ctx).Out
+	input := api.UpdateVolumeRequest{
+		SnapshotRetention: snapshotRetention,
+	}
+
+	updatedVolume, err := flapsClient.UpdateVolume(ctx, volume.ID, input)
+	if err != nil {
+		return fmt.Errorf("failed updating volume: %w", err)
+	}
+
+	if cfg.JSONOutput {
+		return render.JSON(out, updatedVolume)
+	}
+
+	return printVolume(out, updatedVolume, appName)
+}

--- a/internal/command/volumes/update.go
+++ b/internal/command/volumes/update.go
@@ -23,7 +23,7 @@ func newUpdate() *cobra.Command {
 		short = "Update a volume for an app."
 
 		long = short + ` Volumes are persistent storage for
-		Fly Machines. The default size is 3 GB. Learn how to add a volume to
+		Fly Machines. Learn how to add a volume to
 		your app: https://fly.io/docs/apps/volume-storage/`
 
 		usage = "update <volumename>"
@@ -54,7 +54,6 @@ func runUpdate(ctx context.Context) error {
 		cfg      = config.FromContext(ctx)
 		client   = client.FromContext(ctx).API()
 		volumeID = flag.FirstArg(ctx)
-		// count      = flag.GetInt(ctx, "count")
 	)
 
 	appName := appconfig.NameFromContext(ctx)
@@ -75,23 +74,6 @@ func runUpdate(ctx context.Context) error {
 		return err
 	}
 
-	var volume *api.Volume
-	if volumeID == "" {
-		app, err := client.GetApp(ctx, appName)
-		if err != nil {
-			return err
-		}
-		volume, err = selectVolume(ctx, flapsClient, app)
-		if err != nil {
-			return err
-		}
-	} else {
-		volume, err = flapsClient.GetVolume(ctx, volumeID)
-		if err != nil {
-			return fmt.Errorf("failed retrieving volume: %w", err)
-		}
-	}
-
 	var snapshotRetention *int
 	if flag.GetInt(ctx, "snapshot-retention") != 0 {
 		snapshotRetention = api.Pointer(flag.GetInt(ctx, "snapshot-retention"))
@@ -102,7 +84,7 @@ func runUpdate(ctx context.Context) error {
 		SnapshotRetention: snapshotRetention,
 	}
 
-	updatedVolume, err := flapsClient.UpdateVolume(ctx, volume.ID, input)
+	updatedVolume, err := flapsClient.UpdateVolume(ctx, volumeID, input)
 	if err != nil {
 		return fmt.Errorf("failed updating volume: %w", err)
 	}

--- a/internal/command/volumes/volumes.go
+++ b/internal/command/volumes/volumes.go
@@ -39,6 +39,7 @@ func New() *cobra.Command {
 
 	cmd.AddCommand(
 		newCreate(),
+		newUpdate(),
 		newList(),
 		newDestroy(),
 		newExtend(),
@@ -54,14 +55,15 @@ func New() *cobra.Command {
 func printVolume(w io.Writer, vol *api.Volume, appName string) error {
 	var buf bytes.Buffer
 
-	fmt.Fprintf(&buf, "%10s: %s\n", "ID", vol.ID)
-	fmt.Fprintf(&buf, "%10s: %s\n", "Name", vol.Name)
-	fmt.Fprintf(&buf, "%10s: %s\n", "App", appName)
-	fmt.Fprintf(&buf, "%10s: %s\n", "Region", vol.Region)
-	fmt.Fprintf(&buf, "%10s: %s\n", "Zone", vol.Zone)
-	fmt.Fprintf(&buf, "%10s: %d\n", "Size GB", vol.SizeGb)
-	fmt.Fprintf(&buf, "%10s: %t\n", "Encrypted", vol.Encrypted)
-	fmt.Fprintf(&buf, "%10s: %s\n", "Created at", vol.CreatedAt.Format(time.RFC822))
+	fmt.Fprintf(&buf, "%20s: %s\n", "ID", vol.ID)
+	fmt.Fprintf(&buf, "%20s: %s\n", "Name", vol.Name)
+	fmt.Fprintf(&buf, "%20s: %s\n", "App", appName)
+	fmt.Fprintf(&buf, "%20s: %s\n", "Region", vol.Region)
+	fmt.Fprintf(&buf, "%20s: %s\n", "Zone", vol.Zone)
+	fmt.Fprintf(&buf, "%20s: %d\n", "Size GB", vol.SizeGb)
+	fmt.Fprintf(&buf, "%20s: %t\n", "Encrypted", vol.Encrypted)
+	fmt.Fprintf(&buf, "%20s: %s\n", "Created at", vol.CreatedAt.Format(time.RFC822))
+	fmt.Fprintf(&buf, "%20s: %d\n", "Snapshot retention", vol.SnapshotRetention)
 
 	_, err := buf.WriteTo(w)
 


### PR DESCRIPTION
### Change Summary

What and Why: add `--snapshot-retention` to volume create and add vol update command with that same flag

How: added a few cobra commands

Related to: internal PRs in internal repos, need to be merged after them

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
