### PR TITLE
Make certain subcommands accept multiple args

### DIFF
--- a/internal/command/ips/release.go
+++ b/internal/command/ips/release.go
@@ -14,11 +14,11 @@ import (
 
 func newRelease() *cobra.Command {
 	const (
-		long  = `Releases an IP address from the application`
-		short = `Release an IP address`
+		long  = `Releases one or more IP addresses from the application`
+		short = `Release IP addresses`
 	)
 
-	cmd := command.New("release [ADDRESS]", short, long, runReleaseIPAddress,
+	cmd := command.New("release [flags] ADDRESS ADDRESS ...", short, long, runReleaseIPAddress,
 		command.RequireSession,
 		command.RequireAppName,
 	)
@@ -28,7 +28,7 @@ func newRelease() *cobra.Command {
 		flag.AppConfig(),
 	)
 
-	cmd.Args = cobra.ExactArgs(1)
+	cmd.Args = cobra.MinimumNArgs(1)
 	return cmd
 }
 
@@ -36,17 +36,19 @@ func runReleaseIPAddress(ctx context.Context) error {
 	client := client.FromContext(ctx).API()
 
 	appName := appconfig.NameFromContext(ctx)
-	address := flag.Args(ctx)[0]
 
-	if ip := net.ParseIP(address); ip == nil {
-		return fmt.Errorf("Invalid IP address: '%s'", address)
+	for _, address := range flag.Args(ctx) {
+
+		if ip := net.ParseIP(address); ip == nil {
+			return fmt.Errorf("Invalid IP address: '%s'", address)
+		}
+
+		if err := client.ReleaseIPAddress(ctx, appName, address); err != nil {
+			return err
+		}
+
+		fmt.Printf("Released %s from %s\n", address, appName)
 	}
-
-	if err := client.ReleaseIPAddress(ctx, appName, address); err != nil {
-		return err
-	}
-
-	fmt.Printf("Released %s from %s\n", address, appName)
 
 	return nil
 }


### PR DESCRIPTION
`flyctl machines destroy`, `flyctl volumes destroy`, and `flyctl ips release` all previously only took a single argument. This commit implements support for these commands taking multiple arguments. The implementation is fairly naive and could be improved, e.g. by changing the remote API to take multiple arguments and only making a single API call.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
