### PR TITLE
Detect Defaults for Laravel Scanner: DB, Redis

### DIFF
--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -115,7 +115,7 @@ func extractPhpVersion() (string, error) {
 	return "", fmt.Errorf("could not find php version")
 }
 
-var dbRegStr = "^ *(DB_CONNECTION|DATABASE_URL) *= *[a-zA-Z]+"
+var dbRegStr = "^ *(DB_CONNECTION|DATABASE_URL) *=(\"|')? *[a-zA-Z]+(\"|')?"
 var redisRegStr = "^[^#]*redis"
 
 // extractConnections detects the database connection of a laravel fly app
@@ -129,6 +129,7 @@ var redisRegStr = "^[^#]*redis"
 //	skipDb - reports whether a connection or redis was detected
 func extractConnections(path string) (db DatabaseKind, redis bool, skipDb bool) {
 	// Get File Content
+
 	file, err := os.Open(path)
 	if err != nil {
 		return 0, false, true

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -115,6 +115,9 @@ func extractPhpVersion() (string, error) {
 	return "", fmt.Errorf("could not find php version")
 }
 
+
+var dbRegStr = "^ *DB_CONNECTION *= *[a-zA-Z]+"
+var redisRegStr = "^[^#]*redis"
 // extractConnections detects the database connection of a laravel fly app
 // By checking the .env file in the project's base directory for connection keywords.
 // This ignores commented out lines and prioritizes the first connection occurance over others
@@ -133,9 +136,9 @@ func extractConnections(path string) (db DatabaseKind, redis bool, skipDb bool) 
 
 	// Set up Regex to match
 	// -not commented out, with DB_CONNECTION
-	dbReg := regexp.MustCompile("^ *DB_CONNECTION *= *[a-zA-Z]+")
+	dbReg := regexp.MustCompile( dbRegStr )
 	// -not commented out with redis keyword
-	redisReg := regexp.MustCompile("^[^#]*redis")
+	redisReg := regexp.MustCompile( redisRegStr )
 
 	// Default Return Variables
 	db = 0

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -160,7 +160,7 @@ func extractConnections(path string) (db DatabaseKind, redis bool, skipDb bool) 
 			if strings.Contains(text, "mysql") {
 				db = DatabaseKindMySQL
 				skipDb = false
-			} else if strings.Contains(text, "pgsql") ||  strings.Contains(text, "postgres") {
+			} else if strings.Contains(text, "pgsql") || strings.Contains(text, "postgres") {
 				db = DatabaseKindPostgres
 				skipDb = false
 			} else if strings.Contains(text, "sqlite") {

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -115,13 +115,15 @@ func extractPhpVersion() (string, error) {
 	return "", fmt.Errorf("could not find php version")
 }
 
-func extractConnections(path string) (DatabaseKind, bool, bool) {
-	/*
-		Determine the default db
-		Determine whether redis connection is desired
-			returns ( db, redis, skipDB )
-	*/
-
+// extractConnections detects the database connection of a laravel fly app
+// By checking the .env file in the project's base directory for connection keywords.
+// This ignores commented out lines and prioritizes the first connection occurance over others
+// 
+// Returns three variables:
+// 		db - DatabaseKind of the connection extracted
+//		redis - reports whether redis was detected
+//		skipDb - reports whether a connection or redis was detected
+func extractConnections(path string) (db DatabaseKind, redis bool, skipDb bool) {
 	// Get File Content
 	file, err := os.Open(path)
 	if err != nil {
@@ -136,9 +138,9 @@ func extractConnections(path string) (DatabaseKind, bool, bool) {
 	redisReg := regexp.MustCompile("^[^#]*redis")
 
 	// Default Return Variables
-	var db DatabaseKind = 0
-	redis := false
-	skipDb := true
+	db = 0
+	redis = false
+	skipDb = true
 
 	// Check each line for
 	// match on redis or db regex
@@ -161,7 +163,7 @@ func extractConnections(path string) (DatabaseKind, bool, bool) {
 				skipDb = false
 			}
 		}
-	}
+	}	
 
 	return db, redis, skipDb
 }

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -4,12 +4,12 @@ import (
 	"bufio"
 	"encoding/base64"
 	"fmt"
+	"github.com/superfly/flyctl/helpers"
 	"os"
 	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
-	"github.com/superfly/flyctl/helpers"
 )
 
 type ComposerLock struct {
@@ -37,7 +37,7 @@ func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 			"LOG_STDERR_FORMATTER":  "Monolog\\Formatter\\JsonFormatter",
 			"SESSION_DRIVER":        "cookie",
 			"SESSION_SECURE_COOKIE": "true",
-		}, 
+		},
 		Family: "Laravel",
 		Files:  files,
 		Port:   8080,
@@ -66,11 +66,11 @@ func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 
 	s.BuildArgs = map[string]string{
 		"PHP_VERSION":  phpVersion,
-		"NODE_VERSION": "18", 
+		"NODE_VERSION": "18",
 	}
 
 	// Extract DB, Redis config from dotenv
-	db, redis, skipDB := extractConnections( ".env" )
+	db, redis, skipDB := extractConnections(".env")
 	s.SkipDatabase = skipDB
 	s.RedisDesired = redis
 	if db != 0 {
@@ -115,11 +115,11 @@ func extractPhpVersion() (string, error) {
 	return "", fmt.Errorf("could not find php version")
 }
 
-func extractConnections( path string )  (DatabaseKind, bool, bool) {
+func extractConnections(path string) (DatabaseKind, bool, bool) {
 	/*
-	Determine the default db 
-	Determine whether redis connection is desired
-		returns ( db, redis, skipDB )
+		Determine the default db
+		Determine whether redis connection is desired
+			returns ( db, redis, skipDB )
 	*/
 
 	// Get File Content
@@ -129,15 +129,15 @@ func extractConnections( path string )  (DatabaseKind, bool, bool) {
 	}
 	defer file.Close()
 
-	// Set up Regex to match 
+	// Set up Regex to match
 	// -not commented out, with DB_CONNECTION
-	dbReg := regexp.MustCompile( "DB_CONNECTION *= *[a-zA-Z]+" )
+	dbReg := regexp.MustCompile("DB_CONNECTION *= *[a-zA-Z]+")
 	// -not commented out with redis keyword
-	redisReg := regexp.MustCompile( "^[^#]*redis" )
+	redisReg := regexp.MustCompile("^[^#]*redis")
 
 	// Default Return Variables
 	var db DatabaseKind = 0
-	redis := false 
+	redis := false
 	skipDb := true
 
 	// Check each line for
@@ -146,22 +146,22 @@ func extractConnections( path string )  (DatabaseKind, bool, bool) {
 	for scanner.Scan() {
 		text := scanner.Text()
 
-		if redisReg.MatchString( text ){
-			redis  = true
+		if redisReg.MatchString(text) {
+			redis = true
 			skipDb = false
-		}else if db==0 && dbReg.MatchString( text )  {
-			if strings.Contains( text, "mysql" ){
+		} else if db == 0 && dbReg.MatchString(text) {
+			if strings.Contains(text, "mysql") {
 				db = DatabaseKindMySQL
 				skipDb = false
-			}else if strings.Contains(text,"pgsql") {
+			} else if strings.Contains(text, "pgsql") {
 				db = DatabaseKindPostgres
 				skipDb = false
-			}else if strings.Contains(text,"sqlite"){
+			} else if strings.Contains(text, "sqlite") {
 				db = DatabaseKindSqlite
 				skipDb = false
 			}
 		}
 	}
-	
+
 	return db, redis, skipDb
 }

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -115,7 +115,7 @@ func extractPhpVersion() (string, error) {
 	return "", fmt.Errorf("could not find php version")
 }
 
-var dbRegStr = "^ *(DB_CONNECTION|DATABASE_URL) *=(\"|')? *[a-zA-Z]+(\"|')?"
+var dbRegStr = "^ *(DB_CONNECTION|DATABASE_URL) *= *(\"|')? *[a-zA-Z]+(\"|')?"
 var redisRegStr = "^[^#]*redis"
 
 // extractConnections detects the database connection of a laravel fly app
@@ -158,17 +158,21 @@ func extractConnections(path string) (db DatabaseKind, redis bool, skipDb bool) 
 			skipDb = false
 		} else if db == 0 && dbReg.MatchString(text) {
 			if strings.Contains(text, "mysql") {
+				fmt.Println( "mysql" )
 				db = DatabaseKindMySQL
 				skipDb = false
 			} else if strings.Contains(text, "pgsql") || strings.Contains(text, "postgres") {
+				fmt.Println( "pgsql" )
 				db = DatabaseKindPostgres
 				skipDb = false
 			} else if strings.Contains(text, "sqlite") {
+				fmt.Println( "sqlite" )
 				db = DatabaseKindSqlite
 				skipDb = false
 			}
 		}
 	}
+	os.Exit( 1 )
 
 	return db, redis, skipDb
 }

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -115,17 +115,18 @@ func extractPhpVersion() (string, error) {
 	return "", fmt.Errorf("could not find php version")
 }
 
-
 var dbRegStr = "^ *DB_CONNECTION *= *[a-zA-Z]+"
 var redisRegStr = "^[^#]*redis"
+
 // extractConnections detects the database connection of a laravel fly app
 // By checking the .env file in the project's base directory for connection keywords.
 // This ignores commented out lines and prioritizes the first connection occurance over others
-// 
+//
 // Returns three variables:
-// 		db - DatabaseKind of the connection extracted
-//		redis - reports whether redis was detected
-//		skipDb - reports whether a connection or redis was detected
+//
+//	db - DatabaseKind of the connection extracted
+//	redis - reports whether redis was detected
+//	skipDb - reports whether a connection or redis was detected
 func extractConnections(path string) (db DatabaseKind, redis bool, skipDb bool) {
 	// Get File Content
 	file, err := os.Open(path)
@@ -136,9 +137,9 @@ func extractConnections(path string) (db DatabaseKind, redis bool, skipDb bool) 
 
 	// Set up Regex to match
 	// -not commented out, with DB_CONNECTION
-	dbReg := regexp.MustCompile( dbRegStr )
+	dbReg := regexp.MustCompile(dbRegStr)
 	// -not commented out with redis keyword
-	redisReg := regexp.MustCompile( redisRegStr )
+	redisReg := regexp.MustCompile(redisRegStr)
 
 	// Default Return Variables
 	db = 0
@@ -166,7 +167,7 @@ func extractConnections(path string) (db DatabaseKind, redis bool, skipDb bool) 
 				skipDb = false
 			}
 		}
-	}	
+	}
 
 	return db, redis, skipDb
 }

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -115,12 +115,12 @@ func extractPhpVersion() (string, error) {
 	return "", fmt.Errorf("could not find php version")
 }
 
