### PR TITLE
Add a100-40gb and a100-80gb GPU machine aliases

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -418,8 +418,8 @@ var MachinePresets map[string]*MachineGuest = map[string]*MachineGuest{
 	"performance-8x":  {CPUKind: "performance", CPUs: 8, MemoryMB: 8 * MIN_MEMORY_MB_PER_CPU},
 	"performance-16x": {CPUKind: "performance", CPUs: 16, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
 
-	"a100-40gb": {GPUKind: "a100-pcie-40gb", CPUKind: "performance", CPUs: 8, MemoryMB: 8 * MIN_MEMORY_MB_PER_CPU},
-	"a100-80gb": {GPUKind: "a100-sxm4-80gb", CPUKind: "performance", CPUs: 8, MemoryMB: 8 * MIN_MEMORY_MB_PER_CPU},
+	"a100-40gb": {GPUKind: "a100-pcie-40gb", CPUKind: "performance", CPUs: 8, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
+	"a100-80gb": {GPUKind: "a100-sxm4-80gb", CPUKind: "performance", CPUs: 8, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
 }
 
 type MachineMetrics struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -413,6 +413,9 @@ var MachinePresets map[string]*MachineGuest = map[string]*MachineGuest{
 	"performance-4x":  {CPUKind: "performance", CPUs: 4, MemoryMB: 4 * MIN_MEMORY_MB_PER_CPU},
 	"performance-8x":  {CPUKind: "performance", CPUs: 8, MemoryMB: 8 * MIN_MEMORY_MB_PER_CPU},
 	"performance-16x": {CPUKind: "performance", CPUs: 16, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
+
+	"a100-40gb": {GPUKind: "a100-pcie-40gb", CPUKind: "performance", CPUs: 8, MemoryMB: 8 * MIN_MEMORY_MB_PER_CPU},
+	"a100-80gb": {GPUKind: "a100-sxm4-80gb", CPUKind: "performance", CPUs: 8, MemoryMB: 8 * MIN_MEMORY_MB_PER_CPU},
 }
 
 type MachineMetrics struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -368,10 +368,14 @@ func (mg *MachineGuest) ToSize() string {
 	if mg == nil {
 		return ""
 	}
-	switch mg.CPUKind {
-	case "shared":
+	switch {
+	case mg.GPUKind == "a100-pcie-40gb":
+		return "a100-40gb"
+	case mg.GPUKind == "a100-sxm4-80gb":
+		return "a100-80gb"
+	case mg.CPUKind == "shared":
 		return fmt.Sprintf("shared-cpu-%dx", mg.CPUs)
-	case "performance":
+	case mg.CPUKind == "performance":
 		return fmt.Sprintf("performance-%dx", mg.CPUs)
 	default:
 		return "unknown"

--- a/internal/command/platform/vmsizes.go
+++ b/internal/command/platform/vmsizes.go
@@ -53,10 +53,14 @@ func runMachineVMSizes(ctx context.Context) error {
 	sort.Slice(sortedPresets, func(i, j int) bool {
 		a := sortedPresets[i].guest
 		b := sortedPresets[j].guest
-		if a.CPUs == b.CPUs {
+		switch {
+		case a.CPUs != b.CPUs:
+			return a.CPUs < b.CPUs
+		case a.MemoryMB != b.MemoryMB:
 			return a.MemoryMB < b.MemoryMB
+		default:
+			return a.GPUKind < b.GPUKind
 		}
-		return a.CPUs < b.CPUs
 	})
 
 	// Filter and display shared cpu sizes.

--- a/internal/command/platform/vmsizes.go
+++ b/internal/command/platform/vmsizes.go
@@ -39,14 +39,17 @@ func runMachineVMSizes(ctx context.Context) error {
 		guest   *api.MachineGuest
 		strings []string
 	}
+
 	sortedPresets := lo.MapToSlice(api.MachinePresets, func(key string, value *api.MachineGuest) preset {
 		arr := []string{
 			key,
 			cores(value.CPUs),
 			memory(value.MemoryMB),
+			value.GPUKind,
 		}
 		return preset{value, arr}
 	})
+
 	sort.Slice(sortedPresets, func(i, j int) bool {
 		a := sortedPresets[i].guest
 		b := sortedPresets[j].guest
@@ -58,24 +61,25 @@ func runMachineVMSizes(ctx context.Context) error {
 
 	// Filter and display shared cpu sizes.
 	shared := lo.FilterMap(sortedPresets, func(p preset, _ int) ([]string, bool) {
-		if p.guest.CPUKind == "shared" {
-			return p.strings, true
-		}
-		return nil, false
+		return p.strings, p.guest.CPUKind == "shared" && p.guest.GPUKind == ""
 	})
-	err := render.Table(out, "Machines platform", shared, "Name", "CPU Cores", "Memory")
-	if err != nil {
-		return fmt.Errorf("failed to render shared vm-sizes: %s", err)
+	if err := render.Table(out, "Machines platform", shared, "Name", "CPU Cores", "Memory"); err != nil {
+		return err
 	}
 
 	// Filter and display performance cpu sizes.
 	performance := lo.FilterMap(sortedPresets, func(p preset, _ int) ([]string, bool) {
-		if p.guest.CPUKind == "performance" {
-			return p.strings, true
-		}
-		return nil, false
+		return p.strings, p.guest.CPUKind == "performance" && p.guest.GPUKind == ""
 	})
-	return render.Table(out, "", performance, "Name", "CPU Cores", "Memory")
+	if err := render.Table(out, "", performance, "Name", "CPU Cores", "Memory"); err != nil {
+		return err
+	}
+
+	// Filter and display gpu sizes.
+	gpus := lo.FilterMap(sortedPresets, func(p preset, _ int) ([]string, bool) {
+		return p.strings, p.guest.GPUKind != ""
+	})
+	return render.Table(out, "", gpus, "Name", "CPU Cores", "Memory", "GPU model")
 }
 
 func cores(cores int) string {

--- a/internal/flag/machines.go
+++ b/internal/flag/machines.go
@@ -7,11 +7,18 @@ import (
 	"strings"
 
 	"github.com/docker/go-units"
+	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/helpers"
 )
 
-var validGPUKinds = []string{"a100-pcie-40gb", "a100-sxm4-80gb"}
+var (
+	validGPUKinds  = []string{"a100-pcie-40gb", "a100-sxm4-80gb"}
+	gpuKindAliases = map[string]string{
+		"a100-40gb": "a100-pcie-40gb",
+		"a100-80gb": "a100-sxm4-80gb",
+	}
+)
 
 // Returns a MachineGuest based on the flags provided overwriting a default VM
 func GetMachineGuest(ctx context.Context, guest *api.MachineGuest) (*api.MachineGuest, error) {
@@ -60,6 +67,7 @@ func GetMachineGuest(ctx context.Context, guest *api.MachineGuest) (*api.Machine
 
 	if IsSpecified(ctx, "vm-gpu-kind") {
 		m := GetString(ctx, "vm-gpu-kind")
+		m = lo.ValueOr(gpuKindAliases, m, m)
 		if !slices.Contains(validGPUKinds, m) {
 			return nil, fmt.Errorf("--vm-gpu-kind must be set to one of: %v", strings.Join(validGPUKinds, ", "))
 		}


### PR DESCRIPTION
### Change Summary

Add VM size aliases (aka `--vm-size`):
*  `a100-40gb` vm size to performance-8x + A100-PCIe-40gb gpu card.
*  `a100-80gb` vm size to performance-8x + A100-SXM4-80gb gpu card.

Also add aliases for `--vm-gpu-kind=a100-40gb` and `--vm-gpu-kind=a100-80gb` for convenience.

```
l$ fly platform vm-sizes
Machines platform
NAME            CPU CORES       MEMORY
shared-cpu-1x   1               256 MB
shared-cpu-2x   2               512 MB
shared-cpu-4x   4               1 GB
shared-cpu-8x   8               2 GB

NAME            CPU CORES       MEMORY
performance-1x  1               2 GB
performance-2x  2               4 GB
performance-4x  4               8 GB
performance-8x  8               16 GB
performance-16x 16              32 GB

NAME            CPU CORES       MEMORY  GPU MODEL
a100-40gb       8               32 GB   a100-pcie-40gb
a100-80gb       8               32 GB   a100-sxm4-80gb

```

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
