### PR TITLE
Don't check for private ipv6 address in DNS check

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -1003,12 +1003,12 @@ func (md *machineDeployment) checkDNS(ctx context.Context) error {
 
 			var numIPv4, numIPv6 int
 			for _, ipAddr := range ipAddrs {
-				ip := net.ParseIP(ipAddr.Address)
-				if ip.To4() != nil {
+				if ipAddr.Type == "v4" || ipAddr.Type == "shared_v4" {
 					numIPv4 += 1
-				} else {
+				} else if ipAddr.Type == "v6" {
 					numIPv6 += 1
 				}
+
 			}
 
 			m.SetQuestion(fqdn, dns.TypeA)


### PR DESCRIPTION
Dumb bug, this was incredibly stupid to overlook

### Change Summary

What and Why:

The way we were checking which IPs the DNS AAAA query would return also expected IPv6 addresses.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
