### PR TITLE
`launch`: allow recovery from "no personal organization found"

### DIFF
--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -482,7 +482,7 @@ func determineOrg(ctx context.Context) (*api.Organization, string, error) {
 	orgSlug := flag.GetOrg(ctx)
 	if orgSlug == "" {
 		if !foundPersonal {
-			return nil, "", errors.New("no personal organization found")
+			return nil, "", recoverableInUiError{errors.New("no personal organization found")}
 		}
 
 		return &personal, "fly launch defaults to the personal org", nil
@@ -491,7 +491,7 @@ func determineOrg(ctx context.Context) (*api.Organization, string, error) {
 	org, foundSlug := bySlug[orgSlug]
 	if !foundSlug {
 		if !foundPersonal {
-			return nil, "", errors.New("no personal organization found")
+			return nil, "", recoverableInUiError{errors.New("no personal organization found")}
 		}
 
 		return &personal, recoverableSpecifyInUi, recoverableInUiError{fmt.Errorf("organization '%s' not found", orgSlug)}

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -482,7 +482,7 @@ func determineOrg(ctx context.Context) (*api.Organization, string, error) {
 	orgSlug := flag.GetOrg(ctx)
 	if orgSlug == "" {
 		if !foundPersonal {
-			return nil, "", recoverableInUiError{errors.New("no personal organization found")}
+			return nil, recoverableSpecifyInUi, recoverableInUiError{errors.New("no personal organization found")}
 		}
 
 		return &personal, "fly launch defaults to the personal org", nil
@@ -491,7 +491,7 @@ func determineOrg(ctx context.Context) (*api.Organization, string, error) {
 	org, foundSlug := bySlug[orgSlug]
 	if !foundSlug {
 		if !foundPersonal {
-			return nil, "", recoverableInUiError{errors.New("no personal organization found")}
+			return nil, recoverableSpecifyInUi, recoverableInUiError{errors.New("no personal organization found")}
 		}
 
 		return &personal, recoverableSpecifyInUi, recoverableInUiError{fmt.Errorf("organization '%s' not found", orgSlug)}


### PR DESCRIPTION
### Change Summary

What and Why: slight UX improvement for people using macaroons with no personal org access. prompts them to correct org settings in web UI instead of exiting with an error.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
