### PR TITLE
Simplify the machine restart policy

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -720,12 +720,11 @@ func determineMachineConfig(
 			// An empty policy was explicitly requested.
 			machineConf.Restart.Policy = ""
 		} else if machineConf.AutoDestroy {
+			// Autodestroy only works when the restart policy is set to no, so unless otherwise specified, we set the restart policy to no.
+			machineConf.Restart.Policy = api.MachineRestartPolicyNo
 		} else if !input.updating {
 			// This is a new machine; apply the default.
-			if machineConf.AutoDestroy {
-				// Autodestroy only works when the restart policy is set to no, so unless otherwise specified, we set the restart policy to no.
-				machineConf.Restart.Policy = api.MachineRestartPolicyNo
-			} else if machineConf.Schedule != "" {
+			if machineConf.Schedule != "" {
 				machineConf.Restart.Policy = api.MachineRestartPolicyOnFailure
 			} else {
 				machineConf.Restart.Policy = api.MachineRestartPolicyAlways


### PR DESCRIPTION
We can just set the policy to no, instead of having a random empty branch

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
