### PR TITLE
Feat/conc deploy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/pkg/sftp v1.13.6
 	github.com/samber/lo v1.38.1
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
+	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.17.0
@@ -153,7 +154,6 @@ require (
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/skeema/knownhosts v1.2.0 // indirect
-	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/superfly/ltx v0.3.12 // indirect
 	github.com/vbatts/tar-split v0.11.3 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Khan/genqlient/graphql"
@@ -83,7 +84,7 @@ type machineDeployment struct {
 	isFirstDeploy          bool
 	machineGuest           *api.MachineGuest
 	increasedAvailability  bool
-	listenAddressChecked   map[string]struct{}
+	listenAddressChecked   sync.Map
 	updateOnly             bool
 	excludeRegions         map[string]interface{}
 	onlyRegions            map[string]interface{}
@@ -172,7 +173,6 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		leaseDelayBetween:      leaseDelayBetween,
 		releaseCmdTimeout:      args.ReleaseCmdTimeout,
 		increasedAvailability:  args.IncreasedAvailability,
-		listenAddressChecked:   make(map[string]struct{}),
 		updateOnly:             args.UpdateOnly,
 		machineGuest:           args.Guest,
 		excludeRegions:         args.ExcludeRegions,

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -705,10 +705,9 @@ func (md *machineDeployment) warnAboutProcessGroupChanges(ctx context.Context, d
 func (md *machineDeployment) warnAboutIncorrectListenAddress(ctx context.Context, lm machine.LeasableMachine) {
 	group := lm.Machine().ProcessGroup()
 
-	if _, ok := md.listenAddressChecked[group]; ok {
+	if _, seen := md.listenAddressChecked.LoadOrStore(group, struct{}{}); seen {
 		return
 	}
-	md.listenAddressChecked[group] = struct{}{}
 
 	groupConfig, err := md.appConfig.Flatten(group)
 	if err != nil {


### PR DESCRIPTION
### Change Summary

Current rolling deploy strategy uses a batching mechanism that pause until the whole batch is done before continuing with the next one. This approach was an huge improvement over the original and very slow sequential and one-at-a-time update before it, but it still feels slow for apps with 10+ machines. Also current batch base implementation doesn't consider process groups and it could take a whole group down if it fits in a batch.

This PR implements true concurrent updates respecting the max unavailable setting at any time and doing it per process group.

Related to: https://github.com/superfly/flyctl/pull/2679

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
