### PR TITLE
`launch`: match on *pointers* to provider plans, not to values

### DIFF
--- a/internal/command/launch/describe_plan.go
+++ b/internal/command/launch/describe_plan.go
@@ -19,7 +19,7 @@ const descriptionNone = "<none>"
 func describePostgresPlan(ctx context.Context, p plan.PostgresPlan, org *api.Organization) (string, error) {
 	provider := p.Provider()
 	switch provider.(type) {
-	case plan.FlyPostgresPlan:
+	case *plan.FlyPostgresPlan:
 		return describeFlyPostgresPlan(ctx, provider.(*plan.FlyPostgresPlan), org)
 	}
 	return descriptionNone, nil
@@ -51,7 +51,7 @@ func describeFlyPostgresPlan(ctx context.Context, p *plan.FlyPostgresPlan, org *
 func describeRedisPlan(ctx context.Context, p plan.RedisPlan, org *api.Organization) (string, error) {
 	provider := p.Provider()
 	switch provider.(type) {
-	case plan.UpstashRedisPlan:
+	case *plan.UpstashRedisPlan:
 		return describeUpstashRedisPlan(ctx, provider.(*plan.UpstashRedisPlan), org)
 	}
 	return descriptionNone, nil

--- a/internal/command/launch/describe_plan.go
+++ b/internal/command/launch/describe_plan.go
@@ -17,10 +17,9 @@ import (
 const descriptionNone = "<none>"
 
 func describePostgresPlan(ctx context.Context, p plan.PostgresPlan, org *api.Organization) (string, error) {
-	provider := p.Provider()
-	switch provider.(type) {
+	switch provider := p.Provider().(type) {
 	case *plan.FlyPostgresPlan:
-		return describeFlyPostgresPlan(ctx, provider.(*plan.FlyPostgresPlan), org)
+		return describeFlyPostgresPlan(ctx, provider, org)
 	}
 	return descriptionNone, nil
 }
@@ -49,10 +48,9 @@ func describeFlyPostgresPlan(ctx context.Context, p *plan.FlyPostgresPlan, org *
 }
 
 func describeRedisPlan(ctx context.Context, p plan.RedisPlan, org *api.Organization) (string, error) {
-	provider := p.Provider()
-	switch provider.(type) {
+	switch provider := p.Provider().(type) {
 	case *plan.UpstashRedisPlan:
-		return describeUpstashRedisPlan(ctx, provider.(*plan.UpstashRedisPlan), org)
+		return describeUpstashRedisPlan(ctx, provider, org)
 	}
 	return descriptionNone, nil
 }


### PR DESCRIPTION
### Change Summary

What and Why: `describePostgresPlan()` and `describeRedisPlan()` now matches on *pointers* to plans instead of the actual plan itself. Because that's what `.Provider()` returns. Oops.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