-var dbRegStr = "^ *DB_CONNECTION *= *[a-zA-Z]+"
+var dbRegStr = "^ *(DB_CONNECTION|DATABASE_URL) *= *[a-zA-Z]+"
 var redisRegStr = "^[^#]*redis"
 
 // extractConnections detects the database connection of a laravel fly app
-// By checking the .env file in the project's base directory for connection keywords.
-// This ignores commented out lines and prioritizes the first connection occurance over others
+// by checking the .env file in the project's base directory for connection keywords.
+// This ignores commented out lines and prioritizes the first connection occurance over others.
 //
 // Returns three variables:
 //
@@ -159,7 +159,7 @@ func extractConnections(path string) (db DatabaseKind, redis bool, skipDb bool) 
 			if strings.Contains(text, "mysql") {
 				db = DatabaseKindMySQL
 				skipDb = false
-			} else if strings.Contains(text, "pgsql") {
+			} else if strings.Contains(text, "pgsql") ||  strings.Contains(text, "postgres") {
 				db = DatabaseKindPostgres
 				skipDb = false
 			} else if strings.Contains(text, "sqlite") {

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -158,21 +158,17 @@ func extractConnections(path string) (db DatabaseKind, redis bool, skipDb bool) 
 			skipDb = false
 		} else if db == 0 && dbReg.MatchString(text) {
 			if strings.Contains(text, "mysql") {
-				fmt.Println( "mysql" )
 				db = DatabaseKindMySQL
 				skipDb = false
 			} else if strings.Contains(text, "pgsql") || strings.Contains(text, "postgres") {
-				fmt.Println( "pgsql" )
 				db = DatabaseKindPostgres
 				skipDb = false
 			} else if strings.Contains(text, "sqlite") {
-				fmt.Println( "sqlite" )
 				db = DatabaseKindSqlite
 				skipDb = false
 			}
 		}
 	}
