### PR TITLE
Fix: `fly m run --shell` fails because organisation ID contains uppercase letters

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -515,7 +515,7 @@ func getOrCreateEphemeralShellApp(ctx context.Context, client *api.Client) (*api
 		appc, err = client.CreateApp(ctx, api.CreateAppInput{
 			OrganizationID: org.ID,
 			// i'll never find love again like the kind you give like the kind you send
-			Name: fmt.Sprintf("flyctl-interactive-shells-%s-%d", org.ID, rand.Intn(1_000_000)),
+			Name: fmt.Sprintf("flyctl-interactive-shells-%s-%d", strings.ToLower(org.ID), rand.Intn(1_000_000)),
 		})
 
 		if err != nil {


### PR DESCRIPTION
### Change Summary

What and Why:

Currently, if you try to create a machine outside of an app directory, `fly m run` attempts to create a new app for you, using the organisation ID within the name. Org ID can contain uppercase letters and we don't allow these in app names, so the command fails.

```
$ fly m run --shell --org personal
Error: create interactive shell app: Validation failed: Name may only contain numbers, lowercase letters and dashes
```

This change calls `strings.ToLower()` on the organisation ID.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
