### PR TITLE
`launch`: Use appconfig.Compute for Plan guest information.

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -213,10 +213,10 @@ func run(ctx context.Context) error {
 		return err
 	}
 
-	return DeployWithConfig(ctx, appConfig, flag.GetYes(ctx), nil)
+	return DeployWithConfig(ctx, appConfig, flag.GetYes(ctx))
 }
 
-func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes bool, optionalGuest *api.MachineGuest) (err error) {
+func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes bool) (err error) {
 	io := iostreams.FromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	apiClient := client.FromContext(ctx).API()
@@ -245,7 +245,7 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes
 	}
 
 	fmt.Fprintf(io.Out, "\nWatch your deployment at https://fly.io/apps/%s/monitoring\n\n", appName)
-	if err := deployToMachines(ctx, appConfig, appCompact, img, optionalGuest); err != nil {
+	if err := deployToMachines(ctx, appConfig, appCompact, img); err != nil {
 		return err
 	}
 
@@ -289,7 +289,6 @@ func deployToMachines(
 	appConfig *appconfig.Config,
 	appCompact *api.AppCompact,
 	img *imgsrc.DeploymentImage,
-	guest *api.MachineGuest,
 ) (err error) {
 	// It's important to push appConfig into context because MachineDeployment will fetch it from there
 	ctx = appconfig.WithConfig(ctx, appConfig)
@@ -319,11 +318,9 @@ func deployToMachines(
 		return err
 	}
 
-	if guest == nil {
-		guest, err = flag.GetMachineGuest(ctx, nil)
-		if err != nil {
-			return err
-		}
+	guest, err := flag.GetMachineGuest(ctx, nil)
+	if err != nil {
+		return err
 	}
 
 	excludeRegions := make(map[string]interface{})

--- a/internal/command/launch/deploy.go
+++ b/internal/command/launch/deploy.go
@@ -83,7 +83,7 @@ func (state *launchState) firstDeploy(ctx context.Context) error {
 				return err
 			}
 		}
-		return deploy.DeployWithConfig(ctx, state.appConfig, flag.GetBool(ctx, "now"), nil)
+		return deploy.DeployWithConfig(ctx, state.appConfig, flag.GetBool(ctx, "now"))
 	}
 
 	// Alternative deploy documentation if our standard deploy method is not correct

--- a/internal/command/launch/deploy.go
+++ b/internal/command/launch/deploy.go
@@ -83,7 +83,7 @@ func (state *launchState) firstDeploy(ctx context.Context) error {
 				return err
 			}
 		}
-		return deploy.DeployWithConfig(ctx, state.appConfig, flag.GetBool(ctx, "now"), state.Plan.Guest())
+		return deploy.DeployWithConfig(ctx, state.appConfig, flag.GetBool(ctx, "now"), nil)
 	}
 
 	// Alternative deploy documentation if our standard deploy method is not correct

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -3,7 +3,6 @@ package launch
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
@@ -90,6 +89,8 @@ func (state *launchState) updateComputeFromDeprecatedGuestFields(ctx context.Con
 		// If the UI returns a compute field, then we don't need to do any forward-compat patching.
 		return nil
 	}
