### PR TITLE
Extend DNS check timeout

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -297,7 +297,6 @@ func (m machineUpdateEntries) machines() []machine.LeasableMachine {
 }
 
 func errorIsTimeout(err error) bool {
-
 	// Match an error against various known timeout conditions.
 	// This is probably a sign that we need to standardize this better, but it works for now.
 
@@ -996,7 +995,8 @@ func (md *machineDeployment) checkDNS(ctx context.Context) error {
 
 		b := backoff.NewExponentialBackOff()
 		b.InitialInterval = 1 * time.Second
-		b.MaxElapsedTime = 30 * time.Second
+		b.MaxInterval = 5 * time.Second
+		b.MaxElapsedTime = 60 * time.Second
 
 		return backoff.Retry(func() error {
 			m := new(dns.Msg)


### PR DESCRIPTION
### Change Summary

What and Why: This PR limits the maximum interval and extends out the timeout to account for worst case DNS propagation scenarios.

How: Update hardcoded timeout values in the backoff.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
