### PR TITLE
Doctor: add dns and http tests

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -575,18 +575,20 @@ func (c *Client) Dialer(ctx context.Context, slug string) (d Dialer, err error) 
 
 // ConnectToTunnel is a convenience method for connect to a wireguard tunnel
 // and returning a Dialer. Only suitable for use in the new CLI commands.
-func (c *Client) ConnectToTunnel(ctx context.Context, slug string) (d Dialer, err error) {
+func (c *Client) ConnectToTunnel(ctx context.Context, slug string, silent bool) (d Dialer, err error) {
 	io := iostreams.FromContext(ctx)
 
 	dialer, err := c.Dialer(ctx, slug)
 	if err != nil {
 		return nil, err
 	}
-	io.StartProgressIndicatorMsg(fmt.Sprintf("Opening a wireguard tunnel to %s", slug))
+	if !silent {
+		io.StartProgressIndicatorMsg(fmt.Sprintf("Opening a wireguard tunnel to %s", slug))
+		defer io.StopProgressIndicator()
+	}
 	if err := c.WaitForTunnel(ctx, slug); err != nil {
 		return nil, fmt.Errorf("tunnel unavailable for organization %s: %w", slug, err)
 	}
-	io.StopProgressIndicator()
 	return dialer, err
 }
 

--- a/internal/build/imgsrc/nixpacks_builder.go
+++ b/internal/build/imgsrc/nixpacks_builder.go
@@ -152,7 +152,7 @@ func (*nixpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFact
 			return nil, "", fmt.Errorf("could not find machine IP")
 		}
 
-		dialer, err := agentclient.ConnectToTunnel(ctx, app.Organization.Slug)
+		dialer, err := agentclient.ConnectToTunnel(ctx, app.Organization.Slug, false)
 		if err != nil {
 			build.BuilderInitFinish()
 			build.BuildFinish()

--- a/internal/command/doctor/doctor.go
+++ b/internal/command/doctor/doctor.go
@@ -173,7 +173,7 @@ followed by 'flyctl agent restart', and we'll run WireGuard over HTTPS.
 We can't resolve internal DNS for your personal organization.
 This is likely a platform issue, please contact support.
 `)
-		// Intentionally not returning yet, we want to also run the Flaps check.
+		return nil
 	}
 
 	lprint(nil, "Testing WireGuard Flaps... ")
@@ -183,11 +183,6 @@ This is likely a platform issue, please contact support.
 We can't access Flaps via a WireGuard tunnel into your personal organization.
 This is likely a platform issue, please contact support.
 `)
-		return nil
-	}
-
-	// Check if the DNS test failed. If so, *now* we return.
-	if checks["dns"] != "ok" {
 		return nil
 	}
 

--- a/internal/command/doctor/doctor.go
+++ b/internal/command/doctor/doctor.go
@@ -166,24 +166,8 @@ followed by 'flyctl agent restart', and we'll run WireGuard over HTTPS.
 	// Check if we can access DNS and Flaps via WireGuard
 	// ------------------------------------------------------------
 
-	lprint(nil, "Creating WireGuard TCP Tunnel... ")
-	dialer, err := getWireguardDialer(ctx)
-	if !check("wgdialer", err) {
-		lprint(nil, `
-We can't create a WireGuard TCP tunnel for your personal organization.
-
-If this is the first time you've ever used 'flyctl' on this machine, you
-can try running 'flyctl doctor' again.
-
-If this was working before, you can ask 'flyctl' to create a new peer for
-you by running 'flyctl wireguard reset', or you can try restarting the 'flyctl' agent with
-'flyctl agent restart'.
-`)
-		return nil
-	}
-
 	lprint(nil, "Testing WireGuard DNS... ")
