### PR TITLE
Prune macaroon auth discharges that will expired in the next minute

### DIFF
--- a/internal/command/macaroons.go
+++ b/internal/command/macaroons.go
@@ -88,7 +88,17 @@ func pruneBadMacaroons(t *tokens.Tokens) bool {
 			return true
 		}
 
-		if expired := time.Now().After(m.Expiration()); expired {
+		if time.Now().After(m.Expiration()) {
+			updated = true
+			return true
+		}
+
+		// preemptively prune auth tokens that will expire in the next minute.
+		// The hope is that we can replace discharge tokens *before* they expire
+		// so requests don't fail.
+		//
+		// TODO: this is hacky
+		if m.Location == flyio.LocationAuthentication && time.Now().Add(time.Minute).After(m.Expiration()) {
 			updated = true
 			return true
 		}


### PR DESCRIPTION
Should make https://github.com/superfly/flyctl/pull/3232 less likely to cause issues.