-	os.Exit( 1 )
 
 	return db, redis, skipDb
 }

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -127,11 +127,11 @@ func extractConnections(path string) (DatabaseKind, bool, bool) {
 	if err != nil {
 		return 0, false, true
 	}
-	defer file.Close()
+	defer file.Close() //skipcq: GO-S2307
 
 	// Set up Regex to match
 	// -not commented out, with DB_CONNECTION
-	dbReg := regexp.MustCompile("DB_CONNECTION *= *[a-zA-Z]+")
+	dbReg := regexp.MustCompile("^ *DB_CONNECTION *= *[a-zA-Z]+")
 	// -not commented out with redis keyword
 	redisReg := regexp.MustCompile("^[^#]*redis")
 

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -1,11 +1,13 @@
 package scanner
 
 import (
+	"bufio"
 	"encoding/base64"
 	"fmt"
 	"os/exec"
 	"regexp"
 	"strconv"
+	"strings"
 	"github.com/superfly/flyctl/helpers"
 )
 
@@ -24,7 +26,6 @@ func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 		return nil, nil
 	}
 
-	fmt.Println( "Testing flyctl" )
 	files := templates("templates/laravel")
 
 	s := &SourceInfo{
@@ -67,23 +68,12 @@ func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 		"NODE_VERSION": "18", 
 	}
 
