### PR TITLE
Fix SIGINT on Deployments

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/ctrlc"
 	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/iostreams"
 
@@ -176,6 +177,12 @@ func New() (cmd *cobra.Command) {
 }
 
 func run(ctx context.Context) error {
+	hook := ctrlc.Hook(func() {
+		metrics.FlushMetrics(ctx)
+	})
+
+	defer hook.Done()
+
 	appName := appconfig.NameFromContext(ctx)
 	flapsClient, err := flaps.NewFromAppName(ctx, appName)
 	if err != nil {

--- a/internal/ctrlc/ctrlc.go
+++ b/internal/ctrlc/ctrlc.go
@@ -1,15 +1,12 @@
 package ctrlc
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/signal"
 	"runtime"
 	"sync"
 	"syscall"
-
-	"github.com/superfly/flyctl/internal/metrics"
 )
 
 type Handle struct{ *boundSignal }
@@ -46,8 +43,6 @@ func Hook(event func()) Handle {
 			// most terminals print ^C, this makes things easier to read.
 			fmt.Fprintf(os.Stderr, "\n")
 		}
-		ctx := context.Background()
-		metrics.FlushMetrics(ctx)
 		event()
 	}()
 	return Handle{&boundSignal{sig: signalCh}}


### PR DESCRIPTION
### Change Summary

What and Why:

The way I was sending metrics when a user SIGINTS was pretty stupid, so I'm redoing it so as to correctly use the ctrlc hooks. I also only installed the hook on deployments, since that's where we really care about *needing* metrics.

How:

Install a ctrlc hook to flush metrics if a deploy is cancelled.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
 (bug fix)