### PR TITLE
Add DNS check timeout flag

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -107,6 +107,12 @@ var CommonFlags = flag.Set{
 		Description: "Perform DNS checks during deployment",
 		Default:     true,
 	},
+	flag.Duration{
+		Name:        "dns-check-timeout",
+		Description: "Time allowed to perform DNS checks during deployment",
+		Default:     60 * time.Second,
+		Hidden:      true,
+	},
 	flag.Float64{
 		Name:        "max-unavailable",
 		Description: "Max number of unavailable machines during rolling updates. A number between 0 and 1 means percent of total machines",
@@ -399,6 +405,7 @@ func deployToMachines(
 		SkipSmokeChecks:        flag.GetDetach(ctx) || !flag.GetBool(ctx, "smoke-checks"),
 		SkipHealthChecks:       flag.GetDetach(ctx),
 		SkipDNSChecks:          flag.GetDetach(ctx) || !flag.GetBool(ctx, "dns-checks"),
+		DNSCheckTimeout:        flag.GetDuration(ctx, "dns-check-timeout"),
 		WaitTimeout:            waitTimeout,
 		ReleaseCmdTimeout:      releaseCmdTimeout,
 		LeaseTimeout:           leaseTimeout,

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -46,6 +46,7 @@ type MachineDeploymentArgs struct {
 	SkipSmokeChecks        bool
 	SkipHealthChecks       bool
 	SkipDNSChecks          bool
+	DNSCheckTimeout        time.Duration
 	MaxUnavailable         *float64
 	RestartOnly            bool
 	WaitTimeout            *time.Duration
@@ -81,6 +82,7 @@ type machineDeployment struct {
 	skipSmokeChecks        bool
 	skipHealthChecks       bool
 	skipDNSChecks          bool
+	dnsCheckTimeout        time.Duration
 	maxUnavailable         float64
 	restartOnly            bool
 	waitTimeout            time.Duration


### PR DESCRIPTION
### Change Summary

What and Why: Allow the user to configure how long the DNS checks should retry until failing.

How: Implement a flag called `--dns-check-timeout`

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
