### PR TITLE
Ask for organization before finalizing the launch plan

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -166,6 +166,10 @@ func run(ctx context.Context) (err error) {
 		}
 
 		if flag.GetBool(ctx, "manifest") {
+			if incompleteLaunchManifest {
+				return errors.New("manifest generation incomplete")
+			}
+
 			jsonEncoder := json.NewEncoder(io.Out)
 			jsonEncoder.SetIndent("", "  ")
 			return jsonEncoder.Encode(launchManifest)

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -191,7 +191,7 @@ func run(ctx context.Context) (err error) {
 
 	fmt.Fprintf(
 		io.Out,
-		"We're about to launch your %s on Fly.io. Here's what you're getting:\n\n%s\n",
+		"\nWe're about to launch your %s on Fly.io. Here's what you're getting:\n\n%s\n",
 		familyToAppType(family),
 		summary,
 	)

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -17,7 +17,6 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/iostreams"
-	"github.com/superfly/flyctl/scanner"
 )
 
 func New() (cmd *cobra.Command) {
@@ -138,9 +137,8 @@ func run(ctx context.Context) (err error) {
 	// TODO: Metrics
 
 	var (
-		launchManifest     *LaunchManifest
-		cache              *planBuildCache
-		hasPrintedPreamble bool // "We're about to launch your [xyz] app on Fly.io"
+		launchManifest *LaunchManifest
+		cache          *planBuildCache
 	)
 
 	launchManifest, err = getManifestArgument(ctx)
@@ -153,7 +151,7 @@ func run(ctx context.Context) (err error) {
 
 	if launchManifest == nil {
 
-		launchManifest, cache, err = buildManifest(ctx, canEnterUi, &hasPrintedPreamble)
+		launchManifest, cache, err = buildManifest(ctx, canEnterUi)
 		if err != nil {
 			var recoverableErr recoverableInUiError
 			if errors.As(err, &recoverableErr) && canEnterUi {
@@ -186,16 +184,15 @@ func run(ctx context.Context) (err error) {
 		return err
 	}
 
-	if !hasPrintedPreamble {
-		printLaunchPreamble(ctx, state.sourceInfo)
-	} else if !incompleteLaunchManifest {
-		// If we've already printed the preamble, interject "ok" so it's more clear that we're done with setup.
-		// We don't want to print "ok" if there's a problem with the launch manifest, because that would be misleading.
-		fmt.Fprintf(io.Out, "Ok! ")
+	family := ""
+	if state.sourceInfo != nil {
+		family = state.sourceInfo.Family
 	}
+
 	fmt.Fprintf(
 		io.Out,
-		"Here's what you're getting:\n\n%s\n",
+		"We're about to launch your %s on Fly.io. Here's what you're getting:\n\n%s\n",
+		familyToAppType(family),
 		summary,
 	)
 
@@ -243,17 +240,6 @@ func familyToAppType(family string) string {
 		return "app"
 	}
 	return fmt.Sprintf("%s app", family)
-}
-
-func printLaunchPreamble(ctx context.Context, sourceInfo *scanner.SourceInfo) {
-	io := iostreams.FromContext(ctx)
-
-	family := ""
-	if sourceInfo != nil {
-		family = sourceInfo.Family
-	}
-
-	fmt.Fprintf(io.Out, "We're about to launch your %s on Fly.io. ", familyToAppType(family))
 }
 
 // warnLegacyBehavior warns the user if they are using a legacy flag

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -17,10 +17,6 @@ func (state *launchState) Launch(ctx context.Context) error {
 
 	io := iostreams.FromContext(ctx)
 
-	// TODO(Allison): are we still supporting the launch-into usecase?
-	// I'm assuming *not* for now, because it's confusing UX and this
-	// is the perfect time to remove it.
-
 	state.updateConfig(ctx)
 
 	app, err := state.createApp(ctx)

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -466,8 +466,6 @@ func determineOrg(ctx context.Context) (*api.Organization, string, error) {
 		clientApi = client.API()
 	)
 
-	// TODO: Ensure callers can handle recoverable errors with nil org
-
 	// First, check and see if we passed the --org argument.
 	orgSlug := flag.GetOrg(ctx)
 

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -86,8 +86,6 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 		return nil, nil, err
 	}
 
-	// TODO(allison): possibly add some automatic suffixing to app names if they already exist
-
 	org, orgExplanation, err := determineOrg(ctx)
 	if err != nil {
 		if err := tryRecoverErr(err); err != nil {

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -72,7 +72,7 @@ func appNameTakenErr(appName string) error {
 	}
 }
 
-func buildManifest(ctx context.Context, canEnterUi bool, hasPrintedPreamble *bool) (*LaunchManifest, *planBuildCache, error) {
+func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *planBuildCache, error) {
 	var recoverableInUiErrors []recoverableInUiError
 	tryRecoverErr := func(e error) error {
 		var asRecoverableErr recoverableInUiError
@@ -119,7 +119,7 @@ func buildManifest(ctx context.Context, canEnterUi bool, hasPrintedPreamble *boo
 		return nil, nil, err
 	}
 
-	org, orgExplanation, err := determineOrg(ctx, srcInfo, hasPrintedPreamble)
+	org, orgExplanation, err := determineOrg(ctx)
 	if err != nil {
 		if err := tryRecoverErr(err); err != nil {
 			return nil, nil, err
@@ -479,7 +479,7 @@ func tryFindFallbackOrg(ctx context.Context) *api.Organization {
 }
 
 // determineOrg returns the org specified on the command line, or the personal org if left unspecified
-func determineOrg(ctx context.Context, sourceInfo *scanner.SourceInfo, hasPrintedPreamble *bool) (*api.Organization, string, error) {
+func determineOrg(ctx context.Context) (*api.Organization, string, error) {
 	var (
 		io        = iostreams.FromContext(ctx)
 		client    = client.FromContext(ctx)
@@ -505,10 +505,6 @@ func determineOrg(ctx context.Context, sourceInfo *scanner.SourceInfo, hasPrinte
 	}
 
 	// Since there was no override, let's have the user pick an org.
-	if !*hasPrintedPreamble {
-		printLaunchPreamble(ctx, sourceInfo)
-		*hasPrintedPreamble = true
-	}
 	fmt.Fprintf(io.Out, "Please select an organization:\n")
 	org, err := prompt.Org(ctx)
 	if err != nil {

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -86,6 +86,20 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 		return nil, nil, err
 	}
 
+	org, orgExplanation, err := determineOrg(ctx)
+	if err != nil {
+		if err := tryRecoverErr(err); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	region, regionExplanation, err := determineRegion(ctx, appConfig, org.PaidPlan)
+	if err != nil {
+		if err := tryRecoverErr(err); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	httpServicePort := 8080
 	if copiedConfig {
 		// Check imported fly.toml is a valid V2 config before creating the app
@@ -115,20 +129,6 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 	srcInfo, appConfig.Build, err = determineSourceInfo(ctx, appConfig, copiedConfig, workingDir)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	org, orgExplanation, err := determineOrg(ctx)
-	if err != nil {
-		if err := tryRecoverErr(err); err != nil {
-			return nil, nil, err
-		}
-	}
-
-	region, regionExplanation, err := determineRegion(ctx, appConfig, org.PaidPlan)
-	if err != nil {
-		if err := tryRecoverErr(err); err != nil {
-			return nil, nil, err
-		}
 	}
 
 	appName, appNameExplanation, err := determineAppName(ctx, appConfig, configPath)


### PR DESCRIPTION
### Change Summary

What and Why: This solves two problems.
1. Users got annoyed that we picked Personal by default. This is totally understandable - we can pick reasonable default for everything else, but we have no information from which we can derive what organization the user wants. Asking directly will end up being faster and better UX here.
2. We want to support per-org launch features, such as waitlisted/beta addons, and this allows us to go into the launch web page with the exact knowledge of what org the app's going in. This simplifies the process on our side, and reduces surface area for bugs as we're introducing new addons and extensions.

How: We prompt for the org during the launch, just like we did with legacy launch.

Related to: discussion in #fly-launch, [user feedback](https://community.fly.io/t/the-new-launch/16490/4?u=allison)

---

### Documentation

Not sure what the docs ramifications are of this, waiting to hear back about that :)

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
