### PR TITLE
Replace `GetApp` in `fly tokens list` and `fly pg attach`

### DIFF
--- a/api/resource_tokens.go
+++ b/api/resource_tokens.go
@@ -4,6 +4,33 @@ import (
 	"context"
 )
 
+func (c *Client) GetAppLimitedAccessTokens(ctx context.Context, appName string) ([]LimitedAccessToken, error) {
+	query := `
+		query ($appName: String!) {
+			app(name: $appName) {
+				limitedAccessTokens {
+					nodes {
+						id
+						name
+						expiresAt
+					}
+				}
+			}
+		}
+	`
+
+	req := c.NewRequest(query)
+	req.Var("appName", appName)
+	ctx = ctxWithAction(ctx, "get_app_limited_access_tokens")
+
+	data, err := c.RunWithContext(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return data.App.LimitedAccessTokens.Nodes, nil
+}
+
 func (c *Client) RevokeLimitedAccessToken(ctx context.Context, id string) error {
 	query := `
 		mutation($input:DeleteLimitedAccessTokenInput!) {

--- a/internal/command/postgres/attach.go
+++ b/internal/command/postgres/attach.go
@@ -108,14 +108,14 @@ func runAttach(ctx context.Context) error {
 		SuperUser:    flag.GetBool(ctx, "superuser"),
 	}
 
-	pgAppFull, err := client.GetApp(ctx, pgAppName)
+	ips, err := client.GetIPAddresses(ctx, pgAppName)
 	if err != nil {
-		return fmt.Errorf("failed retrieving postgres app %s: %w", pgAppName, err)
+		return fmt.Errorf("failed retrieving IP addresses for postgres app %s: %w", pgAppName, err)
 	}
 
 	var flycast *string
 
-	for _, ip := range pgAppFull.IPAddresses.Nodes {
+	for _, ip := range ips {
 		if ip.Type == "private_v6" {
 			flycast = &ip.Address
 		}
@@ -155,19 +155,19 @@ func AttachCluster(ctx context.Context, params AttachParams) error {
 	}
 
 	// Verify that the target app exists.
-	_, err = client.GetApp(ctx, appName)
+	_, err = client.GetAppBasic(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("failed retrieving app %s: %w", appName, err)
 	}
 
-	pgAppFull, err := client.GetApp(ctx, pgAppName)
+	ips, err := client.GetIPAddresses(ctx, pgAppName)
 	if err != nil {
-		return fmt.Errorf("failed retrieving postgres app %s: %w", pgAppName, err)
+		return fmt.Errorf("failed retrieving IP addresses for postgres app %s: %w", pgAppName, err)
 	}
 
 	var flycast *string
 
-	for _, ip := range pgAppFull.IPAddresses.Nodes {
+	for _, ip := range ips {
 		if ip.Type == "private_v6" {
 			flycast = &ip.Address
 		}

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -53,12 +53,12 @@ func runList(ctx context.Context) (err error) {
 			return command.ErrRequireAppName
 		}
 
-		app, err := apiClient.GetApp(ctx, appName)
+		tokens, err := apiClient.GetAppLimitedAccessTokens(ctx, appName)
 		if err != nil {
-			return fmt.Errorf("failed retrieving app %s: %w", appName, err)
+			return fmt.Errorf("failed retrieving tokens for app %s: %w", appName, err)
 		}
 
-		for _, token := range app.LimitedAccessTokens.Nodes {
+		for _, token := range tokens {
 			rows = append(rows, []string{token.Id, token.Name, token.ExpiresAt.String()})
 		}
 


### PR DESCRIPTION
### Change Summary

**What and Why:**

`GetApp` returns a lot of information from the GraphQL API, including a list of all of an app's Machines (including destroyed ones!). For large apps or apps with a lot of history, this can be very slow.

https://github.com/superfly/flyctl/pull/3015 sped up `fly volumes` commands by replacing `GetApp`. This PR is a follow-on that (finally) gives the same treatment to `fly tokens list` and `fly pg attach`.

The remaining uses of `GetApp` are in `fly turboku` and `fly migrate-to-v2`, neither of which seem worth updating.

**How:**

* For `fly tokens list`, create and use a new `GetAppLimitedAccessTokens` query.
* For `fly pg attach`, use `GetAppBasic` and `GetIPAddresses` as appropriate.

**Related to:**

* https://github.com/superfly/flyctl/pull/3015

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
