### PR TITLE
metrics: don't exec 'metrics send' after 'metrics send'

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -110,9 +110,11 @@ func newRunE(fn Runner, preparers ...preparers.Preparer) func(*cobra.Command, []
 		task.FromContext(ctx).RunFinalizer(func(ctx context.Context) {
 			io := iostreams.FromContext(ctx)
 
-			err := metrics.FlushMetrics()
-			if err != nil {
-				fmt.Fprintln(io.ErrOut, "Error spawning metrics process: ", err)
+			if !metrics.IsFlushMetricsDisabled(ctx) {
+				err := metrics.FlushMetrics()
+				if err != nil {
+					fmt.Fprintln(io.ErrOut, "Error spawning metrics process: ", err)
+				}
 			}
 		})
 

--- a/internal/command/metrics/metrics.go
+++ b/internal/command/metrics/metrics.go
@@ -40,7 +40,9 @@ func newSend() (cmd *cobra.Command) {
 		long  = short + "\n"
 	)
 
-	cmd = command.New("send", short, long, run)
+	cmd = command.New("send", short, long, run, func(ctx context.Context) (context.Context, error) {
+		return metrics.WithDisableFlushMetrics(ctx), nil
+	})
 	cmd.Hidden = true
 	cmd.Args = cobra.NoArgs
 

--- a/internal/metrics/helpers.go
+++ b/internal/metrics/helpers.go
@@ -75,3 +75,21 @@ func StartTiming(ctx context.Context, metricSlug string) func() {
 		Send(ctx, metricSlug, map[string]float64{"duration_seconds": time.Since(start).Seconds()})
 	}
 }
+
+type disableFlushMetricsKey struct{}
+
+// WithDisableFlushMetrics returns a context with a flag that disables
+// FlushMetrics call after a command completes.
+func WithDisableFlushMetrics(ctx context.Context) context.Context {
+	return context.WithValue(ctx, disableFlushMetricsKey{}, true)
+}
+
+// IsFlushMetricsDisabled returns true if FlushMetrics should not be called after a command completes.
+func IsFlushMetricsDisabled(ctx context.Context) bool {
+	val, ok := ctx.Value(disableFlushMetricsKey{}).(bool)
+	if !ok {
+		return false
+	}
+
+	return val
+}


### PR DESCRIPTION
This just leads to an infinite loop of execs.
