### PR TITLE
Fix go.mod api requirement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
-	github.com/superfly/flyctl/api v0.0.0
+	github.com/superfly/flyctl/api v0.0.0-20231211222908-989df2bf70f3
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.9


### PR DESCRIPTION
It is not possible to import flaps outside the flyctl project at the moment, because the root go.mod depends on a non-existent version of the api package.

```
go: downloading github.com/superfly/flyctl/api v0.0.0
go: github.com/superfly/flyctl/flaps imports
        github.com/superfly/flyctl/api: reading github.com/superfly/flyctl/api/go.mod at revision api/v0.0.0: unknown revision api/v0.0.0
go: github.com/superfly/flyctl/flaps imports
        github.com/superfly/flyctl/api/tokens: reading github.com/superfly/flyctl/api/go.mod at revision api/v0.0.0: unknown revision api/v0.0.0
```

The flyctl projects works, because it uses a `replace` directive to use the local api package instead of the version specified.

I'm not sure what the right answer is here; starting this pull request to get feedback!

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
