### PR TITLE
`fly m run`: set `interact` correctly

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -346,7 +346,7 @@ func runMachineRun(ctx context.Context) error {
 		imageOrPath:        imageOrPath,
 		region:             input.Region,
 		updating:           false,
-		interact:           true,
+		interact:           interact,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
### Change Summary

Set `interact` correctly so that the command is not overridden to `/bin/sleep inf` except for interactive Machines.

Related to: https://community.fly.io/t/fly-machine-run-is-no-longer-executing-cmd-and-machine-stays-stuck/16199

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
