### PR TITLE
Rename PostgreSQL to Postgres

### DIFF
--- a/internal/command/extensions/supabase/create.go
+++ b/internal/command/extensions/supabase/create.go
@@ -16,7 +16,7 @@ import (
 func create() (cmd *cobra.Command) {
 
 	const (
-		short = "Provision a Supabase PostgreSQL database"
+		short = "Provision a Supabase Postgres database"
 		long  = short + "\n"
 	)
 

--- a/internal/command/extensions/supabase/supabase.go
+++ b/internal/command/extensions/supabase/supabase.go
@@ -8,7 +8,7 @@ import (
 func New() (cmd *cobra.Command) {
 
 	const (
-		short = "Provision and manage Supabase PostgreSQL databases"
+		short = "Provision and manage Supabase Postgres databases"
 		long  = short + "\n"
 	)
 

--- a/internal/command/launch/launch_databases.go
+++ b/internal/command/launch/launch_databases.go
@@ -129,7 +129,7 @@ func (state *launchState) createFlyPostgres(ctx context.Context) error {
 		}
 
 		if err != nil {
-			const msg = "Error creating Postgresql database. Be warned that this may affect deploys"
+			const msg = "Error creating Postgres database. Be warned that this may affect deploys"
 			fmt.Fprintln(io.Out, io.ColorScheme().Red(msg))
 		}
 

--- a/internal/command/launch/legacy/srcinfo.go
+++ b/internal/command/launch/legacy/srcinfo.go
@@ -142,7 +142,7 @@ func createDatabases(ctx context.Context, srcInfo *scanner.SourceInfo, appName s
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
 
-	confirmPg, err := prompt.Confirm(ctx, "Would you like to set up a Postgresql database now?")
+	confirmPg, err := prompt.Confirm(ctx, "Would you like to set up a Postgres database now?")
 	if confirmPg && err == nil {
 		db_app_name := fmt.Sprintf("%s-db", appName)
 		should_attach_db := false
@@ -150,7 +150,7 @@ func createDatabases(ctx context.Context, srcInfo *scanner.SourceInfo, appName s
 		if apps, err := client.GetApps(ctx, nil); err == nil {
 			for _, app := range apps {
 				if app.Name == db_app_name {
-					msg := fmt.Sprintf("We found an existing Postgresql database with the name %s. Would you like to attach it to your app?", app.Name)
+					msg := fmt.Sprintf("We found an existing Postgres database with the name %s. Would you like to attach it to your app?", app.Name)
 					confirmAttachPg, err := prompt.Confirm(ctx, msg)
 
 					if confirmAttachPg && err == nil {
@@ -186,7 +186,7 @@ func createDatabases(ctx context.Context, srcInfo *scanner.SourceInfo, appName s
 		} else {
 			err := LaunchPostgres(ctx, appName, org, region)
 			if err != nil {
-				const msg = "Error creating Postgresql database. Be warned that this may affect deploys"
+				const msg = "Error creating Postgres database. Be warned that this may affect deploys"
 				fmt.Fprintln(io.Out, colorize.Red(msg))
 			}
 		}

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -21,7 +21,7 @@ import (
 
 func newCreate() *cobra.Command {
 	const (
-		short = "Create a new PostgreSQL cluster"
+		short = "Create a new Postgres cluster"
 		long  = short + "\n"
 	)
 

--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -104,7 +104,7 @@ If you do upgrade, you can run 'fly launch' again to get the required deployment
 If you don't want to upgrade, you'll need to add a few files and configuration options manually.
 We've placed a Dockerfile compatible with other Phoenix 1.6 apps in this directory. See
 https://hexdocs.pm/phoenix/fly.html for details, including instructions for setting up
-a PostgreSQL database.
+a Postgres database.
 `
 	}
 


### PR DESCRIPTION
We want to start calling PostgreSQL just "Postgres", so this is a first step towards that. In particular, we want this for Supabase which uses "Postgres".