### PR TITLE
Require unique zone for volumes during v2 migration

### DIFF
--- a/internal/command/migrate_to_v2/volumes.go
+++ b/internal/command/migrate_to_v2/volumes.go
@@ -105,6 +105,7 @@ func (m *v2PlatformMigrator) migrateAppVolumes(ctx context.Context) error {
 				Name:                vol.Name,
 				ComputeRequirements: m.machineGuests[processGroup],
 				Region:              region,
+				RequireUniqueZone:   api.Pointer(true),
 			})
 			if err != nil && strings.HasSuffix(err.Error(), " is not a valid candidate") {
 				return fmt.Errorf("unfortunately the worker hosting your volume %s (%s) does not have capacity for another volume to support the migration; some other options: 1) try again later and there might be more space on the worker, 2) run a manual migration https://community.fly.io/t/manual-migration-to-apps-v2/11870, or 3) wait until we support volume migrations across workers (we're working on it!)", vol.ID, vol.Name)


### PR DESCRIPTION
### Change Summary

What and Why: Volumes should typically be migrated to unique hosts for improved reliability/durability.

How: Mark the `RequireUniqueZone` as `true` in the `CreateVolume()` call.

Related to:

Shout out to @matttpt for spotting the issue 🎉 

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
