### PR TITLE
Add `fly volume snapshot create`

### DIFF
--- a/api/volume_types.go
+++ b/api/volume_types.go
@@ -47,4 +47,5 @@ type VolumeSnapshot struct {
 	Size      int       `json:"size"`
 	Digest    string    `json:"digest"`
 	CreatedAt time.Time `json:"created_at"`
+	Status    string    `json:"status"`
 }

--- a/flaps/actions.go
+++ b/flaps/actions.go
@@ -26,7 +26,8 @@ const (
 	volumeCreate
 	volumetUpdate
 	volumeGet
-	volumeSnapshot
+	volumeSnapshotCreate
+	volumeSnapshotList
 	volumeExtend
 	volumeDelete
 )
@@ -79,8 +80,10 @@ func (a *flapsAction) String() string {
 		return "volume_list"
 	case volumetUpdate:
 		return "volume_update"
-	case volumeSnapshot:
-		return "volume_snapshot"
+	case volumeSnapshotCreate:
+		return "volume_snapshot_create"
+	case volumeSnapshotList:
+		return "volume_snapshot_list"
 	case volumeExtend:
 		return "volume_extend"
 	case volumeDelete:

--- a/flaps/flaps_volumes.go
+++ b/flaps/flaps_volumes.go
@@ -80,11 +80,22 @@ func (f *Client) GetVolumeSnapshots(ctx context.Context, volumeId string) ([]api
 
 	out := make([]api.VolumeSnapshot, 0)
 
-	err := f.sendRequestVolumes(ctx, volumeSnapshot, http.MethodGet, getVolumeSnapshotsEndpoint, nil, &out, nil)
+	err := f.sendRequestVolumes(ctx, volumeSnapshotList, http.MethodGet, getVolumeSnapshotsEndpoint, nil, &out, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get volume %s snapshots: %w", volumeId, err)
 	}
 	return out, nil
+}
+
+func (f *Client) CreateVolumeSnapshot(ctx context.Context, volumeId string) error {
+	err := f.sendRequestVolumes(
+		ctx, volumeSnapshotCreate, http.MethodPost, fmt.Sprintf("/%s/snapshots", volumeId),
+		nil, nil, nil,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to snapshot %s: %w", volumeId, err)
+	}
+	return nil
 }
 
 type ExtendVolumeRequest struct {

--- a/internal/command/volumes/create.go
+++ b/internal/command/volumes/create.go
@@ -35,7 +35,6 @@ func newCreate() *cobra.Command {
 		command.RequireSession,
 		command.RequireAppName,
 	)
-
 	cmd.Args = cobra.ExactArgs(1)
 
 	flag.Add(cmd,

--- a/internal/command/volumes/snapshots/create.go
+++ b/internal/command/volumes/snapshots/create.go
@@ -1,0 +1,57 @@
+package snapshots
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+)
+
+func newCreate() *cobra.Command {
+	const (
+		short = "Snapshot a volume"
+		long  = "Snapshot a volume\n"
+		usage = "create <volume-id>"
+	)
+
+	cmd := command.New(usage, short, long, create, command.RequireSession)
+	cmd.Args = cobra.ExactArgs(1)
+
+	flag.Add(cmd, flag.JSONOutput())
+	return cmd
+}
+
+func create(ctx context.Context) error {
+	var client = client.FromContext(ctx).API()
+
+	volumeId := flag.FirstArg(ctx)
+
+	appName := appconfig.NameFromContext(ctx)
+	if appName == "" {
+		n, err := client.GetAppNameFromVolume(ctx, volumeId)
+		if err != nil {
+			return err
+		}
+		appName = *n
+	}
+
+	flapsClient, err := flaps.NewFromAppName(ctx, appName)
+	if err != nil {
+		return err
+	}
+
+	err = flapsClient.CreateVolumeSnapshot(ctx, volumeId)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Scheduled to snapshot volume %s\n", volumeId)
+
+	return nil
+}

--- a/internal/command/volumes/snapshots/list.go
+++ b/internal/command/volumes/snapshots/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -38,6 +39,13 @@ func newList() *cobra.Command {
 
 	flag.Add(cmd, flag.JSONOutput())
 	return cmd
+}
+
+func timeToString(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return humanize.Time(t)
 }
 
 func runList(ctx context.Context) error {
@@ -84,12 +92,18 @@ func runList(ctx context.Context) error {
 
 	rows := make([][]string, 0, len(snapshots))
 	for _, snapshot := range snapshots {
+		id := snapshot.ID
+		if id == "" {
+			id = "(pending)"
+		}
+
 		rows = append(rows, []string{
-			snapshot.ID,
+			id,
+			snapshot.Status,
 			strconv.Itoa(snapshot.Size),
-			humanize.Time(snapshot.CreatedAt),
+			timeToString(snapshot.CreatedAt),
 		})
 	}
 
-	return render.Table(io.Out, "Snapshots", rows, "ID", "Size", "Created At")
+	return render.Table(io.Out, "Snapshots", rows, "ID", "Status", "Size", "Created At")
 }

--- a/internal/command/volumes/snapshots/snapshots.go
+++ b/internal/command/volumes/snapshots/snapshots.go
@@ -22,6 +22,7 @@ func New() *cobra.Command {
 
 	snapshots.AddCommand(
 		newList(),
+		newCreate(),
 	)
 
 	return snapshots


### PR DESCRIPTION
This new command is used to snapshot volumes on-demand.

### Change Summary

What and Why: Adding a new command to snapshot volumes on-demand. In addition to daily snapshots, customers are now able to take arbitrary number of snapshots.

How: By adding the functionality on the server-side. In other words, we cannot merge the PR until we update the servers.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
