### PR TITLE
Avoid an extra lookup for Machine data on lease acquisition

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -685,6 +685,7 @@ type MachineLeaseData struct {
 	Nonce     string `json:"nonce,omitempty"`
 	ExpiresAt int64  `json:"expires_at,omitempty"`
 	Owner     string `json:"owner,omitempty"`
+	Version   string `json:"version,omitempty"`
 }
 
 type MachineStartResponse struct {

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/alecthomas/chroma/quick"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
-	"time"
 )
 
 func newStatus() *cobra.Command {


### PR DESCRIPTION
### Change Summary

What and Why: Current lease acquisition perform 2 api calls, one to grab the lease and a follow up to update machine data in case the machine updated between the first time it was queried and the lease was acquired. This extra calls add hundred of milliseconds (400-500ms in my tests) that can be prevented by comparing the current machine version value to the version at the time the lease is acquired.

How: Return machine version as part of the lease data and compare it to machine version, do not attempt to update machine data it versions match.

Related to: https://github.com/superfly/flyctl/pull/3079

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
