### PR TITLE
Fix typo in error message for invalid region

### DIFF
--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -75,7 +75,7 @@ func (state *launchState) Region(ctx context.Context) (api.Region, error) {
 		return r.Code == state.Plan.RegionCode
 	})
 	if !ok {
-		return region, fmt.Errorf("region %s not found", state.Plan.RegionCode)
+		return region, fmt.Errorf("region %s not found. Is %s a valid region according to `fly platform regions`?", state.Plan.RegionCode)
 	}
 	return region, nil
 }

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -75,7 +75,7 @@ func (state *launchState) Region(ctx context.Context) (api.Region, error) {
 		return r.Code == state.Plan.RegionCode
 	})
 	if !ok {
-		return region, fmt.Errorf("region %state not found", state.Plan.RegionCode)
+		return region, fmt.Errorf("region %s not found", state.Plan.RegionCode)
 	}
 	return region, nil
 }

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -75,7 +75,7 @@ func (state *launchState) Region(ctx context.Context) (api.Region, error) {
 		return r.Code == state.Plan.RegionCode
 	})
 	if !ok {
-		return region, fmt.Errorf("region %s not found. Is %s a valid region according to `fly platform regions`?", state.Plan.RegionCode)
+		return region, fmt.Errorf("region %s not found. Is this a valid region according to `fly platform regions`?", state.Plan.RegionCode)
 	}
 	return region, nil
 }


### PR DESCRIPTION
### Change Summary

What and Why:

Users trying to deploy to the removed region `maa` are receiving the error `region maatate not found`. This PR fixes a display bug.

There's still a bigger problem: `maa` still shows up in output of `fly platform regions` and I believe, from the third link below, that we're still detecting it as a user's nearest region and trying to deploy them there when they don't specify!

How:

Fix typo `%state` to `%s` in [/internal/command/launch/state.go](https://github.com/superfly/flyctl/blob/363a4dd4b22920ae0779c67208040d45c565d817/internal/command/launch/state.go#L78)

Related to:

* https://community.fly.io/t/problem-launch/17319
* https://github.com/superfly/docs/issues/1257
* https://github.com/superfly/docs/pull/1249 -- from this one, I think that not only 

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
