### PR TITLE
Django: Add --noinput to migrate command in ReleaseCmd

### DIFF
--- a/scanner/django.go
+++ b/scanner/django.go
@@ -191,7 +191,7 @@ Optionally, you can use django.core.management.utils.get_random_secret_key() to 
 		checksPass(sourceDir, dirContains("Pipfile", "psycopg")) ||
 		checksPass(sourceDir, dirContains("pyproject.toml", "psycopg")) {
 		vars["hasPostgres"] = true
-		s.ReleaseCmd = "python manage.py migrate"
+		s.ReleaseCmd = "python manage.py migrate --noinput"
 
 		if !checksPass(sourceDir, dirContains("requirements.txt", "django-environ", "dj-database-url")) {
 			s.DeployDocs = s.DeployDocs + `


### PR DESCRIPTION
### Change Summary

Add [`--noinput`](https://docs.djangoproject.com/en/stable/ref/django-admin/#cmdoption-migrate-noinput) to Django migrate command in ReleaseCmd.

The `--noinput` option suppresses all user prompts - useful in this case when the deployment process is automated.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
