### PR TITLE
Send user OAuth token to auth.fly.io when fetching discharge tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/superfly/flyctl/api v0.0.0-20230714194642-3abf5055f01a
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
-	github.com/superfly/macaroon v0.1.0
+	github.com/superfly/macaroon v0.2.4
 	github.com/superfly/tokenizer v0.0.2
 	github.com/vektah/gqlparser v1.3.1
 	github.com/vektah/gqlparser/v2 v2.5.10

--- a/go.sum
+++ b/go.sum
@@ -698,8 +698,8 @@ github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2
 github.com/superfly/lfsc-go v0.1.1/go.mod h1:zVb0VENz/Il8Nmvvd4XAsX2bWhQ+sr0nK8vv9PeezcE=
 github.com/superfly/ltx v0.3.12 h1:Z7z1sc4g34/jUi3XO84+zBlIsbaoh2RJ3b4zTQpBK/M=
 github.com/superfly/ltx v0.3.12/go.mod h1:ly+Dq7UVacQVEI5/b0r6j+PSNy9ibwx1yikcWAaSkhE=
-github.com/superfly/macaroon v0.1.0 h1:PGmTkt+W86zSFrtRoEoYqbOYzdZUFxJlXTql4ZWEcEo=
-github.com/superfly/macaroon v0.1.0/go.mod h1:Kt6/EdSYfFjR4GIe+erMwcJgU8iMu1noYVceQ5dNdKo=
+github.com/superfly/macaroon v0.2.4 h1:FpcThh/qwqOMfGB3/vf3b+OOgtN1/LmF0zS6J3z4P5c=
+github.com/superfly/macaroon v0.2.4/go.mod h1:Kt6/EdSYfFjR4GIe+erMwcJgU8iMu1noYVceQ5dNdKo=
 github.com/superfly/tokenizer v0.0.2 h1:gBREpm08sPWUHsqKHKHFy/AIKwrqpg+VBD/wtJ6x5Jk=
 github.com/superfly/tokenizer v0.0.2/go.mod h1:jO8bIWFsfcBghh7I6cFJHmJb5E3RQr0v4F0Rnev3Yj4=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -72,10 +72,6 @@ func (t *Tokens) Macaroons() string {
 	return strings.Join(t.macaroonTokens, ",")
 }
 
-var tpClient = flyio.DischargeClient(
-	tp.WithUserURLCallback(tryOpenUserURL),
-)
-
 // DischargeThirdPartyCaveats attempts to fetch any necessary discharge tokens
 // for 3rd party caveats found within macaroon tokens.
 //
@@ -86,7 +82,16 @@ func (t *Tokens) DischargeThirdPartyCaveats(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	switch needDischarge, err := tpClient.NeedsDischarge(macaroons); {
+	opts := []tp.ClientOption{tp.WithUserURLCallback(tryOpenUserURL)}
+	if len(t.userTokens) != 0 {
+		opts = append(opts, tp.WithBearerAuthentication(
+			"auth.fly.io",
+			strings.Join(t.userTokens, ","),
+		))
+	}
+	c := flyio.DischargeClient(opts...)
+
+	switch needDischarge, err := c.NeedsDischarge(macaroons); {
 	case err != nil:
 		return false, err
 	case !needDischarge:
@@ -95,7 +100,7 @@ func (t *Tokens) DischargeThirdPartyCaveats(ctx context.Context) (bool, error) {
 
 	logger.FromContext(ctx).Debug("Attempting to upgrade authentication token...")
 
-	withDischarges, err := tpClient.FetchDischargeTokens(ctx, macaroons)
+	withDischarges, err := c.FetchDischargeTokens(ctx, macaroons)
 
 	// withDischarges will be non-empty in the event of partial success
 	if withDischarges != "" && withDischarges != macaroons {
@@ -109,6 +114,8 @@ func (t *Tokens) DischargeThirdPartyCaveats(ctx context.Context) (bool, error) {
 // PruneBadMacaroons removes expired and invalid macaroon tokens.
 func (t *Tokens) PruneBadMacaroons() bool {
 	var updated bool
+
+	// TODO: remove unused discharge tokens
 
 	t.macaroonTokens = slices.DeleteFunc(t.macaroonTokens, func(tok string) bool {
 		raws, err := macaroon.Parse(tok)

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -72,10 +72,9 @@ func (t *Tokens) Macaroons() string {
 	return strings.Join(t.macaroonTokens, ",")
 }
 
-var tpClient = &tp.Client{
-	FirstPartyLocation: flyio.LocationPermission,
-	UserURLCallback:    tryOpenUserURL,
-}
+var tpClient = flyio.DischargeClient(
+	tp.WithUserURLCallback(tryOpenUserURL),
+)
 
 // DischargeThirdPartyCaveats attempts to fetch any necessary discharge tokens
 // for 3rd party caveats found within macaroon tokens.


### PR DESCRIPTION
### Change Summary

What and Why:

If there is a third party caveat requiring normal fly.io user auth, this avoids us having to send the user to auth.fly.io to discharge it.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
