### PR TITLE
Support overriding compute requirements while cloning machines

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -83,6 +83,7 @@ func newClone() *cobra.Command {
 			Default:     false,
 		},
 		flag.Detach(),
+		flag.VMSizeFlags,
 	)
 
 	return cmd
@@ -162,6 +163,11 @@ func runMachineClone(ctx context.Context) (err error) {
 		targetConfig.Init.Cmd = mConfig.Init.Cmd
 		targetConfig.Services = mConfig.Services
 		targetConfig.Checks = mConfig.Checks
+	}
+
+	targetConfig.Guest, err = flag.GetMachineGuest(ctx, targetConfig.Guest)
+	if err != nil {
+		return err
 	}
 
 	targetConfig.Image = source.FullImageRef()


### PR DESCRIPTION
### Change Summary

At the moment it is not possible to change the compute requirements of a cloned machine.

This PR adds the --vm* and --host-dedication-id flags to `fly m clone` 

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