+	// Fallback for versions of the UI that don't support a Compute field in the Plan.
+
 	defer func() {
 		// Set the plan's compute field to the calculated compute field.
 		// This makes sure that code expecting a compute definition in the plan is able to find it
@@ -97,39 +98,10 @@ func (state *launchState) updateComputeFromDeprecatedGuestFields(ctx context.Con
 		state.Plan.Compute = state.appConfig.Compute
 	}()
 
-	// Fallback for versions of the UI that don't support a Compute field in the Plan.
-	var (
-		io                   = iostreams.FromContext(ctx)
-		defaultGroup         = state.appConfig.DefaultProcessName()
-		matchedComputeStrong *appconfig.Compute
-		matchedComputeWeak   *appconfig.Compute
-	)
-
-	{ // Temporary: set the appconfig Compute configuration based on the plan
-		for _, compute := range state.appConfig.Compute {
-			if slices.Contains(compute.Processes, defaultGroup) {
-				if matchedComputeStrong != nil {
-					fmt.Fprintf(io.Out, "Warning: multiple compute configurations match the default process group %s\n", defaultGroup)
-				}
-				matchedComputeStrong = compute
-			} else if len(compute.Processes) == 0 {
-				if matchedComputeWeak != nil {
-					fmt.Fprintf(io.Out, "Warning: multiple compute configurations exist that match all processes\n")
-				}
-				matchedComputeWeak = compute
-			}
-		}
-		// NOTE: the calls to applyGuestToCompute here will *still* clobbers guest config like kernel or gpu,
-		//       even though we're trying to be good citizens and modifying instead of overwriting the compute config.
-		//       The only real solution to this is updating the UI to return a Compute field.
-		switch {
-		case matchedComputeStrong != nil:
-			applyGuestToCompute(matchedComputeStrong, state.Plan.Guest())
-		case matchedComputeWeak != nil:
-			applyGuestToCompute(matchedComputeWeak, state.Plan.Guest())
-		default:
-			state.appConfig.Compute = append(state.appConfig.Compute, guestToCompute(state.Plan.Guest()))
-		}
+	if compute := state.appConfig.ComputeForGroup(state.appConfig.DefaultProcessName()); compute != nil {
+		applyGuestToCompute(compute, state.Plan.Guest())
+	} else {
+		state.appConfig.Compute = append(state.appConfig.Compute, guestToCompute(state.Plan.Guest()))
 	}
 
 	return nil

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flaps"
@@ -99,12 +98,7 @@ func (state *launchState) updateConfig(ctx context.Context) {
 	} else {
 		state.appConfig.HTTPService = nil
 	}
-	state.appConfig.Compute = []*appconfig.Compute{
-		{
-			MachineGuest: state.Plan.Guest(),
-			Processes:    lo.Keys(state.appConfig.Processes),
-		},
-	}
+	state.appConfig.Compute = state.Plan.Compute
 }
 
 // createApp creates the fly.io app for the plan

--- a/internal/command/launch/plan/plan.go
+++ b/internal/command/launch/plan/plan.go
@@ -1,6 +1,7 @@
 package plan
 
 import (
+	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/version"
 )
@@ -12,6 +13,17 @@ type LaunchPlan struct {
 	RegionCode       string `json:"region"`
 	HighAvailability bool   `json:"ha"`
 
+	// Deprecated: The UI currently returns this instead of Compute, but new development should use Compute.
+	CPUKind string `json:"vm_cpukind,omitempty"`
+	// Deprecated: The UI currently returns this instead of Compute, but new development should use Compute.
+	CPUs int `json:"vm_cpus,omitempty"`
+	// Deprecated: The UI currently returns this instead of Compute, but new development should use Compute.
+	MemoryMB int `json:"vm_memory,omitempty"`
+	// Deprecated: The UI currently returns this instead of Compute, but new development should use Compute.
+	VmSize string `json:"vm_size,omitempty"`
+
+	// In the future, we'll use this over CPUKind, CPUs, MemoryMB, and VmSize.
+	// As of writing this, however, the UI does not return this field.
 	Compute []*appconfig.Compute `json:"compute"`
 
 	HttpServicePort int `json:"http_service_port,omitempty"`
@@ -22,4 +34,19 @@ type LaunchPlan struct {
 
 	ScannerFamily string          `json:"scanner_family"`
 	FlyctlVersion version.Version `json:"flyctl_version"`
+}
+
+// Guest returns the guest described by the *raw* guest fields in a Plan.
+// When the UI starts returning Compute, this will be deprecated.
+func (p *LaunchPlan) Guest() *api.MachineGuest {
+	// TODO(Allison): Determine whether we should use VmSize or CPUKind/CPUs
+	guest := api.MachineGuest{
+		CPUs:    p.CPUs,
+		CPUKind: p.CPUKind,
+	}
+	if false {
+		guest.SetSize(p.VmSize)
+	}
+	guest.MemoryMB = p.MemoryMB
+	return &guest
 }

--- a/internal/command/launch/plan/plan.go
+++ b/internal/command/launch/plan/plan.go
@@ -1,7 +1,7 @@
 package plan
 
 import (
-	"github.com/superfly/flyctl/api"
+	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/version"
 )
 
@@ -12,10 +12,7 @@ type LaunchPlan struct {
 	RegionCode       string `json:"region"`
 	HighAvailability bool   `json:"ha"`
 
-	CPUKind  string `json:"vm_cpukind,omitempty"`
-	CPUs     int    `json:"vm_cpus,omitempty"`
-	MemoryMB int    `json:"vm_memory,omitempty"`
-	VmSize   string `json:"vm_size,omitempty"`
+	Compute []*appconfig.Compute `json:"compute"`
 
 	HttpServicePort int `json:"http_service_port,omitempty"`
 
@@ -25,24 +22,4 @@ type LaunchPlan struct {
 
 	ScannerFamily string          `json:"scanner_family"`
 	FlyctlVersion version.Version `json:"flyctl_version"`
-}
-
-func (p *LaunchPlan) Guest() *api.MachineGuest {
-	// TODO(Allison): Determine whether we should use VmSize or CPUKind/CPUs
-	guest := api.MachineGuest{
-		CPUs:    p.CPUs,
-		CPUKind: p.CPUKind,
-	}
-	if false {
-		guest.SetSize(p.VmSize)
-	}
-	guest.MemoryMB = p.MemoryMB
-	return &guest
-}
-
-func (p *LaunchPlan) SetGuestFields(guest *api.MachineGuest) {
-	p.CPUs = guest.CPUs
-	p.CPUKind = guest.CPUKind
-	p.MemoryMB = guest.MemoryMB
-	p.VmSize = guest.ToSize()
 }

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -152,6 +152,16 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 		}
 	}
 
+	// HACK: This is a temporary solution to work around the fact that the UI doesn't
+	//       understand the "compute" field. We want to move towards supporting the
+	//       full compute definition at some point.
+	appConfig.Compute = compute
+	fakeDefaultMachine, err := appConfig.ToMachineConfig(appConfig.DefaultProcessName(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	guest := fakeDefaultMachine.Guest
+
 	// TODO: Determine databases requested by the sourceInfo, and add them to the plan.
 
 	lp := &plan.LaunchPlan{
@@ -160,6 +170,10 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 		RegionCode:       region.Code,
 		HighAvailability: flag.GetBool(ctx, "ha"),
 		Compute:          compute,
+		CPUKind:          guest.CPUKind,
+		CPUs:             guest.CPUs,
+		MemoryMB:         guest.MemoryMB,
+		VmSize:           guest.ToSize(),
 		HttpServicePort:  httpServicePort,
 		Postgres:         plan.PostgresPlan{},
 		Redis:            plan.RedisPlan{},
@@ -563,12 +577,13 @@ func getRegionByCode(ctx context.Context, regionCode string) (*api.Region, error
 	return nil, fmt.Errorf("Unknown region '%s'. Run `fly platform regions` to see valid names", regionCode)
 }
 
-func guestToCompute(g *api.MachineGuest) *appconfig.Compute {
+func applyGuestToCompute(c *appconfig.Compute, g *api.MachineGuest) {
 	for k, v := range api.MachinePresets {
 		if reflect.DeepEqual(*v, *g) {
-			return &appconfig.Compute{
-				Size: k,
-			}
+			c.MachineGuest = nil
+			c.Memory = ""
+			c.Size = k
+			return
 		}
 	}
 	var memStr string
@@ -578,12 +593,15 @@ func guestToCompute(g *api.MachineGuest) *appconfig.Compute {
 		memStr = fmt.Sprintf("%dmb", g.MemoryMB)
 	}
 	clonedGuest := helpers.Clone(g)
-	clonedGuest.MemoryMB = 0
-	return &appconfig.Compute{
-		MachineGuest: clonedGuest,
-		Memory:       memStr,
-		Processes:    nil,
-	}
+	c.MachineGuest = clonedGuest
+	c.Memory = memStr
+	c.MemoryMB = 0
+}
+
+func guestToCompute(g *api.MachineGuest) *appconfig.Compute {
+	var c appconfig.Compute
+	applyGuestToCompute(&c, g)
+	return &c
 }
 
 // determineCompute returns the guest type to use for a new app.

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -16,7 +16,7 @@ type launchPlanSource struct {
 	appNameSource  string
 	regionSource   string
 	orgSource      string
-	guestSource    string
+	computeSource  string
 	postgresSource string
 	redisSource    string
 }
@@ -81,7 +81,16 @@ func (state *launchState) Region(ctx context.Context) (api.Region, error) {
 // Used to confirm the plan before executing it.
 func (state *launchState) PlanSummary(ctx context.Context) (string, error) {
 
-	guest := state.Plan.Guest()
+	// Expensive but should accurately simulate the whole path
+	fakeMachine, err := state.appConfig.ToMachineConfig(state.appConfig.DefaultProcessName(), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve machine guest config: %w", err)
+	}
+	guestStr := fakeMachine.Guest.String()
+
+	if len(state.Plan.Compute) > 1 {
+		guestStr += fmt.Sprintf(", %d more", len(state.Plan.Compute)-1)
+	}
 
 	org, err := state.Org(ctx)
 	if err != nil {
@@ -107,7 +116,7 @@ func (state *launchState) PlanSummary(ctx context.Context) (string, error) {
 		{"Organization", org.Name, state.PlanSource.orgSource},
 		{"Name", state.Plan.AppName, state.PlanSource.appNameSource},
 		{"Region", region.Name, state.PlanSource.regionSource},
-		{"App Machines", guest.String(), state.PlanSource.guestSource},
+		{"App Machines", guestStr, state.PlanSource.computeSource},
 		{"Postgres", postgresStr, state.PlanSource.postgresSource},
 		{"Redis", redisStr, state.PlanSource.redisSource},
 	}

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -81,15 +81,19 @@ func (state *launchState) Region(ctx context.Context) (api.Region, error) {
 // Used to confirm the plan before executing it.
 func (state *launchState) PlanSummary(ctx context.Context) (string, error) {
 
-	// Expensive but should accurately simulate the whole path
+	// It feels wrong to modify the appConfig here, but in well-formed states these should be identical anyway.
+	state.appConfig.Compute = state.Plan.Compute
+
+	// Expensive but should accurately simulate the whole machine building path, meaning we end up with the same
+	// guest description that will be deployed down the road :)
 	fakeMachine, err := state.appConfig.ToMachineConfig(state.appConfig.DefaultProcessName(), nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve machine guest config: %w", err)
 	}
 	guestStr := fakeMachine.Guest.String()
 
-	if len(state.Plan.Compute) > 1 {
-		guestStr += fmt.Sprintf(", %d more", len(state.Plan.Compute)-1)
+	if len(state.appConfig.Compute) > 1 {
+		guestStr += fmt.Sprintf(", %d more", len(state.appConfig.Compute)-1)
 	}
 
 	org, err := state.Org(ctx)

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -38,9 +38,9 @@ func TestFlyLaunchV2(t *testing.T) {
 		"primary_region": f.PrimaryRegion(),
 		"build":          map[string]any{"image": "nginx"},
 		"vm": []any{map[string]any{
-			"cpu_kind":  "shared",
-			"cpus":      int64(1),
-			"memory_mb": int64(1024),
+			"cpu_kind": "shared",
+			"cpus":     int64(1),
+			"memory":   "1gb",
 		}},
 		"http_service": map[string]any{
 			"force_https":          true,
@@ -78,9 +78,9 @@ func TestFlyLaunchWithTOML(t *testing.T) {
 			"status": map[string]any{"type": "tcp", "port": int64(5500)},
 		},
 		"vm": []any{map[string]any{
-			"cpu_kind":  "shared",
-			"cpus":      int64(1),
-			"memory_mb": int64(1024),
+			"cpu_kind": "shared",
+			"cpus":     int64(1),
+			"memory":   "1gb",
 		}},
 	}
 	require.EqualValues(f, want, toml)


### PR DESCRIPTION
### Change Summary

What and Why: The Launch Plan now uses `appconfig.Compute` instead of the disparate fields like `CPUs` or `MemoryMB`. We still support reading those fields from the UI, though, and throw them into the default process' Compute definition when modifying the plan.

This means that the UI could be changed to write the Compute field instead of these individual fields, which would allow defining multiple guests for different groups (although I'm not sure we want that), but importantly it would allow defining things like launching GPU machines.

How: When we create the plan, we fill in both the Compute field, and all the deprecated individual fields. When we read the Plan from the UI, if the Compute field is empty (meaning the UI has not transmitted it back to us), we'll reconstruct it by taking the Compute from the appConfig, and modifying the default group's Compute with the values the UI passed back to us.

This should be totally transparent to users, should make fly.toml import a little bit better, and should future-proof Launch for things to come :)

Related to: conversation with Daniel in #fly-launch

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
