### PR TITLE
Ensure VMs are stopped before performing volume copy

### DIFF
--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -580,17 +580,6 @@ func (m *v2PlatformMigrator) Migrate(ctx context.Context) (err error) {
 		return abortedErr
 	}
 
-	if !m.isPostgres && m.usesForkedVolumes {
-		tb.Detail("Making snapshots of volumes for the new machines")
-		err = m.migrateAppVolumes(ctx)
-		if err != nil {
-			return err
-		}
-		if cancelableCtx.Err() != nil {
-			return abortedErr
-		}
-	}
-
 	if m.requiresDowntime() {
 		tb.Detail("Scaling down to zero VMs. This will cause temporary downtime until new VMs come up.")
 
@@ -601,6 +590,17 @@ func (m *v2PlatformMigrator) Migrate(ctx context.Context) (err error) {
 	}
 	if cancelableCtx.Err() != nil {
 		return abortedErr
+	}
+
+	if !m.isPostgres && m.usesForkedVolumes {
+		tb.Detail("Making snapshots of volumes for the new machines")
+		err = m.migrateAppVolumes(ctx)
+		if err != nil {
+			return err
+		}
+		if cancelableCtx.Err() != nil {
+			return abortedErr
+		}
 	}
 
 	tb.Detail("Enabling machine creation on app")


### PR DESCRIPTION
### Change Summary

What and Why: This change ensures instances are stopped before copying volumes. This is needed for systems that need to guarantee write durability such as distributed consensus (e.g. Consul).

How: Switch the "stop nomad instances" and "clone volumes" sections in the migration code.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
