### PR TITLE
Fix image reference construction

### DIFF
--- a/internal/command/status/machines.go
+++ b/internal/command/status/machines.go
@@ -284,8 +284,7 @@ func renderPGStatus(ctx context.Context, app *api.AppCompact, machines []*api.Ma
 	var updatable []*api.Machine
 
 	for _, machine := range machines {
-		image := fmt.Sprintf("%s:%s", machine.ImageRef.Repository, machine.ImageRef.Tag)
-
+		image := machine.FullImageRef()
 		latestImage, err := client.GetLatestImageDetails(ctx, image)
 
 		if err != nil && strings.Contains(err.Error(), "Unknown repository") {


### PR DESCRIPTION
### Change Summary
Fixes bug that fails to construct a proper image reference when the tag is absent. 


