### PR TITLE
appconfig: add 'http_options.h2_backend' port option

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -520,8 +520,9 @@ type TLSOptions struct {
 }
 
 type HTTPOptions struct {
-	Compress *bool                `json:"compress,omitempty" toml:"compress,omitempty"`
-	Response *HTTPResponseOptions `json:"response,omitempty" toml:"response,omitempty"`
+	Compress  *bool                `json:"compress,omitempty" toml:"compress,omitempty"`
+	Response  *HTTPResponseOptions `json:"response,omitempty" toml:"response,omitempty"`
+	H2Backend *bool                `json:"h2_backend,omitempty" toml:"h2_backend,omitempty"`
 }
 
 type HTTPResponseOptions struct {


### PR DESCRIPTION
The option tells fly-proxy that it's Ok to forward HTTP/2 requests (h2c)
to an app and not downgrade them to HTTP/1.
