### PR TITLE
[[mounts]] learns about `initial_size`

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -132,9 +132,10 @@ type Static struct {
 }
 
 type Mount struct {
-	Source      string   `toml:"source" json:"source,omitempty"`
-	Destination string   `toml:"destination" json:"destination,omitempty"`
-	Processes   []string `json:"processes,omitempty" toml:"processes,omitempty"`
+	Source      string   `toml:"source,omitempty" json:"source,omitempty"`
+	Destination string   `toml:"destination,omitempty" json:"destination,omitempty"`
+	InitialSize string   `toml:"initial_size,omitempty" json:"initial_size,omitempty"`
+	Processes   []string `toml:"processes,omitempty" json:"processes,omitempty"`
 }
 
 type Build struct {

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -299,8 +299,9 @@ func TestToDefinition(t *testing.T) {
 			},
 		},
 		"mounts": []map[string]any{{
-			"source":      "data",
-			"destination": "/data",
+			"source":       "data",
+			"destination":  "/data",
+			"initial_size": "30gb",
 		}},
 		"processes": map[string]any{
 			"web":  "run web",

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -578,6 +578,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 		Mounts: []Mount{{
 			Source:      "data",
 			Destination: "/data",
+			InitialSize: "30gb",
 		}},
 
 		Processes: map[string]string{

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -106,6 +106,7 @@ host_dedication_id = "06031957"
 
 [mounts]
   source = "data"
+  initial_size = "30gb"
   destination = "/data"
 
 [[compute]]

--- a/internal/appconfig/testdata/validate-mounts.toml
+++ b/internal/appconfig/testdata/validate-mounts.toml
@@ -1,0 +1,29 @@
+app = "foo"
+primary_region = "ord"
+
+[processes]
+app = ""
+vpn = ""
+foo = ""
+
+[[mounts]]
+source = "data"
+destination = "/data"
+initial_size = "15Mb"
+processes = ["vpn"]
+
+[[mounts]]
+source = "data"
+destination = "/data"
+initial_size = "unparseable"
+processes = ["foo"]
+
+[[mounts]]
+source = "foo"
+destination = "bar"
+processes = ["app"]
+
+[[mounts]]
+source = "data"
+destination = "/data"
+processes = ["app"]

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -312,6 +312,11 @@ func (cfg *Config) validateConsoleCommand() (extraInfo string, err error) {
 }
 
 func (cfg *Config) validateMounts() (extraInfo string, err error) {
+	if cfg.configFilePath == "--flatten--" && len(cfg.Mounts) > 1 {
+		extraInfo += fmt.Sprintf("group '%s' has more than one [[mounts]] section defined\n", cfg.defaultGroupName)
+		err = ValidationError
+	}
+
 	for _, m := range cfg.Mounts {
 		if m.InitialSize != "" {
 			v, vErr := helpers.ParseSize(m.InitialSize, units.FromHumanSize, units.GB)

--- a/internal/appconfig/validation_test.go
+++ b/internal/appconfig/validation_test.go
@@ -2,16 +2,17 @@ package appconfig
 
 import (
 	"context"
+	"os"
+	"testing"
+
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
 	"github.com/superfly/flyctl/internal/cmdutil/preparers"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/logger"
-	"os"
-	"testing"
 )
 
-func TestConfig_ValidateGroups(t *testing.T) {
+func _getValidationContext(t *testing.T) context.Context {
 	ctx := logger.NewContext(context.Background(), logger.New(os.Stderr, logger.Info, false))
 	ctx = flag.NewContext(ctx, &pflag.FlagSet{})
 	ctx, err := preparers.DetermineUserHomeDir(ctx)
@@ -22,12 +23,16 @@ func TestConfig_ValidateGroups(t *testing.T) {
 	require.NoError(t, err)
 	ctx, err = preparers.InitClient(ctx)
 	require.NoError(t, err)
+	return ctx
+}
 
+func TestConfig_ValidateGroups(t *testing.T) {
 	cfg, err := LoadConfig("./testdata/validategroups.toml")
 	require.NoError(t, err)
 	require.NoError(t, cfg.SetMachinesPlatform())
 	cfg.Deploy = &Deploy{Strategy: "canary"}
 
+	ctx := _getValidationContext(t)
 	err, x := cfg.Validate(ctx)
 	require.Error(t, err, x)
 	require.Contains(t, x, "error canary deployment strategy is not supported when using mounted volumes")
@@ -37,4 +42,19 @@ func TestConfig_ValidateGroups(t *testing.T) {
 
 	err, _ = cfg.ValidateGroups(ctx, []string{"foo"})
 	require.NoError(t, err)
+}
+
+func TestConfig_ValidateMounts(t *testing.T) {
+	cfg, err := LoadConfig("./testdata/validate-mounts.toml")
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetMachinesPlatform())
+
+	ctx := _getValidationContext(t)
+	err, x := cfg.Validate(ctx)
+	require.Error(t, err, x)
+	require.Contains(t, x, "has an initial_size '15Mb' value which is smaller than 1GB")
+
+	err, x = cfg.ValidateGroups(ctx, []string{"app"})
+	require.Error(t, err, x)
+	require.Contains(t, x, "group 'app' has more than one [[mounts]] section defined")
 }


### PR DESCRIPTION
### Change Summary

Passing `--volume-initial-size` cli flag has proven cumbersome and it is not possible to set it by process group

This PR adds `initial_size` directive to `[[mounts]]` so `fly deploy` create volumes with the expected minimum size on the first deploy attempt.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
