### PR TITLE
add a --shell argument to `flyctl m run`

### DIFF
--- a/internal/command/apps/list.go
+++ b/internal/command/apps/list.go
@@ -3,6 +3,7 @@ package apps
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -64,11 +65,17 @@ func runList(ctx context.Context) (err error) {
 		return
 	}
 
+	var verbose = flag.GetBool(ctx, "verbose")
+
 	rows := make([][]string, 0, len(apps))
 	for _, app := range apps {
 		latestDeploy := ""
 		if app.Deployed && app.CurrentRelease != nil {
 			latestDeploy = format.RelativeTime(app.CurrentRelease.CreatedAt)
+		}
+
+		if !verbose && strings.HasPrefix(app.Name, "flyctl-interactive-shells-") {
+			app.Name = "(interactive shells app)"
 		}
 
 		rows = append(rows, []string{

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -221,11 +221,6 @@ func newRun() *cobra.Command {
 			Description: "Enable LSVD for this machine",
 			Hidden:      true,
 		},
-		flag.Bool{
-			Name:        "it",
-			Description: "Open a shell on the machine once created",
-			Hidden:      false,
-		},
 		flag.String{
 			Name:        "user",
 			Description: "Username, if we're shelling into the machine now.",
@@ -260,14 +255,13 @@ func runMachineRun(ctx context.Context) error {
 		colorize = io.ColorScheme()
 		err      error
 		app      *api.AppCompact
-		interact = flag.GetBool(ctx, "it")
+		interact = false
 		shell    = flag.GetBool(ctx, "shell")
 		destroy  = flag.GetBool(ctx, "rm")
 	)
 
 	if shell {
 		destroy = true
-		appName = ""
 		interact = true
 	}
 

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -338,6 +338,7 @@ func runMachineRun(ctx context.Context) error {
 		imageOrPath:        imageOrPath,
 		region:             input.Region,
 		updating:           false,
+		interact:           true,
 	})
 	if err != nil {
 		return err
@@ -544,9 +545,12 @@ type determineMachineConfigInput struct {
 	imageOrPath        string
 	region             string
 	updating           bool
+	interact           bool
 }
 
-func determineMachineConfig(ctx context.Context, input *determineMachineConfigInput) (*api.MachineConfig, error) {
+func determineMachineConfig(
+	ctx context.Context,
+	input *determineMachineConfigInput) (*api.MachineConfig, error) {
 	machineConf := mach.CloneConfig(&input.initialMachineConf)
 
 	var err error
@@ -588,6 +592,10 @@ func determineMachineConfig(ctx context.Context, input *determineMachineConfigIn
 	} else {
 		// Called from `run`. Command is specified by arguments.
 		machineConf.Init.Cmd = flag.Args(ctx)[1:]
+	}
+
+	if input.interact {
+		machineConf.Init.Exec = []string{"/bin/sleep", "inf"}
 	}
 
 	if flag.IsSpecified(ctx, "skip-dns-registration") {

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -222,7 +222,7 @@ func newRun() *cobra.Command {
 		},
 		flag.Bool{
 			Name:        "it",
-			Description: "Open a shell on the machine once run",
+			Description: "Open a shell on the machine once created",
 			Hidden:      false,
 		},
 		flag.String{
@@ -239,7 +239,7 @@ func newRun() *cobra.Command {
 		},
 		flag.Bool{
 			Name:        "shell",
-			Description: "Open a shell on the machine once run (implies --it --rm --org)",
+			Description: "Open a shell on the machine once created (implies --it --rm)",
 			Hidden:      false,
 		},
 


### PR DESCRIPTION
### Change Summary

What and Why:

There's `flyctl console`, but it requires an existing app, which is more than you sometimes want to do to just pop a shell inside an org somewhere. There's `fly m run`, but it doesn't immediately launch a shell. Two great tastes.

How:

Add "shell", "user", and "command". If you don't specify an app name, we'll create a random one without prompting. 

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
