### PR TITLE
Do not attempt to leases machines on scale operation if too slow

### DIFF
--- a/internal/command/scale/count.go
+++ b/internal/command/scale/count.go
@@ -39,6 +39,7 @@ For pricing, see https://fly.io/docs/about/pricing/`
 		flag.String{Name: "region", Shorthand: "r", Description: "Comma separated list of regions to act on. Defaults to all regions where there is at least one machine running for the app", CompletionFn: completion.CompleteRegions},
 		flag.Bool{Name: "with-new-volumes", Description: "New machines each get a new volumes even if there are unattached volumes available"},
 		flag.String{Name: "from-snapshot", Description: "New volumes are restored from snapshot, use 'last' for most recent snapshot. The default is an empty volume"},
+		flag.Bool{Name: "do-not-acquire-leases", Description: "Do not attempt to acquire machine leases before scaling to speed up execution"},
 		flag.VMSizeFlags,
 	)
 	return cmd


### PR DESCRIPTION
### Change Summary

What and Why: Attempting to scale apps with a large number of machines is a slow operation because of lease grabbing.
The lease grabbing is performed sequentially and requires two api calls, one to grab the lease and a second one to update the machine config. 

How: Add a `--do-not-acquire-leases` flag to `fly scale count` and disable lease grabbing on apps with 30+ machines.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
