### PR TITLE
Update help message for scale vm

### DIFF
--- a/internal/command/scale/vm.go
+++ b/internal/command/scale/vm.go
@@ -15,7 +15,7 @@ import (
 
 func newScaleVm() *cobra.Command {
 	const (
-		short = "Change an app's VM to a named size (eg. shared-cpu-1x, dedicated-cpu-1x, dedicated-cpu-2x...)"
+		short = "Change an app's VM to a named size (eg. shared-cpu-1x, performance-1x, performance-2x...)"
 		long  = `Change an application's VM size to one of the named VM sizes.
 
 For a full list of supported sizes use the command 'flyctl platform vm-sizes'


### PR DESCRIPTION
### Change Summary

What and Why:

Update help message to reflect actual vm names.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
