### PR TITLE
Set isFirstDeploy if there are no launch machines

### DIFF
--- a/flaps/flaps_machines.go
+++ b/flaps/flaps_machines.go
@@ -222,7 +222,7 @@ func (f *Client) ListActive(ctx context.Context) ([]*api.Machine, error) {
 	return machines, nil
 }
 
-// ListFlyAppsMachines returns apps that are part of the Fly apps platform.
+// ListFlyAppsMachines returns apps that are part of Fly Launch.
 // Destroyed machines and console machines are excluded.
 // Unlike other List functions, this function retries multiple times.
 func (f *Client) ListFlyAppsMachines(ctx context.Context) ([]*api.Machine, *api.Machine, error) {

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/google/shlex"
+	"github.com/logrusorgru/aurora"
 	"github.com/morikuni/aec"
 	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
@@ -254,6 +255,7 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 			return err
 		}
 		if len(activeMachines) > 0 {
+			fmt.Fprintf(md.io.ErrOut, "%s Your app doesn't have any Fly Launch machines, so we'll create one now. Learn more at \nhttps://fly.io/docs/apps/deploy/#machines-not-managed-by-fly-launch\n\n", aurora.Yellow("[WARNING]"))
 			md.isFirstDeploy = true
 		}
 	}

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -237,7 +237,7 @@ func (md *machineDeployment) setFirstDeploy(ctx context.Context) error {
 	// by checking for any existent machine.
 	// This is not exaustive as the app could still be scaled down to zero but the
 	// workaround works better for now until it is fixed
-	md.isFirstDeploy = !md.app.Deployed && md.machineSet.IsEmpty()
+	md.isFirstDeploy = md.isFirstDeploy || (!md.app.Deployed && md.machineSet.IsEmpty())
 	return nil
 }
 
@@ -254,15 +254,7 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 			return err
 		}
 		if len(activeMachines) > 0 {
-			return fmt.Errorf(
-				"found %d machines that are unmanaged. `fly deploy` only updates machines with %s=%s in their metadata. Use `fly machine list` to list machines and `fly machine update --metadata %s=%s <machine id>` to update individual machines with the metadata. Once done, `fly deploy` will update machines with the metadata based on your %s app configuration",
-				len(activeMachines),
-				api.MachineConfigMetadataKeyFlyPlatformVersion,
-				api.MachineFlyPlatformVersion2,
-				api.MachineConfigMetadataKeyFlyPlatformVersion,
-				api.MachineFlyPlatformVersion2,
-				appconfig.DefaultConfigFileName,
-			)
+			md.isFirstDeploy = true
 		}
 	}
 

--- a/internal/command/status/machines.go
+++ b/internal/command/status/machines.go
@@ -208,7 +208,7 @@ func RenderMachineStatus(ctx context.Context, app *api.AppCompact, out io.Writer
 	}
 
 	if len(unmanaged) > 0 {
-		msg := fmt.Sprintf("Found machines that aren't part of the Fly Apps Platform, run %s to see them.\n", io.ColorScheme().Yellow("fly machines list"))
+		msg := fmt.Sprintf("Found machines that aren't part of Fly Launch, run %s to see them.\n", io.ColorScheme().Yellow("fly machines list"))
 		fmt.Fprint(out, msg)
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why:
Currently, if someone tries to deploy on an app with no managed machines (such as scaling down to 0), we'll just return an answer. IMO the correct answer is just to create a new machine.

Related to:
https://flyio.discourse.team/t/machines-apps-with-both-fly-launch-and-unmanaged-machines/4661/8

https://github.com/superfly/docs/pull/1297

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
