### PR TITLE
Use org's raw slug when streaming logs from NATS

### DIFF
--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -324,6 +324,7 @@ func (client *Client) GetAppBasic(ctx context.Context, appName string) (*AppBasi
 				organization {
 					id
 					slug
+					rawSlug
 					paidPlan
 				}
 			}

--- a/logs/nats.go
+++ b/logs/nats.go
@@ -38,7 +38,7 @@ func NewNatsStream(ctx context.Context, apiClient *api.Client, opts *LogOptions)
 		return nil, fmt.Errorf("failed connecting to WireGuard tunnel: %w", err)
 	}
 
-	nc, err := newNatsClient(ctx, dialer, app.Organization.Slug)
+	nc, err := newNatsClient(ctx, dialer, app.Organization.RawSlug)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating nats connection: %w", err)
 	}


### PR DESCRIPTION
### Change Summary

What and Why:

Flaps can't resolve `personal` slug without a GraphQL query. When using macaroon auth, we try to avoid GraphQL queries in flaps.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
