### PR TITLE
Write flyctl errors to GH actions annotations

### DIFF
--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -408,7 +408,7 @@ func runBuildKitBuild(ctx context.Context, docker *dockerclient.Client, opts Ima
 		return nil
 	})
 	err = eg.Wait()
-	return "", errors.New("HELLO I AM AN ERROR")
+
 	if err != nil {
 		return "", err
 	}

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -408,6 +408,7 @@ func runBuildKitBuild(ctx context.Context, docker *dockerclient.Client, opts Ima
 		return nil
 	})
 	err = eg.Wait()
+	return "", errors.New("HELLO I AM AN ERROR")
 	if err != nil {
 		return "", err
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -168,7 +168,7 @@ func printGHAErrorAnnotation(cmd *cobra.Command, err error) {
 	//
 	errMsg = strings.ReplaceAll(errMsg, "\n", "⏎")
 
-	fmt.Printf("::error title=flyctl error output::%s\n", errMsg)
+	fmt.Printf("::error title=flyctl error::%s\n", errMsg)
 }
 
 // TODO: remove this once generation of the docs has been refactored.

--- a/test/preflight/testlib/test_env.go
+++ b/test/preflight/testlib/test_env.go
@@ -93,6 +93,9 @@ func NewTestEnvFromEnv(t testing.TB) *FlyctlTestEnv {
 		envVariables:    make(map[string]string),
 	})
 
+	// annotate github actions output with cli errors
+	env.Setenv("FLY_GHA_ERROR_ANNOTATION", "1")
+
 	fmt.Println("workdir", env.workDir)
 	return env
 }

--- a/test/preflight/testlib/test_env.go
+++ b/test/preflight/testlib/test_env.go
@@ -95,6 +95,7 @@ func NewTestEnvFromEnv(t testing.TB) *FlyctlTestEnv {
 
 	// annotate github actions output with cli errors
 	env.Setenv("FLY_GHA_ERROR_ANNOTATION", "1")
+	env.Setenv("GITHUB_ACTIONS", os.Getenv("GITHUB_ACTIONS"))
 
 	fmt.Println("workdir", env.workDir)
 	return env


### PR DESCRIPTION
Adds support for writing an error before exit to the GitHub Actions annotated output. This is intended to help surface errors when automating flyctl in test environments. 

If `GITHUB_ACTIONS` and `FLY_GHA_ERROR_ANNOTATION` are set, you'll see something like this in the GHA Job summary:

<img width="675" alt="image" src="https://github.com/superfly/flyctl/assets/5628/3b899ae0-5890-424c-ab3f-6b58febee7df">


