### PR TITLE
add additional configuration options for dns

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -656,7 +656,15 @@ type MachineInit struct {
 }
 
 type DNSConfig struct {
-	SkipRegistration bool `json:"skip_registration,omitempty"`
+	SkipRegistration bool        `json:"skip_registration,omitempty"`
+	Nameservers      []string    `json:"nameservers,omitempty"`
+	Searches         []string    `json:"searches,omitempty"`
+	Options          []dnsOption `json:"options,omitempty"`
+}
+
+type dnsOption struct {
+	Name  string  `json:"name,omitempty"`
+	Value *string `json:"value,omitempty"`
 }
 
 type StopConfig struct {


### PR DESCRIPTION
### Change Summary

What and Why:

Add the ability to configure the `resolv.conf` file. Can specify additional nameservers, searches and options.

How:

Adds the relevant fields to the machine configuration

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
