### PR TITLE
Fix a crash when SIGINTing `fly consul detach`

### DIFF
--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -427,7 +427,7 @@ func (lm *leasableMachine) ReleaseLease(ctx context.Context) error {
 	if contextWasAlreadyCanceled {
 		var cancel context.CancelFunc
 		cancelTimeout := 500 * time.Millisecond
-		ctx, cancel = context.WithTimeout(context.TODO(), cancelTimeout)
+		ctx, cancel = context.WithTimeout(ctx, cancelTimeout)
 		terminal.Infof("detected canceled context and allowing %s to release machine %s lease\n", cancelTimeout, lm.FormattedMachineId())
 		defer cancel()
 	}

--- a/internal/machine/machine_set.go
+++ b/internal/machine/machine_set.go
@@ -106,7 +106,7 @@ func (ms *machineSet) ReleaseLeases(ctx context.Context) error {
 	if contextWasAlreadyCanceled {
 		var cancel context.CancelFunc
 		cancelTimeout := 500 * time.Millisecond
-		ctx, cancel = context.WithTimeout(context.TODO(), cancelTimeout)
+		ctx, cancel = context.WithTimeout(ctx, cancelTimeout)
 		terminal.Infof("detected canceled context and allowing %s to release machine leases\n", cancelTimeout)
 		defer cancel()
 	}


### PR DESCRIPTION
We weren't passing the proper context, for some reason

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
