### PR TITLE
Configurable wait timeouts

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -88,9 +88,11 @@ type Config struct {
 }
 
 type Deploy struct {
-	ReleaseCommand string   `toml:"release_command,omitempty" json:"release_command,omitempty"`
-	Strategy       string   `toml:"strategy,omitempty" json:"strategy,omitempty"`
-	MaxUnavailable *float64 `toml:"max_unavailable,omitempty" json:"max_unavailable,omitempty"`
+	ReleaseCommand        string        `toml:"release_command,omitempty" json:"release_command,omitempty"`
+	ReleaseCommandTimeout *api.Duration `toml:"release_command_timeout,omitempty" json:"release_command_timeout,omitempty"`
+	Strategy              string        `toml:"strategy,omitempty" json:"strategy,omitempty"`
+	MaxUnavailable        *float64      `toml:"max_unavailable,omitempty" json:"max_unavailable,omitempty"`
+	WaitTimeout           *api.Duration `toml:"wait_timeout,omitempty" json:"wait_timeout,omitempty"`
 }
 
 type File struct {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -57,20 +57,23 @@ var CommonFlags = flag.Set{
 		Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
 	},
 	flag.Yes(),
-	flag.Int{
+	flag.String{
 		Name:        "wait-timeout",
-		Description: "Seconds to wait for individual machines to transition states and become healthy.",
-		Default:     int(DefaultWaitTimeout.Seconds()),
+		Description: "Time duration to wait for individual machines to transition states and become healthy.",
+		Default:     DefaultWaitTimeout.String(),
 	},
 	flag.String{
 		Name:        "release-command-timeout",
-		Description: "Seconds to wait for a release command finish running, or 'none' to disable.",
-		Default:     strconv.Itoa(int(DefaultReleaseCommandTimeout.Seconds())),
+		Description: "Time duration to wait for a release command finish running, or 'none' to disable.",
+		Default:     DefaultReleaseCommandTimeout.String(),
 	},
-	flag.Int{
-		Name:        "lease-timeout",
-		Description: "Seconds to lease individual machines while running deployment. All machines are leased at the beginning and released at the end. The lease is refreshed periodically for this same time, which is why it is short. flyctl releases leases in most cases.",
-		Default:     int(DefaultLeaseTtl.Seconds()),
+	flag.String{
+		Name: "lease-timeout",
+		Description: "Time duration to lease individual machines while running deployment." +
+			" All machines are leased at the beginning and released at the end." +
+			"The lease is refreshed periodically for this same time, which is why it is short." +
+			"flyctl releases leases in most cases.",
+		Default: DefaultLeaseTtl.String(),
 	},
 	flag.Bool{
 		Name:        "force-nomad",
@@ -251,15 +254,31 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes
 	return err
 }
 
-func determineRelCmdTimeout(timeout string) (time.Duration, error) {
-	if timeout == "none" {
-		return 0, nil
+func parseDurationFlag(ctx context.Context, flagName string) (*time.Duration, error) {
+	if !flag.IsSpecified(ctx, flagName) {
+		return nil, nil
 	}
-	asInt, err := strconv.Atoi(timeout)
-	if err != nil {
-		return 0, fmt.Errorf("invalid release command timeout '%v': valid options are a number of seconds, or 'none'", timeout)
+
+	v := flag.GetString(ctx, flagName)
+	if v == "none" {
+		d := time.Duration(0)
+		return &d, nil
 	}
-	return time.Duration(asInt) * time.Second, nil
+
+	duration, err := time.ParseDuration(v)
+	if err == nil {
+		return &duration, nil
+	}
+
+	if strings.Contains(err.Error(), "missing unit in duration") {
+		asInt, err := strconv.Atoi(v)
+		if err == nil {
+			duration = time.Duration(asInt) * time.Second
+			return &duration, nil
+		}
+	}
+
+	return nil, fmt.Errorf("invalid duration value %v used for --%s flag: valid options are a number of seconds, number with time unit (i.e.: 5m, 180s) or 'none'", v, flagName)
 }
 
 // in a rare twist, the guest param takes precedence over CLI flags!
@@ -278,7 +297,17 @@ func deployToMachines(
 		metrics.Status(ctx, "deploy_machines", err == nil)
 	}()
 
-	releaseCmdTimeout, err := determineRelCmdTimeout(flag.GetString(ctx, "release-command-timeout"))
+	releaseCmdTimeout, err := parseDurationFlag(ctx, "release-command-timeout")
+	if err != nil {
+		return err
+	}
+
+	waitTimeout, err := parseDurationFlag(ctx, "wait-timeout")
+	if err != nil {
+		return err
+	}
+
+	leaseTimeout, err := parseDurationFlag(ctx, "lease-timeout")
 	if err != nil {
 		return err
 	}
@@ -330,10 +359,10 @@ func deployToMachines(
 		PrimaryRegionFlag:      appConfig.PrimaryRegion,
 		SkipSmokeChecks:        flag.GetDetach(ctx) || !flag.GetBool(ctx, "smoke-checks"),
 		SkipHealthChecks:       flag.GetDetach(ctx),
-		WaitTimeout:            time.Duration(flag.GetInt(ctx, "wait-timeout")) * time.Second,
-		LeaseTimeout:           time.Duration(flag.GetInt(ctx, "lease-timeout")) * time.Second,
-		MaxUnavailable:         maxUnavailable,
+		WaitTimeout:            waitTimeout,
 		ReleaseCmdTimeout:      releaseCmdTimeout,
+		LeaseTimeout:           leaseTimeout,
+		MaxUnavailable:         maxUnavailable,
 		Guest:                  guest,
 		IncreasedAvailability:  flag.GetBool(ctx, "ha"),
 		AllocPublicIP:          !flag.GetBool(ctx, "no-public-ips"),

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -884,7 +884,7 @@ func (m *v2PlatformMigrator) deployApp(ctx context.Context) error {
 	input := deploy.MachineDeploymentArgs{
 		AppCompact:       m.appCompact,
 		RestartOnly:      true,
-		WaitTimeout:      waitTimeout,
+		WaitTimeout:      &waitTimeout,
 		SkipHealthChecks: m.skipHealthChecks,
 	}
 	if m.isPostgres {


### PR DESCRIPTION
### Change Summary

When images are too big or the platform suffers slowness pulling application images, the usual workaround is to increase the wait timeout (--wait-timeout flag), but this is something that repeats when the image is large like for GPU apps.

This PRs adds "wait_timeout" directive to fly.toml's `[deploy]` section.
And going a bit further it also adds `release_command_timeout` for those apps where the default 5 minutes is too short and passing `--release-command-timeout` flag on every deploy is cumbersome.  

---

### Documentation

- [ ] Fresh Produce
- [x] https://github.com/superfly/docs/pull/1133
- [ ] n/a
