### PR TITLE
Normalize default volume sizes

### DIFF
--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -125,12 +125,8 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 				initialSize, _ = helpers.ParseSize(m.InitialSize, units.FromHumanSize, units.GB)
 			case md.volumeInitialSize > 0:
 				initialSize = md.volumeInitialSize
-			case guest == nil:
-				initialSize = DefaultVolumeInitialSizeGB
-			case guest.GPUKind != "":
+			case guest != nil && guest.GPUKind != "":
 				initialSize = DefaultGPUVolumeInitialSizeGB
-			case guest.CPUKind != "shared" || guest.CPUs != 1:
-				initialSize = DefaultNonFreeVolumeInitialSizeGB
 			default:
 				initialSize = DefaultVolumeInitialSizeGB
 			}

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -24,13 +24,12 @@ import (
 )
 
 const (
-	DefaultWaitTimeout                = 5 * time.Minute
-	DefaultReleaseCommandTimeout      = 5 * time.Minute
-	DefaultLeaseTtl                   = 13 * time.Second
-	DefaultMaxUnavailable             = 0.33
-	DefaultVolumeInitialSizeGB        = 1
-	DefaultGPUVolumeInitialSizeGB     = 100
-	DefaultNonFreeVolumeInitialSizeGB = 10
+	DefaultWaitTimeout            = 5 * time.Minute
+	DefaultReleaseCommandTimeout  = 5 * time.Minute
+	DefaultLeaseTtl               = 13 * time.Second
+	DefaultMaxUnavailable         = 0.33
+	DefaultVolumeInitialSizeGB    = 3
+	DefaultGPUVolumeInitialSizeGB = 100
 )
 
 type MachineDeployment interface {

--- a/test/preflight/fly_scale_test.go
+++ b/test/preflight/fly_scale_test.go
@@ -33,7 +33,7 @@ primary_region = "%s"
 	require.Equal(f, 1, len(ml))
 
 	// Extend the volume because if not found, scaling will default to 1GB.
-	f.Fly("vol extend -s 2 %s", ml[0].Config.Mounts[0].Volume)
+	f.Fly("vol extend -s 4 %s", ml[0].Config.Mounts[0].Volume)
 
 	f.Fly("scale count -y 2")
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
@@ -61,6 +61,6 @@ primary_region = "%s"
 
 	vl := f.VolumeList(appName)
 	for _, v := range vl {
-		require.Equal(f, v.SizeGb, 2)
+		require.Equal(f, v.SizeGb, 4)
 	}
 }

--- a/test/preflight/fly_volume_test.go
+++ b/test/preflight/fly_volume_test.go
@@ -32,27 +32,27 @@ primary_region = "%s"
 	ml := f.MachinesList(appName)
 	require.Equal(f, 1, len(ml))
 
-	f.Fly("vol extend -s 2 %s", ml[0].Config.Mounts[0].Volume)
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		vl := f.VolumeList(appName)
-		require.Equal(c, vl[0].SizeGb, 2)
-	}, 10*time.Second, 2*time.Second)
-
-	f.Fly("vol extend -s +1 %s", ml[0].Config.Mounts[0].Volume)
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		vl := f.VolumeList(appName)
-		require.Equal(c, vl[0].SizeGb, 3)
-	}, 10*time.Second, 2*time.Second)
-
-	f.Fly("vol extend -s +1gb %s", ml[0].Config.Mounts[0].Volume)
+	f.Fly("vol extend -s 4 %s", ml[0].Config.Mounts[0].Volume)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		vl := f.VolumeList(appName)
 		require.Equal(c, vl[0].SizeGb, 4)
 	}, 10*time.Second, 2*time.Second)
 
-	f.Fly("vol extend -s 5gb %s", ml[0].Config.Mounts[0].Volume)
+	f.Fly("vol extend -s +1 %s", ml[0].Config.Mounts[0].Volume)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		vl := f.VolumeList(appName)
 		require.Equal(c, vl[0].SizeGb, 5)
+	}, 10*time.Second, 2*time.Second)
+
+	f.Fly("vol extend -s +1gb %s", ml[0].Config.Mounts[0].Volume)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		vl := f.VolumeList(appName)
+		require.Equal(c, vl[0].SizeGb, 6)
+	}, 10*time.Second, 2*time.Second)
+
+	f.Fly("vol extend -s 7gb %s", ml[0].Config.Mounts[0].Volume)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		vl := f.VolumeList(appName)
+		require.Equal(c, vl[0].SizeGb, 7)
 	}, 10*time.Second, 2*time.Second)
 }


### PR DESCRIPTION
### Change Summary

We have 4 different defaults volume sizes depending on varying conditions: 1GB, 3GB, 10GB and 100GB.

This PR reduces it to 3GB for all cases except GPU machines that default to 100GB

Closes https://github.com/superfly/flyctl/issues/2868

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
