### PR TITLE
Support org-level SSO for Supabase

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -41,6 +41,8 @@ func (v *AddOnData) GetErrorMessage() string { return v.ErrorMessage }
 type AddOnType string
 
 const (
+	// A Kubernetes cluster
+	AddOnTypeKubernetes AddOnType = "kubernetes"
 	// A PlanetScale database
 	AddOnTypePlanetscale AddOnType = "planetscale"
 	// An Upstash Redis database
@@ -49,6 +51,8 @@ const (
 	AddOnTypeSentry AddOnType = "sentry"
 	// A Supabase database
 	AddOnTypeSupabase AddOnType = "supabase"
+	// A Tigris Data bucket
+	AddOnTypeTigris AddOnType = "tigris"
 	// An Upstash Redis database
 	AddOnTypeUpstashRedis AddOnType = "upstash_redis"
 )
@@ -2213,6 +2217,26 @@ type GetAppsByRoleResponse struct {
 // GetApps returns GetAppsByRoleResponse.Apps, and is useful for accessing the field via an interface.
 func (v *GetAppsByRoleResponse) GetApps() GetAppsByRoleAppsAppConnection { return v.Apps }
 
+// GetExtensionSsoLinkOrganization includes the requested fields of the GraphQL type Organization.
+type GetExtensionSsoLinkOrganization struct {
+	// Single sign-on link for the given extension type
+	ExtensionSsoLink string `json:"extensionSsoLink"`
+}
+
+// GetExtensionSsoLink returns GetExtensionSsoLinkOrganization.ExtensionSsoLink, and is useful for accessing the field via an interface.
+func (v *GetExtensionSsoLinkOrganization) GetExtensionSsoLink() string { return v.ExtensionSsoLink }
+
+// GetExtensionSsoLinkResponse is returned by GetExtensionSsoLink on success.
+type GetExtensionSsoLinkResponse struct {
+	// Find an organization by ID
+	Organization GetExtensionSsoLinkOrganization `json:"organization"`
+}
+
+// GetOrganization returns GetExtensionSsoLinkResponse.Organization, and is useful for accessing the field via an interface.
+func (v *GetExtensionSsoLinkResponse) GetOrganization() GetExtensionSsoLinkOrganization {
+	return v.Organization
+}
+
 // GetNearestRegionNearestRegion includes the requested fields of the GraphQL type Region.
 type GetNearestRegionNearestRegion struct {
 	// The IATA airport code for this region
@@ -3411,6 +3435,18 @@ func (v *__GetAppsByRoleInput) GetRole() string { return v.Role }
 // GetOrganizationId returns __GetAppsByRoleInput.OrganizationId, and is useful for accessing the field via an interface.
 func (v *__GetAppsByRoleInput) GetOrganizationId() string { return v.OrganizationId }
 
+// __GetExtensionSsoLinkInput is used internally by genqlient
+type __GetExtensionSsoLinkInput struct {
+	OrgSlug  string `json:"orgSlug"`
+	Provider string `json:"provider"`
+}
+
+// GetOrgSlug returns __GetExtensionSsoLinkInput.OrgSlug, and is useful for accessing the field via an interface.
+func (v *__GetExtensionSsoLinkInput) GetOrgSlug() string { return v.OrgSlug }
+
+// GetProvider returns __GetExtensionSsoLinkInput.Provider, and is useful for accessing the field via an interface.
+func (v *__GetExtensionSsoLinkInput) GetProvider() string { return v.Provider }
+
 // __GetOrganizationInput is used internally by genqlient
 type __GetOrganizationInput struct {
 	Slug string `json:"slug"`
@@ -4363,6 +4399,43 @@ func GetAppsByRole(
 	var err error
 
 	var data GetAppsByRoleResponse
+	resp := &graphql.Response{Data: &data}
+
+	err = client.MakeRequest(
+		ctx,
+		req,
+		resp,
+	)
+
+	return &data, err
+}
+
+// The query or mutation executed by GetExtensionSsoLink.
+const GetExtensionSsoLink_Operation = `
+query GetExtensionSsoLink ($orgSlug: String!, $provider: String!) {
+	organization(slug: $orgSlug) {
+		extensionSsoLink(provider: $provider)
+	}
+}
+`
+
+func GetExtensionSsoLink(
+	ctx context.Context,
+	client graphql.Client,
+	orgSlug string,
+	provider string,
+) (*GetExtensionSsoLinkResponse, error) {
+	req := &graphql.Request{
+		OpName: "GetExtensionSsoLink",
+		Query:  GetExtensionSsoLink_Operation,
+		Variables: &__GetExtensionSsoLinkInput{
+			OrgSlug:  orgSlug,
+			Provider: provider,
+		},
+	}
+	var err error
+
+	var data GetExtensionSsoLinkResponse
 	resp := &graphql.Response{Data: &data}
 
 	err = client.MakeRequest(

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -118,6 +118,12 @@ query GetAppsByRole($role: String!, $organizationId: ID!) {
 	}
 }
 
+query GetExtensionSsoLink($orgSlug: String!, $provider: String!) {
+	organization(slug: $orgSlug) {
+		extensionSsoLink(provider: $provider)
+	}
+}
+
 fragment OrganizationData on Organization {
 	id
 	slug

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -319,6 +319,11 @@ type AddOnProvider {
 
 enum AddOnType {
   """
+  A Kubernetes cluster
+  """
+  kubernetes
+
+  """
   A PlanetScale database
   """
   planetscale
@@ -337,6 +342,11 @@ enum AddOnType {
   A Supabase database
   """
   supabase
+
+  """
+  A Tigris Data bucket
+  """
+  tigris
 
   """
   An Upstash Redis database
@@ -7489,6 +7499,11 @@ type Organization implements Node {
     """
     last: Int
   ): DomainConnection!
+
+  """
+  Single sign-on link for the given extension type
+  """
+  extensionSsoLink(provider: String!): String
   healthCheckHandlers(
     """
     Returns the elements in the list that come after the specified cursor.

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -303,9 +303,35 @@ func GetExcludedRegions(ctx context.Context, provider gql.ExtensionProviderData)
 	return
 }
 
+func OpenOrgDashboard(ctx context.Context, orgSlug string, provider string) (err error) {
+	var (
+		client = client.FromContext(ctx).API().GenqClient
+	)
+
+	result, err := gql.GetExtensionSsoLink(ctx, client, orgSlug, provider)
+
+	if err != nil {
+		return err
+	}
+
+	err = openUrl(ctx, result.Organization.ExtensionSsoLink)
+
+	return
+}
+
+func openUrl(ctx context.Context, url string) (err error) {
+	io := iostreams.FromContext(ctx)
+
+	fmt.Fprintf(io.Out, "Opening %s ...\n", url)
+
+	if err := open.Run(url); err != nil {
+		return fmt.Errorf("failed opening %s: %w", url, err)
+	}
+	return
+}
+
 func OpenDashboard(ctx context.Context, extensionName string) (err error) {
 	var (
-		io     = iostreams.FromContext(ctx)
 		client = client.FromContext(ctx).API().GenqClient
 	)
 
@@ -316,11 +342,7 @@ func OpenDashboard(ctx context.Context, extensionName string) (err error) {
 	}
 
 	url := result.AddOn.SsoLink
-	fmt.Fprintf(io.Out, "Opening %s ...\n", url)
-
-	if err := open.Run(url); err != nil {
-		return fmt.Errorf("failed opening %s: %w", url, err)
-	}
+	openUrl(ctx, url)
 
 	return
 }

--- a/internal/command/extensions/supabase/dashboard.go
+++ b/internal/command/extensions/supabase/dashboard.go
@@ -24,19 +24,27 @@ func dashboard() (cmd *cobra.Command) {
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.Org(),
 	)
 	cmd.Args = cobra.MaximumNArgs(1)
 	return cmd
 }
 
 func runDashboard(ctx context.Context) (err error) {
+	org := flag.GetOrg(ctx)
 
-	extension, _, err := extensions_core.Discover(ctx, gql.AddOnTypeSupabase)
+	if org != "" {
+		extensions_core.OpenOrgDashboard(ctx, org, "supabase")
+	} else {
+		extension, _, err := extensions_core.Discover(ctx, gql.AddOnTypeSupabase)
 
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
+
+		err = extensions_core.OpenDashboard(ctx, extension.Name)
+
 	}
 
-	err = extensions_core.OpenDashboard(ctx, extension.Name)
 	return
 }


### PR DESCRIPTION
This PR allows signing in to an organization. Before, one could only sign in via a specific database. This option covers cases where an org exists but has no active databases.