### PR TITLE
Fix `fly launch` when using macaroon auth

### DIFF
--- a/api/resource_organizations.go
+++ b/api/resource_organizations.go
@@ -36,6 +36,7 @@ func (client *Client) GetOrganizations(ctx context.Context, filters ...Organizat
 					name
 					type
 					paidPlan
+					viewerRole
 				}
 			}
 		}
@@ -87,37 +88,6 @@ func (client *Client) GetOrganizationBySlug(ctx context.Context, slug string) (*
 	}
 
 	return data.Organization, nil
-}
-
-func (client *Client) GetCurrentOrganizations(ctx context.Context) (Organization, []Organization, error) {
-	query := `
-	query {
-		personalOrganization {
-		  id
-		  slug
-		  name
-		  type
-		  viewerRole
-		}
-		organizations {
-		  nodes {
-			id
-			slug
-			name
-			type
-			viewerRole
-		  }
-		}
-	  }
-	`
-
-	req := client.NewRequest(query)
-
-	data, err := client.RunWithContext(ctx, req)
-	if err != nil {
-		return Organization{}, nil, err
-	}
-	return data.PersonalOrganization, data.Organizations.Nodes, nil
 }
 
 func (client *Client) GetDetailedOrganizationBySlug(ctx context.Context, slug string) (*OrganizationDetails, error) {

--- a/api/types.go
+++ b/api/types.go
@@ -16,23 +16,21 @@ type Query struct {
 		}
 		Nodes []App
 	}
-	App                  App
-	AppCompact           AppCompact
-	AppInfo              AppInfo
-	AppBasic             AppBasic
-	AppStatus            AppStatus
-	AppMonitoring        AppMonitoring
-	AppPostgres          AppPostgres
-	AppCertsCompact      AppCertsCompact
-	Viewer               User
-	PersonalOrganization Organization
-	GqlMachine           GqlMachine
-	Organizations        struct {
+	App             App
+	AppCompact      AppCompact
+	AppInfo         AppInfo
+	AppBasic        AppBasic
+	AppStatus       AppStatus
+	AppMonitoring   AppMonitoring
+	AppPostgres     AppPostgres
+	AppCertsCompact AppCertsCompact
+	Viewer          User
+	GqlMachine      GqlMachine
+	Organizations   struct {
 		Nodes []Organization
 	}
 
-	Organization *Organization
-	// PersonalOrganizations PersonalOrganizations
+	Organization        *Organization
 	OrganizationDetails OrganizationDetails
 	Build               Build
 	Volume              struct {

--- a/internal/flag/completion/completions.go
+++ b/internal/flag/completion/completions.go
@@ -75,12 +75,12 @@ func CompleteOrgs(
 		return fmt.Sprintf("%s\t%s", org.Slug, org.Name)
 	}
 
-	personal, others, err := clientApi.GetCurrentOrganizations(ctx)
+	orgs, err := clientApi.GetOrganizations(ctx)
 	if err != nil {
 		return nil, err
 	}
-	names := []string{format(personal)}
-	for _, org := range others {
+	names := []string{}
+	for _, org := range orgs {
 		names = append(names, format(org))
 	}
 	ret := lo.Filter(names, func(name string, _ int) bool {

--- a/internal/metrics/token.go
+++ b/internal/metrics/token.go
@@ -20,11 +20,11 @@ func queryMetricsToken(ctx context.Context) (string, error) {
 	cfg := config.FromContext(ctx)
 	apiClient := client.FromTokens(cfg.Tokens).API()
 
-	personal, _, err := apiClient.GetCurrentOrganizations(ctx)
+	personal, err := apiClient.GetOrganizationBySlug(ctx, "personal")
 	if err != nil {
 		return "", err
 	}
-	if personal.ID == "" {
+	if personal == nil {
 		return "", errors.New("no personal organization found")
 	}
 


### PR DESCRIPTION
`fly launch` always tries to query information about the user's `personalOrganization`. This is unauthorized when using a macaroon for a different org. This PR removes some unnecessary queries of this sort and teaches a few commands to deal with  not having access to the user's personal org.