### PR TITLE
fly deploy: skip launch for stopped autoscaled machines

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -314,8 +314,8 @@ func suggestChangeWaitTimeout(err error, flagName string) error {
 
 func (md *machineDeployment) waitForMachine(ctx context.Context, e *machineUpdateEntry) error {
 	lm := e.leasableMachine
-	// Don't wait for Standby machines, they are updated but not started
-	if len(lm.Machine().Config.Standbys) > 0 {
+	// Don't wait for SkipLaunch machines, they are updated but not started
+	if e.launchInput.SkipLaunch {
 		return nil
 	}
 

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -16,9 +16,10 @@ func (md *machineDeployment) launchInputForRestart(origMachineRaw *api.Machine) 
 	md.setMachineReleaseData(Config)
 
 	return &api.LaunchMachineInput{
-		ID:     origMachineRaw.ID,
-		Config: Config,
-		Region: origMachineRaw.Region,
+		ID:         origMachineRaw.ID,
+		Config:     Config,
+		Region:     origMachineRaw.Region,
+		SkipLaunch: skipStopped(origMachineRaw, Config),
 	}
 }
 
@@ -141,7 +142,7 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 		ID:                  mID,
 		Region:              origMachineRaw.Region,
 		Config:              mConfig,
-		SkipLaunch:          len(mConfig.Standbys) > 0,
+		SkipLaunch:          len(mConfig.Standbys) > 0 || skipStopped(origMachineRaw, mConfig),
 		RequiresReplacement: machineShouldBeReplaced,
 	}, nil
 }
@@ -170,4 +171,13 @@ func (md *machineDeployment) setMachineReleaseData(mConfig *api.MachineConfig) {
 	} else {
 		delete(mConfig.Metadata, api.MachineConfigMetadataKeyFlyManagedPostgres)
 	}
+}
+
+// Skip launching currently-stopped machines if any services
+// use autoscaling (autostop or autostart).
+func skipStopped(origMachineRaw *api.Machine, mConfig *api.MachineConfig) bool {
+	return origMachineRaw.State == api.MachineStateStopped &&
+		lo.SomeBy(mConfig.Services, func(s api.MachineService) bool {
+			return (s.Autostop != nil && *s.Autostop) || (s.Autostart != nil && *s.Autostart)
+		})
 }


### PR DESCRIPTION
### Change Summary

#### What and Why:

Skips the launch behavior for stopped autoscaled machines during `fly deploy`. This provides better default behavior for autoscaling apps that want to leave a number of stopped instances in place for future scaling up, and that don't wish to scale up to their max instance count after every deploy.

We don't want to always skip launching stopped machines, because we still want a `fly deploy` to start up any crashed stopped machine that's not part of an autoscaled app.

#### How:

Sets `SkipLaunch` to `true` on the deploy/restart `LaunchInput` for machines that are currently stopped, and that have autoscaling enabled on one of their services.

Updates the `waitForMachine` logic to skip waiting for any machines with `SkipLaunch` set which already includes standby machines (but now may include other stopped machines as well).

#### Related to:

https://community.fly.io/t/deploying-a-multi-process-app-and-i-dont-want-any-machines-running-in-one-of-the-groups-after-a-deploy/16257

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
