### PR TITLE
Fix switch-case value for describePostgresPlan() and describeRedisPlan() to allow default postgres/redis config in `fly launch` Summary

### DIFF
--- a/internal/command/launch/describe_plan.go
+++ b/internal/command/launch/describe_plan.go
@@ -17,10 +17,10 @@ import (
 const descriptionNone = "<none>"
 
 func describePostgresPlan(ctx context.Context, p plan.PostgresPlan, org *api.Organization) (string, error) {
-	provider := p.Provider()
-	switch provider.(type) {
+	
+	switch provider := p.Provider().(type) {
 	case *plan.FlyPostgresPlan:
-		return describeFlyPostgresPlan(ctx, provider.(*plan.FlyPostgresPlan), org)
+	  return describeFlyPostgresPlan(ctx, provider, org)
 	}
 	return descriptionNone, nil
 }
@@ -49,10 +49,10 @@ func describeFlyPostgresPlan(ctx context.Context, p *plan.FlyPostgresPlan, org *
 }
 
 func describeRedisPlan(ctx context.Context, p plan.RedisPlan, org *api.Organization) (string, error) {
-	provider := p.Provider()
-	switch provider.(type) {
+	
+	switch provider := p.Provider().(type) {
 	case *plan.UpstashRedisPlan:
-		return describeUpstashRedisPlan(ctx, provider.(*plan.UpstashRedisPlan), org)
+		return describeUpstashRedisPlan(ctx, provider, org)
 	}
 	return descriptionNone, nil
 }

--- a/internal/command/launch/describe_plan.go
+++ b/internal/command/launch/describe_plan.go
@@ -19,7 +19,7 @@ const descriptionNone = "<none>"
 func describePostgresPlan(ctx context.Context, p plan.PostgresPlan, org *api.Organization) (string, error) {
 	provider := p.Provider()
 	switch provider.(type) {
-	case plan.FlyPostgresPlan:
+	case *plan.FlyPostgresPlan:
 		return describeFlyPostgresPlan(ctx, provider.(*plan.FlyPostgresPlan), org)
 	}
 	return descriptionNone, nil
@@ -51,7 +51,7 @@ func describeFlyPostgresPlan(ctx context.Context, p *plan.FlyPostgresPlan, org *
 func describeRedisPlan(ctx context.Context, p plan.RedisPlan, org *api.Organization) (string, error) {
 	provider := p.Provider()
 	switch provider.(type) {
-	case plan.UpstashRedisPlan:
+	case *plan.UpstashRedisPlan:
 		return describeUpstashRedisPlan(ctx, provider.(*plan.UpstashRedisPlan), org)
 	}
 	return descriptionNone, nil

--- a/internal/command/launch/describe_plan.go
+++ b/internal/command/launch/describe_plan.go
@@ -17,10 +17,10 @@ import (
 const descriptionNone = "<none>"
 
 func describePostgresPlan(ctx context.Context, p plan.PostgresPlan, org *api.Organization) (string, error) {
-	
+
 	switch provider := p.Provider().(type) {
 	case *plan.FlyPostgresPlan:
-	  return describeFlyPostgresPlan(ctx, provider, org)
+		return describeFlyPostgresPlan(ctx, provider, org)
 	}
 	return descriptionNone, nil
 }
@@ -49,7 +49,7 @@ func describeFlyPostgresPlan(ctx context.Context, p *plan.FlyPostgresPlan, org *
 }
 
 func describeRedisPlan(ctx context.Context, p plan.RedisPlan, org *api.Organization) (string, error) {
-	
+
 	switch provider := p.Provider().(type) {
 	case *plan.UpstashRedisPlan:
 		return describeUpstashRedisPlan(ctx, provider, org)


### PR DESCRIPTION

### Change Summary

**What and Why:**
Change "switch-case" values of `describePostgresPlan()` and `describeRedisPlan()` to use `*plan.<PLAN_NAME>`.

The `describePostgresPlan`  and `describeRedisPlan` functions help in determining whether default configurations should be used to create their intended apps(Redis/Postgres) for a new potential Fly App to connect with. 

Both functions do some detection on the LaunchManifest plan variable they've received to determine whether to set default values for their intended apps(Postgres/Redis).

But, the case value should be changed to use a `*plan.<PLAN_NAME>` format for the functions to successfully determine that default configuration should be used.

**How:**
Change case values of `describePostgresPlan()` and `describeRedisPlan()` to use `*plan.<PLAN_NAME>`, instead of just `plan.<PLAN_NAME>`

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
