### PR TITLE
Create apps via machines API

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -481,6 +481,7 @@ func gqlGetInstances(ctx context.Context, orgSlug, appName string) instancesResu
 		app(name: $appName) {
 			organization {
 				slug
+				rawSlug
 			}
 			id
 			name

--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -58,6 +58,7 @@ func (client *Client) getAppsPage(ctx context.Context, orgID *string, role *stri
 					platformVersion
 					organization {
 						slug
+						rawSlug
 						name
 					}
 					currentRelease {
@@ -133,6 +134,7 @@ func (client *Client) GetApp(ctx context.Context, appName string) (*App, error) 
 				organization {
 					id
 					slug
+					rawSlug
 					paidPlan
 				}
 				services {
@@ -222,6 +224,7 @@ func (client *Client) GetAppCompact(ctx context.Context, appName string) (*AppCo
 				organization {
 					id
 					slug
+					rawSlug
 					paidPlan
 				}
 				postgresAppRole: role {
@@ -276,6 +279,7 @@ func (client *Client) GetAppInfo(ctx context.Context, appName string) (*AppInfo,
 				organization {
 					id
 					slug
+					rawSlug
 					paidPlan
 				}
 				services {
@@ -377,6 +381,7 @@ func (client *Client) GetAppPostgres(ctx context.Context, appName string) (*AppP
 				organization {
 					id
 					slug
+					rawSlug
 					paidPlan
 				}
 				imageDetails {
@@ -430,6 +435,7 @@ func (client *Client) MoveApp(ctx context.Context, appName string, orgID string)
 					networkId
 					organization {
 						slug
+						rawSlug
 					}
 				}
 			}

--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -402,40 +402,6 @@ func (client *Client) GetAppPostgres(ctx context.Context, appName string) (*AppP
 	return &data.AppPostgres, nil
 }
 
-func (client *Client) CreateApp(ctx context.Context, input CreateAppInput) (*App, error) {
-	query := `
-		mutation($input: CreateAppInput!) {
-			createApp(input: $input) {
-				app {
-					id
-					name
-					organization {
-						slug
-					}
-					config {
-						definition
-					}
-					regions {
-							name
-							code
-					}
-				}
-			}
-		}
-	`
-
-	req := client.NewRequest(query)
-
-	req.Var("input", input)
-
-	data, err := client.RunWithContext(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	return &data.CreateApp.App, nil
-}
-
 func (client *Client) DeleteApp(ctx context.Context, appName string) error {
 	query := `
 			mutation($appId: ID!) {

--- a/api/resource_apps.go
+++ b/api/resource_apps.go
@@ -407,6 +407,40 @@ func (client *Client) GetAppPostgres(ctx context.Context, appName string) (*AppP
 	return &data.AppPostgres, nil
 }
 
+func (client *Client) CreateApp(ctx context.Context, input CreateAppInput) (*App, error) {
+	query := `
+		mutation($input: CreateAppInput!) {
+			createApp(input: $input) {
+				app {
+					id
+					name
+					organization {
+						slug
+					}
+					config {
+						definition
+					}
+					regions {
+							name
+							code
+					}
+				}
+			}
+		}
+	`
+
+	req := client.NewRequest(query)
+
+	req.Var("input", input)
+
+	data, err := client.RunWithContext(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data.CreateApp.App, nil
+}
+
 func (client *Client) DeleteApp(ctx context.Context, appName string) error {
 	query := `
 			mutation($appId: ID!) {

--- a/api/resource_domains.go
+++ b/api/resource_domains.go
@@ -50,6 +50,7 @@ func (c *Client) GetDomain(ctx context.Context, name string) (*Domain, error) {
 					id
 					name
 					slug
+					rawSlug
 				}
 			}
 		}

--- a/api/resource_machines.go
+++ b/api/resource_machines.go
@@ -13,6 +13,7 @@ func (client *Client) GetMachine(ctx context.Context, machineId string) (*GqlMac
 					organization {
 						id
 						slug
+						rawSlug
 					}
 				}
 			}

--- a/api/resource_monitoring.go
+++ b/api/resource_monitoring.go
@@ -15,6 +15,7 @@ func (c *Client) GetAppStatus(ctx context.Context, appName string, showCompleted
 				appUrl
 				organization {
 					slug
+					rawSlug
 				}
 				deploymentStatus {
 					id

--- a/api/resource_organizations.go
+++ b/api/resource_organizations.go
@@ -33,6 +33,7 @@ func (client *Client) GetOrganizations(ctx context.Context, filters ...Organizat
 				nodes {
 					id
 					slug
+					rawSlug
 					name
 					type
 					paidPlan
@@ -95,6 +96,7 @@ func (client *Client) GetDetailedOrganizationBySlug(ctx context.Context, slug st
 		organizationdetails: organization(slug: $slug) {
 		  id
 		  slug
+		  rawSlug
 		  name
 		  type
 		  viewerRole
@@ -138,6 +140,7 @@ func (c *Client) CreateOrganization(ctx context.Context, organizationname string
 					id
 					name
 					slug
+					rawSlug
 					type
 					viewerRole
 				  }
@@ -167,6 +170,7 @@ func (c *Client) CreateOrganizationWithAppsV2DefaultOn(ctx context.Context, orga
 					id
 					name
 					slug
+					rawSlug
 					type
 					viewerRole
 				  }
@@ -224,6 +228,7 @@ func (c *Client) CreateOrganizationInvite(ctx context.Context, id, email string)
 				redeemed
 				organization {
 			  		slug
+					  rawSlug
 				}
 		  }
 		}

--- a/api/resource_organizations.go
+++ b/api/resource_organizations.go
@@ -66,6 +66,7 @@ func (client *Client) GetOrganizationBySlug(ctx context.Context, slug string) (*
 				id
 				internalNumericId
 				slug
+				rawSlug
 				name
 				type
                 limitedAccessTokens {

--- a/api/resource_postgres.go
+++ b/api/resource_postgres.go
@@ -185,16 +185,17 @@ func (client *Client) ListPostgresUsers(ctx context.Context, appName string) ([]
 	return *data.AppPostgres.PostgresAppRole.Users, nil
 }
 
-func (client *Client) EnablePostgresConsul(ctx context.Context, appName string) (*PostgresEnableConsulPayload, error) {
+func (client *Client) EnablePostgresConsul(ctx context.Context, appName, region string) (*PostgresEnableConsulPayload, error) {
 	const query = `
-		mutation($appName: ID!) {
-			enablePostgresConsul(input: {appId: $appName}) {
+		mutation($appName: ID!, $region: String!) {
+			enablePostgresConsul(input: {appId: $appName, region: $region}) {
 				consulUrl
 			}
 		}
 	`
 	req := client.NewRequest(query)
 	req.Var("appName", appName)
+	req.Var("region", region)
 
 	data, err := client.RunWithContext(ctx, req)
 	if err != nil {

--- a/api/resource_remote_builders.go
+++ b/api/resource_remote_builders.go
@@ -22,6 +22,7 @@ func (client *Client) EnsureRemoteBuilder(ctx context.Context, orgID, appName st
 					organization {
 						id
 						slug
+						rawSlug
 					}
 				}
 			}

--- a/flaps/flaps.go
+++ b/flaps/flaps.go
@@ -158,14 +158,37 @@ func newWithUsermodeWireguard(ctx context.Context, params wireguardConnectionPar
 	}, nil
 }
 
-func (f *Client) CreateApp(ctx context.Context, name string, org string) (err error) {
-	in := map[string]interface{}{
-		"app_name": name,
-		"org_slug": org,
+type CreateAppInput struct {
+	AppName   string `json:"app_name"`
+	OrgSlug   string `json:"org_slug"`
+	AppRoleID string `json:"app_role_id,omitempty"`
+	Network   string `json:"network,omitempty"`
+}
+
+type CreateAppOption func(*CreateAppInput)
+
+func WithNetwork(network string) CreateAppOption {
+	return func(i *CreateAppInput) {
+		i.Network = network
+	}
+}
+
+func WithAppRoleID(appRoleID string) CreateAppOption {
+	return func(i *CreateAppInput) {
+		i.AppRoleID = appRoleID
+	}
+}
+
+func (f *Client) CreateApp(ctx context.Context, name string, orgSlug string, opts ...CreateAppOption) (err error) {
+	input := &CreateAppInput{AppName: name, OrgSlug: orgSlug}
+
+	for _, o := range opts {
+		o(input)
 	}
 
-	_, err = f._sendRequest(ctx, http.MethodPost, "/apps", in, nil, nil)
-	return
+	_, err = f._sendRequest(ctx, http.MethodPost, "/apps", input, nil, nil)
+
+	return err
 }
 
 func (f *Client) _sendRequest(ctx context.Context, method, endpoint string, in, out interface{}, headers map[string][]string) (int, error) {

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -449,7 +449,7 @@ func (l *Launcher) setSecrets(ctx context.Context, config *CreateClusterInput) (
 }
 
 func (l *Launcher) generateConsulURL(ctx context.Context, config *CreateClusterInput) (string, error) {
-	data, err := l.client.EnablePostgresConsul(ctx, config.AppName)
+	data, err := l.client.EnablePostgresConsul(ctx, config.AppName, config.Region)
 	if err != nil {
 		return "", err
 	}

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -349,7 +349,12 @@ func (l *Launcher) getPostgresConfig(config *CreateClusterInput) *api.MachineCon
 func (l *Launcher) createApp(ctx context.Context, config *CreateClusterInput) (*api.AppCompact, error) {
 	fmt.Println("Creating app...")
 
-	err := flaps.FromContext(ctx).CreateApp(ctx, config.AppName, config.Organization.ID, flaps.WithAppRoleID("postgres_cluster"))
+	f, err := flaps.NewFromAppName(ctx, config.AppName)
+	if err != nil {
+		return nil, err
+	}
+
+	err = f.CreateApp(ctx, config.AppName, config.Organization.RawSlug, flaps.WithAppRoleID("postgres_cluster"))
 	if err != nil {
 		return nil, err
 	}

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -348,14 +348,13 @@ func (l *Launcher) getPostgresConfig(config *CreateClusterInput) *api.MachineCon
 
 func (l *Launcher) createApp(ctx context.Context, config *CreateClusterInput) (*api.AppCompact, error) {
 	fmt.Println("Creating app...")
-	appInput := api.CreateAppInput{
-		OrganizationID:  config.Organization.ID,
-		Name:            config.AppName,
-		PreferredRegion: &config.Region,
-		AppRoleID:       "postgres_cluster",
+
+	err := flaps.FromContext(ctx).CreateApp(ctx, config.AppName, config.Organization.ID, flaps.WithAppRoleID("postgres_cluster"))
+	if err != nil {
+		return nil, err
 	}
 
-	app, err := l.client.CreateApp(ctx, appInput)
+	app, err := l.client.GetApp(ctx, config.AppName)
 	if err != nil {
 		return nil, err
 	}

--- a/gql/generated.go
+++ b/gql/generated.go
@@ -193,10 +193,15 @@ func (v *AgentGetInstancesAppMachinesMachineConnectionNodesMachineIpsMachineIPCo
 type AgentGetInstancesAppOrganization struct {
 	// Unique organization slug
 	Slug string `json:"slug"`
+	// Unmodified unique org slug
+	RawSlug string `json:"rawSlug"`
 }
 
 // GetSlug returns AgentGetInstancesAppOrganization.Slug, and is useful for accessing the field via an interface.
 func (v *AgentGetInstancesAppOrganization) GetSlug() string { return v.Slug }
+
+// GetRawSlug returns AgentGetInstancesAppOrganization.RawSlug, and is useful for accessing the field via an interface.
+func (v *AgentGetInstancesAppOrganization) GetRawSlug() string { return v.RawSlug }
 
 // AgentGetInstancesResponse is returned by AgentGetInstances on success.
 type AgentGetInstancesResponse struct {
@@ -4456,7 +4461,6 @@ query GetAddOn ($name: String) {
 		ssoLink
 		organization {
 			slug
-			rawSlug
 			paidPlan
 		}
 		addOnProvider {
@@ -4993,7 +4997,6 @@ query ListAddOns ($addOnType: AddOnType) {
 			organization {
 				id
 				slug
-				rawSlug
 			}
 		}
 	}

--- a/gql/generated.go
+++ b/gql/generated.go
@@ -3971,6 +3971,7 @@ query AgentGetInstances ($appName: String!) {
 	app(name: $appName) {
 		organization {
 			slug
+			rawSlug
 		}
 		id
 		name
@@ -4455,6 +4456,7 @@ query GetAddOn ($name: String) {
 		ssoLink
 		organization {
 			slug
+			rawSlug
 			paidPlan
 		}
 		addOnProvider {
@@ -4991,6 +4993,7 @@ query ListAddOns ($addOnType: AddOnType) {
 			organization {
 				id
 				slug
+				rawSlug
 			}
 		}
 	}

--- a/internal/command/apps/create.go
+++ b/internal/command/apps/create.go
@@ -109,7 +109,12 @@ func RunCreate(ctx context.Context) (err error) {
 		opts = append(opts, flaps.WithNetwork(v))
 	}
 
-	if err := flaps.FromContext(ctx).CreateApp(ctx, name, org.ID, opts...); err != nil {
+	f, err := flaps.NewFromAppName(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	if err := f.CreateApp(ctx, name, org.RawSlug, opts...); err != nil {
 		return err
 	}
 

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -106,7 +106,12 @@ func (state *launchState) createApp(ctx context.Context) (*api.App, error) {
 		return nil, err
 	}
 
-	if err := flaps.FromContext(ctx).CreateApp(ctx, state.Plan.AppName, org.ID); err != nil {
+	f, err := flaps.NewFromAppName(ctx, state.Plan.AppName)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := f.CreateApp(ctx, state.Plan.AppName, org.RawSlug); err != nil {
 		return nil, err
 	}
 

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -7,6 +7,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/iostreams"
@@ -104,10 +105,10 @@ func (state *launchState) createApp(ctx context.Context) (*api.App, error) {
 	if err != nil {
 		return nil, err
 	}
-	return apiClient.CreateApp(ctx, api.CreateAppInput{
-		OrganizationID:  org.ID,
-		Name:            state.Plan.AppName,
-		PreferredRegion: &state.Plan.RegionCode,
-		Machines:        true,
-	})
+
+	if err := flaps.FromContext(ctx).CreateApp(ctx, state.Plan.AppName, org.ID); err != nil {
+		return nil, err
+	}
+
+	return apiClient.GetApp(ctx, state.Plan.AppName)
 }

--- a/internal/command/launch/legacy/launch.go
+++ b/internal/command/launch/legacy/launch.go
@@ -167,11 +167,21 @@ func Run(ctx context.Context) (err error) {
 			return err
 		}
 
-		if err := f.CreateApp(ctx, appConfig.AppName, org.RawSlug); err != nil {
-			return err
-		}
+		var createdApp *api.App
+		if shouldUseMachines {
+			if err := f.CreateApp(ctx, appConfig.AppName, org.RawSlug); err != nil {
+				return err
+			}
 
-		createdApp, err := client.GetApp(ctx, appConfig.AppName)
+			createdApp, err = client.GetApp(ctx, appConfig.AppName)
+		} else {
+			createdApp, err = client.CreateApp(ctx, api.CreateAppInput{
+				Name:            appConfig.AppName,
+				OrganizationID:  org.ID,
+				PreferredRegion: &appConfig.PrimaryRegion,
+				Machines:        shouldUseMachines,
+			})
+		}
 		if err != nil {
 			return err
 		}

--- a/internal/command/launch/legacy/launch.go
+++ b/internal/command/launch/legacy/launch.go
@@ -162,7 +162,12 @@ func Run(ctx context.Context) (err error) {
 		}
 	// App doesn't exist, just create a new app
 	case !launchIntoExistingApp:
-		if err := flaps.FromContext(ctx).CreateApp(ctx, appConfig.AppName, org.ID); err != nil {
+		f, err := flaps.NewFromAppName(ctx, appConfig.AppName)
+		if err != nil {
+			return err
+		}
+
+		if err := f.CreateApp(ctx, appConfig.AppName, org.RawSlug); err != nil {
 			return err
 		}
 

--- a/internal/command/launch/legacy/launch.go
+++ b/internal/command/launch/legacy/launch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
 	"github.com/superfly/flyctl/internal/buildinfo"
@@ -161,12 +162,11 @@ func Run(ctx context.Context) (err error) {
 		}
 	// App doesn't exist, just create a new app
 	case !launchIntoExistingApp:
-		createdApp, err := client.CreateApp(ctx, api.CreateAppInput{
-			Name:            appConfig.AppName,
-			OrganizationID:  org.ID,
-			PreferredRegion: &appConfig.PrimaryRegion,
-			Machines:        shouldUseMachines,
-		})
+		if err := flaps.FromContext(ctx).CreateApp(ctx, appConfig.AppName, org.ID); err != nil {
+			return err
+		}
+
+		createdApp, err := client.GetApp(ctx, appConfig.AppName)
 		if err != nil {
 			return err
 		}

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -512,14 +512,14 @@ func getOrCreateEphemeralShellApp(ctx context.Context, client *api.Client) (*api
 	}
 
 	if appc == nil {
-		appc, err = client.CreateApp(ctx, api.CreateAppInput{
-			OrganizationID: org.ID,
-			// i'll never find love again like the kind you give like the kind you send
-			Name: fmt.Sprintf("flyctl-interactive-shells-%s-%d", strings.ToLower(org.ID), rand.Intn(1_000_000)),
-		})
-
-		if err != nil {
+		appName := fmt.Sprintf("flyctl-interactive-shells-%s-%d", strings.ToLower(org.ID), rand.Intn(1_000_000))
+		if err := flaps.FromContext(ctx).CreateApp(ctx, appName, org.ID); err != nil {
 			return nil, fmt.Errorf("create interactive shell app: %w", err)
+		}
+
+		appc, err = client.GetApp(ctx, appName)
+		if err != nil {
+			return nil, fmt.Errorf("fetch interactive shell app: %w", err)
 		}
 	}
 
@@ -554,12 +554,11 @@ func createApp(ctx context.Context, message, name string, client *api.Client) (*
 		}
 	}
 
-	input := api.CreateAppInput{
-		Name:           name,
-		OrganizationID: org.ID,
+	if err := flaps.FromContext(ctx).CreateApp(ctx, name, org.ID); err != nil {
+		return nil, err
 	}
 
-	app, err := client.CreateApp(ctx, input)
+	app, err := client.GetApp(ctx, name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -513,7 +513,13 @@ func getOrCreateEphemeralShellApp(ctx context.Context, client *api.Client) (*api
 
 	if appc == nil {
 		appName := fmt.Sprintf("flyctl-interactive-shells-%s-%d", strings.ToLower(org.ID), rand.Intn(1_000_000))
-		if err := flaps.FromContext(ctx).CreateApp(ctx, appName, org.ID); err != nil {
+
+		f, err := flaps.NewFromAppName(ctx, appName)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := f.CreateApp(ctx, appName, org.RawSlug); err != nil {
 			return nil, fmt.Errorf("create interactive shell app: %w", err)
 		}
 
@@ -554,7 +560,12 @@ func createApp(ctx context.Context, message, name string, client *api.Client) (*
 		}
 	}
 
-	if err := flaps.FromContext(ctx).CreateApp(ctx, name, org.ID); err != nil {
+	f, err := flaps.NewFromAppName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := f.CreateApp(ctx, name, org.RawSlug); err != nil {
 		return nil, err
 	}
 

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -512,7 +512,8 @@ func getOrCreateEphemeralShellApp(ctx context.Context, client *api.Client) (*api
 	}
 
 	if appc == nil {
-		appName := fmt.Sprintf("flyctl-interactive-shells-%s-%d", strings.ToLower(org.ID), rand.Intn(1_000_000))
+		randi := rand.Intn(1_000_000) // skipcq: GSC-G404
+		appName := fmt.Sprintf("flyctl-interactive-shells-%s-%d", strings.ToLower(org.ID), randi)
 
 		f, err := flaps.NewFromAppName(ctx, appName)
 		if err != nil {

--- a/internal/command/migrate_to_v2/migrate_to_v2.go
+++ b/internal/command/migrate_to_v2/migrate_to_v2.go
@@ -322,16 +322,6 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 	leaseDelayBetween := (leaseTimeout - 1*time.Second) / 3
 
 	isPostgres := appCompact.IsPostgresApp()
-
-	pgConsulUrl := ""
-	if isPostgres {
-		consul, err := apiClient.EnablePostgresConsul(ctx, appCompact.Name)
-		if err != nil {
-			return nil, err
-		}
-		pgConsulUrl = consul.ConsulURL
-	}
-
 	if flag.GetBool(ctx, "force-standard-migration") || appFull.ImageDetails.Repository != "flyio/postgres" {
 		isPostgres = false
 	}
@@ -362,7 +352,6 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 		backupMachines:     map[string]int{},
 		machineWaitTimeout: flag.GetDuration(ctx, "wait-timeout"),
 		skipHealthChecks:   flag.GetBool(ctx, "skip-health-checks"),
-		pgConsulUrl:        pgConsulUrl,
 	}
 
 	migrator.applyHacks(ctx)
@@ -373,6 +362,10 @@ func NewV2PlatformMigrator(ctx context.Context, appName string) (V2PlatformMigra
 	}
 	migrator.resolveProcessGroups(ctx)
 	err = migrator.determinePrimaryRegion(ctx)
+	if err != nil {
+		return nil, err
+	}
+	err = migrator.determineConsulURL(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -946,6 +939,17 @@ func (m *v2PlatformMigrator) determinePrimaryRegion(ctx context.Context) error {
 		return errors.New("no region provided")
 	}
 	m.appConfig.PrimaryRegion = region.Code
+	return nil
+}
+
+func (m *v2PlatformMigrator) determineConsulURL(ctx context.Context) error {
+	if m.appCompact.IsPostgresApp() {
+		consul, err := m.apiClient.EnablePostgresConsul(ctx, m.appConfig.AppName, m.appConfig.PrimaryRegion)
+		if err != nil {
+			return err
+		}
+		m.pgConsulUrl = consul.ConsulURL
+	}
 	return nil
 }
 

--- a/internal/command/turboku/turboku.go
+++ b/internal/command/turboku/turboku.go
@@ -8,8 +8,8 @@ import (
 
 	hero "github.com/heroku/heroku-go/v5"
 	"github.com/spf13/cobra"
-	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/deploy"
@@ -106,27 +106,18 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	input := api.CreateAppInput{
-		Name:            flyAppName,
-		OrganizationID:  org.ID,
-		PreferredRegion: api.StringPointer(regionCode),
-	}
-
-	createdApp, err := client.CreateApp(ctx, input)
-
+	err = flaps.FromContext(ctx).CreateApp(ctx, flyAppName, org.ID)
 	switch isTakenError(err) {
-
 	case nil:
-		fmt.Printf("New app created: %s\n", createdApp.Name)
-
+		fmt.Printf("New app created: %s\n", flyAppName)
 	case errAppNameTaken:
 		fmt.Printf("App %s already exists\n", flyAppName)
-
-		createdApp, err = client.GetApp(ctx, flyAppName)
-		if err != nil {
-			return err
-		}
 	default:
+		return err
+	}
+
+	createdApp, err := client.GetApp(ctx, flyAppName)
+	if err != nil {
 		return err
 	}
 

--- a/internal/command/turboku/turboku.go
+++ b/internal/command/turboku/turboku.go
@@ -106,7 +106,12 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	err = flaps.FromContext(ctx).CreateApp(ctx, flyAppName, org.ID)
+	f, err := flaps.NewFromAppName(ctx, flyAppName)
+	if err != nil {
+		return err
+	}
+
+	err = f.CreateApp(ctx, flyAppName, org.RawSlug)
 	switch isTakenError(err) {
 	case nil:
 		fmt.Printf("New app created: %s\n", flyAppName)


### PR DESCRIPTION
Creating an app via the GraphQL API and then immediately trying to fetch it via the machines API can be racey. This PR switches to creating apps using the machines API, which waits until the app has been propagated through corrosion before returning.