### PR TITLE
Set restart-policy  to no when specifying `--rm` by default

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -160,7 +160,7 @@ var runOrCreateFlags = flag.Set{
 	},
 	flag.Bool{
 		Name:        "rm",
-		Description: "Automatically remove the Machine when it exits",
+		Description: "Automatically remove the Machine when it exits. Sets the restart-policy to 'never' if not otherwise specified.",
 	},
 	flag.StringSlice{
 		Name:        "volume",
@@ -710,9 +710,13 @@ func determineMachineConfig(
 		if flag.IsSpecified(ctx, "restart") {
 			// An empty policy was explicitly requested.
 			machineConf.Restart.Policy = ""
+		} else if machineConf.AutoDestroy {
 		} else if !input.updating {
 			// This is a new machine; apply the default.
-			if machineConf.Schedule != "" {
+			if machineConf.AutoDestroy {
+				// Autodestroy only works when the restart policy is set to no, so unless otherwise specified, we set the restart policy to no.
+				machineConf.Restart.Policy = api.MachineRestartPolicyNo
+			} else if machineConf.Schedule != "" {
 				machineConf.Restart.Policy = api.MachineRestartPolicyOnFailure
 			} else {
 				machineConf.Restart.Policy = api.MachineRestartPolicyAlways


### PR DESCRIPTION
### Change Summary

What and Why:

So by default, when creating a  new machine, we set the restart policy to `always`. This [doesn't work when using auto destroy](https://flyio.discourse.team/t/fly-m-run-rm-not-autodestrying-machines/4481/3), so by setting it to `no`, we'll have a more intuitive behvaior.

How:

If `restart-policy` isn't specified, we set it to `no` if we're trying to autodestroy this machine, instead of setting it to 'always'.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
