### PR TITLE
Multi-GPU support

### DIFF
--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -422,9 +422,9 @@ var MachinePresets map[string]*MachineGuest = map[string]*MachineGuest{
 	"performance-8x":  {CPUKind: "performance", CPUs: 8, MemoryMB: 8 * MIN_MEMORY_MB_PER_CPU},
 	"performance-16x": {CPUKind: "performance", CPUs: 16, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
 
-	"a100-40gb": {GPUKind: "a100-pcie-40gb", CPUKind: "performance", CPUs: 8, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
-	"a100-80gb": {GPUKind: "a100-sxm4-80gb", CPUKind: "performance", CPUs: 8, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
-	"l40s":      {GPUKind: "l40s", CPUKind: "performance", CPUs: 8, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
+	"a100-40gb": {GPUKind: "a100-pcie-40gb", GPUs: 1, CPUKind: "performance", CPUs: 8, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
+	"a100-80gb": {GPUKind: "a100-sxm4-80gb", GPUs: 1, CPUKind: "performance", CPUs: 8, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
+	"l40s":      {GPUKind: "l40s", GPUs: 1, CPUKind: "performance", CPUs: 8, MemoryMB: 16 * MIN_MEMORY_MB_PER_CPU},
 }
 
 type MachineMetrics struct {

--- a/api/machine_types.go
+++ b/api/machine_types.go
@@ -328,6 +328,7 @@ type MachineGuest struct {
 	CPUKind          string `json:"cpu_kind,omitempty" toml:"cpu_kind,omitempty"`
 	CPUs             int    `json:"cpus,omitempty" toml:"cpus,omitempty"`
 	MemoryMB         int    `json:"memory_mb,omitempty" toml:"memory_mb,omitempty"`
+	GPUs             int    `json:"gpus,omitempty" toml:"gpus,omitempty"`
 	GPUKind          string `json:"gpu_kind,omitempty" toml:"gpu_kind,omitempty"`
 	HostDedicationID string `json:"host_dedication_id,omitempty" toml:"host_dedication_id,omitempty"`
 

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -175,6 +175,7 @@ func TestToDefinition(t *testing.T) {
 				"memory":             "8gb",
 				"cpu_kind":           "performance",
 				"cpus":               int64(8),
+				"gpus":               int64(2),
 				"gpu_kind":           "a100-pcie-40gb",
 				"host_dedication_id": "isolated-xxx",
 				"memory_mb":          int64(8192),

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -471,6 +471,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 					CPUKind:          "performance",
 					CPUs:             8,
 					MemoryMB:         8192,
+					GPUs:             2,
 					GPUKind:          "a100-pcie-40gb",
 					HostDedicationID: "isolated-xxx",
 					KernelArgs:       []string{"quiet"},

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -115,6 +115,7 @@ host_dedication_id = "06031957"
   cpus = 8
   memory = "8gb"
   memory_mb = 8192
+  gpus = 2
   gpu_kind = "a100-pcie-40gb"
   kernel_args = ["quiet"]
   host_dedication_id = "isolated-xxx"

--- a/internal/flag/machines.go
+++ b/internal/flag/machines.go
@@ -84,9 +84,9 @@ func GetMachineGuest(ctx context.Context, guest *api.MachineGuest) (*api.Machine
 		case guest.GPUKind != "" && guest.GPUs == 0:
 			return nil, fmt.Errorf("--vm-gpus must be greater than zero, got: %d", guest.GPUs)
 		case guest.GPUKind == "" && guest.GPUs > 0:
-			return nil, fmt.Errorf("A GPU model must be set with --vm-gpu-kind flag")
+			return nil, fmt.Errorf("--vm-gpus requires a GPU Model to be set, pass --vm-gpu-kind=X where X is one of: %v", strings.Join(validGPUKinds, ", "))
 		case guest.GPUs < 0:
-			return nil, fmt.Errorf("--vm-gpus must be greater than or equal to zero, got: %d", guest.CPUs)
+			return nil, fmt.Errorf("--vm-gpus must be greater than or equal to zero, got: %d", guest.GPUs)
 		}
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why: Support to attach multiple GPUs to a single machine is coming to Fly.io. 

How: This change adds the client side support of it, from the basic field in machine's guest type to the more user facing `--vm-gpus` CLI flag.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
