### PR TITLE
add skip-stopped option to fly deploy

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -93,6 +93,7 @@ type Deploy struct {
 	Strategy              string        `toml:"strategy,omitempty" json:"strategy,omitempty"`
 	MaxUnavailable        *float64      `toml:"max_unavailable,omitempty" json:"max_unavailable,omitempty"`
 	WaitTimeout           *api.Duration `toml:"wait_timeout,omitempty" json:"wait_timeout,omitempty"`
+	SkipStopped           *bool         `toml:"skip_stopped,omitempty" json:"skip_stopped,omitempty"`
 }
 
 type File struct {

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -472,6 +472,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 			ReleaseCommand: "release command",
 			Strategy:       "rolling-eyes",
 			MaxUnavailable: api.Pointer(0.2),
+			SkipStopped:    new(bool),
 		},
 
 		Env: map[string]string{

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -36,6 +36,7 @@ host_dedication_id = "06031957"
   release_command = "release command"
   strategy = "rolling-eyes"
   max_unavailable = 0.2
+  skip_stopped = false
 
 [env]
   FOO = "BAR"

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -142,6 +142,10 @@ var CommonFlags = flag.Set{
 		Default:     1,
 	},
 	flag.VMSizeFlags,
+	flag.Bool{
+		Name:        "skip-stopped",
+		Description: "Don't start any stopped machines, only update app config. Defaults to true for standby machines or services with autostop/start enabled",
+	},
 }
 
 func New() (cmd *cobra.Command) {
@@ -358,6 +362,11 @@ func deployToMachines(
 		}
 	}
 
+	var skipStopped *bool = nil
+	if flag.IsSpecified(ctx, "skip-stopped") {
+		skipStopped = api.BoolPointer(flag.GetBool(ctx, "skip-stopped"))
+	}
+
 	md, err := NewMachineDeployment(ctx, MachineDeploymentArgs{
 		AppCompact:             appCompact,
 		DeploymentImage:        img.Tag,
@@ -379,6 +388,7 @@ func deployToMachines(
 		OnlyRegions:            onlyRegions,
 		ImmediateMaxConcurrent: flag.GetInt(ctx, "immediate-max-concurrent"),
 		VolumeInitialSize:      flag.GetInt(ctx, "volume-initial-size"),
+		SkipStopped:            skipStopped,
 	})
 	if err != nil {
 		sentry.CaptureExceptionWithAppInfo(err, "deploy", appCompact)

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -56,6 +56,7 @@ type MachineDeploymentArgs struct {
 	OnlyRegions            map[string]interface{}
 	ImmediateMaxConcurrent int
 	VolumeInitialSize      int
+	SkipStopped            *bool
 }
 
 type machineDeployment struct {
@@ -90,6 +91,7 @@ type machineDeployment struct {
 	onlyRegions            map[string]interface{}
 	immediateMaxConcurrent int
 	volumeInitialSize      int
+	skipStopped            *bool
 }
 
 func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (MachineDeployment, error) {
@@ -178,6 +180,11 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		volumeInitialSize = args.VolumeInitialSize
 	}
 
+	skipStopped := args.SkipStopped
+	if skipStopped == nil && appConfig.Deploy != nil {
+		skipStopped = appConfig.Deploy.SkipStopped
+	}
+
 	md := &machineDeployment{
 		apiClient:              apiClient,
 		gqlClient:              apiClient.GenqClient,
@@ -202,6 +209,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		onlyRegions:            args.OnlyRegions,
 		immediateMaxConcurrent: immedateMaxConcurrent,
 		volumeInitialSize:      volumeInitialSize,
+		skipStopped:            args.SkipStopped,
 	}
 	if err := md.setStrategy(); err != nil {
 		return nil, err


### PR DESCRIPTION
This is a follow-up to #2992, allowing the 'skip stopped machines on deploy' behavior implemented there to be configurable through a `--skip-stopped` flag in `fly deploy`, and/or a `deploy.skip_stopped` property in `fly.toml` config, so that it can be selectively enabled in additional situations where autoscaling services are not being used.

I'm kind of hesitant to add to the already-huge pile of feature flags that's currently in `fly deploy`, so I don't know if I'm completely comfortable adding this. However, there is a [customer use-case](https://community.fly.io/t/deploying-a-multi-process-app-and-i-dont-want-any-machines-running-in-one-of-the-groups-after-a-deploy/16257/4?u=wjordan) where this kind of configuration does seem to make sense. I'd like some feedback on whether this seems like a good idea.

The configuration is also not per-process-group, which may also limit its usefulness in more complex apps. (Perhaps this points to future work in making the `[deploy]` section configurable per-process group?)