### PR TITLE
When `--json`, only print valid JSON

### DIFF
--- a/internal/command/certificates/root.go
+++ b/internal/command/certificates/root.go
@@ -163,7 +163,7 @@ func runCertificatesShow(ctx context.Context) error {
 	if cert.ClientStatus == "Ready" {
 		return nil
 	}
-	
+
 	return reportNextStepCert(ctx, hostname, cert, hostcheck)
 }
 
@@ -178,7 +178,7 @@ func runCertificatesCheck(ctx context.Context) error {
 	}
 
 	printCertificate(ctx, cert)
-	
+
 	if cert.ClientStatus == "Ready" {
 		return nil
 	}

--- a/internal/command/certificates/root.go
+++ b/internal/command/certificates/root.go
@@ -150,7 +150,6 @@ func runCertificatesList(ctx context.Context) error {
 
 func runCertificatesShow(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	colorize := io.ColorScheme()
 	apiClient := client.FromContext(ctx).API()
 	appName := appconfig.NameFromContext(ctx)
 	hostname := flag.FirstArg(ctx)
@@ -171,7 +170,6 @@ func runCertificatesShow(ctx context.Context) error {
 
 func runCertificatesCheck(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	colorize := io.ColorScheme()
 	apiClient := client.FromContext(ctx).API()
 	appName := appconfig.NameFromContext(ctx)
 	hostname := flag.FirstArg(ctx)
@@ -383,6 +381,8 @@ func reportNextStepCert(ctx context.Context, hostname string, cert *api.AppCerti
 
 func printCertificate(ctx context.Context, cert *api.AppCertificate) {
 	io := iostreams.FromContext(ctx)
+	colorize := io.ColorScheme()
+	hostname := flag.FirstArg(ctx)
 
 	if config.FromContext(ctx).JSONOutput {
 		render.JSON(io.Out, cert)

--- a/internal/command/certificates/root.go
+++ b/internal/command/certificates/root.go
@@ -149,7 +149,6 @@ func runCertificatesList(ctx context.Context) error {
 }
 
 func runCertificatesShow(ctx context.Context) error {
-	io := iostreams.FromContext(ctx)
 	apiClient := client.FromContext(ctx).API()
 	appName := appconfig.NameFromContext(ctx)
 	hostname := flag.FirstArg(ctx)
@@ -169,7 +168,6 @@ func runCertificatesShow(ctx context.Context) error {
 }
 
 func runCertificatesCheck(ctx context.Context) error {
-	io := iostreams.FromContext(ctx)
 	apiClient := client.FromContext(ctx).API()
 	appName := appconfig.NameFromContext(ctx)
 	hostname := flag.FirstArg(ctx)

--- a/internal/command/certificates/root.go
+++ b/internal/command/certificates/root.go
@@ -160,16 +160,12 @@ func runCertificatesShow(ctx context.Context) error {
 		return err
 	}
 
+	printCertificate(ctx, cert)
+
 	if cert.ClientStatus == "Ready" {
-		if !flag.GetBool(ctx, "json") {
-			fmt.Fprintf(io.Out, "The certificate for %s has been issued.\n\n", colorize.Bold(hostname))
-		}
-		printCertificate(ctx, cert)
 		return nil
 	}
-
-	fmt.Fprintf(io.Out, "The certificate for %s has not been issued yet.\n\n", colorize.Yellow(hostname))
-	printCertificate(ctx, cert)
+	
 	return reportNextStepCert(ctx, hostname, cert, hostcheck)
 }
 
@@ -185,14 +181,11 @@ func runCertificatesCheck(ctx context.Context) error {
 		return err
 	}
 
+	printCertificate(ctx, cert)
+	
 	if cert.ClientStatus == "Ready" {
-		// A certificate has been issued
-		fmt.Fprintf(io.Out, "The certificate for %s has been issued.\n\n", colorize.Bold(hostname))
-		printCertificate(ctx, cert)
 		return nil
 	}
-
-	fmt.Fprintf(io.Out, "The certificate for %s has not been issued yet.\n\n", colorize.Yellow(hostname))
 
 	return reportNextStepCert(ctx, hostname, cert, hostcheck)
 }
@@ -394,6 +387,12 @@ func printCertificate(ctx context.Context, cert *api.AppCertificate) {
 	if config.FromContext(ctx).JSONOutput {
 		render.JSON(io.Out, cert)
 		return
+	}
+
+	if cert.ClientStatus == "Ready" {
+		fmt.Fprintf(io.Out, "The certificate for %s has been issued.\n\n", colorize.Bold(hostname))
+	} else {
+		fmt.Fprintf(io.Out, "The certificate for %s has not been issued yet.\n\n", colorize.Yellow(hostname))
 	}
 
 	myprnt := func(label string, value string) {

--- a/internal/command/certificates/root.go
+++ b/internal/command/certificates/root.go
@@ -161,7 +161,9 @@ func runCertificatesShow(ctx context.Context) error {
 	}
 
 	if cert.ClientStatus == "Ready" {
-		fmt.Fprintf(io.Out, "The certificate for %s has been issued.\n\n", colorize.Bold(hostname))
+		if !flag.GetBool(ctx, "json") {
+			fmt.Fprintf(io.Out, "The certificate for %s has been issued.\n\n", colorize.Bold(hostname))
+		}
 		printCertificate(ctx, cert)
 		return nil
 	}


### PR DESCRIPTION
The code change suppresses the output of a message to stdout before the actual certificate JSON. Without this change, if you try to parse the response as JSON, you get an error because the message and the two line breaks are not valid JSON.

Related to and fixes #2809