### PR TITLE
Ensure secrets are not overwritten when provisioning extensions

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -420,6 +420,8 @@ type AppData struct {
 	Deployed bool   `json:"deployed"`
 	// Fly platform version
 	PlatformVersion PlatformVersionEnum `json:"platformVersion"`
+	// Secrets set on the application
+	Secrets []AppDataSecretsSecret `json:"secrets"`
 	// Organization that owns this app
 	Organization AppDataOrganization `json:"organization"`
 }
@@ -435,6 +437,9 @@ func (v *AppData) GetDeployed() bool { return v.Deployed }
 
 // GetPlatformVersion returns AppData.PlatformVersion, and is useful for accessing the field via an interface.
 func (v *AppData) GetPlatformVersion() PlatformVersionEnum { return v.PlatformVersion }
+
+// GetSecrets returns AppData.Secrets, and is useful for accessing the field via an interface.
+func (v *AppData) GetSecrets() []AppDataSecretsSecret { return v.Secrets }
 
 // GetOrganization returns AppData.Organization, and is useful for accessing the field via an interface.
 func (v *AppData) GetOrganization() AppDataOrganization { return v.Organization }
@@ -522,6 +527,15 @@ func (v *AppDataOrganization) __premarshalJSON() (*__premarshalAppDataOrganizati
 	retval.ProvisionsBetaExtensions = v.OrganizationData.ProvisionsBetaExtensions
 	return &retval, nil
 }
+
+// AppDataSecretsSecret includes the requested fields of the GraphQL type Secret.
+type AppDataSecretsSecret struct {
+	// The name of the secret
+	Name string `json:"name"`
+}
+
+// GetName returns AppDataSecretsSecret.Name, and is useful for accessing the field via an interface.
+func (v *AppDataSecretsSecret) GetName() string { return v.Name }
 
 type BuildFinalImageInput struct {
 	// Sha256 id of docker image
@@ -847,6 +861,11 @@ func (v *CreateAppCreateAppCreateAppPayloadApp) GetPlatformVersion() PlatformVer
 	return v.AppData.PlatformVersion
 }
 
