### PR TITLE
Add [[compute]] section to fly.toml

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -325,13 +325,13 @@ type MachineMount struct {
 }
 
 type MachineGuest struct {
-	CPUKind          string `json:"cpu_kind,omitempty"`
-	CPUs             int    `json:"cpus,omitempty"`
-	MemoryMB         int    `json:"memory_mb,omitempty"`
-	GPUKind          string `json:"gpu_kind,omitempty"`
-	HostDedicationID string `json:"host_dedication_id,omitempty"`
+	CPUKind          string `json:"cpu_kind,omitempty" toml:"cpu_kind,omitempty"`
+	CPUs             int    `json:"cpus,omitempty" toml:"cpus,omitempty"`
+	MemoryMB         int    `json:"memory_mb,omitempty" toml:"memory_mb,omitempty"`
+	GPUKind          string `json:"gpu_kind,omitempty" toml:"gpu_kind,omitempty"`
+	HostDedicationID string `json:"host_dedication_id,omitempty" toml:"host_dedication_id,omitempty"`
 
-	KernelArgs []string `json:"kernel_args,omitempty"`
+	KernelArgs []string `json:"kernel_args,omitempty" toml:"kernel_args,omitempty"`
 }
 
 func (mg *MachineGuest) SetSize(size string) error {
@@ -438,7 +438,7 @@ type MachineCheck struct {
 	HTTPPath *string `json:"path,omitempty"`
 	// For http checks, whether to use http or https
 	HTTPProtocol *string `json:"protocol,omitempty"`
-	//For http checks with https protocol, whether or not to verify the TLS certificate
+	// For http checks with https protocol, whether or not to verify the TLS certificate
 	HTTPSkipTLSVerify *bool `json:"tls_skip_verify,omitempty"`
 	// If the protocol is https, the hostname to use for TLS certificate validation
 	HTTPTLSServerName *string             `json:"tls_server_name,omitempty"`
@@ -573,6 +573,7 @@ type MachineConfig struct {
 	// An object filled with key/value pairs to be set as environment variables
 	Env      map[string]string       `json:"env,omitempty"`
 	Init     MachineInit             `json:"init,omitempty"`
+	Guest    *MachineGuest           `json:"guest,omitempty"`
 	Metadata map[string]string       `json:"metadata,omitempty"`
 	Mounts   []MachineMount          `json:"mounts,omitempty"`
 	Services []MachineService        `json:"services,omitempty"`
@@ -593,7 +594,6 @@ type MachineConfig struct {
 	// Optional boolean telling the Machine to destroy itself once it’s complete (default false)
 	AutoDestroy bool             `json:"auto_destroy,omitempty"`
 	Restart     MachineRestart   `json:"restart,omitempty"`
-	Guest       *MachineGuest    `json:"guest,omitempty"`
 	DNS         *DNSConfig       `json:"dns,omitempty"`
 	Processes   []MachineProcess `json:"processes,omitempty"`
 

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -157,6 +157,7 @@ type Experimental struct {
 
 type Compute struct {
 	Size              string `json:"size,omitempty" toml:"size,omitempty"`
+	Memory            string `json:"memory,omitempty" toml:"memory,omitempty"`
 	*api.MachineGuest `toml:",inline" json:",inline"`
 	Processes         []string `json:"processes,omitempty" toml:"processes,omitempty"`
 }

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -156,6 +156,7 @@ type Experimental struct {
 }
 
 type Compute struct {
+	Size              string `json:"size,omitempty" toml:"size,omitempty"`
 	*api.MachineGuest `toml:",inline" json:",inline"`
 	Processes         []string `json:"processes,omitempty" toml:"processes,omitempty"`
 }

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -63,7 +63,7 @@ type Config struct {
 	Files            []File                    `toml:"files,omitempty" json:"files,omitempty"`
 	HostDedicationID string                    `toml:"host_dedication_id,omitempty" json:"host_dedication_id,omitempty"`
 
-	Compute []Compute `toml:"compute,omitempty" json:"compute,omitempty"`
+	Compute []*Compute `toml:"compute,omitempty" json:"compute,omitempty"`
 
 	// Others, less important.
 	Statics []Static   `toml:"statics,omitempty" json:"statics,omitempty"`
@@ -156,8 +156,8 @@ type Experimental struct {
 }
 
 type Compute struct {
-	api.MachineGuest `toml:",inline" json:",inline"`
-	Processes        []string `json:"processes,omitempty" toml:"processes,omitempty"`
+	*api.MachineGuest `toml:",inline" json:",inline"`
+	Processes         []string `json:"processes,omitempty" toml:"processes,omitempty"`
 }
 
 func (c *Config) ConfigFilePath() string {

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -62,8 +62,8 @@ type Config struct {
 	Checks           map[string]*ToplevelCheck `toml:"checks,omitempty" json:"checks,omitempty"`
 	Files            []File                    `toml:"files,omitempty" json:"files,omitempty"`
 	HostDedicationID string                    `toml:"host_dedication_id,omitempty" json:"host_dedication_id,omitempty"`
-	// MergedFiles is a list of files that have been merged from the app config and flags.
-	MergedFiles []*api.File `toml:"-" json:"-"`
+
+	Compute []Compute `toml:"compute,omitempty" json:"compute,omitempty"`
 
 	// Others, less important.
 	Statics []Static   `toml:"statics,omitempty" json:"statics,omitempty"`
@@ -72,6 +72,9 @@ type Config struct {
 	// RawDefinition contains fly.toml parsed as-is
 	// If you add any config field that is v2 specific, be sure to remove it in SanitizeDefinition()
 	RawDefinition map[string]any `toml:"-" json:"-"`
+
+	// MergedFiles is a list of files that have been merged from the app config and flags.
+	MergedFiles []*api.File `toml:"-" json:"-"`
 
 	// Path to application configuration file, usually fly.toml.
 	configFilePath string
@@ -150,6 +153,11 @@ type Experimental struct {
 	AutoRollback bool     `toml:"auto_rollback,omitempty" json:"auto_rollback,omitempty"`
 	EnableConsul bool     `toml:"enable_consul,omitempty" json:"enable_consul,omitempty"`
 	EnableEtcd   bool     `toml:"enable_etcd,omitempty" json:"enable_etcd,omitempty"`
+}
+
+type Compute struct {
+	api.MachineGuest `toml:",inline" json:",inline"`
+	Processes        []string `json:"processes,omitempty" toml:"processes,omitempty"`
 }
 
 func (c *Config) ConfigFilePath() string {

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -169,6 +169,12 @@ func TestToDefinition(t *testing.T) {
 		"swap_size_mb":       int64(512),
 		"console_command":    "/bin/bash",
 		"host_dedication_id": "06031957",
+		"compute": []map[string]any{
+			{
+				"gpu_kind":  "a100-pcie-40gb",
+				"processes": []any{"app"},
+			},
+		},
 		"build": map[string]any{
 			"builder":      "dockerfile",
 			"image":        "foo/fighter",

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -171,12 +171,13 @@ func TestToDefinition(t *testing.T) {
 		"host_dedication_id": "06031957",
 		"compute": []map[string]any{
 			{
-				"cpu_kind":    "performance",
-				"cpus":        int64(8),
-				"gpu_kind":    "a100-pcie-40gb",
-				"memory_mb":   int64(8192),
-				"kernel_args": []any{"quiet"},
-				"processes":   []any{"app"},
+				"cpu_kind":           "performance",
+				"cpus":               int64(8),
+				"gpu_kind":           "a100-pcie-40gb",
+				"host_dedication_id": "isolated-xxx",
+				"memory_mb":          int64(8192),
+				"kernel_args":        []any{"quiet"},
+				"processes":          []any{"app"},
 			},
 		},
 		"build": map[string]any{

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -171,8 +171,12 @@ func TestToDefinition(t *testing.T) {
 		"host_dedication_id": "06031957",
 		"compute": []map[string]any{
 			{
-				"gpu_kind":  "a100-pcie-40gb",
-				"processes": []any{"app"},
+				"cpu_kind":    "performance",
+				"cpus":        int64(8),
+				"gpu_kind":    "a100-pcie-40gb",
+				"memory_mb":   int64(8192),
+				"kernel_args": []any{"quiet"},
+				"processes":   []any{"app"},
 			},
 		},
 		"build": map[string]any{

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -171,6 +171,8 @@ func TestToDefinition(t *testing.T) {
 		"host_dedication_id": "06031957",
 		"compute": []map[string]any{
 			{
+				"size":               "shared-cpu-1x",
+				"memory":             "8gb",
 				"cpu_kind":           "performance",
 				"cpus":               int64(8),
 				"gpu_kind":           "a100-pcie-40gb",

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -11,6 +11,15 @@ import (
 	"github.com/superfly/flyctl/internal/machine"
 )
 
+func (c *Config) ToMachineGuest() (*api.MachineGuest, error) {
+	// XXX: This is meant to run on flatten config
+	// TODO: Add support for VMSize
+	for _, compute := range c.Compute {
+		return compute.MachineGuest, nil
+	}
+	return nil, nil
+}
+
 func (c *Config) ToMachineConfig(processGroup string, src *api.MachineConfig) (*api.MachineConfig, error) {
 	fc, err := c.Flatten(processGroup)
 	if err != nil {
@@ -193,6 +202,14 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 	// Files
 	mConfig.Files = nil
 	machine.MergeFiles(mConfig, c.MergedFiles)
+
+	// Guest
+	switch guest, err := c.ToMachineGuest(); {
+	case err != nil:
+		return nil, err
+	case guest != nil:
+		mConfig.Guest = guest
+	}
 
 	return mConfig, nil
 }

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -12,18 +12,17 @@ import (
 	"github.com/superfly/flyctl/internal/machine"
 )
 
-func (c *Config) ToMachineGuest() (*api.MachineGuest, error) {
-	// Don't be smart here, we want to retain backwards compability
-	// with apps that doesn't have a [[compute]] section and relies
-	// on `fly deploy` to respect whatever was set by `fly scale`, first deploy
-	// with --vm-* family flags
+func (c *Config) toMachineGuest() (*api.MachineGuest, error) {
+	// XXX: Don't be extra smart here, keep it backwards compatible with apps that don't have a [[compute]] section.
+	// Think about apps that counts on `fly deploy` to respect whatever was set by `fly scale` or the --vm-* family flags.
+	// It is important to return a `nil` guest when fly.toml doesn't contain a [[compute]] section for the process group.
 	if len(c.Compute) == 0 {
 		return nil, nil
 	} else if len(c.Compute) > 2 {
 		return nil, fmt.Errorf("2+ compute sections for group %s", c.DefaultProcessName())
 	}
 
-	// Must be at most one compute after group flattening
+	// At most one compute after group flattening
 	compute := c.Compute[0]
 
 	size := api.DefaultVMSize
@@ -237,7 +236,7 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 	machine.MergeFiles(mConfig, c.MergedFiles)
 
 	// Guest
-	switch guest, err := c.ToMachineGuest(); {
+	switch guest, err := c.toMachineGuest(); {
 	case err != nil:
 		return nil, err
 	case guest != nil:

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -38,6 +38,9 @@ func (c *Config) ToMachineGuest() (*api.MachineGuest, error) {
 	if err := guest.SetSize(size); err != nil {
 		return nil, err
 	}
+	if c.HostDedicationID != "" {
+		guest.HostDedicationID = c.HostDedicationID
+	}
 
 	if compute.MachineGuest != nil {
 		opts := copier.Option{IgnoreEmpty: true, DeepCopy: true}

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -3,6 +3,7 @@ package appconfig
 import (
 	"fmt"
 
+	"github.com/docker/go-units"
 	"github.com/google/shlex"
 	"github.com/jinzhu/copier"
 	"github.com/samber/lo"
@@ -245,8 +246,21 @@ func (c *Config) toMachineGuest() (*api.MachineGuest, error) {
 	if err := guest.SetSize(size); err != nil {
 		return nil, err
 	}
+
 	if c.HostDedicationID != "" {
 		guest.HostDedicationID = c.HostDedicationID
+	}
+
+	if compute.Memory != "" {
+		mb, err := helpers.ParseSize(compute.Memory, units.RAMInBytes, units.MiB)
+		switch {
+		case err != nil:
+			return nil, err
+		case mb == 0:
+			return nil, fmt.Errorf("memory cannot be zero")
+		default:
+			guest.MemoryMB = mb
+		}
 	}
 
 	if compute.MachineGuest != nil {

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -419,7 +419,7 @@ func TestToMachineConfig_compute(t *testing.T) {
 			want: &api.MachineGuest{
 				CPUKind:  "performance",
 				CPUs:     8,
-				MemoryMB: 16384,
+				MemoryMB: 65536,
 				GPUKind:  "a100-pcie-40gb",
 			},
 		},

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -385,3 +385,100 @@ func TestToMachineConfig_services(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, want, got.Services)
 }
+
+func TestToMachineConfig_compute(t *testing.T) {
+	cfg, err := LoadConfig("./testdata/tomachine-compute.toml")
+	require.NoError(t, err)
+
+	testcases := []struct {
+		name      string
+		groupName string
+		want      *api.MachineGuest
+	}{
+		{
+			name:      "app gets compute without processes set",
+			groupName: "app",
+			want: &api.MachineGuest{
+				CPUKind:  "shared",
+				CPUs:     2,
+				MemoryMB: 512,
+			},
+		},
+		{
+			name:      "worker gets compute without processes set",
+			groupName: "worker",
+			want: &api.MachineGuest{
+				CPUKind:  "shared",
+				CPUs:     2,
+				MemoryMB: 512,
+			},
+		},
+		{
+			name:      "whisper gets gpu and performance-8x",
+			groupName: "whisper",
+			want: &api.MachineGuest{
+				CPUKind:  "performance",
+				CPUs:     8,
+				MemoryMB: 16384,
+				GPUKind:  "a100-pcie-40gb",
+			},
+		},
+		{
+			name:      "isolated gets dedication id and shared-cpu-1x",
+			groupName: "isolated",
+			want: &api.MachineGuest{
+				CPUKind:          "shared",
+				CPUs:             1,
+				MemoryMB:         256,
+				HostDedicationID: "lookma-iamsolo",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cfg.ToMachineConfig(tc.groupName, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got.Guest)
+		})
+	}
+}
+
+func TestToMachineConfig_compute_none(t *testing.T) {
+	cfg, err := LoadConfig("./testdata/tomachine-compute-nodefault.toml")
+	require.NoError(t, err)
+
+	testcases := []struct {
+		name      string
+		groupName string
+		want      *api.MachineGuest
+	}{
+		{
+			name:      "app group has no default guest set",
+			groupName: "app",
+			want:      nil,
+		},
+		{
+			name:      "woo group has no default guest set",
+			groupName: "woo",
+			want:      nil,
+		},
+		{
+			name:      "bar gets performance-4x",
+			groupName: "bar",
+			want: &api.MachineGuest{
+				CPUKind:  "performance",
+				CPUs:     4,
+				MemoryMB: 8192,
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := cfg.ToMachineConfig(tc.groupName, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got.Guest)
+		})
+	}
+}

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -482,3 +482,56 @@ func TestToMachineConfig_compute_none(t *testing.T) {
 		})
 	}
 }
+
+func TestToMachineConfig_hostdedicationid(t *testing.T) {
+	cfg, err := LoadConfig("./testdata/tomachine-hostdedicationid.toml")
+	require.NoError(t, err)
+
+	testcases := []struct {
+		name        string
+		groupName   string
+		wantTopHDID string
+		wantGuest   *api.MachineGuest
+	}{
+		{
+			name:        "toplevel hdid must prevail",
+			groupName:   "front",
+			wantTopHDID: "toplevel",
+			wantGuest:   nil,
+		},
+		{
+			name:        "back has hdid set as compute section",
+			groupName:   "back",
+			wantTopHDID: "specific",
+			wantGuest: &api.MachineGuest{
+				CPUKind:          "shared",
+				CPUs:             1,
+				MemoryMB:         256,
+				HostDedicationID: "specific",
+			},
+		},
+		{
+			name:        "other has not hdid set as compute section",
+			groupName:   "other",
+			wantTopHDID: "toplevel",
+			wantGuest: &api.MachineGuest{
+				CPUKind:          "shared",
+				CPUs:             4,
+				MemoryMB:         1024,
+				HostDedicationID: "toplevel",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			flatCfg, err := cfg.Flatten(tc.groupName)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantTopHDID, flatCfg.HostDedicationID)
+
+			got, err := cfg.ToMachineConfig(tc.groupName, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantGuest, got.Guest)
+		})
+	}
+}

--- a/internal/appconfig/processgroups.go
+++ b/internal/appconfig/processgroups.go
@@ -186,6 +186,14 @@ func (c *Config) Flatten(groupName string) (*Config, error) {
 
 	dst.Compute = nil
 	if compute != nil {
+		// Sync what is the top level host_dedication_id with the more specific compute
+		if compute.MachineGuest != nil {
+			if compute.HostDedicationID != "" {
+				c.HostDedicationID = compute.HostDedicationID
+			} else if c.HostDedicationID != "" {
+				compute.HostDedicationID = c.HostDedicationID
+			}
+		}
 		compute.Processes = []string{groupName}
 		dst.Compute = append(dst.Compute, compute)
 	}

--- a/internal/appconfig/processgroups.go
+++ b/internal/appconfig/processgroups.go
@@ -177,6 +177,16 @@ func (c *Config) Flatten(groupName string) (*Config, error) {
 		dst.Metrics[i].Processes = []string{groupName}
 	}
 
+	// [[compute]]
+	// TODO: An empty process list should apply to all groups, and a more specific
+	//       compute section should overrode general compute section
+	dst.Compute = lo.Filter(dst.Compute, func(x *Compute, _ int) bool {
+		return matchesGroups(x.Processes)
+	})
+	for i := range dst.Compute {
+		dst.Compute[i].Processes = []string{groupName}
+	}
+
 	return dst, nil
 }
 

--- a/internal/appconfig/processgroups.go
+++ b/internal/appconfig/processgroups.go
@@ -186,13 +186,9 @@ func (c *Config) Flatten(groupName string) (*Config, error) {
 
 	dst.Compute = nil
 	if compute != nil {
-		// Sync what is the top level host_dedication_id with the more specific compute
-		if compute.MachineGuest != nil {
-			if compute.HostDedicationID != "" {
-				c.HostDedicationID = compute.HostDedicationID
-			} else if c.HostDedicationID != "" {
-				compute.HostDedicationID = c.HostDedicationID
-			}
+		// Sync top level host_dedication_id if set within compute
+		if compute.MachineGuest != nil && compute.MachineGuest.HostDedicationID != "" {
+			dst.HostDedicationID = compute.MachineGuest.HostDedicationID
 		}
 		compute.Processes = []string{groupName}
 		dst.Compute = append(dst.Compute, compute)

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -443,11 +443,12 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 		Compute: []*Compute{
 			{
 				MachineGuest: &api.MachineGuest{
-					CPUKind:    "performance",
-					CPUs:       8,
-					MemoryMB:   8192,
-					GPUKind:    "a100-pcie-40gb",
-					KernelArgs: []string{"quiet"},
+					CPUKind:          "performance",
+					CPUs:             8,
+					MemoryMB:         8192,
+					GPUKind:          "a100-pcie-40gb",
+					HostDedicationID: "isolated-xxx",
+					KernelArgs:       []string{"quiet"},
 				},
 				Processes: []string{"app"},
 			},

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -440,6 +440,14 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 		PrimaryRegion:    "sea",
 		ConsoleCommand:   "/bin/bash",
 		HostDedicationID: "06031957",
+		Compute: []*Compute{
+			{
+				MachineGuest: &api.MachineGuest{
+					GPUKind: "a100-pcie-40gb",
+				},
+				Processes: []string{"app"},
+			},
+		},
 		Experimental: &Experimental{
 			Cmd:          []string{"cmd"},
 			Entrypoint:   []string{"entrypoint"},

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -443,7 +443,11 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 		Compute: []*Compute{
 			{
 				MachineGuest: &api.MachineGuest{
-					GPUKind: "a100-pcie-40gb",
+					CPUKind:    "performance",
+					CPUs:       8,
+					MemoryMB:   8192,
+					GPUKind:    "a100-pcie-40gb",
+					KernelArgs: []string{"quiet"},
 				},
 				Processes: []string{"app"},
 			},

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -442,6 +442,8 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 		HostDedicationID: "06031957",
 		Compute: []*Compute{
 			{
+				Size:   "shared-cpu-1x",
+				Memory: "8gb",
 				MachineGuest: &api.MachineGuest{
 					CPUKind:          "performance",
 					CPUs:             8,

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -114,6 +114,7 @@ host_dedication_id = "06031957"
   memory_mb = 8192
   gpu_kind = "a100-pcie-40gb"
   kernel_args = ["quiet"]
+  host_dedication_id = "isolated-xxx"
   processes = ["app"]
 
 [processes]

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -40,6 +40,10 @@ host_dedication_id = "06031957"
 [env]
   FOO = "BAR"
 
+[[compute]]
+  gpu_kind = "a100-pcie-40gb"
+  processes = ["app"]
+
 [[metrics]]
   port = 9999
   path = "/metrics"

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -40,10 +40,6 @@ host_dedication_id = "06031957"
 [env]
   FOO = "BAR"
 
-[[compute]]
-  gpu_kind = "a100-pcie-40gb"
-  processes = ["app"]
-
 [[metrics]]
   port = 9999
   path = "/metrics"
@@ -111,6 +107,14 @@ host_dedication_id = "06031957"
 [mounts]
   source = "data"
   destination = "/data"
+
+[[compute]]
+  cpu_kind = "performance"
+  cpus = 8
+  memory_mb = 8192
+  gpu_kind = "a100-pcie-40gb"
+  kernel_args = ["quiet"]
+  processes = ["app"]
 
 [processes]
   web = "run web"

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -109,8 +109,10 @@ host_dedication_id = "06031957"
   destination = "/data"
 
 [[compute]]
+  size = "shared-cpu-1x"
   cpu_kind = "performance"
   cpus = 8
+  memory = "8gb"
   memory_mb = 8192
   gpu_kind = "a100-pcie-40gb"
   kernel_args = ["quiet"]

--- a/internal/appconfig/testdata/tomachine-compute-nodefault.toml
+++ b/internal/appconfig/testdata/tomachine-compute-nodefault.toml
@@ -1,0 +1,10 @@
+app = "no-default-compute"
+
+[processes]
+app = ""
+woo = ""
+bar = ""
+
+[[compute]]
+size = "performance-4x"
+processes = ["bar"]

--- a/internal/appconfig/testdata/tomachine-compute.toml
+++ b/internal/appconfig/testdata/tomachine-compute.toml
@@ -1,0 +1,20 @@
+app = "foo"
+
+[processes]
+app = ""
+worker = "/worker"
+whisper = "/whisperme"
+isolated = "/must-run-alone"
+
+# A section that applies to a specific group
+[[compute]]
+gpu_kind = "a100-pcie-40gb"
+processes = ["whisper"]
+
+[[compute]]
+host_dedication_id = "lookma-iamsolo"
+processes = ["isolated"]
+
+# A section without processes set must apply to all process groups
+[[compute]]
+size = "shared-cpu-2x"

--- a/internal/appconfig/testdata/tomachine-compute.toml
+++ b/internal/appconfig/testdata/tomachine-compute.toml
@@ -8,6 +8,7 @@ isolated = "/must-run-alone"
 
 # A section that applies to a specific group
 [[compute]]
+memory = "64gb"
 gpu_kind = "a100-pcie-40gb"
 processes = ["whisper"]
 

--- a/internal/appconfig/testdata/tomachine-hostdedicationid.toml
+++ b/internal/appconfig/testdata/tomachine-hostdedicationid.toml
@@ -1,0 +1,15 @@
+app = "foo"
+host_dedication_id = "toplevel"
+
+[processes]
+front = ""
+back = ""
+other = ""
+
+[[compute]]
+size = "shared-cpu-4x"
+processes = ["other"]
+
+[[compute]]
+host_dedication_id = "specific"
+processes = ["back"]

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -138,9 +138,18 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 		mConfig.Standbys = nil
 	}
 
-	if hdid := md.appConfig.HostDedicationID; hdid != "" && hdid != mConfig.Guest.HostDedicationID {
-		mConfig.Guest.HostDedicationID = md.appConfig.HostDedicationID
+	if hdid := md.appConfig.HostDedicationID; hdid != "" && hdid != origMachineRaw.Config.Guest.HostDedicationID {
+		if len(oMounts) > 0 && len(mMounts) > 0 {
+			// Attempting to rellocate a machine with a volume attached to a different host
+			return nil, fmt.Errorf("can't rellocate machine '%s' to dedication id '%s' because it has an attached volume."+
+				" Retry after forking the volume with `fly volume fork --host-dedication-id %s %s`", mID, hdid, hdid, mMounts[0].Volume)
+		}
 		machineShouldBeReplaced = true
+		// Set HostDedicationID here for the apps that doesn't have a [[compute]] section in fly.toml
+		// but sets it as a top level directive.
+		// This also works when top level HDID is different than [compute.host_dedication_id]
+		// because a flatten config also overrides the top level directive
+		mConfig.Guest.HostDedicationID = hdid
 	}
 
 	return &api.LaunchMachineInput{

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -28,7 +28,12 @@ func (md *machineDeployment) launchInputForLaunch(processGroup string, guest *ap
 	if err != nil {
 		return nil, err
 	}
-	mConfig.Guest = guest
+
+	// Obey the Guest if already set from [[compute]] section
+	if mConfig.Guest == nil {
+		mConfig.Guest = guest
+	}
+
 	mConfig.Image = md.img
 	md.setMachineReleaseData(mConfig)
 	// Get the final process group and prevent empty string

--- a/internal/command/scale/machine_defaults.go
+++ b/internal/command/scale/machine_defaults.go
@@ -87,9 +87,12 @@ func (d *defaultValues) ToMachineConfig(groupName string) (*api.MachineConfig, e
 	if err != nil {
 		return nil, err
 	}
+	// Respect Guest if set by fly.toml
+	if mc.Guest == nil {
+		mc.Guest = lo.ValueOr(d.guestPerGroup, groupName, d.guest)
+	}
 
 	mc.Image = d.image
-	mc.Guest = lo.ValueOr(d.guestPerGroup, groupName, d.guest)
 	mc.Mounts = lo.Map(mc.Mounts, func(mount api.MachineMount, _ int) api.MachineMount {
 		mount.SizeGb = lo.ValueOr(d.volsizeByName, mount.Name, d.volsize)
 		mount.Encrypted = true


### PR DESCRIPTION
### Change Summary

We have been relying on command line flags to tackle this problems:
* Set VM size on first deploy
* Restore VM size when scaling up from zero
* Different process groups have different compute requirements (CPUs, GPUs, Dedications...)
* Default shared-cpu-1x is not a good fit for memory hungry apps  

But the use of the flags is not consistent, they are only required under specific circumstances and easily forgotten.
This PR adds consistency to deploys and scaling by extending fly.toml with a `[[compute]]` section customizable per process group.

```toml
app = "my-cool-assistant"
primary_region = "ord"

[processes]
webapi = "/api"
worker = "/worker"

[[mounts]]
source = "models"
destination = "/models"
initial_size = "100gb"
processes = ["worker"]

[[compute]]
cpus = 4
cpu_kind = "shared"
memory_mb = 1024
processes = ["webapi"]

[[compute]]
cpus = "16"
cpu_kind = "performance"
memory_mb = "64gb"
gpu_kind = "a100-pcie-40gb"
processes = ["worker"]

[http_service]
internal_port = 7860
processes = ["webapi"]
```

## DEMO (it works!)

![compute-demo](https://github.com/superfly/flyctl/assets/37369/5ce81d00-2c3f-4df8-9387-d440d93ede09)

## Follow ups

The following things are planned for upcoming PRs.
1. Volume's initial size
2. Add [[compute]] when passing `--vm-*` flags to `fly launch`

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
