### PR TITLE
`launch`: persist `ha` flag when round-tripping through UI

### DIFF
--- a/api/resource_organizations.go
+++ b/api/resource_organizations.go
@@ -70,6 +70,7 @@ func (client *Client) GetOrganizationBySlug(ctx context.Context, slug string) (*
 				slug
 				name
 				type
+				billable
                 limitedAccessTokens {
 					nodes {
 					    id

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -24,6 +24,15 @@ func (state *launchState) Launch(ctx context.Context) error {
 
 	state.updateConfig(ctx)
 
+	org, err := state.Org(ctx)
+	if err != nil {
+		return err
+	}
+	if !planValidateHighAvailability(ctx, state.Plan, org, !state.warnedNoCcHa) {
+		state.Plan.HighAvailability = false
+		state.warnedNoCcHa = true
+	}
+
 	app, err := state.createApp(ctx)
 	if err != nil {
 		return err

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -71,6 +71,9 @@ func appNameTakenErr(appName string) error {
 }
 
 func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *planBuildCache, error) {
+
+	io := iostreams.FromContext(ctx)
+
 	var recoverableInUiErrors []recoverableInUiError
 	tryRecoverErr := func(e error) error {
 		var asRecoverableErr recoverableInUiError
@@ -109,7 +112,7 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 			return nil, nil, fmt.Errorf("can not use configuration for Fly Launch, check fly.toml: %w", err)
 		}
 		if flag.GetBool(ctx, "manifest") {
-			fmt.Fprintln(iostreams.FromContext(ctx).ErrOut,
+			fmt.Fprintln(io.ErrOut,
 				"Warning: --manifest does not serialize an entire app configuration.\n"+
 					"Creating a manifest from an existing fly.toml may be a lossy process!",
 			)
@@ -152,7 +155,7 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 	highAvailability := flag.GetBool(ctx, "ha")
 	if !org.Billable && highAvailability {
 		highAvailability = false
-		fmt.Fprintln(iostreams.FromContext(ctx).ErrOut, "Warning: No payment method, turning off high availability")
+		fmt.Fprintln(io.ErrOut, "Warning: This organization has no payment method, turning off high availability")
 	}
 
 	lp := &plan.LaunchPlan{

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -8,9 +8,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
-	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command/launch/plan"
-	"github.com/superfly/flyctl/scanner"
 )
 
 // Let's *try* to keep this struct backwards-compatible as we change it
@@ -32,10 +30,9 @@ type launchState struct {
 	workingDir string
 	configPath string
 	LaunchManifest
-	env        map[string]string
-	appConfig  *appconfig.Config
-	sourceInfo *scanner.SourceInfo
-	cache      map[string]interface{}
+	env map[string]string
+	planBuildCache
+	cache map[string]interface{}
 }
 
 func cacheGrab[T any](cache map[string]interface{}, key string, cb func() (T, error)) (T, error) {

--- a/internal/command/launch/webui.go
+++ b/internal/command/launch/webui.go
@@ -74,6 +74,13 @@ func (state *launchState) EditInWebUi(ctx context.Context) error {
 		return err
 	}
 
+	// Patch in some fields that we keep in the plan that aren't persisted by the UI.
+	// Technically, we should probably just be persisting this, but there's
+	// no clear value to the UI having these fields currently.
+	if _, ok := finalSession.Metadata["ha"]; !ok {
+		state.Plan.HighAvailability = oldPlan.HighAvailability
+	}
+	// This should never be changed by the UI!!
 	state.Plan.ScannerFamily = oldPlan.ScannerFamily
 
 	return nil


### PR DESCRIPTION
### Change Summary

What and Why: the UI doesn't return the `ha` flag in its json blob. we could just ask them to do that, but this is easier. If they ever switch to setting this flag up there, this will gracefully accept that anyway.

How: if there is no `ha` key in the returned json blob, load it from the original plan that got beamed up to the UI

Should fix #3159 

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
