### PR TITLE
Make Launch v2 the default 🎉

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -188,21 +188,23 @@ func run(ctx context.Context) (err error) {
 		summary,
 	)
 
-	confirm := false
-	prompt := &survey.Confirm{
-		Message: lo.Ternary(
-			incompleteLaunchManifest,
-			"Would you like to continue in the web UI?",
-			"Do you want to tweak these settings before proceeding?",
-		),
-	}
-	err = survey.AskOne(prompt, &confirm)
-	if err != nil {
-		// TODO(allison): This should probably not just return the error
-		return err
+	editInUi := false
+	if io.IsInteractive() {
+		prompt := &survey.Confirm{
+			Message: lo.Ternary(
+				incompleteLaunchManifest,
+				"Would you like to continue in the web UI?",
+				"Do you want to tweak these settings before proceeding?",
+			),
+		}
+		err = survey.AskOne(prompt, &editInUi)
+		if err != nil {
+			// TODO(allison): This should probably not just return the error
+			return err
+		}
 	}
 
-	if confirm {
+	if editInUi {
 		err = state.EditInWebUi(ctx)
 		if err != nil {
 			return err

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -76,7 +76,7 @@ func New() (cmd *cobra.Command) {
 		},
 		// legacy launch flags (deprecated)
 		flag.Bool{
-			Name:        "no-ui",
+			Name:        "legacy",
 			Description: "Use the legacy CLI interface (deprecated)",
 			Hidden:      true,
 		},
@@ -123,7 +123,7 @@ func run(ctx context.Context) (err error) {
 
 	// NOTE: We depend on legacy launcher behavior for Nomad support, which is needed for the MigrateToV2 tests
 	//       Once we rip out those tests, this can go with them.
-	if flag.GetBool(ctx, "no-ui") || flag.GetBool(ctx, "force-nomad") {
+	if flag.GetBool(ctx, "legacy") || flag.GetBool(ctx, "force-nomad") {
 		return legacy.Run(ctx)
 	}
 

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -71,8 +71,8 @@ func New() (cmd *cobra.Command) {
 		},
 		// Launch V2
 		flag.Bool{
-			Name:        "ui",
-			Description: "Use the Launch V2 interface",
+			Name:        "no-ui",
+			Description: "Use the legacy CLI interface (deprecated)",
 			Hidden:      true,
 		},
 		flag.Bool{
@@ -120,7 +120,7 @@ func getManifestArgument(ctx context.Context) (*LaunchManifest, error) {
 
 func run(ctx context.Context) (err error) {
 
-	if !flag.GetBool(ctx, "ui") {
+	if flag.GetBool(ctx, "no-ui") {
 		return legacy.Run(ctx)
 	}
 

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -55,11 +55,6 @@ func New() (cmd *cobra.Command) {
 			Default:     false,
 		},
 		flag.Bool{
-			Name:        "reuse-app",
-			Description: "Continue even if app name clashes with an existent app",
-			Default:     false,
-		},
-		flag.Bool{
 			Name:        "dockerignore-from-gitignore",
 			Description: "If a .dockerignore does not exist, create one from .gitignore files",
 			Default:     false,
@@ -69,12 +64,6 @@ func New() (cmd *cobra.Command) {
 			Description: "Set internal_port for all services in the generated fly.toml",
 			Default:     -1,
 		},
-		// Launch V2
-		flag.Bool{
-			Name:        "no-ui",
-			Description: "Use the legacy CLI interface (deprecated)",
-			Hidden:      true,
-		},
 		flag.Bool{
 			Name:        "manifest",
 			Description: "Output the generated manifest to stdout",
@@ -83,6 +72,18 @@ func New() (cmd *cobra.Command) {
 		flag.String{
 			Name:        "from-manifest",
 			Description: "Path to a manifest file for Launch ('-' reads from stdin)",
+			Hidden:      true,
+		},
+		// legacy launch flags (deprecated)
+		flag.Bool{
+			Name:        "no-ui",
+			Description: "Use the legacy CLI interface (deprecated)",
+			Hidden:      true,
+		},
+		flag.Bool{
+			Name:        "reuse-app",
+			Description: "Continue even if app name clashes with an existent app",
+			Default:     false,
 			Hidden:      true,
 		},
 	)

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -15,6 +15,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/deploy"
 	"github.com/superfly/flyctl/internal/command/launch/legacy"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -242,7 +243,11 @@ func warnLegacyBehavior(ctx context.Context) error {
 	// TODO(Allison): We probably want to support re-configuring an existing app, but
 	// that is different from the launch-into behavior of reuse-app, which basically just deployed.
 	if flag.IsSpecified(ctx, "reuse-app") {
-		return errors.New("the --reuse-app flag is no longer supported. you are likely looking for 'fly deploy'")
+
+		return flyerr.GenericErr{
+			Err:     "the --reuse-app flag is no longer supported. you are likely looking for 'fly deploy'",
+			Suggest: "for now, you can use 'fly launch --legacy --reuse-app', but this will be removed in a future release",
+		}
 	}
 	return nil
 }

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -120,7 +120,9 @@ func getManifestArgument(ctx context.Context) (*LaunchManifest, error) {
 
 func run(ctx context.Context) (err error) {
 
-	if flag.GetBool(ctx, "no-ui") {
+	// NOTE: We depend on legacy launcher behavior for Nomad support, which is needed for the MigrateToV2 tests
+	//       Once we rip out those tests, this can go with them.
+	if flag.GetBool(ctx, "no-ui") || flag.GetBool(ctx, "force-nomad") {
 		return legacy.Run(ctx)
 	}
 

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -80,7 +80,7 @@ func (state *launchState) updateConfig(ctx context.Context) {
 			ForceHTTPS:         true,
 			AutoStartMachines:  api.Pointer(true),
 			AutoStopMachines:   api.Pointer(true),
-			MinMachinesRunning: api.Pointer(1),
+			MinMachinesRunning: api.Pointer(0),
 			Processes:          []string{"app"},
 		}
 	} else {

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -75,14 +75,16 @@ func (state *launchState) updateConfig(ctx context.Context) {
 		state.appConfig.SetEnvVariables(state.env)
 	}
 	if state.Plan.HttpServicePort != 0 {
-		state.appConfig.HTTPService = &appconfig.HTTPService{
-			InternalPort:       state.Plan.HttpServicePort,
-			ForceHTTPS:         true,
-			AutoStartMachines:  api.Pointer(true),
-			AutoStopMachines:   api.Pointer(true),
-			MinMachinesRunning: api.Pointer(0),
-			Processes:          []string{"app"},
+		if state.appConfig.HTTPService == nil {
+			state.appConfig.HTTPService = &appconfig.HTTPService{
+				ForceHTTPS:         true,
+				AutoStartMachines:  api.Pointer(true),
+				AutoStopMachines:   api.Pointer(true),
+				MinMachinesRunning: api.Pointer(0),
+				Processes:          []string{"app"},
+			}
 		}
+		state.appConfig.HTTPService.InternalPort = state.Plan.HttpServicePort
 	} else {
 		state.appConfig.HTTPService = nil
 	}

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -103,6 +103,7 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 		}
 	}
 
+	httpServicePort := 8080
 	if copiedConfig {
 		// Check imported fly.toml is a valid V2 config before creating the app
 		if err := appConfig.SetMachinesPlatform(); err != nil {
@@ -113,6 +114,11 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 				"Warning: --manifest does not serialize an entire app configuration.\n"+
 					"Creating a manifest from an existing fly.toml may be a lossy process!",
 			)
+		}
+		if service := appConfig.HTTPService; service != nil {
+			httpServicePort = service.InternalPort
+		} else {
+			httpServicePort = 0
 		}
 	}
 
@@ -153,7 +159,7 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 		CPUs:             guest.CPUs,
 		MemoryMB:         guest.MemoryMB,
 		VmSize:           guest.ToSize(),
-		HttpServicePort:  8080,
+		HttpServicePort:  httpServicePort,
 		Postgres:         plan.PostgresPlan{},
 		Redis:            plan.RedisPlan{},
 		FlyctlVersion:    buildinfo.Info().Version,

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -122,7 +122,7 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 		return nil, nil, err
 	}
 
-	appName, appNameExplanation, err := determineAppName(ctx, configPath)
+	appName, appNameExplanation, err := determineAppName(ctx, appConfig, configPath)
 	if err != nil {
 		if err := tryRecoverErr(err); err != nil {
 			return nil, nil, err
@@ -250,8 +250,8 @@ func stateFromManifest(ctx context.Context, m LaunchManifest, optionalCache *pla
 		}
 	}
 
-	if taken, _ := appNameTaken(ctx, appConfig.AppName); taken {
-		return nil, appNameTakenErr(appConfig.AppName)
+	if taken, _ := appNameTaken(ctx, m.Plan.AppName); taken {
+		return nil, appNameTakenErr(m.Plan.AppName)
 	}
 
 	workingDir := flag.GetString(ctx, "path")
@@ -368,44 +368,72 @@ func validateAppName(appName string) error {
 }
 
 // determineAppName determines the app name from the config file or directory name
-func determineAppName(ctx context.Context, configPath string) (string, string, error) {
+func determineAppName(ctx context.Context, appConfig *appconfig.Config, configPath string) (string, string, error) {
+
+	delimiter := "-"
+	findUniqueAppName := func(prefix string) (string, bool) {
+		if prefix != "" {
+			prefix += delimiter
+		}
+		for i := 1; i < 10; i++ {
+			outName := prefix + haikunator.Haikunator().Delimiter(delimiter).String()
+			if taken, _ := appNameTaken(ctx, outName); !taken {
+				return outName, true
+			}
+		}
+		return "", false
+	}
+
+	// This logic is a little overcomplicated. Essentially, just waterfall down options until one returns a valid name.
+	//
+	// Get initial name:
+	//  1. If we've specified --name, use that name.
+	//  2. If we've specified --generate-name, generate a unique name (meaning, jump over step 3)
+	//  3. If we've provided an existing config file, use the app name from that.
+	//  4. Use the directory name.
+	//  5. If none of those sanitize into valid app names, generate one with Haikunator.
+	// Ensure valid name:
+	//  If the name is already taken, try to generate a unique suffix using Haikunator.
+	//  If this fails, return a recoverable error.
 
 	appName := flag.GetString(ctx, "name")
+	if !flag.GetBool(ctx, "generate-name") && appName == "" {
+		appName = appConfig.AppName
+	}
 	if appName == "" {
 		appName = sanitizeAppName(filepath.Base(filepath.Dir(configPath)))
 	}
 	if appName == "" {
-		err := flyerr.GenericErr{
-			Err:     "unable to determine app name",
-			Suggest: "You can specify the app name with the --name flag",
+
+		var found bool
+		appName, found = findUniqueAppName("")
+
+		if !found {
+			return "", recoverableSpecifyInUi, recoverableInUiError{flyerr.GenericErr{
+				Err:     "unable to determine app name",
+				Suggest: "You can specify the app name with the --name flag",
+			}}
 		}
-		return "", recoverableSpecifyInUi, recoverableInUiError{err}
 	}
 	if err := validateAppName(appName); err != nil {
 		return "", recoverableSpecifyInUi, recoverableInUiError{err}
 	}
 	// If the app name is already taken, try to generate a unique suffix.
 	if taken, _ := appNameTaken(ctx, appName); taken {
-		delimiter := "-"
-		var newName string
-		found := false
-		for i := 1; i < 10; i++ {
-			newName = fmt.Sprintf("%s%s%s", appName, delimiter, haikunator.Haikunator().Delimiter(delimiter))
-			if taken, _ := appNameTaken(ctx, newName); !taken {
-				found = true
-				break
-			}
-		}
+
+		var found bool
+		appName, found = findUniqueAppName(appName)
 		if !found {
 			return "", recoverableSpecifyInUi, recoverableInUiError{appNameTakenErr(appName)}
 		}
-		appName = newName
 	}
 	return appName, "derived from your directory name", nil
 }
 
 func appNameTaken(ctx context.Context, name string) (bool, error) {
 	client := client.FromContext(ctx).API()
+	// TODO: I believe this will only check apps that are visible to you.
+	//       We should probably expose a global uniqueness check.
 	_, err := client.GetAppBasic(ctx, name)
 	if err != nil {
 		if api.IsNotFoundError(err) || graphql.IsNotFoundError(err) {

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -108,6 +108,12 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 		if err := appConfig.SetMachinesPlatform(); err != nil {
 			return nil, nil, fmt.Errorf("can not use configuration for Fly Launch, check fly.toml: %w", err)
 		}
+		if flag.GetBool(ctx, "manifest") {
+			fmt.Fprintln(iostreams.FromContext(ctx).ErrOut,
+				"Warning: --manifest does not serialize an entire app configuration.\n"+
+					"Creating a manifest from an existing fly.toml may be a lossy process!",
+			)
+		}
 	}
 
 	workingDir := flag.GetString(ctx, "path")

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -145,7 +145,7 @@ app = "foo"
 	`)
 
 	x := f.FlyAllowExitFailure("launch --no-deploy --org %s --name %s --region %s --force-machines --copy-config", f.OrgSlug(), appName, f.PrimaryRegion())
-	require.Contains(f, x.StdErrString(), `Can not use configuration for Apps V2, check fly.toml`)
+	require.Contains(f, x.StdErrString(), `can not use configuration for Fly Launch, check fly.toml`)
 }
 
 // test --generate-name, --name and reuse imported name


### PR DESCRIPTION
## Change Summary

Replaces the `--ui` flag with a deprecated `--no-ui` flag. `fly launch` now defaults to Launch V2.

### Note: this removes `--reuse-app`! Merging this will remove the launch-into behavior entirely.

Personally, I feel like this is a good thing. Having `launch` work on existing apps is confusing, and we're actively working on better ways to work with existing apps that could replace this functionality while maintaining the separation between deploy and launch.

---

### Documentation

- [X] Fresh Produce (when it's time)
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
