### PR TITLE
Issue app-specific SSH certs where possible

### DIFF
--- a/api/resource_ssh.go
+++ b/api/resource_ssh.go
@@ -54,7 +54,7 @@ mutation($input: EstablishSSHKeyInput!) {
 	return &data.EstablishSSHKey, nil
 }
 
-func (c *Client) IssueSSHCertificate(ctx context.Context, org OrganizationImpl, principals []string, apps []App, valid_hours *int, publicKey ed25519.PublicKey) (*IssuedCertificate, error) {
+func (c *Client) IssueSSHCertificate(ctx context.Context, org OrganizationImpl, principals []string, appNames []string, valid_hours *int, publicKey ed25519.PublicKey) (*IssuedCertificate, error) {
 	req := c.NewRequest(`
 mutation($input: IssueCertificateInput!) {
   issueCertificate(input: $input) {
@@ -62,12 +62,6 @@ mutation($input: IssueCertificateInput!) {
   }
 }
 `)
-
-	appNames := make([]string, 0, len(apps))
-	for _, app := range apps {
-		appNames = append(appNames, app.Name)
-	}
-
 	var pubStr string
 	if len(publicKey) > 0 {
 		sshPub, err := ssh.NewPublicKey(publicKey)

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -410,7 +410,7 @@ func (l *Launcher) setSecrets(ctx context.Context, config *CreateClusterInput) (
 		}
 
 		app := api.App{Name: config.AppName}
-		cert, err := l.client.IssueSSHCertificate(ctx, config.Organization, []string{"root", "fly", "postgres"}, []api.App{app}, nil, pub)
+		cert, err := l.client.IssueSSHCertificate(ctx, config.Organization, []string{"root", "fly", "postgres"}, []string{app.Name}, nil, pub)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -196,6 +196,7 @@ func runConsole(ctx context.Context) error {
 		Dialer:         dialer,
 		Username:       flag.GetString(ctx, "user"),
 		DisableSpinner: false,
+		AppNames:       []string{app.Name},
 	}
 	sshClient, err := ssh.Connect(params, machine.PrivateIP)
 	if err != nil {

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -456,6 +456,7 @@ func runMachineRun(ctx context.Context) error {
 			Dialer:         dialer,
 			Username:       flag.GetString(ctx, "user"),
 			DisableSpinner: false,
+			AppNames:       []string{app.Name},
 		}, machine.PrivateIP)
 		if err != nil {
 			return err

--- a/internal/command/postgres/barman.go
+++ b/internal/command/postgres/barman.go
@@ -472,6 +472,7 @@ func runConsole(ctx context.Context, cmd string) error {
 		Dialer:         dialer,
 		Username:       "root",
 		DisableSpinner: false,
+		AppNames:       []string{app.Name},
 	}
 	sshc, err := ssh.Connect(params, addr)
 	if err != nil {

--- a/internal/command/ssh/connect.go
+++ b/internal/command/ssh/connect.go
@@ -56,12 +56,13 @@ type ConnectParams struct {
 	Username       string
 	Dialer         agent.Dialer
 	DisableSpinner bool
+	AppNames       []string
 }
 
 func Connect(p *ConnectParams, addr string) (*ssh.Client, error) {
 	terminal.Debugf("Fetching certificate for %s\n", addr)
 
-	cert, pk, err := singleUseSSHCertificate(p.Ctx, p.Org)
+	cert, pk, err := singleUseSSHCertificate(p.Ctx, p.Org, p.AppNames)
 	if err != nil {
 		return nil, fmt.Errorf("create ssh certificate: %w (if you haven't created a key for your org yet, try `flyctl ssh issue`)", err)
 	}
@@ -100,7 +101,7 @@ func Connect(p *ConnectParams, addr string) (*ssh.Client, error) {
 	return sshClient, nil
 }
 
-func singleUseSSHCertificate(ctx context.Context, org api.OrganizationImpl) (*api.IssuedCertificate, ed25519.PrivateKey, error) {
+func singleUseSSHCertificate(ctx context.Context, org api.OrganizationImpl, appNames []string) (*api.IssuedCertificate, ed25519.PrivateKey, error) {
 	client := client.FromContext(ctx).API()
 	hours := 1
 
@@ -109,7 +110,7 @@ func singleUseSSHCertificate(ctx context.Context, org api.OrganizationImpl) (*ap
 		return nil, nil, err
 	}
 
-	icert, err := client.IssueSSHCertificate(ctx, org, []string{DefaultSshUsername, "fly"}, nil, &hours, pub)
+	icert, err := client.IssueSSHCertificate(ctx, org, []string{DefaultSshUsername, "fly"}, appNames, &hours, pub)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -176,6 +176,7 @@ func runConsole(ctx context.Context) error {
 		Dialer:         dialer,
 		Username:       flag.GetString(ctx, "user"),
 		DisableSpinner: quiet(ctx),
+		AppNames:       []string{app.Name},
 	}
 	sshc, err := Connect(params, addr)
 	if err != nil {

--- a/internal/command/ssh/sftp.go
+++ b/internal/command/ssh/sftp.go
@@ -111,6 +111,7 @@ func newSFTPConnection(ctx context.Context) (*sftp.Client, error) {
 		Dialer:         dialer,
 		Username:       DefaultSshUsername,
 		DisableSpinner: true,
+		AppNames:       []string{app.Name},
 	}
 
 	conn, err := Connect(params, addr)

--- a/internal/command/ssh/ssh_terminal.go
+++ b/internal/command/ssh/ssh_terminal.go
@@ -63,9 +63,14 @@ func RunSSHCommand(ctx context.Context, app *api.AppCompact, dialer agent.Dialer
 }
 
 func SSHConnect(p *SSHParams, addr string) error {
-	terminal.Debugf("Fetching certificate for %s\n", addr)
+	terminal.Debugf("Fetching certificate for %s at %s\n", p.App, addr)
 
-	cert, pk, err := singleUseSSHCertificate(p.Ctx, p.Org)
+	var appNames []string
+	if p.App != "" {
+		appNames = append(appNames, p.App)
+	}
+
+	cert, pk, err := singleUseSSHCertificate(p.Ctx, p.Org, appNames)
 	if err != nil {
 		return fmt.Errorf("create ssh certificate: %w (if you haven't created a key for your org yet, try `flyctl ssh issue`)", err)
 	}


### PR DESCRIPTION
App-specific certs require fewer permissions to issue. This allows users to do more with limited macaroons.