### PR TITLE
Detect Django when requirements.txt is not in the project root.

### DIFF
--- a/scanner/django.go
+++ b/scanner/django.go
@@ -15,7 +15,10 @@ import (
 
 // setup django with a postgres database
 func configureDjango(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
-	if !checksPass(sourceDir, dirContains("requirements.txt", "(?i)Django")) && !checksPass(sourceDir, dirContains("Pipfile", "(?i)Django")) && !checksPass(sourceDir, dirContains("pyproject.toml", "(?i)Django")) {
+	if !checksPass(sourceDir, dirContains("requirements.txt", "(?i)Django")) &&
+		!checksPass(sourceDir, dirContains("*/requirements.txt", "(?i)Django")) &&
+		!checksPass(sourceDir, dirContains("Pipfile", "(?i)Django")) &&
+		!checksPass(sourceDir, dirContains("pyproject.toml", "(?i)Django")) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
### Change Summary
Improve Django scanner.

What and Why:

Often the generated requirements.txt file contains only
`-r requirements/dev.txt`
or similar so there is no 'django' string in it.

How:
Add another check for requirements.txt in immediate children of root dir. Not looking only for requirements/requirements.txt there could be other namings too.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
