### PR TITLE
print stack traces on `LOG_LEVEL=debug`

### DIFF
--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -135,7 +135,7 @@ func printError(v interface{}) {
 
 	fmt.Fprintln(&buf, aurora.Red("Oops, something went wrong! Could you try that again?"))
 
-	if buildinfo.IsDev() {
+	if buildinfo.IsDev() || os.Getenv("LOG_LEVEL") == "debug" {
 		fmt.Fprintln(&buf)
 		fmt.Fprintln(&buf, v)
 		fmt.Fprintln(&buf, string(debug.Stack()))


### PR DESCRIPTION
### Change Summary

What and Why:

Right now, only dev builds of flyctl print stack traces. I don't work primarily on flyctl so I don't usually have a dev build around, but I still want to see stack traces without checking Sentry.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
