### PR TITLE
Fix version parsing for branches with dots in name

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -259,7 +259,11 @@ func Parse(version string) (Version, error) {
 			parts = strings.SplitN(suffixStr, "-", 2)
 		} else {
 			// handle new calver format, which separates channel and build with a dot
-			parts = strings.SplitN(suffixStr, ".", 2)
+			if pos := strings.LastIndex(suffixStr, "."); pos >= 0 {
+				parts = []string{suffixStr[:pos], suffixStr[pos+1:]}
+			} else {
+				parts = []string{suffixStr}
+			}
 		}
 
 		out.Channel = parts[0]

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -52,6 +52,8 @@ func TestEncode(t *testing.T) {
 		"2023.10.5-some-branch+gitsha-dirty":     {2023, 10, 5, 0, "some-branch", "gitsha-dirty"},
 		"2023.10.5-some-branch+123-gitsha":       {2023, 10, 5, 0, "some-branch", "123-gitsha"},
 		"2023.10.5-some-branch+123-gitsha-dirty": {2023, 10, 5, 0, "some-branch", "123-gitsha-dirty"},
+
+		"2023.10.23-dependabot/go_modules/nhooyr.io/websocket-1.8.9.1698092436": {2023, 10, 23, 1698092436, "dependabot/go_modules/nhooyr.io/websocket-1.8.9", ""},
 	}
 
 	for vString, vStruct := range cases {


### PR DESCRIPTION
### Change Summary

versions parsing fails for branch names with dots
```
Error: can't establish agent: invalid version "2023.10.23-dependabot/go_modules/nhooyr.io/websocket-1.8.9.1698092436": strconv.Atoi: parsing "io/websocket-1.8.9.1698092436": invalid syntax
```
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
