### PR TITLE
Add work_mem and maintenance_work_mem to Postgres config

### DIFF
--- a/internal/command/postgres/config.go
+++ b/internal/command/postgres/config.go
@@ -13,6 +13,8 @@ var pgSettings = map[string]string{
 	"max-wal-senders":            "max_wal_senders",
 	"max-replication-slots":      "max_replication_slots",
 	"max-connections":            "max_connections",
+	"work-mem":                   "work_mem",
+	"maintenance-work-mem":       "maintenance_work_mem",
 	"shared-buffers":             "shared_buffers",
 	"log-statement":              "log_statement",
 	"log-min-duration-statement": "log_min_duration_statement",

--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -71,6 +71,14 @@ func newConfigUpdate() (cmd *cobra.Command) {
 			Name:        "shared-preload-libraries",
 			Description: "Sets the shared libraries to preload. (comma separated string)",
 		},
+		flag.String{
+			Name:        "work-mem",
+			Description: "Sets the maximum amount of memory each Postgres query can use",
+		},
+		flag.String{
+			Name:        "maintenance-work-mem",
+			Description: "Sets the maximum amount of memory used for maintenance operations like ALTER TABLE, CREATE INDEX, and VACUUM",
+		},
 		flag.Bool{
 			Name:        "force",
 			Description: "Skips pg-setting value verification.",


### PR DESCRIPTION
### Change Summary

What and Why:

I wanted to set `maintenance_work_mem` in my Postgres cluster because it was set to 64MB, which is more than 25% of my instance's memory, and that's way too much. I thought `work_mem` would be a useful setting to have available too since it seems like a pretty core Postgres tuning setting.

I don't know what fly's philosophy about adding new Postgres settings is here but thought I'd make a PR to see if you're open to adding new settings.

How:

I just grepped for `shared-preload-libraries` and added `maintenance-work-mem` wherever I saw it.


### Documentation

Not sure where this is documented other than in `--help`. 

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a

