### PR TITLE
`redis`: automatically determine plan

### DIFF
--- a/internal/command/launch/launch_databases.go
+++ b/internal/command/launch/launch_databases.go
@@ -141,9 +141,7 @@ func (state *launchState) createFlyPostgres(ctx context.Context) error {
 
 func (state *launchState) createUpstashRedis(ctx context.Context) error {
 	redisPlan := state.Plan.Redis.UpstashRedis
-	if redisPlan.AppName == "" {
-		redisPlan.AppName = fmt.Sprintf("%s-redis", state.appConfig.AppName)
-	}
+	dbName := fmt.Sprintf("%s-redis", state.Plan.AppName)
 	org, err := state.Org(ctx)
 	if err != nil {
 		return err
@@ -169,7 +167,7 @@ func (state *launchState) createUpstashRedis(ctx context.Context) error {
 		}
 	}
 
-	db, err := redis.Create(ctx, org, redisPlan.AppName, &region, redisPlan.PlanId, len(readReplicaRegions) == 0, redisPlan.Eviction, &readReplicaRegions)
+	db, err := redis.Create(ctx, org, dbName, &region, len(readReplicaRegions) == 0, redisPlan.Eviction, &readReplicaRegions)
 	if err != nil {
 		return err
 	}

--- a/internal/command/launch/plan/postgres.go
+++ b/internal/command/launch/plan/postgres.go
@@ -10,7 +10,7 @@ import (
 )
 
 type PostgresProvider interface {
-	Describe(ctx context.Context) (string, error)
+	Describe(ctx context.Context, org *api.Organization) (string, error)
 }
 
 type PostgresPlan struct {
@@ -27,9 +27,9 @@ func (p *PostgresPlan) Provider() PostgresProvider {
 	return nil
 }
 
-func (p *PostgresPlan) Describe(ctx context.Context) (string, error) {
+func (p *PostgresPlan) Describe(ctx context.Context, org *api.Organization) (string, error) {
 	if provider := p.Provider(); provider != nil {
-		return provider.Describe(ctx)
+		return provider.Describe(ctx, org)
 	}
 	return descriptionNone, nil
 }
@@ -68,7 +68,7 @@ func (p *FlyPostgresPlan) Guest() *api.MachineGuest {
 	return &guest
 }
 
-func (p *FlyPostgresPlan) Describe(ctx context.Context) (string, error) {
+func (p *FlyPostgresPlan) Describe(ctx context.Context, org *api.Organization) (string, error) {
 
 	nodePlural := lo.Ternary(p.Nodes == 1, "", "s")
 	nodesStr := fmt.Sprintf("%d Node%s", p.Nodes, nodePlural)

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -96,12 +96,12 @@ func (state *launchState) PlanSummary(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	postgresStr, err := state.Plan.Postgres.Describe(ctx)
+	postgresStr, err := state.Plan.Postgres.Describe(ctx, org)
 	if err != nil {
 		return "", err
 	}
 
-	redisStr, err := state.Plan.Redis.Describe(ctx)
+	redisStr, err := state.Plan.Redis.Describe(ctx, org)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
### Change Summary

What and Why: Removes plan selection from Upstash Redis - automatically determined based on whether the org already has an existing Redis instance
  - It does? pay-as-you-go plan
  - It doesn't? free plan

Related to: new Upstash pricing model

---

@jsierles I know you said you'd like to simplify things by throwing some of the logic in the backend, but does this stopgap solution work for you? I'm hoping to get Launch v2 deployed, and this is the last remaining piece of it afaik

---

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a
