### PR TITLE
Rename fly.toml's section [[compute]] to [[vm]]

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -62,7 +62,7 @@ type Config struct {
 	Files            []File                    `toml:"files,omitempty" json:"files,omitempty"`
 	HostDedicationID string                    `toml:"host_dedication_id,omitempty" json:"host_dedication_id,omitempty"`
 
-	Compute []*Compute `toml:"compute,omitempty" json:"compute,omitempty"`
+	Compute []*Compute `toml:"vm,omitempty" json:"vm,omitempty"`
 
 	// Others, less important.
 	Statics []Static   `toml:"statics,omitempty" json:"statics,omitempty"`

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -169,7 +169,7 @@ func TestToDefinition(t *testing.T) {
 		"swap_size_mb":       int64(512),
 		"console_command":    "/bin/bash",
 		"host_dedication_id": "06031957",
-		"compute": []map[string]any{
+		"vm": []map[string]any{
 			{
 				"size":               "shared-cpu-1x",
 				"memory":             "8gb",

--- a/internal/appconfig/patches.go
+++ b/internal/appconfig/patches.go
@@ -224,7 +224,7 @@ func patchExperimental(cfg map[string]any) (map[string]any, error) {
 
 func patchCompute(cfg map[string]any) (map[string]any, error) {
 	var compute []map[string]any
-	for _, k := range []string{"compute", "computes"} {
+	for _, k := range []string{"compute", "computes", "vm"} {
 		if raw, ok := cfg[k]; ok {
 			cast, err := ensureArrayOfMap(raw)
 			if err != nil {
@@ -239,7 +239,7 @@ func patchCompute(cfg map[string]any) (map[string]any, error) {
 			compute[idx]["memory"] = castToString(v)
 		}
 	}
-	cfg["compute"] = compute
+	cfg["vm"] = compute
 	return cfg, nil
 }
 

--- a/internal/appconfig/processgroups.go
+++ b/internal/appconfig/processgroups.go
@@ -167,13 +167,13 @@ func (c *Config) Flatten(groupName string) (*Config, error) {
 		dst.Metrics[i].Processes = []string{groupName}
 	}
 
-	// [[compute]]
-	// Find the most specific compute for this process group
+	// [[vm]]
+	// Find the most specific VM compute requirements for this process group
 	// In reality there are only four valid cases:
-	//   1. No [[compute]] section
-	//   2. One [[compute]] section with `processes = [groupname]`
+	//   1. No [[vm]] section
+	//   2. One [[vm]] section with `processes = [groupname]`
 	//   3. Previous case plus global [[compute]] without processes
-	//   4. Only a [[compute]] section without processes set which applies to all groups
+	//   4. Only a [[vm]] section without processes set which applies to all groups
 	compute := lo.MaxBy(
 		// grab only the compute that matches or have no processes set
 		lo.Filter(dst.Compute, func(x *Compute, _ int) bool {

--- a/internal/appconfig/testdata/format-quirks.toml
+++ b/internal/appconfig/testdata/format-quirks.toml
@@ -1,6 +1,6 @@
 app = "foo"
 
-[compute]
+[vm]
 memory = 512
 
 [mount]

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -109,7 +109,7 @@ host_dedication_id = "06031957"
   initial_size = "30gb"
   destination = "/data"
 
-[[compute]]
+[[vm]]
   size = "shared-cpu-1x"
   cpu_kind = "performance"
   cpus = 8

--- a/internal/appconfig/testdata/tomachine-compute-nodefault.toml
+++ b/internal/appconfig/testdata/tomachine-compute-nodefault.toml
@@ -5,6 +5,6 @@ app = ""
 woo = ""
 bar = ""
 
-[[compute]]
+[[vm]]
 size = "performance-4x"
 processes = ["bar"]

--- a/internal/appconfig/testdata/tomachine-compute.toml
+++ b/internal/appconfig/testdata/tomachine-compute.toml
@@ -7,15 +7,16 @@ whisper = "/whisperme"
 isolated = "/must-run-alone"
 
 # A section that applies to a specific group
-[[compute]]
+[[vm]]
 memory = "64gb"
 gpu_kind = "a100-pcie-40gb"
 processes = ["whisper"]
 
+# [[compute]] is an alias for [[vm]]
 [[compute]]
 host_dedication_id = "lookma-iamsolo"
 processes = ["isolated"]
 
 # A section without processes set must apply to all process groups
-[[compute]]
+[[vm]]
 size = "shared-cpu-2x"

--- a/internal/appconfig/testdata/tomachine-hostdedicationid.toml
+++ b/internal/appconfig/testdata/tomachine-hostdedicationid.toml
@@ -6,10 +6,10 @@ front = ""
 back = ""
 other = ""
 
-[[compute]]
+[[vm]]
 size = "shared-cpu-4x"
 processes = ["other"]
 
-[[compute]]
+[[vm]]
 host_dedication_id = "specific"
 processes = ["back"]


### PR DESCRIPTION
### Change Summary

The new compute requirements section was named `[[compute]]` but that is harder to associate to the established `--vm-*` family flag set.

Rename it to `[[vm]]` so `--vm-size`, `--vm-memory`, `--vm-cpus`, `--vm-gpu-kind` can map without much brain stress to toml:

```toml
[[vm]]
  size = "performance-2x"
  memory = "16gb"
```

A nice plus of this stuff is that we can abuse TOML's parsing and write a very short version that works out of the box:

```toml
app = "my-app"
primary_region = "ord"
vm.size = "a100-40gb"
```

NOTE: retains backward compatibility with `[[compute]]` keyword for the few projects that adopted it.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
