### PR TITLE
Validate services have at least one port exposed

### DIFF
--- a/internal/appconfig/testdata/validate-groups.toml
+++ b/internal/appconfig/testdata/validate-groups.toml
@@ -15,10 +15,16 @@ internal_port = 9999
 protocol = "udp"
 processes = ["vpn"]
 
+[[services.ports]]
+port = 80
+
 [[services]]
 internal_port = 1111
 protocol = "tcp"
 processes = ["vpn", "app", "foo"]
+
+[[services.ports]]
+port = 81
 
 [checks.listening]
 port = 8080

--- a/internal/appconfig/testdata/validate-services.toml
+++ b/internal/appconfig/testdata/validate-services.toml
@@ -1,0 +1,20 @@
+app = "foo"
+primary_region = "ord"
+
+[processes]
+app = ""
+foo = ""
+success = ""
+
+# Check:
+# * missing [[services.ports]]
+# * no processes specified
+[[services]]
+internal_port = 8080
+
+[[services]]
+internal_port = 8080
+processes = ["success"]
+
+[[services.ports]]
+port = 80

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -233,6 +233,14 @@ func (cfg *Config) validateServicesSection() (extraInfo string, err error) {
 			}
 		}
 
+		if len(service.Ports) == 0 {
+			extraInfo += fmt.Sprintf(
+				"Service must expose at least one port. Add a [[services.ports]] section to fly.toml; " +
+					"Check docs at https://fly.io/docs/reference/configuration/#services-ports \n",
+			)
+			err = ValidationError
+		}
+
 		for _, check := range service.TCPChecks {
 			extraInfo += validateServiceCheckDurations(check.Interval, check.Timeout, check.GracePeriod, "TCP")
 		}

--- a/internal/appconfig/validation_test.go
+++ b/internal/appconfig/validation_test.go
@@ -25,7 +25,7 @@ func _getValidationContext(t *testing.T) context.Context {
 }
 
 func TestConfig_ValidateGroups(t *testing.T) {
-	cfg, err := LoadConfig("./testdata/validategroups.toml")
+	cfg, err := LoadConfig("./testdata/validate-groups.toml")
 	require.NoError(t, err)
 	require.NoError(t, cfg.SetMachinesPlatform())
 	cfg.Deploy = &Deploy{Strategy: "canary"}
@@ -38,8 +38,8 @@ func TestConfig_ValidateGroups(t *testing.T) {
 	err, x = cfg.ValidateGroups(ctx, []string{"app"})
 	require.Error(t, err, x)
 
-	err, _ = cfg.ValidateGroups(ctx, []string{"foo"})
-	require.NoError(t, err)
+	err, x = cfg.ValidateGroups(ctx, []string{"foo"})
+	require.NoErrorf(t, err, x)
 }
 
 func TestConfig_ValidateMounts(t *testing.T) {
@@ -55,4 +55,19 @@ func TestConfig_ValidateMounts(t *testing.T) {
 	err, x = cfg.ValidateGroups(ctx, []string{"app"})
 	require.Error(t, err, x)
 	require.Contains(t, x, "group 'app' has more than one [[mounts]] section defined")
+}
+
+func TestConfig_ValidateServices(t *testing.T) {
+	cfg, err := LoadConfig("./testdata/validate-services.toml")
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetMachinesPlatform())
+
+	ctx := _getValidationContext(t)
+	err, x := cfg.Validate(ctx)
+	require.Error(t, err, x)
+	require.Contains(t, x, "Service has no processes set")
+	require.Contains(t, x, "Service must expose at least one port")
+
+	err, x = cfg.ValidateGroups(ctx, []string{"success"})
+	require.NoErrorf(t, err, x)
 }

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -255,6 +255,9 @@ func TestAppsV2Config_ProcessGroups(t *testing.T) {
   internal_port = 8080
   protocol = "tcp"
   script_checks = []
+
+		[[services.ports]]
+		port = 80
 `)
 	require.Contains(t, deployOut.StdOutString(), `create 1 "app" machine`)
 
@@ -279,6 +282,9 @@ bar_web = "bash -c 'while true; do sleep 10; done'"
   internal_port = 8080
   protocol = "tcp"
   script_checks = []
+
+		[[services.ports]]
+		port = 80
 `)
 	require.Contains(t, deployOut.StdOutString(), `destroy 1 "app" machine`)
 	require.Contains(t, deployOut.StdOutString(), `create 1 "web" machine`)
@@ -329,6 +335,9 @@ web = "nginx -g 'daemon off;'"
   internal_port = 8080
   protocol = "tcp"
   script_checks = []
+
+		[[services.ports]]
+		port = 80
 `)
 	require.Contains(t, deployOut.StdOutString(), `destroy 2 "bar_web" machines`)
 	machines = f.MachinesList(appName)


### PR DESCRIPTION
### Change Summary

What and Why:

At least one service port must be defined for a service to be valid, check the invalid config earlier.  
<img width="756" alt="image" src="https://github.com/superfly/flyctl/assets/37369/76d00778-7c23-4c06-bbcc-f9fb162d88e4">

How: Enforce the rule as a config validation rule.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
