### PR TITLE
`launch` v2: list flyctl version in launch plan

### DIFF
--- a/internal/command/launch/plan/plan.go
+++ b/internal/command/launch/plan/plan.go
@@ -2,6 +2,7 @@ package plan
 
 import (
 	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/internal/version"
 )
 
 const descriptionNone = "<none>"
@@ -24,7 +25,8 @@ type LaunchPlan struct {
 
 	Redis RedisPlan `json:"redis"`
 
-	ScannerFamily string `json:"scanner_family"`
+	ScannerFamily string          `json:"scanner_family"`
+	FlyctlVersion version.Version `json:"flyctl_version"`
 }
 
 func (p *LaunchPlan) Guest() *api.MachineGuest {

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -15,6 +15,7 @@ import (
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
+	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/command/launch/plan"
 	"github.com/superfly/flyctl/internal/flag"
@@ -149,6 +150,7 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 		HttpServicePort:  8080,
 		Postgres:         plan.PostgresPlan{},
 		Redis:            plan.RedisPlan{},
+		FlyctlVersion:    buildinfo.Info().Version,
 	}
 
 	planSource := &launchPlanSource{


### PR DESCRIPTION
### Change Summary

What and Why:
Throws a field `flyctl_version` in the Launch Plan. This allows the UI side of Launch to branch depending on flyctl version, so we don't return responses that try to (for example) provision resources that the flyctl client doesn't know how to provision (if it's outdated).

This is something that we don't want to rely on too much, because tons of version conditions are liable to ruin code quality, but it's an important tool to have on hand just in case :)

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
