### PR TITLE
`agent`: override wg region with `FLY_AGENT_WG_REGION`

### DIFF
--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -213,13 +213,14 @@ func (s *server) buildTunnel(ctx context.Context, org *api.Organization, recycle
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// not checking the region is intentional, it's static during the lifetime of the agent
 	if tunnel = s.tunnels[org.Slug]; tunnel != nil && !recycle {
 		// tunnel already exists
 		return
 	}
 
 	var state *wg.WireGuardState
-	if state, err = wireguard.StateForOrg(ctx, s.Client, org, "", "", recycle); err != nil {
+	if state, err = wireguard.StateForOrg(ctx, s.Client, org, os.Getenv("FLY_AGENT_WG_REGION"), "", recycle); err != nil {
 		return
 	}
 

--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -45,7 +45,7 @@ func StateForOrg(ctx context.Context, apiClient *api.Client, org *api.Organizati
 	if err != nil {
 		return nil, err
 	}
-	if state != nil && !recycle {
+	if state != nil && !recycle && state.Region == regionCode {
 		return state, nil
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why: Makes the region that the agent's wireguard peers end up in configurable. Not really useful for end-users, but *is* useful for WGCI.

How: The agent respects the environment variable `FLY_AGENT_WG_REGION`, which would just be a region code.

> Note: Using this correctly is a bit tricky, as it's consumed by the agent, not individual flyctl runs, which means if you ran
> ```sh
> export FLY_AGENT_WG_REGION=ord
> fly agent start
> export FLY_AGENT_WG_REGION=atl
> fly <some command that uses wireguard>
> ```
> you'd be using peers in ord 100% of the time.
> 

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
