### PR TITLE
Add flag.Org() to `fly tokens create org` command.

### DIFF
--- a/internal/command/tokens/create.go
+++ b/internal/command/tokens/create.go
@@ -67,6 +67,7 @@ func newOrg() *cobra.Command {
 			Description: "Token name",
 			Default:     "Org deploy token",
 		},
+		flag.Org(),
 	)
 
 	return cmd


### PR DESCRIPTION
### Change Summary

What and Why:

Add a `-o` flag to the `flyctl tokens create org` command. At the moment, this command only works interactively, since org needs to be selected interactively. Adding this flag means this can be scripted.

How:

Add `flag.Org()` to the list of flags.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a
