### PR TITLE
Fix typo in domains subcommand listing

### DIFF
--- a/internal/command/domains/root.go
+++ b/internal/command/domains/root.go
@@ -75,7 +75,7 @@ func newDomainsAdd() *cobra.Command {
 		short = "Add a domain"
 		long  = `Add a domain to an organization`
 	)
-	cmd := command.New("disable", short, long, runDomainsCreate,
+	cmd := command.New("add", short, long, runDomainsCreate,
 		command.RequireSession,
 	)
 	cmd.Args = cobra.MaximumNArgs(2)


### PR DESCRIPTION
### Change Summary

What and Why:

This changes `fly domains disable` to `fly domains add`, which appears to be what the subcommand actually invokes. I noticed the discrepancy in this output:

```
❯ fly domains
Command "domains" is deprecated, `fly domains` will be removed in a future release
Manage domains Notice: this feature is deprecated and no longer supported.
You can still view existing domains, but registration is no longer
possible.

Usage:
  flyctl domains [command]

Available Commands:
  disable     Add a domain
  list        List domains
  show        Show domain
```

How:

Since the function is `newDomainsAdd` and the function it calls is `runDomainsCreate`, this changes the description to match.

Related to:

∅

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
