### PR TITLE
Override high availability flag in `fly launch` if the org is not "billable"

### DIFF
--- a/api/resource_organizations.go
+++ b/api/resource_organizations.go
@@ -36,6 +36,7 @@ func (client *Client) GetOrganizations(ctx context.Context, filters ...Organizat
 					name
 					type
 					paidPlan
+					billable
 					viewerRole
 				}
 			}

--- a/api/types.go
+++ b/api/types.go
@@ -469,6 +469,7 @@ type Organization struct {
 	RawSlug            string
 	Type               string
 	PaidPlan           bool
+	Billable           bool
 	Settings           map[string]any
 
 	Domains struct {

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -149,11 +149,17 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 
 	// TODO: Determine databases requested by the sourceInfo, and add them to the plan.
 
+	highAvailability := flag.GetBool(ctx, "ha")
+	if !org.Billable && highAvailability {
+		highAvailability = false
+		fmt.Fprintln(iostreams.FromContext(ctx).ErrOut, "Warning: No payment method, turning off high availability")
+	}
+
 	lp := &plan.LaunchPlan{
 		AppName:          appName,
 		OrgSlug:          org.Slug,
 		RegionCode:       region.Code,
-		HighAvailability: flag.GetBool(ctx, "ha"),
+		HighAvailability: highAvailability,
 		CPUKind:          guest.CPUKind,
 		CPUs:             guest.CPUs,
 		MemoryMB:         guest.MemoryMB,


### PR DESCRIPTION
### Change Summary

What and Why:

When `fly launch`ing, if the org is not "billable" according to the API, then override the value of the high availability flag so that only 1 Machine is created during deploy.

Previously, "unbillable" users attempting to `fly launch` would get all the way through the build and image push part of a deploy before seeing the message `To create more than 1 machine per app please add a payment method.`, which is a bad UX.

Since these users aren't actually able to deploy more than 1 machine it seems appropriate to just override the high availability flag and tell the user that's what we've done.

This change means the user now sees the following:

```diff
% ~/workspace/superfly/flyctl/bin/flyctl launch
Scanning source code                                                                                                                                                                                                                                  
Detected a Dockerfile app                                                                                                                                                                                                                             
+Warning: No payment method, turning off high availability                                                                                                                                                                                             
Creating app in /path/to/my-app-name                                                                                                                                                                                              
We're about to launch your app on Fly.io. Here's what you're getting:                                                                                                                                                                                 
                                                                                                                                                                                                                                                      
Organization: My Org                 (fly launch defaults to the personal org)                                                                                                                                                                        
Name:         my-app-name.           (specified on the command line)                                                                                                                                                                                  
Region:       London, United Kingdom (this is the fastest region for you)                                                                                                                                                                             
App Machines: shared-cpu-1x, 1GB RAM (most apps need about 1GB of RAM)                                                                                                                                                                                
Postgres:     <none>                 (not requested)                                                                                                                                                                                                  
Redis:        <none>                 (not requested)                                                                                                                                                                                                  
                                                                                                                                                                                                                                                      
? Do you want to tweak these settings before proceeding?
```

How:

The user's org is queried as part of the launch process. I've added the `billable` field to that org query and check it when building the launch plan to determine whether to override the HA flag.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
