### PR TITLE
field does not need to be a pointer type

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -663,8 +663,8 @@ type DNSConfig struct {
 }
 
 type dnsOption struct {
-	Name  string  `json:"name,omitempty"`
-	Value *string `json:"value,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
 }
 
 type StopConfig struct {


### PR DESCRIPTION
### Change Summary

What and Why:

We don't actually need to distinguish between the empty value and a nil value for this type. We know to ignore it if the value is an empty value

How:

Change from `*string` to `string`

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
