### PR TITLE
Launch V2: validate app names, add errors that can be recovered by going into web UI

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -149,9 +149,10 @@ func run(ctx context.Context) (err error) {
 
 		launchManifest, cache, err = buildManifest(ctx, canEnterUi)
 		if err != nil {
-			if errors.Is(err, recoverableInUiError{}) && canEnterUi {
+			var recoverableErr recoverableInUiError
+			if errors.As(err, &recoverableErr) && canEnterUi {
 				fmt.Fprintln(io.ErrOut, "The following problems must be fixed in the Launch UI:")
-				fmt.Fprintln(io.ErrOut, err.Error())
+				fmt.Fprintln(io.ErrOut, recoverableErr.Error())
 				incompleteLaunchManifest = true
 				err = nil
 			} else {

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -154,7 +154,6 @@ func run(ctx context.Context) (err error) {
 				fmt.Fprintln(io.ErrOut, "The following problems must be fixed in the Launch UI:")
 				fmt.Fprintln(io.ErrOut, recoverableErr.Error())
 				incompleteLaunchManifest = true
-				err = nil
 			} else {
 				return err
 			}

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/deploy"
@@ -141,11 +142,21 @@ func run(ctx context.Context) (err error) {
 		return err
 	}
 
+	requireUi := false
+	canEnterUi := !flag.GetBool(ctx, "manifest")
+
 	if launchManifest == nil {
 
-		launchManifest, cache, err = buildManifest(ctx)
+		launchManifest, cache, err = buildManifest(ctx, canEnterUi)
 		if err != nil {
-			return err
+			if errors.Is(err, recoverableInUiError{}) && canEnterUi {
+				fmt.Fprintln(io.ErrOut, "The following problems must be fixed in the Launch UI:")
+				fmt.Fprintln(io.ErrOut, err.Error())
+				requireUi = true
+				err = nil
+			} else {
+				return err
+			}
 		}
 
 		if flag.GetBool(ctx, "manifest") {
@@ -179,7 +190,11 @@ func run(ctx context.Context) (err error) {
 
 	confirm := false
 	prompt := &survey.Confirm{
-		Message: "Do you want to tweak these settings before proceeding?",
+		Message: lo.Ternary(
+			requireUi,
+			"Would you like to continue in the web UI?",
+			"Do you want to tweak these settings before proceeding?",
+		),
 	}
 	err = survey.AskOne(prompt, &confirm)
 	if err != nil {
@@ -192,6 +207,9 @@ func run(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
+	}
+	if requireUi {
+		return errors.New("launch can not continue with errors present")
 	}
 
 	err = state.Launch(ctx)

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -490,12 +490,13 @@ func getRegionByCode(ctx context.Context, regionCode string) (*api.Region, error
 // determineGuest returns the guest type to use for a new app.
 // Currently, it defaults to shared-cpu-1x
 func determineGuest(ctx context.Context, config *appconfig.Config, srcInfo *scanner.SourceInfo) (*api.MachineGuest, string, error) {
-	def := api.MachinePresets["shared-cpu-1x"]
+	def := helpers.Clone(api.MachinePresets["shared-cpu-1x"])
+	def.MemoryMB = 1024
 	reason := "most apps need about 1GB of RAM"
 
 	guest, err := flag.GetMachineGuest(ctx, helpers.Clone(def))
 	if err != nil {
-		return helpers.Clone(def), recoverableSpecifyInUi, recoverableInUiError{err}
+		return def, recoverableSpecifyInUi, recoverableInUiError{err}
 	}
 
 	if def.CPUs != guest.CPUs || def.CPUKind != guest.CPUKind || def.MemoryMB != guest.MemoryMB {

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -330,9 +330,9 @@ func determineBaseAppConfig(ctx context.Context) (*appconfig.Config, bool, error
 	return newCfg, false, nil
 }
 
-// App names must consist of only lowercase letters, numbers, and underscores.
+// App names must consist of only lowercase letters, numbers, and dashes.
 // Non-ascii characters are removed.
-// Special characters are replaced with underscores, and sequences of underscores are collapsed into one.
+// Special characters are replaced with dashes, and sequences of dashes are collapsed into one.
 func sanitizeAppName(dirName string) string {
 	sanitized := make([]rune, 0, len(dirName))
 	lastIsUnderscore := false
@@ -343,7 +343,7 @@ func sanitizeAppName(dirName string) string {
 		}
 		if !unicode.IsLetter(c) && !unicode.IsNumber(c) {
 			if !lastIsUnderscore {
-				sanitized = append(sanitized, '_')
+				sanitized = append(sanitized, '-')
 				lastIsUnderscore = true
 			}
 		} else {
@@ -351,13 +351,13 @@ func sanitizeAppName(dirName string) string {
 			lastIsUnderscore = false
 		}
 	}
-	return string(sanitized)
+	return strings.Trim(string(sanitized), "-")
 }
 
 func validateAppName(appName string) error {
-	failRegex := regexp.MustCompile("[^a-z0-9_]")
+	failRegex := regexp.MustCompile(`[^a-z0-9\-]`)
 	if failRegex.MatchString(appName) {
-		return errors.New("app name must consist of only lowercase letters, numbers, and underscores")
+		return errors.New("app name must consist of only lowercase letters, numbers, and dashes")
 	}
 	return nil
 }

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -495,7 +495,7 @@ func determineGuest(ctx context.Context, config *appconfig.Config, srcInfo *scan
 
 	guest, err := flag.GetMachineGuest(ctx, helpers.Clone(def))
 	if err != nil {
-		return helpers.Clone(def), recoverableSpecifyInUi, err
+		return helpers.Clone(def), recoverableSpecifyInUi, recoverableInUiError{err}
 	}
 
 	if def.CPUs != guest.CPUs || def.CPUKind != guest.CPUKind || def.MemoryMB != guest.MemoryMB {

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -46,6 +46,9 @@ func (e recoverableInUiError) Unwrap() error {
 	return e.base
 }
 
+// state.go uses this as a sentinel value to indicate that a value was not specified,
+// and should therefore be displayed as <unspecified> in the plan display.
+// I'd like to move off this in the future, but this is the quick 'n dirty initial path
 const recoverableSpecifyInUi = "must be specified in UI"
 
 // Cache values between buildManifest and stateFromManifest

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -115,6 +115,12 @@ func (state *launchState) PlanSummary(ctx context.Context) (string, error) {
 		{"Redis", redisStr, state.PlanSource.redisSource},
 	}
 
+	for _, row := range rows {
+		if row[2] == recoverableSpecifyInUi {
+			row[1] = "<unspecified>"
+		}
+	}
+
 	colLengths := []int{0, 0, 0}
 	for _, row := range rows {
 		for i, col := range row {

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -116,6 +116,9 @@ func (state *launchState) PlanSummary(ctx context.Context) (string, error) {
 	}
 
 	for _, row := range rows {
+		// TODO: This is a hack. It'd be nice to not require a special sentinel value for the description,
+		//       but it works OK for now. I'd special-case on value=="" instead, but that isn't *necessarily*
+		//       a failure case for every field.
 		if row[2] == recoverableSpecifyInUi {
 			row[1] = "<unspecified>"
 		}


### PR DESCRIPTION
### Change Summary

What and Why:
 * Sanitizes initial app names, lowercasing ascii characters, replacing special characters with dashes (collapsed dashes, so you don't get multiple at a time), and removing non-ascii characters
 * Validates app names passed via `--name`
 * Adds `recoverableInUiError`, a wrapper type for an error that indicates that the error can be corrected in the Web UI, so that naming validation failures funnel users towards correcting the problem instead of yelling at them
 * Add recovery conditions for many failure modes of Launch, such as invalid app name, org, guest, or region.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
