### PR TITLE
Add support for `error` status when provisioning extensions.

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -19,6 +19,8 @@ type AddOnData struct {
 	PrimaryRegion string `json:"primaryRegion"`
 	// Status of the add-on
 	Status string `json:"status"`
+	// Optional error message when `status` is `error`
+	ErrorMessage string `json:"errorMessage"`
 }
 
 // GetId returns AddOnData.Id, and is useful for accessing the field via an interface.
@@ -32,6 +34,9 @@ func (v *AddOnData) GetPrimaryRegion() string { return v.PrimaryRegion }
 
 // GetStatus returns AddOnData.Status, and is useful for accessing the field via an interface.
 func (v *AddOnData) GetStatus() string { return v.Status }
+
+// GetErrorMessage returns AddOnData.ErrorMessage, and is useful for accessing the field via an interface.
+func (v *AddOnData) GetErrorMessage() string { return v.ErrorMessage }
 
 type AddOnType string
 
@@ -1418,6 +1423,9 @@ func (v *GetAddOnAddOn) GetId() string { return v.AddOnData.Id }
 // GetName returns GetAddOnAddOn.Name, and is useful for accessing the field via an interface.
 func (v *GetAddOnAddOn) GetName() string { return v.AddOnData.Name }
 
+// GetErrorMessage returns GetAddOnAddOn.ErrorMessage, and is useful for accessing the field via an interface.
+func (v *GetAddOnAddOn) GetErrorMessage() string { return v.AddOnData.ErrorMessage }
+
 func (v *GetAddOnAddOn) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -1469,6 +1477,8 @@ type __premarshalGetAddOnAddOn struct {
 	Id string `json:"id"`
 
 	Name string `json:"name"`
+
+	ErrorMessage string `json:"errorMessage"`
 }
 
 func (v *GetAddOnAddOn) MarshalJSON() ([]byte, error) {
@@ -1495,6 +1505,7 @@ func (v *GetAddOnAddOn) __premarshalJSON() (*__premarshalGetAddOnAddOn, error) {
 	retval.AddOnPlan = v.AddOnPlan
 	retval.Id = v.AddOnData.Id
 	retval.Name = v.AddOnData.Name
+	retval.ErrorMessage = v.AddOnData.ErrorMessage
 	return &retval, nil
 }
 
@@ -2029,6 +2040,11 @@ func (v *GetAppWithAddonsAppAddOnsAddOnConnectionNodesAddOn) GetStatus() string 
 	return v.AddOnData.Status
 }
 
+// GetErrorMessage returns GetAppWithAddonsAppAddOnsAddOnConnectionNodesAddOn.ErrorMessage, and is useful for accessing the field via an interface.
+func (v *GetAppWithAddonsAppAddOnsAddOnConnectionNodesAddOn) GetErrorMessage() string {
+	return v.AddOnData.ErrorMessage
+}
+
 func (v *GetAppWithAddonsAppAddOnsAddOnConnectionNodesAddOn) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -2062,6 +2078,8 @@ type __premarshalGetAppWithAddonsAppAddOnsAddOnConnectionNodesAddOn struct {
 	PrimaryRegion string `json:"primaryRegion"`
 
 	Status string `json:"status"`
+
+	ErrorMessage string `json:"errorMessage"`
 }
 
 func (v *GetAppWithAddonsAppAddOnsAddOnConnectionNodesAddOn) MarshalJSON() ([]byte, error) {
@@ -2079,6 +2097,7 @@ func (v *GetAppWithAddonsAppAddOnsAddOnConnectionNodesAddOn) __premarshalJSON() 
 	retval.Name = v.AddOnData.Name
 	retval.PrimaryRegion = v.AddOnData.PrimaryRegion
 	retval.Status = v.AddOnData.Status
+	retval.ErrorMessage = v.AddOnData.ErrorMessage
 	return &retval, nil
 }
 
@@ -4020,6 +4039,7 @@ fragment AddOnData on AddOn {
 	name
 	primaryRegion
 	status
+	errorMessage
 }
 fragment AppData on App {
 	id
@@ -4239,6 +4259,7 @@ fragment AddOnData on AddOn {
 	name
 	primaryRegion
 	status
+	errorMessage
 }
 fragment OrganizationData on Organization {
 	id

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -29,6 +29,7 @@ fragment AddOnData on AddOn {
 	name
 	primaryRegion
 	status
+	errorMessage
 }
 
 mutation CreateAddOn($input: CreateAddOnInput!) {

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -141,10 +141,20 @@ type AddOn implements Node {
   environment: JSON
 
   """
+  Optional error message when `status` is `error`
+  """
+  errorMessage: String
+
+  """
   DNS hostname for the add-on
   """
   hostname: String
   id: ID!
+
+  """
+  Add-on metadata
+  """
+  metadata: JSON
 
   """
   The service name according to the provider
@@ -1569,7 +1579,7 @@ input BuildMachineInput {
   config: JSON!
 
   """
-  id of host dedication
+  [deprecated]
   """
   dedicationId: String
 
@@ -1680,7 +1690,7 @@ input BuildVolumeInput {
   computeRequirements: JSON
 
   """
-  id of host dedication
+  [deprecated]
   """
   dedicationId: String
 
@@ -10709,6 +10719,10 @@ type User implements Node & Principal {
   """
   email: String!
   emailVerified: Boolean!
+
+  """
+  Whether to create new organizations under Hobby plan
+  """
   enablePaidHobby: Boolean!
   featureFlags: [String!]!
   hasNodeproxyApps: Boolean!

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -273,9 +273,11 @@ func WaitForProvision(ctx context.Context, name string) error {
 		}
 
 		if resp.AddOn.Status == "error" {
-			// TODO: Update with `ErrorMessage` when
-			// https://github.com/superfly/web/pull/2428 lands.
-			return errors.New("provisioning failed")
+			if resp.AddOn.ErrorMessage != "" {
+				return errors.New(resp.AddOn.ErrorMessage)
+			} else {
+				return errors.New("provisioning failed")
+			}
 		}
 
 		if resp.AddOn.Status == "ready" {

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -272,6 +272,12 @@ func WaitForProvision(ctx context.Context, name string) error {
 			return err
 		}
 
+		if resp.AddOn.Status == "error" {
+			// TODO: Update with `ErrorMessage` when
+			// https://github.com/superfly/web/pull/2428 lands.
+			return errors.New("provisioning failed")
+		}
+
 		if resp.AddOn.Status == "ready" {
 			return nil
 		}


### PR DESCRIPTION
### Change Summary

Extensions currently have no way to report errors when running provisioning steps outside the request/response cycle (E.g. in a sidekiq job.)

This adds an implicit "error" status with a currently stock error message. When support lands in web, the generic error message can be replaced with a deployment-specific error.

Related to: https://github.com/superfly/web/pull/2428

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
