### PR TITLE
Block metrics on CI

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -21,7 +21,6 @@ jobs:
 
   # create a dev tag for every branch except master
   tag_version:
-    needs: test
     if: ${{ github.ref_type == 'branch' && github.ref_name != 'master' }}
     runs-on: ubuntu-latest
     outputs:

--- a/agent/cmd_unix.go
+++ b/agent/cmd_unix.go
@@ -8,7 +8,7 @@ import (
 	"syscall"
 )
 
-func setSysProcAttributes(cmd *exec.Cmd) {
+func SetSysProcAttributes(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
 		Pgid:    0,

--- a/agent/cmd_windows.go
+++ b/agent/cmd_windows.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func setSysProcAttributes(cmd *exec.Cmd) {
+func SetSysProcAttributes(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		HideWindow:    true,
 		CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP,

--- a/agent/start.go
+++ b/agent/start.go
@@ -46,7 +46,7 @@ func StartDaemon(ctx context.Context) (*Client, error) {
 	env = append(env, fmt.Sprintf("FLY_API_TOKEN=%s", config.Tokens(ctx).GraphQL()))
 	cmd.Env = env
 
-	setSysProcAttributes(cmd)
+	SetSysProcAttributes(cmd)
 
 	if err := cmd.Start(); err != nil {
 		err = forkError{err}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -111,7 +111,7 @@ func newRunE(fn Runner, preparers ...preparers.Preparer) func(*cobra.Command, []
 			io := iostreams.FromContext(ctx)
 
 			if !metrics.IsFlushMetricsDisabled(ctx) {
-				err := metrics.FlushMetrics()
+				err := metrics.FlushMetrics(ctx)
 				if err != nil {
 					fmt.Fprintln(io.ErrOut, "Error spawning metrics process: ", err)
 				}

--- a/internal/command/metrics/metrics.go
+++ b/internal/command/metrics/metrics.go
@@ -1,18 +1,11 @@
 package metrics
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"io"
-	"net/http"
-	"time"
 
-	"github.com/PuerkitoBio/rehttp"
 	"github.com/spf13/cobra"
-	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/command"
-	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -60,31 +53,5 @@ func run(ctx context.Context) error {
 
 	stdin_value := string(stdin_bytes)
 
-	authToken, err := metrics.GetMetricsToken(ctx)
-	if err != nil {
-		return err
-	}
-
-	cfg := config.FromContext(ctx)
-	request, err := http.NewRequest("POST", cfg.MetricsBaseURL+"/metrics_post", bytes.NewBuffer([]byte(stdin_value)))
-	if err != nil {
-		return err
-	}
-
-	request.Header.Set("Authorization", authToken)
-	request.Header.Set("User-Agent", fmt.Sprintf("flyctl/%s", buildinfo.Info().Version))
-
-	retryTransport := rehttp.NewTransport(http.DefaultTransport, rehttp.RetryAll(rehttp.RetryMaxRetries(3), rehttp.RetryTimeoutErr()), rehttp.ConstDelay(0))
-
-	client := http.Client{
-		Transport: retryTransport,
-		Timeout:   time.Second * 5,
-	}
-
-	resp, err := client.Do(request)
-	if err != nil {
-		return err
-	}
-
-	return resp.Body.Close()
+	return metrics.SendMetrics(ctx, stdin_value)
 }

--- a/internal/command/metrics/metrics.go
+++ b/internal/command/metrics/metrics.go
@@ -74,11 +74,11 @@ func run(ctx context.Context) error {
 	request.Header.Set("Authorization", authToken)
 	request.Header.Set("User-Agent", fmt.Sprintf("flyctl/%s", buildinfo.Info().Version))
 
-	retryTransport := rehttp.NewTransport(http.DefaultTransport, rehttp.RetryAll(rehttp.RetryMaxRetries(3), rehttp.RetryTimeoutErr()), rehttp.ConstDelay(time.Second))
+	retryTransport := rehttp.NewTransport(http.DefaultTransport, rehttp.RetryAll(rehttp.RetryMaxRetries(3), rehttp.RetryTimeoutErr()), rehttp.ConstDelay(0))
 
 	client := http.Client{
 		Transport: retryTransport,
-		Timeout:   time.Second * 30,
+		Timeout:   time.Second * 5,
 	}
 
 	resp, err := client.Do(request)

--- a/internal/ctrlc/ctrlc.go
+++ b/internal/ctrlc/ctrlc.go
@@ -1,6 +1,7 @@
 package ctrlc
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -45,7 +46,8 @@ func Hook(event func()) Handle {
 			// most terminals print ^C, this makes things easier to read.
 			fmt.Fprintf(os.Stderr, "\n")
 		}
-		metrics.FlushMetrics()
+		ctx := context.Background()
+		metrics.FlushMetrics(ctx)
 		event()
 	}()
 	return Handle{&boundSignal{sig: signalCh}}

--- a/internal/metrics/db.go
+++ b/internal/metrics/db.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
-	"time"
 
+	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -38,6 +38,8 @@ func FlushMetrics(ctx context.Context) error {
 	cmd.Stdin = &buffer
 	cmd.Env = os.Environ()
 
+	agent.SetSysProcAttributes(cmd)
+
 	if err := cmd.Start(); err != nil {
 		return err
 	}
@@ -53,8 +55,6 @@ func FlushMetrics(ctx context.Context) error {
 		if err := cmd.Wait(); err != nil {
 			return err
 		}
-
-		time.Sleep(time.Second * 5)
 	}
 
 	return nil

--- a/internal/metrics/db.go
+++ b/internal/metrics/db.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -52,6 +53,8 @@ func FlushMetrics(ctx context.Context) error {
 		if err := cmd.Wait(); err != nil {
 			return err
 		}
+
+		time.Sleep(time.Second * 5)
 	}
 
 	return nil

--- a/internal/metrics/db.go
+++ b/internal/metrics/db.go
@@ -2,9 +2,12 @@ package metrics
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"os/exec"
+
+	"github.com/superfly/flyctl/iostreams"
 )
 
 var metrics []metricsMessage = make([]metricsMessage, 0)
@@ -14,7 +17,7 @@ func queueMetric(metric metricsMessage) {
 }
 
 // Spawns a forked `flyctl metrics send` process that sends metrics to the flyctl-metrics server
-func FlushMetrics() error {
+func FlushMetrics(ctx context.Context) error {
 	json, err := json.Marshal(metrics)
 	if err != nil {
 		return err
@@ -34,14 +37,21 @@ func FlushMetrics() error {
 	cmd.Stdin = &buffer
 	cmd.Env = os.Environ()
 
-	err = cmd.Start()
-	if err != nil {
+	if err := cmd.Start(); err != nil {
 		return err
 	}
 
-	err = cmd.Process.Release()
-	if err != nil {
-		return err
+	io := iostreams.FromContext(ctx)
+
+	// On CI, always block on metrics send. This sucks, but the alternative is not getting metrics from CI at all. There are timeouts in place to prevent this from taking more than 15 seconds
+	if io.IsInteractive() {
+		if err := cmd.Process.Release(); err != nil {
+			return err
+		}
+	} else {
+		if err := cmd.Wait(); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/metrics/db.go
+++ b/internal/metrics/db.go
@@ -4,10 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
+	"time"
 
+	"github.com/PuerkitoBio/rehttp"
 	"github.com/superfly/flyctl/agent"
+	"github.com/superfly/flyctl/internal/buildinfo"
+	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -25,37 +32,72 @@ func FlushMetrics(ctx context.Context) error {
 
 	}
 
-	flyctl, err := os.Executable()
-	if err != nil {
-		return err
-	}
-
-	cmd := exec.Command(flyctl, "metrics", "send")
-
-	buffer := bytes.Buffer{}
-	buffer.Write(json)
-
-	cmd.Stdin = &buffer
-	cmd.Env = os.Environ()
-
-	agent.SetSysProcAttributes(cmd)
-
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-
-	io := iostreams.FromContext(ctx)
+	iostream := iostreams.FromContext(ctx)
 
 	// On CI, always block on metrics send. This sucks, but the alternative is not getting metrics from CI at all. There are timeouts in place to prevent this from taking more than 15 seconds
-	if io.IsInteractive() {
+
+	if iostream.IsInteractive() {
+		flyctl, err := os.Executable()
+		if err != nil {
+			return err
+		}
+
+		cmd := exec.Command(flyctl, "metrics", "send")
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			return err
+		}
+
+		go func() {
+			defer stdin.Close()
+			io.WriteString(stdin, string(json))
+		}()
+
+		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env, "FLY_NO_UPDATE_CHECK=1")
+
+		agent.SetSysProcAttributes(cmd)
+
+		if err := cmd.Start(); err != nil {
+			return err
+		}
+
 		if err := cmd.Process.Release(); err != nil {
 			return err
 		}
 	} else {
-		if err := cmd.Wait(); err != nil {
-			return err
-		}
+		SendMetrics(ctx, string(json))
 	}
 
 	return nil
+}
+
+func SendMetrics(ctx context.Context, json string) error {
+	authToken, err := GetMetricsToken(ctx)
+	if err != nil {
+		return err
+	}
+
+	cfg := config.FromContext(ctx)
+	request, err := http.NewRequest("POST", cfg.MetricsBaseURL+"/metrics_post", bytes.NewBuffer([]byte(json)))
+	if err != nil {
+		return err
+	}
+
+	request.Header.Set("Authorization", authToken)
+	request.Header.Set("User-Agent", fmt.Sprintf("flyctl/%s", buildinfo.Info().Version))
+
+	retryTransport := rehttp.NewTransport(http.DefaultTransport, rehttp.RetryAll(rehttp.RetryMaxRetries(3), rehttp.RetryTimeoutErr()), rehttp.ConstDelay(0))
+
+	client := http.Client{
+		Transport: retryTransport,
+		Timeout:   time.Second * 5,
+	}
+
+	resp, err := client.Do(request)
+	if err != nil {
+		return err
+	}
+
+	return resp.Body.Close()
 }

--- a/internal/metrics/db.go
+++ b/internal/metrics/db.go
@@ -49,8 +49,8 @@ func FlushMetrics(ctx context.Context) error {
 		}
 
 		go func() {
-			defer stdin.Close()
 			io.WriteString(stdin, string(json))
+			stdin.Close()
 		}()
 
 		cmd.Env = os.Environ()

--- a/internal/metrics/db.go
+++ b/internal/metrics/db.go
@@ -72,6 +72,7 @@ func FlushMetrics(ctx context.Context) error {
 	return nil
 }
 
+// / Spens up to 15 seconds sending all metrics collected so far to flyctl-metrics post endpoint
 func SendMetrics(ctx context.Context, json string) error {
 	authToken, err := GetMetricsToken(ctx)
 	if err != nil {


### PR DESCRIPTION
The alternative is that metrics are never sent on CI, which is bad of course. There's still a timeout of at most 15 seconds, so worst case this won't block deploys for a considerable length of time.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
