### PR TITLE
Fix a nil pointer dereference

### DIFF
--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -139,6 +139,9 @@ func (*buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 	if err != nil {
 		return nil, "", err
 	}
+	if img == nil {
+		return nil, "", fmt.Errorf("no image found")
+	}
 
 	return &DeploymentImage{
 		ID:   img.ID,

--- a/internal/build/imgsrc/nixpacks_builder.go
+++ b/internal/build/imgsrc/nixpacks_builder.go
@@ -233,6 +233,9 @@ func (*nixpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFact
 	if err != nil {
 		return nil, "", err
 	}
+	if img == nil {
+		return nil, "", fmt.Errorf("no image found")
+	}
 
 	return &DeploymentImage{
 		ID:   img.ID,


### PR DESCRIPTION
We hit this in a few testflight tests simultaneously https://flyio.sentry.io/issues/4571145485/events/latest/?project=4492967&query=&referrer=latest-event&statsPeriod=15m. https://buildkite.com/flyio/testflight/builds/26288

Presumably, DockerHub was having a hard time for a second.