### PR TITLE
Do not run tag_version job for dependabot PRs

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -21,7 +21,7 @@ jobs:
 
   # create a dev tag for every branch except master
   tag_version:
-    if: ${{ github.ref_type == 'branch' && github.ref_name != 'master' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.ref_type == 'branch' && github.ref_name != 'master' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.next }}


### PR DESCRIPTION
### Change Summary

What and Why: Dependabot PRs always fails because of missing secret used to create a new release. We haven't added the token to dependabot secrets, the other way is to skip the version now so it doesn't always show a failed build while security clearance is done.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
