### PR TITLE
adjust --no-deploy desc for launch ui experience

### DIFF
--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -297,7 +297,7 @@ func (d Duration) addTo(cmd *cobra.Command) {
 func Org() String {
 	return String{
 		Name:         flagnames.Org,
-		Description:  "The target Fly organization",
+		Description:  "The target Fly.io organization",
 		Shorthand:    "o",
 		CompletionFn: completion.CompleteOrgs,
 	}
@@ -371,7 +371,7 @@ func Now() Bool {
 func NoDeploy() Bool {
 	return Bool{
 		Name:        "no-deploy",
-		Description: "Do not prompt for deployment",
+		Description: "Do not deploy the new app after initial creation and configuration",
 	}
 }
 

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -371,7 +371,7 @@ func Now() Bool {
 func NoDeploy() Bool {
 	return Bool{
 		Name:        "no-deploy",
-		Description: "Do not deploy the new app after initial creation and configuration",
+		Description: "Do not immediately deploy the new app after fly launch creates and configures it",
 	}
 }
 


### PR DESCRIPTION
### Change Summary

What and Why:

Need to adjust the description for the `fly launch --no-deploy` flag to reflect the launch ui experience.

How:

Updated the help text

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
