### PR TITLE
Add L40S gpu kind

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -374,6 +374,8 @@ func (mg *MachineGuest) ToSize() string {
 		return "a100-40gb"
 	case mg.GPUKind == "a100-sxm4-80gb":
 		return "a100-80gb"
+	case mg.GPUKind == "l40s":
+		return "l40s"
 	case mg.CPUKind == "shared":
 		return fmt.Sprintf("shared-cpu-%dx", mg.CPUs)
 	case mg.CPUKind == "performance":
@@ -421,6 +423,7 @@ var MachinePresets map[string]*MachineGuest = map[string]*MachineGuest{
 
 	"a100-40gb": {GPUKind: "a100-pcie-40gb", CPUKind: "performance", CPUs: 8, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
 	"a100-80gb": {GPUKind: "a100-sxm4-80gb", CPUKind: "performance", CPUs: 8, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
+	"l40s":      {GPUKind: "l40s", CPUKind: "performance", CPUs: 8, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
 }
 
 type MachineMetrics struct {

--- a/internal/flag/machines.go
+++ b/internal/flag/machines.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	validGPUKinds  = []string{"a100-pcie-40gb", "a100-sxm4-80gb"}
+	validGPUKinds  = []string{"a100-pcie-40gb", "a100-sxm4-80gb", "l40s"}
 	gpuKindAliases = map[string]string{
 		"a100-40gb": "a100-pcie-40gb",
 		"a100-80gb": "a100-sxm4-80gb",


### PR DESCRIPTION
### Change Summary

What and Why: Nvidia L40S are here

How: Add `l40s` gpu kind and preset alias.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [x] https://github.com/superfly/docs/pull/1232
- [ ] n/a
