### PR TITLE
`doctor`: bugfix: forgot to find/replace a "personal" to orgSlug

### DIFF
--- a/internal/command/doctor/wireguard.go
+++ b/internal/command/doctor/wireguard.go
@@ -93,7 +93,7 @@ func runPersonalOrgCheckFlaps(ctx context.Context, orgSlug string) error {
 	}
 
 	// Connect to the personal org via WireGuard
-	org, err := apiClient.GetOrganizationBySlug(ctx, "personal")
+	org, err := apiClient.GetOrganizationBySlug(ctx, orgSlug)
 	if err != nil {
 		// shouldn't happen, already verified auth token
 		return fmt.Errorf("wireguard dialer: can't get org %s: %w", orgSlug, err)


### PR DESCRIPTION
### Change Summary

I made a find & replace error, this is what you get for not testing with a limited token!

Replaces the final hardcoded "personal" to `orgSlug`

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
