### PR TITLE
patches for initial_size and memory as integers

### DIFF
--- a/internal/appconfig/patches.go
+++ b/internal/appconfig/patches.go
@@ -16,6 +16,7 @@ var configPatches = []patchFuncType{
 	patchProcesses,
 	patchExperimental,
 	patchTopLevelChecks,
+	patchCompute,
 	patchMounts,
 	patchMetrics,
 	patchTopFields,
@@ -221,6 +222,27 @@ func patchExperimental(cfg map[string]any) (map[string]any, error) {
 	return cfg, nil
 }
 
+func patchCompute(cfg map[string]any) (map[string]any, error) {
+	var compute []map[string]any
+	for _, k := range []string{"compute", "computes"} {
+		if raw, ok := cfg[k]; ok {
+			cast, err := ensureArrayOfMap(raw)
+			if err != nil {
+				return nil, fmt.Errorf("Error processing compute: %w", err)
+			}
+			delete(cfg, k)
+			compute = append(compute, cast...)
+		}
+	}
+	for idx, c := range compute {
+		if v, ok := c["memory"]; ok {
+			compute[idx]["memory"] = castToString(v)
+		}
+	}
+	cfg["compute"] = compute
+	return cfg, nil
+}
+
 func patchMounts(cfg map[string]any) (map[string]any, error) {
 	var mounts []map[string]any
 	for _, k := range []string{"mount", "mounts"} {
@@ -229,7 +251,13 @@ func patchMounts(cfg map[string]any) (map[string]any, error) {
 			if err != nil {
 				return nil, fmt.Errorf("Error processing mounts: %w", err)
 			}
+			delete(cfg, k)
 			mounts = append(mounts, cast...)
+		}
+	}
+	for idx, x := range mounts {
+		if v, ok := x["initial_size"]; ok {
+			mounts[idx]["initial_size"] = castToString(v)
 		}
 	}
 	cfg["mounts"] = mounts

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -236,6 +236,28 @@ func TestLoadTOMLAppConfigMountsArray(t *testing.T) {
 	}, cfg)
 }
 
+func TestLoadTOMLAppConfigFormatQuirks(t *testing.T) {
+	const path = "./testdata/format-quirks.toml"
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	// Nullify cfg.RawDefinition because Compute section is apps v2 only
+	cfg.RawDefinition = nil
+
+	assert.Equal(t, &Config{
+		configFilePath:   "./testdata/format-quirks.toml",
+		defaultGroupName: "app",
+		AppName:          "foo",
+		Compute: []*Compute{{
+			Memory: "512",
+		}},
+		Mounts: []Mount{{
+			Source:      "data",
+			Destination: "/data",
+			InitialSize: "200",
+		}},
+	}, cfg)
+}
+
 func TestLoadTOMLAppConfigEnvList(t *testing.T) {
 	const path = "./testdata/env-list.toml"
 	cfg, err := LoadConfig(path)

--- a/internal/appconfig/testdata/format-quirks.toml
+++ b/internal/appconfig/testdata/format-quirks.toml
@@ -1,0 +1,9 @@
+app = "foo"
+
+[compute]
+memory = 512
+
+[mount]
+source = "data"
+destination = "/data"
+initial_size = 200


### PR DESCRIPTION
### Change Summary

[[mount.initial_size]] and `[[compute.memory` are strings that accepts units like in `2gb`, `1024mb`, ... but it is common to also pass unit-less values as integers because their corresponding cli flags accepts that.

This PR converts integer values to strings so fly.toml parsing doesn't fail and do the expected.

```toml
app = "foo"

[[compute]]
memory = 512

[[mounts]]
source = "data"
destination = "/data"
initial_size = 200
``` 
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