-	err = runPersonalOrgCheckDns(ctx, dialer)
+	err = runPersonalOrgCheckDns(ctx)
 	if !check("wgdns", err) {
 		lprint(nil, `
 We can't resolve internal DNS for your personal organization.
@@ -193,7 +177,7 @@ This is likely a platform issue, please contact support.
 	}
 
 	lprint(nil, "Testing WireGuard Flaps... ")
-	err = runPersonalOrgCheckFlaps(ctx, dialer)
+	err = runPersonalOrgCheckFlaps(ctx)
 	if !check("wgflaps", err) {
 		lprint(nil, `
 We can't access Flaps via a WireGuard tunnel into your personal organization.

--- a/internal/command/doctor/wireguard.go
+++ b/internal/command/doctor/wireguard.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"net"
@@ -9,8 +10,10 @@ import (
 
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/command/dig"
 	"github.com/superfly/flyctl/internal/command/ping"
+	"github.com/superfly/flyctl/internal/flag"
 )
 
 // TODO: These probably shouldn't be hardcoded to use the "personal" org,
@@ -90,12 +93,14 @@ func runPersonalOrgCheckFlaps(ctx context.Context) error {
 
 	apiClient := client.FromContext(ctx).API()
 
+	// Set up the agent connection
 	ac, err := agent.DefaultClient(ctx)
 	if err != nil {
 		// shouldn't happen, already tested agent
 		return fmt.Errorf("wireguard dialer: weird error: %w", err)
 	}
 
+	// Connect to the personal org via WireGuard
 	org, err := apiClient.GetOrganizationBySlug(ctx, "personal")
 	if err != nil {
 		// shouldn't happen, already verified auth token
@@ -107,22 +112,45 @@ func runPersonalOrgCheckFlaps(ctx context.Context) error {
 		return fmt.Errorf("wireguard dialer: %w", err)
 	}
 
-	dialer := &net.Dialer{
-		Timeout: 10 * time.Second,
-		Resolver: &net.Resolver{
-			PreferGo: true,
-			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-				return wgDialer.DialContext(ctx, network, address)
-			},
-		},
+	// HACK: Set the quiet flag to true so that the agent doesn't print out progress indicators
+	quietCtx := flag.NewContext(ctx, helpers.Clone(flag.FromContext(ctx)))
+	_ = flag.FromContext(quietCtx).BoolP("quiet", "q", true, "suppress output")
+
+	// Wait for the connection to be established
+	err = ac.WaitForDNS(quietCtx, wgDialer, org.Slug, "_api.internal")
+	if err != nil {
+		return fmt.Errorf("wireguard dialer: failed to wait for DNS to resolve: %w", err)
 	}
 
-	httpClient := http.Client{Transport: &http.Transport{DialContext: dialer.DialContext}}
+	// Resolve the IP address of _api.internal
+	ip, err := ac.Resolve(ctx, org.Slug, "_api.internal:4280")
+	if err != nil {
+		return fmt.Errorf("wireguard dialer: failed to resolve _api.internal: %w", err)
+	}
 
-	// Make an HTTP request to _api.internal:4280.
-	// It should 404. This is a success.
+	// Dial the IP address of _api.internal
+	conn, err := wgDialer.DialContext(ctx, "tcp", ip)
+	if err != nil {
+		return fmt.Errorf("wireguard dialer: failed to dial _api.internal: %w", err)
+	}
 
-	resp, err := httpClient.Get("http://_api.internal:4280")
+	// Make an HTTP request to _api.internal:4280. This should return a 404.
+	req, err := http.NewRequest("GET", "http://_api.internal:4280", nil)
+	if err != nil {
+		return fmt.Errorf("wireguard dialer: failed to create HTTP request: %w", err)
+	}
+
+	// Send the HTTP request
+	if err = req.Write(conn); err != nil {
+		return fmt.Errorf("wireguard dialer: failed to write HTTP request: %w", err)
+	}
+
+	// Read the HTTP response
+	resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+	if err != nil {
+		return fmt.Errorf("wireguard dialer: failed to read HTTP response: %w", err)
+	}
+
 	if err != nil {
 		return fmt.Errorf("wireguard dialer: failed to make HTTP request: %w", err)
 	}

--- a/internal/command/doctor/wireguard.go
+++ b/internal/command/doctor/wireguard.go
@@ -1,0 +1,93 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/superfly/flyctl/agent"
+	"github.com/superfly/flyctl/client"
+	"github.com/superfly/flyctl/internal/command/dig"
+	"github.com/superfly/flyctl/internal/command/ping"
+)
+
+// TODO: These probably shouldn't be hardcoded to use the "personal" org,
+//       as it's completely valid to use flyctl with a token that doesn't have access to a personal org.
+
+func runPersonalOrgPing(ctx context.Context) (err error) {
+	client := client.FromContext(ctx).API()
+
+	ac, err := agent.DefaultClient(ctx)
+	if err != nil {
+		// shouldn't happen, already tested agent
+		return fmt.Errorf("wireguard ping gateway: weird error: %w", err)
+	}
+
+	org, err := client.GetOrganizationBySlug(ctx, "personal")
+	if err != nil {
+		// shouldn't happen, already verified auth token
+		return fmt.Errorf("wireguard ping gateway: weird error: %w", err)
+	}
+
+	pinger, err := ac.Pinger(ctx, "personal")
+	if err != nil {
+		return fmt.Errorf("wireguard ping gateway: %w", err)
+	}
+
+	defer pinger.Close()
+
+	_, ns, err := dig.ResolverForOrg(ctx, ac, org.Slug)
+	if err != nil {
+		return fmt.Errorf("wireguard ping gateway: %w", err)
+	}
+
+	replyBuf := make([]byte, 1000)
+
+	for i := 0; i < 30; i++ {
+		_, err = pinger.WriteTo(ping.EchoRequest(0, i, time.Now(), 12), &net.IPAddr{IP: net.ParseIP(ns)})
+
+		pinger.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+		_, _, err := pinger.ReadFrom(replyBuf)
+		if err != nil {
+			continue
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("ping gateway: no response from gateway received")
+}
+
+func getWireguardDialer(ctx context.Context) (agent.Dialer, error) {
+	client := client.FromContext(ctx).API()
+
+	ac, err := agent.DefaultClient(ctx)
+	if err != nil {
+		// shouldn't happen, already tested agent
+		return nil, fmt.Errorf("wireguard dialer: weird error: %w", err)
+	}
+
+	org, err := client.GetOrganizationBySlug(ctx, "personal")
+	if err != nil {
+		// shouldn't happen, already verified auth token
+		return nil, fmt.Errorf("wireguard dialer: weird error: %w", err)
+	}
+
+	dialer, err := ac.ConnectToTunnel(ctx, org.Slug)
+	if err != nil {
+		return nil, fmt.Errorf("wireguard dialer: %w", err)
+	}
+
+	return dialer, nil
+}
+
+func runPersonalOrgCheckDns(ctx context.Context, dialer agent.Dialer) error {
+
+	panic("TODO: DNS check")
+}
+
+func runPersonalOrgCheckFlaps(ctx context.Context, dialer agent.Dialer) error {
+
+	panic("TODO: HTTP/Flaps check")
+}

--- a/internal/command/doctor/wireguard.go
+++ b/internal/command/doctor/wireguard.go
@@ -59,35 +59,33 @@ func runPersonalOrgPing(ctx context.Context) (err error) {
 	return fmt.Errorf("ping gateway: no response from gateway received")
 }
 
-func getWireguardDialer(ctx context.Context) (agent.Dialer, error) {
+func runPersonalOrgCheckDns(ctx context.Context) error {
 	client := client.FromContext(ctx).API()
 
 	ac, err := agent.DefaultClient(ctx)
 	if err != nil {
 		// shouldn't happen, already tested agent
-		return nil, fmt.Errorf("wireguard dialer: weird error: %w", err)
+		return fmt.Errorf("wireguard dialer: weird error: %w", err)
 	}
 
 	org, err := client.GetOrganizationBySlug(ctx, "personal")
 	if err != nil {
 		// shouldn't happen, already verified auth token
-		return nil, fmt.Errorf("wireguard dialer: weird error: %w", err)
+		return fmt.Errorf("wireguard dialer: weird error: %w", err)
 	}
 
-	dialer, err := ac.ConnectToTunnel(ctx, org.Slug, true)
+	records, err := ac.LookupTxt(ctx, org.Slug, "_peer.internal")
 	if err != nil {
-		return nil, fmt.Errorf("wireguard dialer: %w", err)
+		return fmt.Errorf("wireguard dialer: %w", err)
+	}
+	if len(records) == 0 {
+		return fmt.Errorf("wireguard dialer: no TXT records found for _peer.internal")
 	}
 
-	return dialer, nil
+	return nil
 }
 
-func runPersonalOrgCheckDns(ctx context.Context, dialer agent.Dialer) error {
-
-	panic("TODO: DNS check")
-}
-
-func runPersonalOrgCheckFlaps(ctx context.Context, dialer agent.Dialer) error {
+func runPersonalOrgCheckFlaps(ctx context.Context) error {
 
 	panic("TODO: HTTP/Flaps check")
 }

--- a/internal/command/doctor/wireguard.go
+++ b/internal/command/doctor/wireguard.go
@@ -74,7 +74,7 @@ func getWireguardDialer(ctx context.Context) (agent.Dialer, error) {
 		return nil, fmt.Errorf("wireguard dialer: weird error: %w", err)
 	}
 
-	dialer, err := ac.ConnectToTunnel(ctx, org.Slug)
+	dialer, err := ac.ConnectToTunnel(ctx, org.Slug, true)
 	if err != nil {
 		return nil, fmt.Errorf("wireguard dialer: %w", err)
 	}

--- a/internal/command/doctor/wireguard.go
+++ b/internal/command/doctor/wireguard.go
@@ -78,12 +78,9 @@ func runPersonalOrgCheckDns(ctx context.Context) error {
 		return fmt.Errorf("wireguard dialer: weird error: %w", err)
 	}
 
-	records, err := ac.LookupTxt(ctx, org.Slug, "_peer.internal")
+	_, err = ac.Resolve(ctx, org.Slug, "_api.internal")
 	if err != nil {
-		return fmt.Errorf("wireguard dialer: %w", err)
-	}
-	if len(records) == 0 {
-		return fmt.Errorf("wireguard dialer: no TXT records found for _peer.internal")
+		return fmt.Errorf("wireguard dialer: failed to lookup _api.internal: %w", err)
 	}
 
 	return nil

--- a/internal/command/doctor/wireguard.go
+++ b/internal/command/doctor/wireguard.go
@@ -10,10 +10,8 @@ import (
 
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/client"
-	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/command/dig"
 	"github.com/superfly/flyctl/internal/command/ping"
-	"github.com/superfly/flyctl/internal/flag"
 )
 
 // TODO: These probably shouldn't be hardcoded to use the "personal" org,
@@ -108,10 +106,6 @@ func runPersonalOrgCheckFlaps(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("wireguard dialer: %w", err)
 	}
-
-	// HACK: Set the quiet flag to true so that the agent client doesn't print out progress indicators
-	quietCtx := flag.NewContext(ctx, helpers.Clone(flag.FromContext(ctx)))
-	_ = flag.FromContext(quietCtx).BoolP("quiet", "q", true, "suppress output")
 
 	// Resolve the IP address of _api.internal
 	ip, err := ac.Resolve(ctx, org.Slug, "_api.internal:4280")

--- a/internal/command/doctor/wireguard.go
+++ b/internal/command/doctor/wireguard.go
@@ -109,15 +109,9 @@ func runPersonalOrgCheckFlaps(ctx context.Context) error {
 		return fmt.Errorf("wireguard dialer: %w", err)
 	}
 
-	// HACK: Set the quiet flag to true so that the agent doesn't print out progress indicators
+	// HACK: Set the quiet flag to true so that the agent client doesn't print out progress indicators
 	quietCtx := flag.NewContext(ctx, helpers.Clone(flag.FromContext(ctx)))
 	_ = flag.FromContext(quietCtx).BoolP("quiet", "q", true, "suppress output")
-
-	// Wait for the connection to be established
-	err = ac.WaitForDNS(quietCtx, wgDialer, org.Slug, "_api.internal")
-	if err != nil {
-		return fmt.Errorf("wireguard dialer: failed to wait for DNS to resolve: %w", err)
-	}
 
 	// Resolve the IP address of _api.internal
 	ip, err := ac.Resolve(ctx, org.Slug, "_api.internal:4280")
@@ -148,9 +142,6 @@ func runPersonalOrgCheckFlaps(ctx context.Context) error {
 		return fmt.Errorf("wireguard dialer: failed to read HTTP response: %w", err)
 	}
 
-	if err != nil {
-		return fmt.Errorf("wireguard dialer: failed to make HTTP request: %w", err)
-	}
 	if resp.StatusCode != 404 {
 		return fmt.Errorf("wireguard dialer: expected 404, got %d", resp.StatusCode)
 	}

--- a/internal/command/machine/proxy.go
+++ b/internal/command/machine/proxy.go
@@ -64,7 +64,7 @@ func runMachineProxy(ctx context.Context) error {
 		return err
 	}
 
-	dialer, err := agentclient.ConnectToTunnel(ctx, orgSlug)
+	dialer, err := agentclient.ConnectToTunnel(ctx, orgSlug, flag.GetBool(ctx, "quiet"))
 	if err != nil {
 		return err
 	}

--- a/internal/command/proxy/proxy.go
+++ b/internal/command/proxy/proxy.go
@@ -103,7 +103,7 @@ func run(ctx context.Context) (err error) {
 		return err
 	}
 
-	dialer, err := agentclient.ConnectToTunnel(ctx, orgSlug)
+	dialer, err := agentclient.ConnectToTunnel(ctx, orgSlug, flag.GetBool(ctx, "quiet"))
 	if err != nil {
 		return err
 	}

--- a/internal/command/redis/proxy.go
+++ b/internal/command/redis/proxy.go
@@ -79,7 +79,7 @@ func getRedisProxyParams(ctx context.Context, localProxyPort string) (*proxy.Con
 		return nil, "", err
 	}
 
-	dialer, err := agentclient.ConnectToTunnel(ctx, database.Organization.Slug)
+	dialer, err := agentclient.ConnectToTunnel(ctx, database.Organization.Slug, false)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
### Change Summary

What and Why: adds distinct tests for DNS and Flaps over WireGuard. The intent is mostly to use these for automated testing.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
