### PR TITLE
Laravel: Allow Octane-flavored Frankenphp

### DIFF
--- a/scanner/templates/laravel/.dockerignore
+++ b/scanner/templates/laravel/.dockerignore
@@ -9,6 +9,7 @@ storage/logs/*
 *.env*
 .rr.yml
 rr
+frankenphp
 vendor
 
 # 2. Ignore common files/directories we don't need


### PR DESCRIPTION
### Change Summary

What and Why:

For the Laravel template, we ignore the user's local `frankenphp` binary which may be built for their local dev machine's architecture. We'll be updating the `Dockerfile` to install the correct `frankenphp` binary in the remote builder.
