### PR TITLE
Revert to fix bluegreen deployments

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -314,8 +314,8 @@ func suggestChangeWaitTimeout(err error, flagName string) error {
 
 func (md *machineDeployment) waitForMachine(ctx context.Context, e *machineUpdateEntry) error {
 	lm := e.leasableMachine
-	// Don't wait for SkipLaunch machines, they are updated but not started
-	if e.launchInput.SkipLaunch {
+	// Don't wait for Standby machines, they are updated but not started
+	if len(lm.Machine().Config.Standbys) > 0 {
 		return nil
 	}
 

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -16,10 +16,9 @@ func (md *machineDeployment) launchInputForRestart(origMachineRaw *api.Machine) 
 	md.setMachineReleaseData(Config)
 
 	return &api.LaunchMachineInput{
-		ID:         origMachineRaw.ID,
-		Config:     Config,
-		Region:     origMachineRaw.Region,
-		SkipLaunch: skipStopped(origMachineRaw, Config),
+		ID:     origMachineRaw.ID,
+		Config: Config,
+		Region: origMachineRaw.Region,
 	}
 }
 
@@ -142,7 +141,7 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *api.Machine) (
 		ID:                  mID,
 		Region:              origMachineRaw.Region,
 		Config:              mConfig,
-		SkipLaunch:          len(mConfig.Standbys) > 0 || skipStopped(origMachineRaw, mConfig),
+		SkipLaunch:          len(mConfig.Standbys) > 0,
 		RequiresReplacement: machineShouldBeReplaced,
 	}, nil
 }
@@ -171,13 +170,4 @@ func (md *machineDeployment) setMachineReleaseData(mConfig *api.MachineConfig) {
 	} else {
 		delete(mConfig.Metadata, api.MachineConfigMetadataKeyFlyManagedPostgres)
 	}
-}
-
-// Skip launching currently-stopped machines if any services
-// use autoscaling (autostop or autostart).
-func skipStopped(origMachineRaw *api.Machine, mConfig *api.MachineConfig) bool {
-	return origMachineRaw.State == api.MachineStateStopped &&
-		lo.SomeBy(mConfig.Services, func(s api.MachineService) bool {
-			return (s.Autostop != nil && *s.Autostop) || (s.Autostart != nil && *s.Autostart)
-		})
 }


### PR DESCRIPTION
This reverts commit e2d15d62a963c6a86daeefcfb435788575ba98f1.

I've confirmed with a test app that this fixes bluegreen deployments.

https://community.fly.io/t/machine-doesnt-start-on-deployment/16375