### PR TITLE
Change default volume sizes created on first deploy

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -360,6 +360,7 @@ func (mg *MachineGuest) SetSize(size string) error {
 	mg.CPUs = guest.CPUs
 	mg.CPUKind = guest.CPUKind
 	mg.MemoryMB = guest.MemoryMB
+	mg.GPUKind = guest.GPUKind
 	return nil
 }
 

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -139,7 +139,7 @@ var CommonFlags = flag.Set{
 	flag.Int{
 		Name:        "volume-initial-size",
 		Description: "The initial size in GB for volumes created on first deploy",
-		Default:     1,
+		Default:     DefaultVolumeInitialSizeGB,
 	},
 	flag.VMSizeFlags,
 	flag.StringSlice{

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -139,7 +139,6 @@ var CommonFlags = flag.Set{
 	flag.Int{
 		Name:        "volume-initial-size",
 		Description: "The initial size in GB for volumes created on first deploy",
-		Default:     DefaultVolumeInitialSizeGB,
 	},
 	flag.VMSizeFlags,
 	flag.StringSlice{

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -118,21 +118,21 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 				continue
 			}
 
-			initialSize := md.volumeInitialSize
-			if m.InitialSize != "" {
+			var initialSize int
+			switch {
+			case m.InitialSize != "":
 				// Ignore the error because invalid values are caught at config validation time
 				initialSize, _ = helpers.ParseSize(m.InitialSize, units.FromHumanSize, units.GB)
-			} else if initialSize == DefaultVolumeInitialSizeGB {
-				switch {
-				case initialSize != DefaultVolumeInitialSizeGB:
-					// keep it that way
-				case guest == nil:
-					// keep it that way
-				case guest.GPUKind != "":
-					initialSize = DefaultGPUVolumeInitialSizeGB
-				case guest.CPUKind != "shared" || guest.CPUs != 1:
-					initialSize = DefaultNonFreeVolumeInitialSizeGB
-				}
+			case md.volumeInitialSize > 0:
+				initialSize = md.volumeInitialSize
+			case guest == nil:
+				initialSize = DefaultVolumeInitialSizeGB
+			case guest.GPUKind != "":
+				initialSize = DefaultGPUVolumeInitialSizeGB
+			case guest.CPUKind != "shared" || guest.CPUs != 1:
+				initialSize = DefaultNonFreeVolumeInitialSizeGB
+			default:
+				initialSize = DefaultVolumeInitialSizeGB
 			}
 
 			fmt.Fprintf(

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -175,10 +175,6 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	if immedateMaxConcurrent < 1 {
 		immedateMaxConcurrent = 1
 	}
-	volumeInitialSize := 1
-	if args.VolumeInitialSize > 0 {
-		volumeInitialSize = args.VolumeInitialSize
-	}
 
 	md := &machineDeployment{
 		apiClient:              apiClient,
@@ -203,7 +199,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		excludeRegions:         args.ExcludeRegions,
 		onlyRegions:            args.OnlyRegions,
 		immediateMaxConcurrent: immedateMaxConcurrent,
-		volumeInitialSize:      volumeInitialSize,
+		volumeInitialSize:      args.VolumeInitialSize,
 		processGroups:          args.ProcessGroups,
 	}
 	if err := md.setStrategy(); err != nil {

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -24,10 +24,13 @@ import (
 )
 
 const (
-	DefaultWaitTimeout           = 5 * time.Minute
-	DefaultReleaseCommandTimeout = 5 * time.Minute
-	DefaultLeaseTtl              = 13 * time.Second
-	DefaultMaxUnavailable        = 0.33
+	DefaultWaitTimeout                = 5 * time.Minute
+	DefaultReleaseCommandTimeout      = 5 * time.Minute
+	DefaultLeaseTtl                   = 13 * time.Second
+	DefaultMaxUnavailable             = 0.33
+	DefaultVolumeInitialSizeGB        = 1
+	DefaultGPUVolumeInitialSizeGB     = 100
+	DefaultNonFreeVolumeInitialSizeGB = 10
 )
 
 type MachineDeployment interface {


### PR DESCRIPTION
### Change Summary

Volumes of 1GB are fine when testing a new app and don't want to go over the free tier quote, but they are no useful when apps require larger machines that doesn't even fit within the free tier. This is more notorious with GPU apps where It is cumbersome to have to remember about `--volume-initial-size` when launching an app for the first time. 

This PR change the default volume size based on the machine size:
* `shared-cpu-1x` will continue to create 1GB volumes
*  `a100-40gb` and `a100-80gb` will default to 100GB
*  any other size will create 10GB volumes.

At the moment, after creating a 1GB volume,`fly deploy` recommends to use `fly volume extend` to increase it size, but it could be the case that the host where the volume landed doesn't have enough resources to do that on a second call and require migrating the volume somewhere else. By creating larger volume sizes it aims to reduce the risk of hitting a capacity issue early on the app onboarding.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
