### PR TITLE
`launch`: move responsibility of creating volumes to `fly deploy`

### DIFF
--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -87,6 +88,12 @@ func (state *launchState) updateConfig(ctx context.Context) {
 		state.appConfig.HTTPService.InternalPort = state.Plan.HttpServicePort
 	} else {
 		state.appConfig.HTTPService = nil
+	}
+	state.appConfig.Compute = []*appconfig.Compute{
+		{
+			MachineGuest: state.Plan.Guest(),
+			Processes:    lo.Keys(state.appConfig.Processes),
+		},
 	}
 }
 


### PR DESCRIPTION
### Change Summary

What and Why: it's in the title!

This makes volume creation more consistent, as there's one place (deploy) that creates volumes on demand.

I included a drive-by fix to throw the machine guest into `appconfig.Config.Compute` as well

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
