### PR TITLE
Chore: appease deepsource in `fly doctor` wireguard tests

### DIFF
--- a/internal/command/doctor/wireguard.go
+++ b/internal/command/doctor/wireguard.go
@@ -117,7 +117,7 @@ func runPersonalOrgCheckFlaps(ctx context.Context, orgSlug string) error {
 	}
 
 	// Make an HTTP request to _api.internal:4280. This should return a 404.
-	req, err := http.NewRequest("GET", "http://_api.internal:4280", nil)
+	req, err := http.NewRequest("GET", "http://_api.internal:4280", http.NoBody)
 	if err != nil {
 		return fmt.Errorf("wireguard dialer: failed to create HTTP request: %w", err)
 	}

--- a/internal/command/doctor/wireguard.go
+++ b/internal/command/doctor/wireguard.go
@@ -117,7 +117,7 @@ func runPersonalOrgCheckFlaps(ctx context.Context, orgSlug string) error {
 	}
 
 	// Make an HTTP request to _api.internal:4280. This should return a 404.
-	req, err := http.NewRequest("GET", "http://_api.internal:4280", http.NoBody)
+	req, err := http.NewRequest("GET", "http://_api.internal:4280", http.NoBody) // skipcq: GO-S1028
 	if err != nil {
 		return fmt.Errorf("wireguard dialer: failed to create HTTP request: %w", err)
 	}


### PR DESCRIPTION
### Change Summary

What and Why: Replaces a nil body with `http.NoBody` and throws a `// skipcq` on a warning about flaps URLs not being https

These got introduced during a sprint to get wgci working :)

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
