### PR TITLE
Speed up `fly volumes` commands by switching to `GetAppBasic`

### DIFF
--- a/internal/command/volumes/destroy.go
+++ b/internal/command/volumes/destroy.go
@@ -67,7 +67,7 @@ func runDestroy(ctx context.Context) error {
 	ctx = flaps.NewContext(ctx, flapsClient)
 
 	if volID == "" {
-		app, err := client.GetApp(ctx, appName)
+		app, err := client.GetAppBasic(ctx, appName)
 		if err != nil {
 			return err
 		}

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -67,7 +67,7 @@ func runExtend(ctx context.Context) error {
 	}
 	ctx = flaps.NewContext(ctx, flapsClient)
 
-	app, err := client.GetApp(ctx, appName)
+	app, err := client.GetAppBasic(ctx, appName)
 	if err != nil {
 		return err
 	}

--- a/internal/command/volumes/fork.go
+++ b/internal/command/volumes/fork.go
@@ -73,7 +73,7 @@ func runFork(ctx context.Context) error {
 
 	var vol *api.Volume
 	if volID == "" {
-		app, err := client.GetApp(ctx, appName)
+		app, err := client.GetAppBasic(ctx, appName)
 		if err != nil {
 			return err
 		}

--- a/internal/command/volumes/list.go
+++ b/internal/command/volumes/list.go
@@ -45,7 +45,7 @@ func runList(ctx context.Context) error {
 
 	appName := appconfig.NameFromContext(ctx)
 
-	app, err := apiClient.GetApp(ctx, appName)
+	app, err := apiClient.GetAppBasic(ctx, appName)
 	if err != nil {
 		return err
 	}

--- a/internal/command/volumes/show.go
+++ b/internal/command/volumes/show.go
@@ -66,7 +66,7 @@ func runShow(ctx context.Context) error {
 
 	var volume *api.Volume
 	if volumeID == "" {
-		app, err := client.GetApp(ctx, appName)
+		app, err := client.GetAppBasic(ctx, appName)
 		if err != nil {
 			return err
 		}

--- a/internal/command/volumes/volumes.go
+++ b/internal/command/volumes/volumes.go
@@ -92,7 +92,7 @@ func countVolumesMatchingName(ctx context.Context, volumeName string) (int32, er
 	return matches, nil
 }
 
-func renderTable(ctx context.Context, volumes []api.Volume, app *api.App, out io.Writer) error {
+func renderTable(ctx context.Context, volumes []api.Volume, app *api.AppBasic, out io.Writer) error {
 	apiClient := client.FromContext(ctx).API()
 	rows := make([][]string, 0, len(volumes))
 	for _, volume := range volumes {
@@ -135,7 +135,7 @@ func renderTable(ctx context.Context, volumes []api.Volume, app *api.App, out io
 	return render.Table(out, "", rows, "ID", "State", "Name", "Size", "Region", "Zone", "Encrypted", "Attached VM", "Created At")
 }
 
-func selectVolume(ctx context.Context, flapsClient *flaps.Client, app *api.App) (*api.Volume, error) {
+func selectVolume(ctx context.Context, flapsClient *flaps.Client, app *api.AppBasic) (*api.Volume, error) {
 	if !iostreams.FromContext(ctx).IsInteractive() {
 		return nil, fmt.Errorf("volume ID must be specified when not running interactively")
 	}


### PR DESCRIPTION
### Change Summary

#### What and Why:

`fly volumes` commands currently use the `GetApp` GraphQL query, which reports a lot of information, including a list of Machines. For apps with a lot of Machines (including destroyed ones), this can take a few seconds for the API to prepare. These commands don't actually need that information, though. They will be faster if we don't fetch it (and it may reduce a bit of load on the API too!).

#### How:

Use `GetAppBasic` instead.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
