### PR TITLE
deploy: hint that machines may time out due to region issue

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -312,12 +312,13 @@ func errorIsTimeout(err error) bool {
 
 // suggestChangeWaitTimeout appends a suggestion to change the specified flag name
 // if and only if the error is caused by a timeout.
-// If the err is not a timeout, it's returned unchanged.
+// If the error is not a timeout, it's returned unchanged.
 func suggestChangeWaitTimeout(err error, flagName string) error {
 	if errorIsTimeout(err) {
 		err = flyerr.GenericErr{
-			Err:     err.Error(),
-			Suggest: fmt.Sprintf("You can increase the timeout with the --%s flag", flagName),
+			Err:      err.Error(),
+			Descript: "Your machine was created, but never started. This could mean that your app is taking a long time to start,\nbut it could be indicative of a region issue.",
+			Suggest:  fmt.Sprintf("You can try deploying to a different region,\nor you can try increasing the timeout with the --%s flag", flagName),
 		}
 	}
 	return err

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -286,12 +286,19 @@ func (m machineUpdateEntries) machines() []machine.LeasableMachine {
 }
 
 func errorIsTimeout(err error) bool {
-	// Trying to match the errors in a typed way is incredibly difficult and makes this function massive.
+
+	// Match an error against various known timeout conditions.
+	// This is probably a sign that we need to standardize this better, but it works for now.
+
+	var timeoutErr machine.WaitTimeoutErr
+	if errors.As(err, &timeoutErr) {
+		return true
+	}
+
 	if strings.Contains(err.Error(), "net/http: request canceled") {
 		return true
 	}
 
-	// Look for an underlying context.DeadlineExceeded error
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -181,7 +181,11 @@ func (lm *leasableMachine) WaitForState(ctx context.Context, desiredState string
 		case errors.Is(waitCtx.Err(), context.Canceled):
 			return err
 		case errors.Is(waitCtx.Err(), context.DeadlineExceeded):
-			return fmt.Errorf("timed out waiting for machine to reach %s state: %w", desiredState, err)
+			return WaitTimeoutErr{
+				machineID: lm.machine.ID,
+				timeout:   timeout,
+				action:    desiredState,
+			}
 		case notFoundResponse && desiredState != api.MachineStateDestroyed:
 			return err
 		case !notFoundResponse && err != nil:

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -182,9 +182,9 @@ func (lm *leasableMachine) WaitForState(ctx context.Context, desiredState string
 			return err
 		case errors.Is(waitCtx.Err(), context.DeadlineExceeded):
 			return WaitTimeoutErr{
-				machineID: lm.machine.ID,
-				timeout:   timeout,
-				action:    desiredState,
+				machineID:    lm.machine.ID,
+				timeout:      timeout,
+				desiredState: desiredState,
 			}
 		case notFoundResponse && desiredState != api.MachineStateDestroyed:
 			return err

--- a/internal/machine/wait.go
+++ b/internal/machine/wait.go
@@ -75,7 +75,7 @@ func (e WaitTimeoutErr) Error() string {
 }
 
 func (e WaitTimeoutErr) Description() string {
-	return fmt.Sprintf("The machine %s took more than %s to %s", e.machineID, e.timeout, e.action)
+	return fmt.Sprintf("The machine %s took more than %s to reach \"%s\"", e.machineID, e.timeout, e.action)
 }
 
 var invalidAction flyerr.GenericErr = flyerr.GenericErr{

--- a/internal/machine/wait.go
+++ b/internal/machine/wait.go
@@ -47,9 +47,9 @@ func WaitForStartOrStop(ctx context.Context, machine *api.Machine, action string
 			return err
 		case errors.Is(waitCtx.Err(), context.DeadlineExceeded):
 			return WaitTimeoutErr{
-				machineID: machine.ID,
-				timeout:   timeout,
-				action:    waitOnAction,
+				machineID:    machine.ID,
+				timeout:      timeout,
+				desiredState: waitOnAction,
 			}
 		default:
 			var flapsErr *flaps.FlapsError
@@ -65,9 +65,9 @@ func WaitForStartOrStop(ctx context.Context, machine *api.Machine, action string
 }
 
 type WaitTimeoutErr struct {
-	machineID string
-	timeout   time.Duration
-	action    string
+	machineID    string
+	timeout      time.Duration
+	desiredState string
 }
 
 func (e WaitTimeoutErr) Error() string {
@@ -75,7 +75,11 @@ func (e WaitTimeoutErr) Error() string {
 }
 
 func (e WaitTimeoutErr) Description() string {
-	return fmt.Sprintf("The machine %s took more than %s to reach \"%s\"", e.machineID, e.timeout, e.action)
+	return fmt.Sprintf("The machine %s took more than %s to reach \"%s\"", e.machineID, e.timeout, e.desiredState)
+}
+
+func (e WaitTimeoutErr) DesiredState() string {
+	return e.desiredState
 }
 
 var invalidAction flyerr.GenericErr = flyerr.GenericErr{

--- a/internal/machine/wait.go
+++ b/internal/machine/wait.go
@@ -49,7 +49,7 @@ func WaitForStartOrStop(ctx context.Context, machine *api.Machine, action string
 			return WaitTimeoutErr{
 				machineID: machine.ID,
 				timeout:   timeout,
-				action:    action,
+				action:    waitOnAction,
 			}
 		default:
 			var flapsErr *flaps.FlapsError


### PR DESCRIPTION
### Change Summary

What and Why: if your deploy times out while waiting for a machine to reach "started," it suggests changing the wait timeout *only*. This is misleading, as this error can sometimes be caused by hosts that are having issues.

How: This shares the blame a bit, telling users that this could *also* be due to a region issue, giving them more to work off of.

Related to: https://github.com/superfly/reflyability/issues/12

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
