### PR TITLE
Added check for Vite app

### DIFF
--- a/scanner/jsFramework.go
+++ b/scanner/jsFramework.go
@@ -155,6 +155,10 @@ func configureJsFramework(sourceDir string, config *ScannerConfig) (*SourceInfo,
 	if !ok || devdeps == nil {
 		devdeps = make(map[string]interface{})
 	}
+	scripts, ok := packageJson["scripts"].(map[string]interface{})
+	if !ok || scripts == nil {
+		scripts = make(map[string]interface{})
+	}
 
 	// infer db from dependencies
 	if deps["pg"] != nil {
@@ -208,6 +212,9 @@ func configureJsFramework(sourceDir string, config *ScannerConfig) (*SourceInfo,
 		srcInfo.Family = "Nuxt"
 	} else if deps["remix"] != nil || deps["@remix-run/node"] != nil {
 		srcInfo.Family = "Remix"
+	} else if scripts["dev"] == "vite" {
+		srcInfo.Family = "Vite"
+		srcInfo.Port = 80
 	}
 
 	return srcInfo, nil


### PR DESCRIPTION
### Change Summary

With the release of `dockerfile-node` version 0.4.11, we now check for Vite apps so we tweak the Dockerfile to not use Node, but rather Nginx. As such, I've included the extra check in `flyctl`, as we've done for the other JS frameworks.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
