### PR TITLE
`deploy`: don't persist "exec" if it's been removed from config

### DIFF
--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -124,7 +124,6 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 		mConfig.Init.Entrypoint = c.Experimental.Entrypoint
 		mConfig.Init.Exec = c.Experimental.Exec
 	} else {
-		cmd = nil
 		mConfig.Init.Entrypoint = nil
 		mConfig.Init.Exec = nil
 	}

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -123,6 +123,10 @@ func (c *Config) updateMachineConfig(src *api.MachineConfig) (*api.MachineConfig
 		}
 		mConfig.Init.Entrypoint = c.Experimental.Entrypoint
 		mConfig.Init.Exec = c.Experimental.Exec
+	} else {
+		cmd = nil
+		mConfig.Init.Entrypoint = nil
+		mConfig.Init.Exec = nil
 	}
 	mConfig.Init.Cmd = cmd
 	mConfig.Init.SwapSizeMB = c.SwapSizeMB


### PR DESCRIPTION
### Change Summary

What and Why: If you specify this in your app config:
```toml
[experimental]
  exec = ["sleep", "inf"]
```
deploy, then remove the whole experimental section, subsequent deploys would still deploy machines with `sleep inf` as their command. This PR should prevent that from happening.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
