### PR TITLE
fly status: optimize GetLatestImageDetails API calls

### DIFF
--- a/internal/command/status/machines.go
+++ b/internal/command/status/machines.go
@@ -107,12 +107,19 @@ func RenderMachineStatus(ctx context.Context, app *api.AppCompact, out io.Writer
 
 	var updatable []*api.Machine
 
+	unknownRepos := map[string]bool{}
+
 	for _, machine := range machines {
 		image := fmt.Sprintf("%s:%s", machine.ImageRef.Repository, machine.ImageRef.Tag)
+		// Skip API call for already-seen unknown repos, or default deploy-label prefix.
+		if unknownRepos[image] || strings.HasPrefix(machine.ImageRef.Tag, "deployment-") {
+			continue
+		}
 
 		latestImage, err := client.GetLatestImageDetails(ctx, image)
 		if err != nil {
 			if strings.Contains(err.Error(), "Unknown repository") {
+				unknownRepos[image] = true
 				continue
 			}
 			return fmt.Errorf("unable to fetch latest image details for %s: %w", image, err)


### PR DESCRIPTION
This is a narrow optimization to skip the `GetLatestImageDetails` API call for image refs that have already returned 'unknown repository' (reducing this to a single API call per unique image currently used by the app), or that have the default deploy-label prefix (`deployment-`).

There's probably a more thorough way to avoid these calls we can come up with later, but this was a simple, local way to handle most of the common use-cases as a quick improvement.

On an app with ~40 machine instances, this lowers the `fly status` duration from ~6 seconds to ~1 second by skipping many unnecessary API-call round-trips.