### PR TITLE
Plumb `tokens.Tokens` struct into `api.Client`

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	genq "github.com/Khan/genqlient/graphql"
+	"github.com/superfly/flyctl/internal/tokens"
 	"github.com/superfly/graphql"
 )
 
@@ -47,11 +48,15 @@ type InstrumentationService interface {
 
 // Client - API client encapsulating the http and GraphQL clients
 type Client struct {
-	httpClient  *http.Client
-	client      *graphql.Client
-	GenqClient  genq.Client
-	accessToken string
-	logger      Logger
+	httpClient *http.Client
+	client     *graphql.Client
+	GenqClient genq.Client
+	tokens     *tokens.Tokens
+	logger     Logger
+}
+
+func (c *Client) Authenticated() bool {
+	return c.tokens.GraphQL() != ""
 }
 
 // NewClient - creates a new Client, takes an access token
@@ -67,6 +72,7 @@ func NewClient(accessToken, name, version string, logger Logger) *Client {
 
 type ClientOptions struct {
 	AccessToken      string
+	Tokens           *tokens.Tokens
 	Name             string
 	Version          string
 	BaseURL          string
@@ -75,12 +81,20 @@ type ClientOptions struct {
 	Transport        *Transport
 }
 
-func (t *Transport) setDefaults(opts ClientOptions) {
+func (opts ClientOptions) tokens() *tokens.Tokens {
+	if opts.Tokens == nil {
+		opts.Tokens = tokens.Parse(opts.AccessToken)
+	}
+
+	return opts.Tokens
+}
+
+func (t *Transport) setDefaults(opts *ClientOptions) {
 	if t.UnderlyingTransport == nil {
 		t.UnderlyingTransport = defaultTransport
 	}
-	if t.Token == "" {
-		t.Token = opts.AccessToken
+	if t.Tokens == nil && t.Token == "" {
+		t.Tokens = opts.tokens()
 	}
 	if t.UserAgent == "" {
 		t.UserAgent = fmt.Sprintf("%s/%s", opts.Name, opts.Version)
@@ -98,14 +112,14 @@ func NewClientFromOptions(opts ClientOptions) *Client {
 	if transport == nil {
 		transport = &Transport{}
 	}
-	transport.setDefaults(opts)
+	transport.setDefaults(&opts)
 
 	httpClient, _ := NewHTTPClient(opts.Logger, transport)
 	url := fmt.Sprintf("%s/graphql", opts.BaseURL)
 	client := graphql.NewClient(url, graphql.WithHTTPClient(httpClient))
 	genqClient := genq.NewClient(url, httpClient)
 
-	return &Client{httpClient, client, genqClient, opts.AccessToken, opts.Logger}
+	return &Client{httpClient, client, genqClient, opts.tokens(), opts.Logger}
 }
 
 // NewRequest - creates a new GraphQL request
@@ -200,15 +214,23 @@ func GetAccessToken(ctx context.Context, email, password, otp string) (token str
 type Transport struct {
 	UnderlyingTransport http.RoundTripper
 	UserAgent           string
-	Token               string
+	Token               string // deprecated
+	Tokens              *tokens.Tokens
 	EnableDebugTrace    bool
 }
 
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("Authorization", AuthorizationHeader(t.Token))
+	req.Header.Set("Authorization", t.tokens().GraphQLHeader())
 	req.Header.Set("User-Agent", t.UserAgent)
 	if t.EnableDebugTrace {
 		req.Header.Set("Fly-Force-Trace", "true")
 	}
 	return t.UnderlyingTransport.RoundTrip(req)
+}
+
+func (t *Transport) tokens() *tokens.Tokens {
+	if t.Tokens == nil {
+		t.Tokens = tokens.Parse(t.Token)
+	}
+	return t.Tokens
 }

--- a/api/client.go
+++ b/api/client.go
@@ -220,7 +220,8 @@ type Transport struct {
 }
 
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("Authorization", t.tokens().GraphQLHeader())
+	t.addAuthorization(req)
+
 	req.Header.Set("User-Agent", t.UserAgent)
 	if t.EnableDebugTrace {
 		req.Header.Set("Fly-Force-Trace", "true")
@@ -233,4 +234,12 @@ func (t *Transport) tokens() *tokens.Tokens {
 		t.Tokens = tokens.Parse(t.Token)
 	}
 	return t.Tokens
+}
+
+func (t *Transport) addAuthorization(req *http.Request) {
+	hdr, ok := req.Context().Value(contextKeyAuthorization).(string)
+	if !ok {
+		hdr = t.tokens().GraphQLHeader()
+	}
+	req.Header.Set("Authorization", hdr)
 }

--- a/api/context.go
+++ b/api/context.go
@@ -1,0 +1,16 @@
+package api
+
+import "context"
+
+type contextKey string
+
+const (
+	contextKeyAuthorization = contextKey("authorization")
+	contextKeyRequestStart  = contextKey("RequestStart")
+)
+
+// WithAuthorizationHeader returns a context that instructs the client to use
+// the specified Authorization header value.
+func WithAuthorizationHeader(ctx context.Context, hdr string) context.Context {
+	return context.WithValue(ctx, contextKeyAuthorization, hdr)
+}

--- a/api/http.go
+++ b/api/http.go
@@ -45,12 +45,6 @@ type LoggingTransport struct {
 	mu             sync.Mutex
 }
 
-type contextKey struct {
-	name string
-}
-
-var contextKeyRequestStart = &contextKey{"RequestStart"}
-
 func (t *LoggingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := context.WithValue(req.Context(), contextKeyRequestStart, time.Now())
 	req = req.WithContext(ctx)

--- a/api/resource_logs.go
+++ b/api/resource_logs.go
@@ -30,6 +30,8 @@ func (c *Client) GetAppLogs(ctx context.Context, appName, token, region, instanc
 
 	url := fmt.Sprintf("%s/api/v1/apps/%s/logs?%s", baseURL, appName, data.Encode())
 
+	ctx = WithAuthorizationHeader(ctx, c.tokens.BubblegumHeader())
+
 	var req *http.Request
 	if req, err = http.NewRequestWithContext(ctx, "GET", url, nil); err != nil {
 		return

--- a/api/types.go
+++ b/api/types.go
@@ -3,6 +3,8 @@ package api
 import (
 	"fmt"
 	"time"
+
+	"github.com/superfly/flyctl/internal/sentry"
 )
 
 // Query - Master query which encapsulates all possible returned structures
@@ -393,6 +395,14 @@ type AppCompact struct {
 func (app *AppCompact) IsPostgresApp() bool {
 	// check app.PostgresAppRole.Name == "postgres_cluster"
 	return app.PostgresAppRole != nil && app.PostgresAppRole.Name == "postgres_cluster"
+}
+
+func (app *AppCompact) SentryAppInfo() *sentry.AppInfo {
+	return &sentry.AppInfo{
+		Name:             app.Name,
+		PlatformVersion:  app.PlatformVersion,
+		OrganizationSlug: app.Organization.RawSlug,
+	}
 }
 
 type AppInfo struct {

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -17,6 +17,7 @@ import (
 	"github.com/superfly/flyctl/internal/command_context"
 	"github.com/superfly/flyctl/internal/instrument"
 	"github.com/superfly/flyctl/internal/metrics"
+	"github.com/superfly/flyctl/internal/tokens"
 
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/api"
@@ -33,7 +34,7 @@ const headerFlyRequestId = "fly-request-id"
 type Client struct {
 	appName    string
 	baseUrl    *url.URL
-	authToken  string
+	tokens     *tokens.Tokens
 	httpClient *http.Client
 	userAgent  string
 }
@@ -89,7 +90,7 @@ func NewWithOptions(ctx context.Context, opts NewClientOpts) (*Client, error) {
 	return &Client{
 		appName:    opts.AppName,
 		baseUrl:    flapsUrl,
-		authToken:  config.Tokens(ctx).Flaps(),
+		tokens:     config.Tokens(ctx),
 		httpClient: httpClient,
 		userAgent:  strings.TrimSpace(fmt.Sprintf("fly-cli/%s", buildinfo.Version())),
 	}, nil
@@ -151,7 +152,7 @@ func newWithUsermodeWireguard(ctx context.Context, params wireguardConnectionPar
 	return &Client{
 		appName:    params.appName,
 		baseUrl:    flapsBaseUrl,
-		authToken:  config.Tokens(ctx).Flaps(),
+		tokens:     config.Tokens(ctx),
 		httpClient: httpClient,
 		userAgent:  strings.TrimSpace(fmt.Sprintf("fly-cli/%s", buildinfo.Version())),
 	}, nil
@@ -277,7 +278,7 @@ func (f *Client) NewRequest(ctx context.Context, method, path string, in interfa
 	}
 	req.Header = headers
 
-	req.Header.Add("Authorization", api.AuthorizationHeader(f.authToken))
+	req.Header.Add("Authorization", f.tokens.FlapsHeader())
 
 	return req, nil
 }

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -61,7 +61,7 @@ func InitClient(ctx context.Context) (context.Context, error) {
 	api.SetInstrumenter(instrument.ApiAdapter)
 	api.SetTransport(httptracing.NewTransport(http.DefaultTransport))
 
-	c := client.FromToken(cfg.Tokens.GraphQL())
+	c := client.FromTokens(cfg.Tokens)
 	logger.Debug("client initialized.")
 
 	return client.NewContext(ctx, c), nil

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -541,9 +541,6 @@ func updateMacaroons(ctx context.Context) (context.Context, error) {
 	}
 
 	if pruned || discharged {
-		ctx = client.NewContext(ctx, client.FromToken(tokens.GraphQL()))
-		log.Debug("client reinitialized.")
-
 		if tokens.FromConfigFile {
 			path := state.ConfigFile(ctx)
 

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -393,13 +393,13 @@ func deployToMachines(
 		ProcessGroups:          processGroups,
 	})
 	if err != nil {
-		sentry.CaptureExceptionWithAppInfo(err, "deploy", appCompact)
+		sentry.CaptureExceptionWithAppInfo(err, "deploy", appCompact.SentryAppInfo())
 		return err
 	}
 
 	err = md.DeployMachinesApp(ctx)
 	if err != nil {
-		sentry.CaptureExceptionWithAppInfo(err, "deploy", appCompact)
+		sentry.CaptureExceptionWithAppInfo(err, "deploy", appCompact.SentryAppInfo())
 	}
 	return err
 }

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -896,12 +896,12 @@ func (m *v2PlatformMigrator) deployApp(ctx context.Context) error {
 	ctx = appconfig.WithConfig(ctx, m.appConfig)
 	md, err := deploy.NewMachineDeployment(ctx, input)
 	if err != nil {
-		sentry.CaptureExceptionWithAppInfo(err, "migrate-to-v2", m.appCompact)
+		sentry.CaptureExceptionWithAppInfo(err, "migrate-to-v2", m.appCompact.SentryAppInfo())
 		return err
 	}
 	err = md.DeployMachinesApp(ctx)
 	if err != nil {
-		sentry.CaptureExceptionWithAppInfo(err, "migrate-to-v2", m.appCompact)
+		sentry.CaptureExceptionWithAppInfo(err, "migrate-to-v2", m.appCompact.SentryAppInfo())
 		return err
 	}
 	return nil

--- a/internal/command/secrets/secrets.go
+++ b/internal/command/secrets/secrets.go
@@ -117,13 +117,13 @@ func DeploySecrets(ctx context.Context, app *api.AppCompact, stage bool, detach 
 		SkipHealthChecks: detach,
 	})
 	if err != nil {
-		sentry.CaptureExceptionWithAppInfo(err, "secrets", app)
+		sentry.CaptureExceptionWithAppInfo(err, "secrets", app.SentryAppInfo())
 		return err
 	}
 
 	err = md.DeployMachinesApp(ctx)
 	if err != nil {
-		sentry.CaptureExceptionWithAppInfo(err, "secrets", app)
+		sentry.CaptureExceptionWithAppInfo(err, "secrets", app.SentryAppInfo())
 	}
 	return err
 

--- a/internal/metrics/token.go
+++ b/internal/metrics/token.go
@@ -18,7 +18,7 @@ func queryMetricsToken(ctx context.Context) (string, error) {
 	// We use this over the context API client because we're trying to
 	// authenticate the human user, not the specific credentials they're using.
 	cfg := config.FromContext(ctx)
-	apiClient := client.NewClient(cfg.Tokens.GraphQL())
+	apiClient := client.FromTokens(cfg.Tokens).API()
 
 	personal, _, err := apiClient.GetCurrentOrganizations(ctx)
 	if err != nil {

--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -11,7 +11,6 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/logrusorgru/aurora"
 
-	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/internal/buildinfo"
 )
 
@@ -96,8 +95,14 @@ func CaptureMessage(msg string, opts ...CaptureOption) {
 	})
 }
 
-func CaptureExceptionWithAppInfo(err error, featureName string, appCompact *api.AppCompact) {
-	if appCompact == nil {
+type AppInfo struct {
+	OrganizationSlug string
+	PlatformVersion  string
+	Name             string
+}
+
+func CaptureExceptionWithAppInfo(err error, featureName string, app *AppInfo) {
+	if app == nil {
 		CaptureException(
 			err,
 			WithTag("feature", featureName),
@@ -107,13 +112,13 @@ func CaptureExceptionWithAppInfo(err error, featureName string, appCompact *api.
 	CaptureException(
 		err,
 		WithTag("feature", featureName),
-		WithTag("app-platform-version", appCompact.PlatformVersion),
+		WithTag("app-platform-version", app.PlatformVersion),
 		WithContexts(map[string]sentry.Context{
 			"app": map[string]interface{}{
-				"name": appCompact.Name,
+				"name": app.Name,
 			},
 			"organization": map[string]interface{}{
-				"slug": appCompact.Organization.Slug,
+				"slug": app.OrganizationSlug,
 			},
 		}),
 	)

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -64,6 +64,14 @@ func (t *Tokens) NATS() string {
 	return t.normalized(false, false)
 }
 
+func (t *Tokens) Bubblegum() string {
+	return t.normalized(false, false)
+}
+
+func (t *Tokens) BubblegumHeader() string {
+	return t.normalized(false, true)
+}
+
 func (t *Tokens) GraphQL() string {
 	return t.normalized(true, false)
 }

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -49,23 +49,31 @@ func Parse(token string) *Tokens {
 }
 
 func (t *Tokens) Flaps() string {
-	return t.normalized(false)
+	return t.normalized(false, false)
+}
+
+func (t *Tokens) FlapsHeader() string {
+	return t.normalized(false, true)
 }
 
 func (t *Tokens) Docker() string {
-	return t.normalized(false)
+	return t.normalized(false, false)
 }
 
 func (t *Tokens) NATS() string {
-	return t.normalized(false)
+	return t.normalized(false, false)
 }
 
 func (t *Tokens) GraphQL() string {
-	return t.normalized(true)
+	return t.normalized(true, false)
+}
+
+func (t *Tokens) GraphQLHeader() string {
+	return t.normalized(true, true)
 }
 
 func (t *Tokens) All() string {
-	return t.normalized(true)
+	return t.normalized(true, false)
 }
 
 func (t *Tokens) Macaroons() string {
@@ -135,14 +143,22 @@ func (t *Tokens) PruneBadMacaroons() bool {
 	return updated
 }
 
-func (t *Tokens) normalized(macaroonsAndUserTokens bool) string {
+func (t *Tokens) normalized(macaroonsAndUserTokens, includeScheme bool) string {
+	scheme := ""
+	if includeScheme {
+		scheme = "Bearer "
+		if len(t.macaroonTokens) > 0 {
+			scheme = "FlyV1 "
+		}
+	}
+
 	if macaroonsAndUserTokens {
-		return strings.Join(append(t.macaroonTokens, t.userTokens...), ",")
+		return scheme + strings.Join(append(t.macaroonTokens, t.userTokens...), ",")
 	}
 	if len(t.macaroonTokens) == 0 {
-		return strings.Join(t.userTokens, ",")
+		return scheme + strings.Join(t.userTokens, ",")
 	}
-	return t.Macaroons()
+	return scheme + t.Macaroons()
 }
 
 // stripAuthorizationScheme strips any FlyV1/Bearer schemes from token.

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -7,7 +7,7 @@ import (
 func TestAuthorizationHeader(t *testing.T) {
 	check := func(macaroonAndUserTokens bool, input, expectedOutput string) {
 		t.Helper()
-		if tok := Parse(input).normalized(macaroonAndUserTokens); tok != expectedOutput {
+		if tok := Parse(input).normalized(macaroonAndUserTokens, false); tok != expectedOutput {
 			t.Fatalf("expected token to be '%s', got '%s'", expectedOutput, tok)
 		}
 	}


### PR DESCRIPTION
This PR plumbs the `tokens.Tokens` struct that is loaded from the user's config down into the `api.Client`. This allows the `tokens.Tokens` struct to be updated without having to replace the `api.Client` in the context. It also allows the `api.Client` to use different tokens for different requests without having to re-parse the token string it was configured with.

For example, this PR also fixes a bug where we were sending oauth+macaroon tokens to bubblegum-api when fetching old logs when that app only knows how to handle oauth _or_ macaroon tokens in a request.

I was careful not to break existing APIs in the `api` package. This makes for less-than-ideal APIs and some deprecated fields. If we're okay with breaking changes, I'd restructure things a bit.