### PR TITLE
Respect privacy by not sending an empty metrics request when analytic…

### DIFF
--- a/internal/metrics/db.go
+++ b/internal/metrics/db.go
@@ -26,6 +26,12 @@ func queueMetric(metric metricsMessage) {
 
 // Spawns a forked `flyctl metrics send` process that sends metrics to the flyctl-metrics server
 func FlushMetrics(ctx context.Context) error {
+	if len(metrics) == 0 {
+		// Don't bother sending an empty request if there are no metrics to flush
+		// This is important to prevent leaking requests when analytics is disabled
+		return nil
+	}
+
 	json, err := json.Marshal(metrics)
 	if err != nil {
 		return err


### PR DESCRIPTION
…s are disabled

### Change Summary

What and Why: Reported by @tv42, disabling analytics still sends an empty metrics' request.  

How: Don't send the request if there is no metrics to send.

Related to: closes https://github.com/superfly/flyctl/issues/3162

```
❯ strace -f -e execve -e 'signal=!URG' -e 'quiet=attach,exit' bin/flyctl platform vm-sizes
execve("bin/flyctl", ["bin/flyctl", "platform", "vm-sizes"], 0x7ffea56e7938 /* 41 vars */) = 0
Machines platform
NAME            CPU CORES       MEMORY
shared-cpu-1x   1               256 MB
shared-cpu-2x   2               512 MB
shared-cpu-4x   4               1 GB
shared-cpu-8x   8               2 GB

NAME            CPU CORES       MEMORY
performance-1x  1               2 GB
performance-2x  2               4 GB
performance-4x  4               8 GB
performance-8x  8               16 GB
performance-16x 16              32 GB

NAME            CPU CORES       MEMORY  GPU MODEL
a100-40gb       8               32 GB   a100-pcie-40gb
a100-80gb       8               32 GB   a100-sxm4-80gb
l40s            8               32 GB   l40s

```

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
