### PR TITLE
Copy VM specifications from fly.toml

### DIFF
--- a/internal/command/launch/legacy/launch.go
+++ b/internal/command/launch/legacy/launch.go
@@ -420,6 +420,15 @@ func buildPlanFromLegacyOptions(
 	// Sensible default, but not necessarily what's about to be launched.
 	// Should work fine though, at least until we (hopefully soon) rip this legacy code out.
 	guest := api.MachinePresets["shared-cpu-1x"]
+	if len(appConfig.Compute) > 0 {
+		// We purposely don't copy GPU since there's no way to configure that in the web UI as of 01/19/2024
+		vm := appConfig.Compute[0]
+		guest.CPUKind = vm.CPUKind
+		guest.CPUs = vm.CPUs
+		guest.MemoryMB = vm.MemoryMB
+	}
+
+	fmt.Println("guest: ", guest)
 
 	launchPlan := &plan.LaunchPlan{
 		AppName:    appConfig.AppName,

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -567,6 +567,14 @@ func determineGuest(ctx context.Context, config *appconfig.Config, srcInfo *scan
 		return def, recoverableSpecifyInUi, recoverableInUiError{err}
 	}
 
+	if len(config.Compute) > 0 {
+		// We purposely don't copy GPU since there's no way to configure that in the web UI as of 01/19/2024
+		vm := config.Compute[0]
+		guest.CPUKind = vm.CPUKind
+		guest.CPUs = vm.CPUs
+		guest.MemoryMB = vm.MemoryMB
+	}
+
 	if def.CPUs != guest.CPUs || def.CPUKind != guest.CPUKind || def.MemoryMB != guest.MemoryMB {
 		reason = "specified on the command line"
 	}


### PR DESCRIPTION
Previously, we were just setting the value of CPU and memory to a GB. We're still doing that now if there isn't an existing VM value in fly.toml