+// GetSecrets returns CreateAppCreateAppCreateAppPayloadApp.Secrets, and is useful for accessing the field via an interface.
+func (v *CreateAppCreateAppCreateAppPayloadApp) GetSecrets() []AppDataSecretsSecret {
+	return v.AppData.Secrets
+}
+
 // GetOrganization returns CreateAppCreateAppCreateAppPayloadApp.Organization, and is useful for accessing the field via an interface.
 func (v *CreateAppCreateAppCreateAppPayloadApp) GetOrganization() AppDataOrganization {
 	return v.AppData.Organization
@@ -890,6 +909,8 @@ type __premarshalCreateAppCreateAppCreateAppPayloadApp struct {
 
 	PlatformVersion PlatformVersionEnum `json:"platformVersion"`
 
+	Secrets []AppDataSecretsSecret `json:"secrets"`
+
 	Organization AppDataOrganization `json:"organization"`
 }
 
@@ -910,6 +931,7 @@ func (v *CreateAppCreateAppCreateAppPayloadApp) __premarshalJSON() (*__premarsha
 	retval.Name = v.AppData.Name
 	retval.Deployed = v.AppData.Deployed
 	retval.PlatformVersion = v.AppData.PlatformVersion
+	retval.Secrets = v.AppData.Secrets
 	retval.Organization = v.AppData.Organization
 	return &retval, nil
 }
@@ -1855,6 +1877,9 @@ func (v *GetAddOnAddOnApp) GetDeployed() bool { return v.AppData.Deployed }
 // GetPlatformVersion returns GetAddOnAddOnApp.PlatformVersion, and is useful for accessing the field via an interface.
 func (v *GetAddOnAddOnApp) GetPlatformVersion() PlatformVersionEnum { return v.AppData.PlatformVersion }
 
+// GetSecrets returns GetAddOnAddOnApp.Secrets, and is useful for accessing the field via an interface.
+func (v *GetAddOnAddOnApp) GetSecrets() []AppDataSecretsSecret { return v.AppData.Secrets }
+
 // GetOrganization returns GetAddOnAddOnApp.Organization, and is useful for accessing the field via an interface.
 func (v *GetAddOnAddOnApp) GetOrganization() AppDataOrganization { return v.AppData.Organization }
 
@@ -1892,6 +1917,8 @@ type __premarshalGetAddOnAddOnApp struct {
 
 	PlatformVersion PlatformVersionEnum `json:"platformVersion"`
 
+	Secrets []AppDataSecretsSecret `json:"secrets"`
+
 	Organization AppDataOrganization `json:"organization"`
 }
 
@@ -1910,6 +1937,7 @@ func (v *GetAddOnAddOnApp) __premarshalJSON() (*__premarshalGetAddOnAddOnApp, er
 	retval.Name = v.AppData.Name
 	retval.Deployed = v.AppData.Deployed
 	retval.PlatformVersion = v.AppData.PlatformVersion
+	retval.Secrets = v.AppData.Secrets
 	retval.Organization = v.AppData.Organization
 	return &retval, nil
 }
@@ -2135,6 +2163,9 @@ func (v *GetAppApp) GetDeployed() bool { return v.AppData.Deployed }
 // GetPlatformVersion returns GetAppApp.PlatformVersion, and is useful for accessing the field via an interface.
 func (v *GetAppApp) GetPlatformVersion() PlatformVersionEnum { return v.AppData.PlatformVersion }
 
+// GetSecrets returns GetAppApp.Secrets, and is useful for accessing the field via an interface.
+func (v *GetAppApp) GetSecrets() []AppDataSecretsSecret { return v.AppData.Secrets }
+
 // GetOrganization returns GetAppApp.Organization, and is useful for accessing the field via an interface.
 func (v *GetAppApp) GetOrganization() AppDataOrganization { return v.AppData.Organization }
 
@@ -2172,6 +2203,8 @@ type __premarshalGetAppApp struct {
 
 	PlatformVersion PlatformVersionEnum `json:"platformVersion"`
 
+	Secrets []AppDataSecretsSecret `json:"secrets"`
+
 	Organization AppDataOrganization `json:"organization"`
 }
 
@@ -2190,6 +2223,7 @@ func (v *GetAppApp) __premarshalJSON() (*__premarshalGetAppApp, error) {
 	retval.Name = v.AppData.Name
 	retval.Deployed = v.AppData.Deployed
 	retval.PlatformVersion = v.AppData.PlatformVersion
+	retval.Secrets = v.AppData.Secrets
 	retval.Organization = v.AppData.Organization
 	return &retval, nil
 }
@@ -2260,6 +2294,9 @@ func (v *GetAppWithAddonsApp) GetPlatformVersion() PlatformVersionEnum {
 	return v.AppData.PlatformVersion
 }
 
+// GetSecrets returns GetAppWithAddonsApp.Secrets, and is useful for accessing the field via an interface.
+func (v *GetAppWithAddonsApp) GetSecrets() []AppDataSecretsSecret { return v.AppData.Secrets }
+
 // GetOrganization returns GetAppWithAddonsApp.Organization, and is useful for accessing the field via an interface.
 func (v *GetAppWithAddonsApp) GetOrganization() AppDataOrganization { return v.AppData.Organization }
 
@@ -2299,6 +2336,8 @@ type __premarshalGetAppWithAddonsApp struct {
 
 	PlatformVersion PlatformVersionEnum `json:"platformVersion"`
 
+	Secrets []AppDataSecretsSecret `json:"secrets"`
+
 	Organization AppDataOrganization `json:"organization"`
 }
 
@@ -2318,6 +2357,7 @@ func (v *GetAppWithAddonsApp) __premarshalJSON() (*__premarshalGetAppWithAddonsA
 	retval.Name = v.AppData.Name
 	retval.Deployed = v.AppData.Deployed
 	retval.PlatformVersion = v.AppData.PlatformVersion
+	retval.Secrets = v.AppData.Secrets
 	retval.Organization = v.AppData.Organization
 	return &retval, nil
 }
@@ -2462,6 +2502,11 @@ func (v *GetAppsByRoleAppsAppConnectionNodesApp) GetPlatformVersion() PlatformVe
 	return v.AppData.PlatformVersion
 }
 
