### PR TITLE
Warn instead of fail on service definitions without ports

### DIFF
--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -238,7 +238,8 @@ func (cfg *Config) validateServicesSection() (extraInfo string, err error) {
 			//      fix fly.toml configuration -- 2024-01-15
 			extraInfo += fmt.Sprintf(
 				"WARNING: Service must expose at least one port. Add a [[services.ports]] section to fly.toml; " +
-					"Check docs at https://fly.io/docs/reference/configuration/#services-ports \n ",
+					"Check docs at https://fly.io/docs/reference/configuration/#services-ports \n " +
+					"Validation for _services without ports_ will hard fail after February 15, 2024.",
 			)
 			//err = ValidationError
 		}

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -234,11 +234,13 @@ func (cfg *Config) validateServicesSection() (extraInfo string, err error) {
 		}
 
 		if len(service.Ports) == 0 {
+			// XXX: Warn about services without ports instead of hard failing so users have time to
+			//      fix fly.toml configuration -- 2024-01-15
 			extraInfo += fmt.Sprintf(
-				"Service must expose at least one port. Add a [[services.ports]] section to fly.toml; " +
-					"Check docs at https://fly.io/docs/reference/configuration/#services-ports \n",
+				"WARNING: Service must expose at least one port. Add a [[services.ports]] section to fly.toml; " +
+					"Check docs at https://fly.io/docs/reference/configuration/#services-ports \n ",
 			)
-			err = ValidationError
+			//err = ValidationError
 		}
 
 		for _, check := range service.TCPChecks {

--- a/internal/appconfig/validation_test.go
+++ b/internal/appconfig/validation_test.go
@@ -64,7 +64,7 @@ func TestConfig_ValidateServices(t *testing.T) {
 
 	ctx := _getValidationContext(t)
 	err, x := cfg.Validate(ctx)
-	require.Error(t, err, x)
+	//require.Error(t, err, x)
 	require.Contains(t, x, "Service has no processes set")
 	require.Contains(t, x, "Service must expose at least one port")
 

--- a/internal/appconfig/validation_test.go
+++ b/internal/appconfig/validation_test.go
@@ -64,7 +64,7 @@ func TestConfig_ValidateServices(t *testing.T) {
 
 	ctx := _getValidationContext(t)
 	err, x := cfg.Validate(ctx)
-	//require.Error(t, err, x)
+	require.Error(t, err, x)
 	require.Contains(t, x, "Service has no processes set")
 	require.Contains(t, x, "Service must expose at least one port")
 


### PR DESCRIPTION
### Change Summary

What and Why: Hard failing on missing service ports was too aggressive and had alienated users that found their automated deploys suddenly failing without notice.    

How: Switch to a one Warning notice with a one month deadline. 

Related to: https://github.com/superfly/flyctl/pull/3174#issuecomment-1891090082

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
