### PR TITLE
more explicit output for IP types

### DIFF
--- a/internal/command/ips/list.go
+++ b/internal/command/ips/list.go
@@ -2,6 +2,7 @@ package ips
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/client"
@@ -37,6 +38,7 @@ func newList() *cobra.Command {
 func runIPAddressesList(ctx context.Context) error {
 	cfg := config.FromContext(ctx)
 	client := client.FromContext(ctx).API()
+	out := iostreams.FromContext(ctx).Out
 
 	appName := appconfig.NameFromContext(ctx)
 	ipAddresses, err := client.GetIPAddresses(ctx, appName)
@@ -45,10 +47,10 @@ func runIPAddressesList(ctx context.Context) error {
 	}
 
 	if cfg.JSONOutput {
-		out := iostreams.FromContext(ctx).Out
 		return render.JSON(out, ipAddresses)
 	}
 
 	renderListTable(ctx, ipAddresses)
+	fmt.Println("Learn more about Fly.io public, private, shared and dedicated IP addresses in our docs: https://fly.io/docs/reference/services/#ip-addresses")
 	return nil
 }

--- a/internal/command/ips/render.go
+++ b/internal/command/ips/render.go
@@ -22,17 +22,19 @@ func renderListTable(ctx context.Context, ipAddresses []api.IPAddress) {
 			ipType = "public"
 		}
 
+		createdAt := format.RelativeTime(ipAddr.CreatedAt)
+
 		switch {
 		case ipAddr.Type == "v4":
-			rows = append(rows, []string{"v4", ipAddr.Address, "public (dedicated)", ipAddr.Region, ""})
+			rows = append(rows, []string{"v4", ipAddr.Address, "public (dedicated, $2/mo)", ipAddr.Region, createdAt})
 		case ipAddr.Type == "shared_v4":
-			rows = append(rows, []string{"v4", ipAddr.Address, "public (shared)", ipAddr.Region, ""})
+			rows = append(rows, []string{"v4", ipAddr.Address, "public (shared)", ipAddr.Region, createdAt})
 		case ipAddr.Type == "v6":
-			rows = append(rows, []string{"v6", ipAddr.Address, "public", ipAddr.Region, ""})
+			rows = append(rows, []string{"v6", ipAddr.Address, "public (dedicated)", ipAddr.Region, createdAt})
 		case ipAddr.Type == "private_v6":
-			rows = append(rows, []string{"v6", ipAddr.Address, "private", ipAddr.Region, ""})
+			rows = append(rows, []string{"v6", ipAddr.Address, "private", ipAddr.Region, createdAt})
 		default:
-			rows = append(rows, []string{ipAddr.Type, ipAddr.Address, ipType, ipAddr.Region, format.RelativeTime(ipAddr.CreatedAt)})
+			rows = append(rows, []string{ipAddr.Type, ipAddr.Address, ipType, ipAddr.Region, createdAt})
 		}
 	}
 

--- a/internal/command/ips/render.go
+++ b/internal/command/ips/render.go
@@ -22,9 +22,16 @@ func renderListTable(ctx context.Context, ipAddresses []api.IPAddress) {
 			ipType = "public"
 		}
 
-		if ipAddr.Type == "shared_v4" {
+		switch {
+		case ipAddr.Type == "v4":
+			rows = append(rows, []string{"v4", ipAddr.Address, "public (dedicated)", ipAddr.Region, ""})
+		case ipAddr.Type == "v6":
+			rows = append(rows, []string{"v6", ipAddr.Address, "public (dedicated)", ipAddr.Region, ""})
+		case ipAddr.Type == "shared_v4":
 			rows = append(rows, []string{"v4", ipAddr.Address, "public (shared)", ipAddr.Region, ""})
-		} else {
+		case ipAddr.Type == "private_v6":
+			rows = append(rows, []string{"v6", ipAddr.Address, "private", ipAddr.Region, ""})
+		default:
 			rows = append(rows, []string{ipAddr.Type, ipAddr.Address, ipType, ipAddr.Region, format.RelativeTime(ipAddr.CreatedAt)})
 		}
 	}

--- a/internal/command/ips/render.go
+++ b/internal/command/ips/render.go
@@ -25,10 +25,10 @@ func renderListTable(ctx context.Context, ipAddresses []api.IPAddress) {
 		switch {
 		case ipAddr.Type == "v4":
 			rows = append(rows, []string{"v4", ipAddr.Address, "public (dedicated)", ipAddr.Region, ""})
-		case ipAddr.Type == "v6":
-			rows = append(rows, []string{"v6", ipAddr.Address, "public (dedicated)", ipAddr.Region, ""})
 		case ipAddr.Type == "shared_v4":
 			rows = append(rows, []string{"v4", ipAddr.Address, "public (shared)", ipAddr.Region, ""})
+		case ipAddr.Type == "v6":
+			rows = append(rows, []string{"v6", ipAddr.Address, "public", ipAddr.Region, ""})
 		case ipAddr.Type == "private_v6":
 			rows = append(rows, []string{"v6", ipAddr.Address, "private", ipAddr.Region, ""})
 		default:

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -41,7 +41,7 @@ func RelativeTime(t time.Time) string {
 		}
 	}
 
-	return Time(t)
+	return t.Format("Jan 2 2006 15:04")
 }
 
 // Time is shorthand for t.Format(time.RFC3339).


### PR DESCRIPTION
### Change Summary

What and Why:
<img width="956" alt="CleanShot 2024-01-02 at 13 32 28@2x" src="https://github.com/superfly/flyctl/assets/82/02fca9b4-a958-4fb2-b81c-1125ad704370">

Output whether an IP is dedicated, shared and the incurred cost, if any. The cost is hard-coded for now so this can be used by users looking to migrate off dedicated IPs sooner than later.

Related to:

Confusion around IP billing changes paired with unclear UIs around IP resources.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