+// GetSecrets returns GetAppsByRoleAppsAppConnectionNodesApp.Secrets, and is useful for accessing the field via an interface.
+func (v *GetAppsByRoleAppsAppConnectionNodesApp) GetSecrets() []AppDataSecretsSecret {
+	return v.AppData.Secrets
+}
+
 // GetOrganization returns GetAppsByRoleAppsAppConnectionNodesApp.Organization, and is useful for accessing the field via an interface.
 func (v *GetAppsByRoleAppsAppConnectionNodesApp) GetOrganization() AppDataOrganization {
 	return v.AppData.Organization
@@ -2501,6 +2546,8 @@ type __premarshalGetAppsByRoleAppsAppConnectionNodesApp struct {
 
 	PlatformVersion PlatformVersionEnum `json:"platformVersion"`
 
+	Secrets []AppDataSecretsSecret `json:"secrets"`
+
 	Organization AppDataOrganization `json:"organization"`
 }
 
@@ -2519,6 +2566,7 @@ func (v *GetAppsByRoleAppsAppConnectionNodesApp) __premarshalJSON() (*__premarsh
 	retval.Name = v.AppData.Name
 	retval.Deployed = v.AppData.Deployed
 	retval.PlatformVersion = v.AppData.PlatformVersion
+	retval.Secrets = v.AppData.Secrets
 	retval.Organization = v.AppData.Organization
 	return &retval, nil
 }
@@ -4096,6 +4144,9 @@ fragment AppData on App {
 	name
 	deployed
 	platformVersion
+	secrets {
+		name
+	}
 	organization {
 		... OrganizationData
 	}
@@ -4433,6 +4484,9 @@ fragment AppData on App {
 	name
 	deployed
 	platformVersion
+	secrets {
+		name
+	}
 	organization {
 		... OrganizationData
 	}
@@ -4541,6 +4595,9 @@ fragment AppData on App {
 	name
 	deployed
 	platformVersion
+	secrets {
+		name
+	}
 	organization {
 		... OrganizationData
 	}
@@ -4636,6 +4693,9 @@ fragment AppData on App {
 	name
 	deployed
 	platformVersion
+	secrets {
+		name
+	}
 	organization {
 		... OrganizationData
 	}
@@ -4699,6 +4759,9 @@ fragment AppData on App {
 	name
 	deployed
 	platformVersion
+	secrets {
+		name
+	}
 	organization {
 		... OrganizationData
 	}

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -143,6 +143,9 @@ fragment AppData on App {
 	name
 	deployed
 	platformVersion
+	secrets {
+		name
+	}
 	organization {
 		...OrganizationData
 	}

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -21,8 +21,9 @@ import (
 )
 
 type Extension struct {
-	Data gql.ExtensionData
-	App  gql.AppData
+	Data        gql.ExtensionData
+	App         gql.AppData
+	SetsSecrets bool
 }
 
 type ExtensionParams struct {
@@ -211,7 +212,7 @@ func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension 
 			colorize.Green(primaryRegion), provider.DisplayName)
 	}
 
-	SetSecrets(ctx, &targetApp, extension.Data.Environment.(map[string]interface{}))
+	setSecretsFromExtension(ctx, &targetApp, &extension)
 
 	return extension, nil
 }
@@ -412,13 +413,40 @@ func Discover(ctx context.Context, provider gql.AddOnType) (addOn *gql.AddOnData
 	return
 }
 
-func SetSecrets(ctx context.Context, app *gql.AppData, secrets map[string]interface{}) (err error) {
+func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *Extension) (err error) {
 	var (
-		io     = iostreams.FromContext(ctx)
-		client = client.FromContext(ctx).API().GenqClient
+		io              = iostreams.FromContext(ctx)
+		client          = client.FromContext(ctx).API().GenqClient
+		setSecrets bool = true
+		secrets         = extension.Data.Environment.(map[string]interface{})
 	)
 
 	if app.Name != "" {
+		appResp, err := gql.GetApp(ctx, client, app.Name)
+
+		if err != nil {
+			return err
+		}
+
+		var matchingNames []string
+
+		for _, s := range appResp.App.Secrets {
+			if _, exists := secrets[s.Name]; exists {
+				matchingNames = append(matchingNames, s.Name)
+			}
+		}
+
+		if len(matchingNames) > 0 {
+			fmt.Fprintf(io.Out, "Secrets %v already exist on app %s. They won't be set automatically.\n\n", matchingNames, app.Name)
+			setSecrets = false
+		}
+
+	} else {
+		setSecrets = false
+	}
+
+	if setSecrets {
+		extension.SetsSecrets = true
 		fmt.Fprintf(io.Out, "Setting the following secrets on %s:\n", app.Name)
 		input := gql.SetSecretsInput{
 			AppId: app.Id,
@@ -432,6 +460,9 @@ func SetSecrets(ctx context.Context, app *gql.AppData, secrets map[string]interf
 
 		_, err = gql.SetSecrets(ctx, client, input)
 
+		if err != nil {
+			return err
+		}
 	} else {
 		fmt.Fprintf(io.Out, "Set one or more of the following secrets on your target app.\n")
 		for key, value := range secrets {

--- a/internal/command/extensions/planetscale/create.go
+++ b/internal/command/extensions/planetscale/create.go
@@ -50,6 +50,9 @@ func runPlanetscaleCreate(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if extension.SetsSecrets {
+		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(extension.App), false, false)
+	}
 
-	return secrets.DeploySecrets(ctx, gql.ToAppCompact(extension.App), false, false)
+	return err
 }

--- a/internal/command/extensions/sentry/create.go
+++ b/internal/command/extensions/sentry/create.go
@@ -35,6 +35,8 @@ func runSentryCreate(ctx context.Context) (err error) {
 		AppName:  appName,
 		Provider: "sentry",
 	})
-	secrets.DeploySecrets(ctx, gql.ToAppCompact(extension.App), false, false)
+	if extension.SetsSecrets {
+		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(extension.App), false, false)
+	}
 	return
 }

--- a/internal/command/extensions/supabase/create.go
+++ b/internal/command/extensions/supabase/create.go
@@ -59,7 +59,9 @@ func runCreate(ctx context.Context) (err error) {
 		return err
 	}
 
-	secrets.DeploySecrets(ctx, gql.ToAppCompact(extension.App), false, false)
+	if extension.SetsSecrets {
+		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(extension.App), false, false)
+	}
 
 	return
 }

--- a/internal/command/extensions/tigris/create.go
+++ b/internal/command/extensions/tigris/create.go
@@ -59,7 +59,9 @@ func runCreate(ctx context.Context) (err error) {
 		return err
 	}
 
-	secrets.DeploySecrets(ctx, gql.ToAppCompact(extension.App), false, false)
+	if extension.SetsSecrets {
+		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(extension.App), false, false)
+	}
 
-	return
+	return err
 }


### PR DESCRIPTION
This PR prevents commands like `fly ext supabase create` from overwriting existing secrets with the same name as those provided by the extension. This only affects cases when running `fly ext` commands within an app context. This bit me a few times, so surely will bite others.