-	// Set DB
-	db, skipDB, err := extractDB()
-	if err == nil {
-		fmt.Println( "No errors! Setting DB" )
+	// Extract DB, Redis config from dotenv
+	db, redis, skipDB := extractConnections( ".env" )
+	s.SkipDatabase = skipDB
+	s.RedisDesired = redis
+	if db != 0 {
 		s.DatabaseDesired = db
-		s.SkipDatabase = skipDB
-	}else{
-		fmt.Println( "Unable to find DB!" )
-		s.SkipDatabase = false
-	}
-
-	// Enable REDIS?
-	if detectRedis(){
-		s.RedisDesired = true
-		s.SkipDatabase = false
-	}else{
-		s.RedisDesired = false
 	}
 
 	return s, nil
@@ -124,23 +114,56 @@ func extractPhpVersion() (string, error) {
 	return "", fmt.Errorf("could not find php version")
 }
 
-func extractDB() (DatabaseKind, bool, error){
-	
-	if fileContains( ".env", "DB_CONNECTION=mysql" ) {
-		return DatabaseKindMySQL,false,nil
-	}else if fileContains( ".env", "DB_CONNECTION=pgsql" ) {
-		return DatabaseKindPostgres,false,nil
-	}else if fileContains( ".env", "DB_CONNECTION=sqlite" ) {
-		return DatabaseKindSqlite,true,nil
-	}	
-	
-	return 0, false, fmt.Errorf("could not find database connection type")
-}
+func extractConnections( path string )  (DatabaseKind, bool, bool) {
+	/*
+	Determine the default db 
+	Determine whether redis connection is desired
+		returns ( db, redis, skipDB )
+	*/
 
-func detectRedis( ) (bool){
-	if fileContains( ".env", "redis" ) {
-		return true
-	}else{
-		return false
+	// Get File Content
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, false, true
 	}
-} 
+	defer file.Close()
+
+
+	// Set up Regex to match 
+	// -not commented out, with DB_CONNECTION
+	dbReg := regexp.MustCompile( "DB_CONNECTION *= *[a-zA-Z]+" )
+	// -not commented out with redis keyword
+	redisReg := regexp.MustCompile( "^[^#]*redis" )
+
+
+	// Default Return Variables
+	var db DatabaseKind = 0
+	redis := false 
+	skipDb := true
+
+
+	// Check each line for
+	// match on redis or db regex
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		text := scanner.Text()
+
+		if redisReg.MatchString( text ){
+			redis  = true
+			skipDb = false
+		}else if db==0 && dbReg.MatchString( text )  {
+			if strings.Contains( text, "mysql" ){
+				db = DatabaseKindMySQL
+				skipDb = false
+			}else if strings.Contains(text,"pgsql") {
+				db = DatabaseKindPostgres
+				skipDb = false
+			}else if strings.Contains(text,"sqlite"){
+				db = DatabaseKindSqlite
+				skipDb = false
+			}
+		}
+	}
+	
+	return db, redis, skipDb
+}

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/base64"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strconv"

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -129,19 +129,16 @@ func extractConnections( path string )  (DatabaseKind, bool, bool) {
 	}
 	defer file.Close()
 
-
 	// Set up Regex to match 
 	// -not commented out, with DB_CONNECTION
 	dbReg := regexp.MustCompile( "DB_CONNECTION *= *[a-zA-Z]+" )
 	// -not commented out with redis keyword
 	redisReg := regexp.MustCompile( "^[^#]*redis" )
 
-
 	// Default Return Variables
 	var db DatabaseKind = 0
 	redis := false 
 	skipDb := true
-
 
 	// Check each line for
 	// match on redis or db regex


### PR DESCRIPTION


### Change Summary

**What and Why:**
We need to set defaults for apps deployed in Fly.io, [see here!](https://community.fly.io/t/the-new-launch/16490). This is also [true for Laravel apps](https://flyio.slack.com/archives/C042W39VAMB/p1700229728827279). So this PR contains changes to detect DBs and redis connection set in the local .env file, and set those as defaults for the Laravel Fly App, closely following the changes already available in the [rails scanner.](https://github.com/superfly/flyctl/blob/master/scanner/rails.go#L80-L110)

**How:**
Checks the .env file of a Laravel directory and scans for db connection strings like "mysql", "pgsql", and "sqlite". If any of the connections above are available,  sets it as the default DesiredDatabase value. 
Additionally, detects the "redis" keyword and sets the configuration value of "RedisDesired" as true.

**Related to:**
1. Setting of [defaults Fresh Produce](https://community.fly.io/t/the-new-launch/16490)
2. The Rails Scanner( this PR would take inspiration on the [rails scanner](https://github.com/superfly/flyctl/blob/master/scanner/rails.go#L80-L110) for detecting defaults )


---

### Documentation
(will add docs in the laravel section of our docs) 
- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
