### PR TITLE
Fix appconfig tests broken by tigris_bucket field

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -129,7 +129,7 @@ func (f File) toMachineFile() (*api.File, error) {
 type Static struct {
 	GuestPath    string `toml:"guest_path" json:"guest_path,omitempty" validate:"required"`
 	UrlPrefix    string `toml:"url_prefix" json:"url_prefix,omitempty" validate:"required"`
-	TigrisBucket string `toml:"tigris_bucket" json:"tigris_bucket"`
+	TigrisBucket string `toml:"tigris_bucket,omitempty" json:"tigris_bucket"`
 }
 
 type Mount struct {


### PR DESCRIPTION
### Change Summary

What and Why: `internal/appconfig` tests are failing because of zero valued `tigris_bucket` dumping

```
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -216,4 +216,5 @@
        	            	  (string) (len=7) "statics": ([]interface {}) (len=1) {
        	            	-  (map[string]interface {}) (len=2) {
        	            	+  (map[string]interface {}) (len=3) {
        	            	    (string) (len=10) "guest_path": (string) (len=16) "/path/to/statics",
        	            	+   (string) (len=13) "tigris_bucket": (string) "",
        	            	    (string) (len=10) "url_prefix": (string) (len=14) "/static-assets"
        	            	    
```

How: Add `omitempty` 

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
