### PR TITLE
only try get secrets if they are actually set

### DIFF
--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"time"
 
@@ -419,8 +420,14 @@ func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *E
 		io              = iostreams.FromContext(ctx)
 		client          = client.FromContext(ctx).API().GenqClient
 		setSecrets bool = true
-		secrets         = extension.Data.Environment.(map[string]interface{})
 	)
+
+	environment := extension.Data.Environment
+	if environment == nil || reflect.ValueOf(environment).IsNil() {
+		return nil
+	}
+
+	secrets := extension.Data.Environment.(map[string]interface{})
 
 	if app.Name != "" {
 		appResp, err := gql.GetApp(ctx, client, app.Name)


### PR DESCRIPTION
### Change Summary

What and Why:

Provisioning was failing for our new extension

How:

Don't set the secrets immediately, first check if they are null

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
