### PR TITLE
launch: fix app name sanitization bug that rejected OK app names

### DIFF
--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -355,7 +355,7 @@ func sanitizeAppName(dirName string) string {
 	lastIsUnderscore := false
 
 	for _, c := range dirName {
-		if c <= unicode.MaxASCII {
+		if c >= unicode.MaxASCII {
 			continue
 		}
 		if !unicode.IsLetter(c) && !unicode.IsNumber(c) {

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -409,16 +409,20 @@ func determineAppName(ctx context.Context, appConfig *appconfig.Config, configPa
 	//  If this fails, return a recoverable error.
 
 	appName := flag.GetString(ctx, "name")
+	cause := "specified on the command line"
 	if !flag.GetBool(ctx, "generate-name") && appName == "" {
 		appName = appConfig.AppName
+		cause = "from your fly.toml"
 	}
 	if appName == "" {
 		appName = sanitizeAppName(filepath.Base(filepath.Dir(configPath)))
+		cause = "derived from your directory name"
 	}
 	if appName == "" {
 
 		var found bool
 		appName, found = findUniqueAppName("")
+		cause = "generated"
 
 		if !found {
 			return "", recoverableSpecifyInUi, recoverableInUiError{flyerr.GenericErr{
@@ -439,7 +443,7 @@ func determineAppName(ctx context.Context, appConfig *appconfig.Config, configPa
 			return "", recoverableSpecifyInUi, recoverableInUiError{appNameTakenErr(appName)}
 		}
 	}
-	return appName, "derived from your directory name", nil
+	return appName, cause, nil
 }
 
 func appNameTaken(ctx context.Context, name string) (bool, error) {


### PR DESCRIPTION
### Change Summary

What and Why: fixes logic that was backwards in the app name sanitization code. this is what happens when you *only* test edge cases and not happy paths, apparently.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
