### PR TITLE
buildpacks builder: add volume mount support

### DIFF
--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -88,6 +88,14 @@ func (*buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 	}
 	build.ContextBuildFinish()
 
+	if opts.BuildpacksDockerHost != "" {
+		cmdfmt.PrintDone(streams.ErrOut, fmt.Sprintf("BuildpacksDockerHost=%v", opts.BuildpacksDockerHost))
+	}
+
+	if len(opts.BuildpacksVolumes) > 0 {
+		cmdfmt.PrintDone(streams.ErrOut, fmt.Sprintf("BuildpacksVolumes=%v", opts.BuildpacksVolumes))
+	}
+
 	err = packClient.Build(ctx, packclient.BuildOptions{
 		AppPath:        opts.WorkingDir,
 		Builder:        builder,
@@ -102,6 +110,9 @@ func (*buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 			Build: projectTypes.Build{
 				Exclude: excludes,
 			},
+		},
+		ContainerConfig: packclient.ContainerConfig{
+			Volumes: opts.BuildpacksVolumes,
 		},
 	})
 	build.ImageBuildFinish()

--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -75,10 +75,6 @@ func (*buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 	msg := fmt.Sprintf("docker host: %s %s %s", serverInfo.ServerVersion, serverInfo.OSType, serverInfo.Architecture)
 	cmdfmt.PrintDone(streams.ErrOut, msg)
 
-	if opts.BuildpacksDockerHost != "" {
-		cmdfmt.PrintDone(streams.ErrOut, fmt.Sprintf("buildpacks docker host: %v", opts.BuildpacksDockerHost))
-	}
-
 	build.ContextBuildStart()
 	excludes, err := readDockerignore(opts.WorkingDir, opts.IgnorefilePath, "")
 	if err != nil {
@@ -89,11 +85,10 @@ func (*buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 	build.ContextBuildFinish()
 
 	if opts.BuildpacksDockerHost != "" {
-		cmdfmt.PrintDone(streams.ErrOut, fmt.Sprintf("BuildpacksDockerHost=%v", opts.BuildpacksDockerHost))
+		cmdfmt.PrintDone(streams.ErrOut, fmt.Sprintf("buildpacks docker host: %v", opts.BuildpacksDockerHost))
 	}
-
 	if len(opts.BuildpacksVolumes) > 0 {
-		cmdfmt.PrintDone(streams.ErrOut, fmt.Sprintf("BuildpacksVolumes=%v", opts.BuildpacksVolumes))
+		cmdfmt.PrintDone(streams.ErrOut, fmt.Sprintf("buildpacks volumes: %+v", opts.BuildpacksVolumes))
 	}
 
 	err = packClient.Build(ctx, packclient.BuildOptions{

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -45,6 +45,7 @@ type ImageOptions struct {
 	Buildpacks           []string
 	Label                map[string]string
 	BuildpacksDockerHost string
+	BuildpacksVolumes    []string
 }
 
 type RefOptions struct {

--- a/internal/command/command_run.go
+++ b/internal/command/command_run.go
@@ -49,6 +49,7 @@ func DetermineImage(ctx context.Context, appName string, imageOrPath string) (im
 			Target:               flag.GetString(ctx, "build-target"),
 			NoCache:              flag.GetBool(ctx, "no-build-cache"),
 			BuildpacksDockerHost: flag.GetString(ctx, "buildpacks-docker-host"),
+			BuildpacksVolumes:    flag.GetStringSlice(ctx, "buildpacks-volume"),
 		}
 
 		dockerfilePath := cfg.Dockerfile()

--- a/internal/command/command_run.go
+++ b/internal/command/command_run.go
@@ -48,7 +48,7 @@ func DetermineImage(ctx context.Context, appName string, imageOrPath string) (im
 			ImageLabel:           flag.GetString(ctx, "image-label"),
 			Target:               flag.GetString(ctx, "build-target"),
 			NoCache:              flag.GetBool(ctx, "no-build-cache"),
-			BuildpacksDockerHost: flag.GetString(ctx, "buildpacks-docker-host"),
+			BuildpacksDockerHost: flag.GetString(ctx, flag.BuildpacksDockerHost),
 			BuildpacksVolumes:    flag.GetStringSlice(ctx, "buildpacks-volume"),
 		}
 

--- a/internal/command/command_run.go
+++ b/internal/command/command_run.go
@@ -49,7 +49,7 @@ func DetermineImage(ctx context.Context, appName string, imageOrPath string) (im
 			Target:               flag.GetString(ctx, "build-target"),
 			NoCache:              flag.GetBool(ctx, "no-build-cache"),
 			BuildpacksDockerHost: flag.GetString(ctx, flag.BuildpacksDockerHost),
-			BuildpacksVolumes:    flag.GetStringSlice(ctx, "buildpacks-volume"),
+			BuildpacksVolumes:    flag.GetStringSlice(ctx, flag.BuildpacksVolume),
 		}
 
 		dockerfilePath := cfg.Dockerfile()

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -49,6 +49,7 @@ var CommonFlags = flag.Set{
 	flag.Nixpacks(),
 	flag.BuildOnly(),
 	flag.BpDockerHost(),
+	flag.BpVolume(),
 	flag.Bool{
 		Name:        "provision-extensions",
 		Description: "Provision any extensions assigned as a default to first deployments",

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -96,6 +96,7 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgs
 		Builder:              build.Builder,
 		Buildpacks:           build.Buildpacks,
 		BuildpacksDockerHost: flag.GetString(ctx, "buildpacks-docker-host"),
+		BuildpacksVolumes:    flag.GetStringSlice(ctx, "buildpacks-volume"),
 	}
 
 	// flyctl supports key=value form while Docker supports id=key,src=/path/to/secret form.

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -95,7 +95,7 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgs
 		BuiltInSettings:      build.Settings,
 		Builder:              build.Builder,
 		Buildpacks:           build.Buildpacks,
-		BuildpacksDockerHost: flag.GetString(ctx, "buildpacks-docker-host"),
+		BuildpacksDockerHost: flag.GetString(ctx, flag.BuildpacksDockerHost),
 		BuildpacksVolumes:    flag.GetStringSlice(ctx, "buildpacks-volume"),
 	}
 

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -96,7 +96,7 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgs
 		Builder:              build.Builder,
 		Buildpacks:           build.Buildpacks,
 		BuildpacksDockerHost: flag.GetString(ctx, flag.BuildpacksDockerHost),
-		BuildpacksVolumes:    flag.GetStringSlice(ctx, "buildpacks-volume"),
+		BuildpacksVolumes:    flag.GetStringSlice(ctx, flag.BuildpacksVolume),
 	}
 
 	// flyctl supports key=value form while Docker supports id=key,src=/path/to/secret form.

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -557,11 +557,11 @@ This option may set DOCKER_HOST environment variable for the build container if 
 }
 
 // BuildpacksVolume the host volume that will be mounted to the buildpacks build container
-const buildpacksVolume = "buildpacks-volume"
+const BuildpacksVolume = "buildpacks-volume"
 
 func BpVolume() StringSlice {
 	return StringSlice{
-		Name: buildpacksVolume,
+		Name: BuildpacksVolume,
 		Description: `Mount host volume into the build container, in the form '<host path>:<target path>[:<options>]'.
 - 'host path': Name of the volume or absolute directory path to mount.
 - 'target path': The path where the file or directory is available in the container.

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -555,3 +555,21 @@ This option may set DOCKER_HOST environment variable for the build container if 
 `,
 	}
 }
+
+// BuildpacksVolume the host volume that will be mounted to the buildpacks build container
+const buildpacksVolume = "buildpacks-volume"
+
+func BpVolume() StringSlice {
+	return StringSlice{
+		Name: buildpacksVolume,
+		Description: `Mount host volume into the build container, in the form '<host path>:<target path>[:<options>]'.
+- 'host path': Name of the volume or absolute directory path to mount.
+- 'target path': The path where the file or directory is available in the container.
+- 'options' (default "ro"): An optional comma separated list of mount options.
+    - "ro", volume contents are read-only.
+    - "rw", volume contents are readable and writeable.
+    - "volume-opt=<key>=<value>", can be specified more than once, takes a key-value pair consisting of the option name and its value.
+Repeat for each volume in order (comma-separated lists not accepted)
+`,
+	}
+}

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -543,11 +543,11 @@ func ProcessGroup(desc string) String {
 }
 
 // BuildpacksDockerHost address to docker daemon that will be exposed to the buildpacks build container
-const buildpacksDockerHost = "buildpacks-docker-host"
+const BuildpacksDockerHost = "buildpacks-docker-host"
 
 func BpDockerHost() String {
 	return String{
-		Name: buildpacksDockerHost,
+		Name: BuildpacksDockerHost,
 		Description: `Address to docker daemon that will be exposed to the build container.
 If not set (or set to empty string) the standard socket location will be used.
 Special value 'inherit' may be used in which case DOCKER_HOST environment variable will be used.


### PR DESCRIPTION
### Change Summary

add volume mount support for the`buildpacks` builder

What and Why:

currently there's no way to mount local volume to buildpacks. like we need to support private modules on github.

ref https://paketo.io/docs/howto/go/#import-private-go-modules

for example, we need bind git credentails:

we will need to bind the `git-binding` dir to `/platform/bindings/git-binding`

How:

by add a `--buildpacks-volume` cli flag, user can now mount volume to buildpacks builder containers.

like this:

prepare the service bindings dirs:

```shell
echo git-credentials > $HOME/.git-binding-type


cat << EOF > $HOME/.git-binding-credentials

url=https://github.com
username=foo
password=github_pat_xxxxxxxxxx

EOF
```

now we can build success:

```shell
flyctl --verbose --debug deploy --local-only \
--env "CGO_ENABLED=0" \
--env GOPRIVATE="github.com/foo/private-go-mod" \
--buildpacks-volume $HOME/.git-binding-type:/platform/bindings/git-binding/type \
--buildpacks-volume $HOME/.git-binding-credentials:/platform/bindings/git-binding/credentials
```

Related to:

this PR is a continued enhancement for the`buildpacks` builder after https://github.com/superfly/flyctl/pull/1643

---

### Documentation

- [x] n/a
