### PR TITLE
Clean application config of Nomad related methods

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -26,7 +26,6 @@ const (
 
 func NewConfig() *Config {
 	return &Config{
-		RawDefinition:    map[string]any{},
 		defaultGroupName: api.MachineProcessGroupApp,
 		configFilePath:   "--config path unset--",
 	}
@@ -68,21 +67,13 @@ type Config struct {
 	Statics []Static   `toml:"statics,omitempty" json:"statics,omitempty"`
 	Metrics []*Metrics `toml:"metrics,omitempty" json:"metrics,omitempty"`
 
-	// RawDefinition contains fly.toml parsed as-is
-	// If you add any config field that is v2 specific, be sure to remove it in SanitizeDefinition()
-	RawDefinition map[string]any `toml:"-" json:"-"`
-
 	// MergedFiles is a list of files that have been merged from the app config and flags.
 	MergedFiles []*api.File `toml:"-" json:"-"`
 
 	// Path to application configuration file, usually fly.toml.
 	configFilePath string
 
-	// Indicates the intended platform to use: machines or nomad
-	platformVersion string
-
 	// Set when it fails to unmarshal fly.toml into Config
-	// Don't hard fail because RawDefinition still holds the app configuration for Nomad apps
 	v2UnmarshalError error
 
 	// The default group name to refer to (used with flatten configs)
@@ -311,10 +302,6 @@ func (cfg *Config) URL() *url.URL {
 	default:
 		return nil
 	}
-}
-
-func (cfg *Config) PlatformVersion() string {
-	return cfg.platformVersion
 }
 
 // MergeFiles merges the provided files with the files in the config wherein the provided files

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -17,11 +17,6 @@ import (
 const (
 	// DefaultConfigFileName denotes the default application configuration file name.
 	DefaultConfigFileName = "fly.toml"
-	// Config is versioned, initially, to separate nomad from machine apps without having to consult
-	// the API
-	MachinesPlatform = "machines"
-	NomadPlatform    = "nomad"
-	DetachedPlatform = "detached"
 )
 
 func NewConfig() *Config {
@@ -29,11 +24,6 @@ func NewConfig() *Config {
 		defaultGroupName: api.MachineProcessGroupApp,
 		configFilePath:   "--config path unset--",
 	}
-}
-
-type Metrics struct {
-	*api.MachineMetrics
-	Processes []string `json:"processes,omitempty" toml:"processes,omitempty"`
 }
 
 // Config wraps the properties of app configuration.
@@ -78,6 +68,11 @@ type Config struct {
 
 	// The default group name to refer to (used with flatten configs)
 	defaultGroupName string
+}
+
+type Metrics struct {
+	*api.MachineMetrics
+	Processes []string `json:"processes,omitempty" toml:"processes,omitempty"`
 }
 
 type Deploy struct {

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -133,18 +133,6 @@ func TestConfigPortGetter(t *testing.T) {
 func TestCloneAppconfig(t *testing.T) {
 	config := &Config{
 		AppName: "testcfg",
-		RawDefinition: map[string]any{
-			"mounts": []Mount{
-				{
-					Source:      "src-raw",
-					Destination: "dst-raw",
-				},
-				{
-					Source:      "src2",
-					Destination: "dst2",
-				},
-			},
-		},
 		Mounts: []Mount{{
 			Source:      "src",
 			Destination: "dst",

--- a/internal/appconfig/definition.go
+++ b/internal/appconfig/definition.go
@@ -2,7 +2,6 @@ package appconfig
 
 import (
 	"github.com/pelletier/go-toml/v2"
-	"github.com/samber/lo"
 	"github.com/superfly/flyctl/api"
 )
 
@@ -26,17 +25,4 @@ func FromDefinition(definition *api.Definition) (*Config, error) {
 		return nil, err
 	}
 	return unmarshalTOML(buf)
-}
-
-// SanitizedDefinition returns a definition cleaned from any extra fields
-// not valid for Web API GQL endpoints.
-func (c *Config) SanitizedDefinition() map[string]any {
-	// Beware this is a shallow Copy
-	definition := lo.Assign(c.RawDefinition)
-	delete(definition, "app")
-	delete(definition, "build")
-	delete(definition, "primary_region")
-	delete(definition, "http_service")
-	delete(definition, "console_command")
-	return definition
 }

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -109,48 +109,6 @@ func TestFromDefinition(t *testing.T) {
 		},
 		configFilePath:   "--config path unset--",
 		defaultGroupName: "app",
-		RawDefinition: map[string]any{
-			"env": map[string]any{},
-			"experimental": map[string]any{
-				"auto_rollback": true,
-			},
-			"kill_signal":  "SIGINT",
-			"kill_timeout": float64(5),
-			"processes":    []any{},
-			"services": []any{
-				map[string]any{
-					"concurrency": map[string]any{
-						"hard_limit": float64(25),
-						"soft_limit": float64(20),
-						"type":       "connections",
-					},
-					"http_checks":   []any{},
-					"internal_port": float64(8080),
-					"ports": []any{
-						map[string]any{
-							"force_https": true,
-							"handlers":    []any{"http"},
-							"port":        float64(80),
-						},
-						map[string]any{
-							"handlers": []any{"tls", "http"},
-							"port":     float64(443),
-						},
-					},
-					"processes":     []any{"app"},
-					"protocol":      "tcp",
-					"script_checks": []any{},
-					"tcp_checks": []any{
-						map[string]any{
-							"grace_period":  "1s",
-							"interval":      "15s",
-							"restart_limit": float64(0),
-							"timeout":       "2s",
-						},
-					},
-				},
-			},
-		},
 	}, cfg)
 }
 

--- a/internal/appconfig/from_machine_set.go
+++ b/internal/appconfig/from_machine_set.go
@@ -16,7 +16,7 @@ import (
 	"github.com/superfly/flyctl/terminal"
 )
 
-func FromAppAndMachineSet(ctx context.Context, appCompact *api.AppCompact, machines machine.MachineSet) (*Config, string, error) {
+func FromAppAndMachineSet(ctx context.Context, appName string, machines machine.MachineSet) (*Config, string, error) {
 	var (
 		warnings                  []string
 		io                        = iostreams.FromContext(ctx)
@@ -28,7 +28,7 @@ func FromAppAndMachineSet(ctx context.Context, appCompact *api.AppCompact, machi
 		warnings = append(warnings, warningMsg)
 	}
 	for _, m := range machines.GetMachines() {
-		appConfig, machineWarning := fromAppAndOneMachine(ctx, appCompact, m, processGroups)
+		appConfig, machineWarning := fromAppAndOneMachine(ctx, appName, m, processGroups)
 		warnings = append(warnings, machineWarning)
 		tomlString, err := appConfig.marshalTOML()
 		if err != nil {
@@ -87,7 +87,7 @@ func prettyDiff(original, new string, colorize *iostreams.ColorScheme) string {
 	return ""
 }
 
-func fromAppAndOneMachine(ctx context.Context, appCompact *api.AppCompact, m machine.LeasableMachine, processGroups *processGroupInfo) (*Config, string) {
+func fromAppAndOneMachine(ctx context.Context, appName string, m machine.LeasableMachine, processGroups *processGroupInfo) (*Config, string) {
 	var (
 		warningMsg     string
 		primaryRegion  string
@@ -130,7 +130,7 @@ fly.toml only supports one mount per machine at this time. These mounts will be 
 		}
 	}
 	cfg := NewConfig()
-	cfg.AppName = appCompact.Name
+	cfg.AppName = appName
 	cfg.PrimaryRegion = primaryRegion
 	cfg.Env = m.Machine().Config.Env
 	cfg.Metrics = []*Metrics{

--- a/internal/appconfig/platformversion.go
+++ b/internal/appconfig/platformversion.go
@@ -5,6 +5,5 @@ func (c *Config) SetMachinesPlatform() error {
 	if c.v2UnmarshalError != nil {
 		return c.v2UnmarshalError
 	}
-	c.platformVersion = MachinesPlatform
 	return nil
 }

--- a/internal/appconfig/platformversion.go
+++ b/internal/appconfig/platformversion.go
@@ -1,7 +1,5 @@
 package appconfig
 
-import "fmt"
-
 func (c *Config) EnsureV2Config() error {
 	return c.v2UnmarshalError
 }
@@ -12,23 +10,5 @@ func (c *Config) SetMachinesPlatform() error {
 		return c.v2UnmarshalError
 	}
 	c.platformVersion = MachinesPlatform
-	return nil
-}
-
-// SetMachinesPlatform informs the TOML marshaller that this config is for the machines platform
-func (c *Config) SetDetachedPlatform() error {
-	if c.v2UnmarshalError != nil {
-		return c.v2UnmarshalError
-	}
-	c.platformVersion = DetachedPlatform
-	return nil
-}
-
-// SetNomadPlatform informs the TOML marshaller that this config is for the nomad platform
-func (c *Config) SetNomadPlatform() error {
-	if len(c.RawDefinition) == 0 {
-		return fmt.Errorf("Can't set platformVersion to Nomad on an empty RawDefinition")
-	}
-	c.platformVersion = NomadPlatform
 	return nil
 }

--- a/internal/appconfig/platformversion.go
+++ b/internal/appconfig/platformversion.go
@@ -32,23 +32,3 @@ func (c *Config) SetNomadPlatform() error {
 	c.platformVersion = NomadPlatform
 	return nil
 }
-
-func (c *Config) SetPlatformVersion(platform string) error {
-	switch platform {
-	case MachinesPlatform:
-		return c.SetMachinesPlatform()
-	case NomadPlatform:
-		return c.SetNomadPlatform()
-	case DetachedPlatform:
-		return c.SetDetachedPlatform()
-	case "":
-		return fmt.Errorf("Empty value as platform version")
-	default:
-		return fmt.Errorf("Unknown platform version: '%s'", platform)
-	}
-}
-
-// ForMachines is true when the config is intended for the machines platform
-func (c *Config) ForMachines() bool {
-	return c.platformVersion == MachinesPlatform
-}

--- a/internal/appconfig/platformversion.go
+++ b/internal/appconfig/platformversion.go
@@ -1,9 +1,5 @@
 package appconfig
 
-func (c *Config) EnsureV2Config() error {
-	return c.v2UnmarshalError
-}
-
 // SetMachinesPlatform informs the TOML marshaller that this config is for the machines platform
 func (c *Config) SetMachinesPlatform() error {
 	if c.v2UnmarshalError != nil {

--- a/internal/appconfig/platformversion_test.go
+++ b/internal/appconfig/platformversion_test.go
@@ -10,25 +10,7 @@ import (
 func TestSetMachinesPlatform(t *testing.T) {
 	cfg := NewConfig()
 	assert.NoError(t, cfg.SetMachinesPlatform())
-	assert.NoError(t, cfg.SetPlatformVersion(MachinesPlatform))
 
 	cfg.v2UnmarshalError = fmt.Errorf("Failed to parse fly.toml")
 	assert.Error(t, cfg.SetMachinesPlatform())
-	assert.Error(t, cfg.SetPlatformVersion(MachinesPlatform))
-}
-
-func TestSetNomadPlatform(t *testing.T) {
-	cfg := NewConfig()
-	assert.Error(t, cfg.SetNomadPlatform())
-	assert.Error(t, cfg.SetPlatformVersion(NomadPlatform))
-
-	cfg.RawDefinition["app"] = "foo"
-	assert.NoError(t, cfg.SetNomadPlatform())
-	assert.NoError(t, cfg.SetPlatformVersion(NomadPlatform))
-}
-
-func TestSetPlatformVersion(t *testing.T) {
-	cfg := NewConfig()
-	assert.Error(t, cfg.SetPlatformVersion(""))
-	assert.Error(t, cfg.SetPlatformVersion("thenewkidsontheblock"))
 }

--- a/internal/appconfig/processgroups.go
+++ b/internal/appconfig/processgroups.go
@@ -88,7 +88,6 @@ func (c *Config) Flatten(groupName string) (*Config, error) {
 	}
 
 	dst := helpers.Clone(c)
-	dst.platformVersion = c.platformVersion
 	dst.configFilePath = "--flatten--"
 	dst.defaultGroupName = groupName
 

--- a/internal/appconfig/processgroups.go
+++ b/internal/appconfig/processgroups.go
@@ -13,32 +13,11 @@ import (
 
 // ProcessNames lists each key of c.Processes, sorted lexicographically
 // If c.Processes == nil, returns ["app"]
-func (c *Config) ProcessNames() (names []string) {
-	switch {
-	case c == nil:
+func (c *Config) ProcessNames() []string {
+	if c == nil {
 		return []string{api.MachineProcessGroupApp}
-	case c.platformVersion == MachinesPlatform:
-		if len(c.Processes) != 0 {
-			names = lo.Keys(c.Processes)
-		}
-	case c.platformVersion == "":
-		fallthrough
-	case c.platformVersion == DetachedPlatform:
-		fallthrough
-	case c.platformVersion == NomadPlatform:
-		switch cast := c.RawDefinition["processes"].(type) {
-		case map[string]any:
-			if len(cast) != 0 {
-				names = lo.Keys(cast)
-			}
-		case map[string]string:
-			if len(cast) != 0 {
-				names = lo.Keys(cast)
-			}
-		}
 	}
-
-	switch {
+	switch names := lo.Keys(c.Processes); {
 	case len(names) == 1:
 		return names
 	case len(names) > 1:

--- a/internal/appconfig/processgroups_test.go
+++ b/internal/appconfig/processgroups_test.go
@@ -67,34 +67,6 @@ func TestProcessNames(t *testing.T) {
 				cfg, err = LoadConfig(tc.filepath)
 				require.NoError(t, err)
 			}
-			// Test unknown platform version
-			assert.Equal(t, tc.defaultProcessName, cfg.DefaultProcessName())
-			assert.Equal(t, tc.processNames, cfg.ProcessNames())
-			assert.Equal(t, tc.format, cfg.FormatProcessNames())
-
-			// XXX: Break here because SetPlatform calls crash on nil Config
-			if cfg == nil {
-				return
-			}
-
-			// Test for machines
-			require.NoError(t, cfg.SetMachinesPlatform())
-			assert.Equal(t, tc.defaultProcessName, cfg.DefaultProcessName())
-			assert.Equal(t, tc.processNames, cfg.ProcessNames())
-			assert.Equal(t, tc.format, cfg.FormatProcessNames())
-
-			if cfg.RawDefinition == nil {
-				return
-			}
-
-			// Test for detached
-			require.NoError(t, cfg.SetDetachedPlatform())
-			assert.Equal(t, tc.defaultProcessName, cfg.DefaultProcessName())
-			assert.Equal(t, tc.processNames, cfg.ProcessNames())
-			assert.Equal(t, tc.format, cfg.FormatProcessNames())
-
-			// Test for nomad
-			require.NoError(t, cfg.SetNomadPlatform())
 			assert.Equal(t, tc.defaultProcessName, cfg.DefaultProcessName())
 			assert.Equal(t, tc.processNames, cfg.ProcessNames())
 			assert.Equal(t, tc.format, cfg.FormatProcessNames())

--- a/internal/appconfig/remote.go
+++ b/internal/appconfig/remote.go
@@ -32,48 +32,23 @@ func FromAppCompact(ctx context.Context, appCompact *api.AppCompact) (*Config, e
 func getConfig(ctx context.Context, apiClient *api.Client, appCompact *api.AppCompact) (*Config, error) {
 	appName := appCompact.Name
 
-	switch appCompact.PlatformVersion {
-	// Need a more elegant way to find out what side of detached we are on
-	case NomadPlatform, "detached":
-		serverCfg, err := apiClient.GetConfig(ctx, appName)
-		if err != nil {
-			return nil, err
-		}
-		cfg, err := FromDefinition(&serverCfg.Definition)
-		if err != nil {
-			return nil, err
-		}
-		if err := cfg.SetNomadPlatform(); err != nil {
-			return nil, err
-		}
-		cfg.AppName = appName
-		return cfg, nil
-	case MachinesPlatform:
-		cfg, err := getAppV2ConfigFromReleases(ctx, apiClient, appCompact.Name)
-		if cfg == nil {
-			cfg, err = getAppV2ConfigFromMachines(ctx, apiClient, appCompact)
-		}
-		if err != nil {
-			return nil, err
-		}
-		if err := cfg.SetMachinesPlatform(); err != nil {
-			return nil, err
-		}
-		cfg.AppName = appName
-		return cfg, nil
-	default:
-		if !appCompact.Deployed {
-			return nil, fmt.Errorf("Undeployed app '%s' has no platform version set", appName)
-		}
-		return nil, fmt.Errorf("likely a bug, unknown platform version '%s' for app '%s'. ", appCompact.PlatformVersion, appName)
+	cfg, err := getAppV2ConfigFromReleases(ctx, apiClient, appName)
+	if cfg == nil {
+		cfg, err = getAppV2ConfigFromMachines(ctx, apiClient, appCompact)
 	}
+	if err != nil {
+		return nil, err
+	}
+	if err := cfg.SetMachinesPlatform(); err != nil {
+		return nil, err
+	}
+	cfg.AppName = appName
+	return cfg, nil
 }
 
 func getAppV2ConfigFromMachines(ctx context.Context, apiClient *api.Client, appCompact *api.AppCompact) (*Config, error) {
-	var (
-		flapsClient = flaps.FromContext(ctx)
-		io          = iostreams.FromContext(ctx)
-	)
+	flapsClient := flaps.FromContext(ctx)
+	io := iostreams.FromContext(ctx)
 	activeMachines, err := machine.ListActive(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error listing active machines for %s app: %w", appCompact.Name, err)

--- a/internal/appconfig/remote.go
+++ b/internal/appconfig/remote.go
@@ -15,26 +15,9 @@ import (
 func FromRemoteApp(ctx context.Context, appName string) (*Config, error) {
 	apiClient := client.FromContext(ctx).API()
 
-	appCompact, err := apiClient.GetAppCompact(ctx, appName)
-	if err != nil {
-		return nil, fmt.Errorf("error getting app: %w", err)
-	}
-
-	return getConfig(ctx, apiClient, appCompact)
-}
-
-func FromAppCompact(ctx context.Context, appCompact *api.AppCompact) (*Config, error) {
-	apiClient := client.FromContext(ctx).API()
-
-	return getConfig(ctx, apiClient, appCompact)
-}
-
-func getConfig(ctx context.Context, apiClient *api.Client, appCompact *api.AppCompact) (*Config, error) {
-	appName := appCompact.Name
-
 	cfg, err := getAppV2ConfigFromReleases(ctx, apiClient, appName)
 	if cfg == nil {
-		cfg, err = getAppV2ConfigFromMachines(ctx, apiClient, appCompact)
+		cfg, err = getAppV2ConfigFromMachines(ctx, apiClient, appName)
 	}
 	if err != nil {
 		return nil, err
@@ -46,15 +29,16 @@ func getConfig(ctx context.Context, apiClient *api.Client, appCompact *api.AppCo
 	return cfg, nil
 }
 
-func getAppV2ConfigFromMachines(ctx context.Context, apiClient *api.Client, appCompact *api.AppCompact) (*Config, error) {
+func getAppV2ConfigFromMachines(ctx context.Context, apiClient *api.Client, appName string) (*Config, error) {
 	flapsClient := flaps.FromContext(ctx)
 	io := iostreams.FromContext(ctx)
+
 	activeMachines, err := machine.ListActive(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error listing active machines for %s app: %w", appCompact.Name, err)
+		return nil, fmt.Errorf("error listing active machines for %s app: %w", appName, err)
 	}
 	machineSet := machine.NewMachineSet(flapsClient, io, activeMachines)
-	appConfig, warnings, err := FromAppAndMachineSet(ctx, appCompact, machineSet)
+	appConfig, warnings, err := FromAppAndMachineSet(ctx, appName, machineSet)
 	if err != nil {
 		return nil, fmt.Errorf("failed to grab app config from existing machines, error: %w", err)
 	}

--- a/internal/appconfig/serde.go
+++ b/internal/appconfig/serde.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/pelletier/go-toml/v2"
-	"github.com/samber/lo"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -79,18 +78,10 @@ func (c *Config) WriteToDisk(ctx context.Context, path string) (err error) {
 
 // MarshalJSON implements the json.Marshaler interface
 func (c *Config) MarshalJSON() ([]byte, error) {
-	switch {
-	case c == nil:
+	if c == nil {
 		return json.Marshal(nil)
-	case c.platformVersion == MachinesPlatform:
-		return json.Marshal(*c)
-	default:
-		sections, err := c.rawSections()
-		if err != nil {
-			return nil, err
-		}
-		return json.Marshal(lo.Assign(sections...))
 	}
+	return json.Marshal(*c)
 }
 
 // marshalTOML serializes the configuration to TOML format
@@ -104,155 +95,34 @@ func (c *Config) marshalTOML() ([]byte, error) {
 	encoder.SetIndentTables(true)
 	encoder.SetMarshalJsonNumbers(true)
 
-	switch {
-	case c == nil:
-		break
-	case c.platformVersion == MachinesPlatform:
+	if c != nil {
 		if err := encoder.Encode(c); err != nil {
 			return nil, err
 		}
-	default:
-		// FallBack for Nomad apps
-		sections, err := c.rawSections()
-		if err != nil {
-			return nil, err
-		}
-		for _, section := range sections {
-			if err := encoder.Encode(section); err != nil {
-				return nil, err
-			}
-		}
 	}
+
 	return b.Bytes(), nil
 }
 
-// rawSections returns configuration parts in serialization order for Nomad apps
-func (c *Config) rawSections() ([]map[string]any, error) {
-	// Write app name first to be sure it will be there at the top
-	sections := []map[string]any{
-		{"app": c.AppName},
-	}
-
-	rawData := c.SanitizedDefinition()
-	// Restore sections removed by SanitizedDefinition
-	if c.Build != nil {
-		rawData["build"] = c.Build
-	}
-	if c.PrimaryRegion != "" {
-		rawData["primary_region"] = c.PrimaryRegion
-	}
-	if c.HTTPService != nil {
-		rawData["http_service"] = c.HTTPService
-	}
-
-	if len(rawData) > 0 {
-		// roundtrip through json encoder to convert float64 numbers to json.Number,
-		// otherwise numbers are floats in toml
-		var buf bytes.Buffer
-		if err := json.NewEncoder(&buf).Encode(rawData); err != nil {
-			return nil, err
-		}
-
-		d := json.NewDecoder(&buf)
-		d.UseNumber()
-		if err := d.Decode(&rawData); err != nil {
-			return nil, err
-		}
-		sections = append(sections, rawData)
-	}
-
-	return sections, nil
-}
-
 func unmarshalTOML(buf []byte) (*Config, error) {
-	// Keep this map as vanilla as possible
-	// This is what we send to Web API for Nomad apps
-	rawDefinition := map[string]any{}
-	if err := toml.Unmarshal(buf, &rawDefinition); err != nil {
-		return nil, err
-	}
-
-	// Unmarshal twice due to in-place updates
 	cfgMap := map[string]any{}
 	if err := toml.Unmarshal(buf, &cfgMap); err != nil {
 		return nil, err
 	}
-
 	cfg, err := applyPatches(cfgMap)
-	// In case of parsing error fallback to Nomad only compatibility
+
+	// In case of parsing error fallback to bare compatibility
 	if err != nil {
+		// Unmarshal twice due to in-place cfgMap updates performed by patches
+		raw := map[string]any{}
+		if err := toml.Unmarshal(buf, &raw); err != nil {
+			return nil, err
+		}
 		cfg = &Config{v2UnmarshalError: err}
-		if name, ok := (rawDefinition["app"]).(string); ok {
+		if name, ok := (raw["app"]).(string); ok {
 			cfg.AppName = name
 		}
-		cfg.Build = unmarshalBuild(rawDefinition)
 	}
 
-	cfg.RawDefinition = rawDefinition
 	return cfg, nil
-}
-
-// Fallback method when we fail to parse fly.toml into Config
-// XXX: High chances we can ditch and unmarshal directly into Build struct
-func unmarshalBuild(data map[string]interface{}) *Build {
-	buildConfig, ok := (data["build"]).(map[string]interface{})
-	if !ok {
-		return nil
-	}
-
-	b := &Build{
-		Args:       map[string]string{},
-		Settings:   map[string]interface{}{},
-		Buildpacks: []string{},
-	}
-
-	configValueSet := false
-	for k, v := range buildConfig {
-		switch k {
-		case "builder":
-			b.Builder = fmt.Sprint(v)
-			configValueSet = configValueSet || b.Builder != ""
-		case "buildpacks":
-			if bpSlice, ok := v.([]interface{}); ok {
-				for _, argV := range bpSlice {
-					b.Buildpacks = append(b.Buildpacks, fmt.Sprint(argV))
-				}
-			}
-		case "args":
-			if argMap, ok := v.(map[string]interface{}); ok {
-				for argK, argV := range argMap {
-					b.Args[argK] = fmt.Sprint(argV)
-				}
-			}
-		case "builtin":
-			b.Builtin = fmt.Sprint(v)
-			configValueSet = configValueSet || b.Builtin != ""
-		case "settings":
-			if settingsMap, ok := v.(map[string]interface{}); ok {
-				for settingK, settingV := range settingsMap {
-					b.Settings[settingK] = settingV // fmt.Sprint(argV)
-				}
-			}
-		case "image":
-			b.Image = fmt.Sprint(v)
-			configValueSet = configValueSet || b.Image != ""
-		case "dockerfile":
-			b.Dockerfile = fmt.Sprint(v)
-			configValueSet = configValueSet || b.Dockerfile != ""
-		case "ignorefile":
-			b.Ignorefile = fmt.Sprint(v)
-			configValueSet = configValueSet || b.Ignorefile != ""
-		case "build_target", "build-target":
-			b.DockerBuildTarget = fmt.Sprint(v)
-			configValueSet = configValueSet || b.DockerBuildTarget != ""
-		default:
-			b.Args[k] = fmt.Sprint(v)
-		}
-	}
-
-	if !configValueSet && len(b.Args) == 0 {
-		return nil
-	}
-
-	return b
 }

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -133,51 +133,7 @@ func TestLoadTOMLAppConfigInvalidV2(t *testing.T) {
 	assert.Equal(t, &Config{
 		configFilePath:   "./testdata/always-invalid-v2.toml",
 		v2UnmarshalError: fmt.Errorf("Unknown type for service concurrency: int64"),
-
-		AppName: "unsupported-format",
-		Build: &Build{
-			Builder:           "dockerfile",
-			Image:             "foo/fighter",
-			Builtin:           "whatisthis",
-			Dockerfile:        "Dockerfile",
-			Ignorefile:        ".gitignore",
-			DockerBuildTarget: "target",
-			Buildpacks:        []string{"packme", "well"},
-			Settings: map[string]any{
-				"foo":   "bar",
-				"other": int64(2),
-			},
-
-			Args: map[string]string{
-				"param1": "value1",
-				"param2": "value2",
-			},
-		},
-
-		RawDefinition: map[string]any{
-			"app": "unsupported-format",
-			"build": map[string]any{
-				"builder":      "dockerfile",
-				"image":        "foo/fighter",
-				"builtin":      "whatisthis",
-				"dockerfile":   "Dockerfile",
-				"ignorefile":   ".gitignore",
-				"build-target": "target",
-				"buildpacks":   []any{"packme", "well"},
-				"args": map[string]any{
-					"param1": "value1",
-					"param2": "value2",
-				},
-				"settings": map[string]any{
-					"foo":   "bar",
-					"other": int64(2),
-				},
-			},
-			"services": []any{map[string]any{
-				"concurrency":   int64(20),
-				"internal_port": "8080",
-			}},
-		},
+		AppName:          "unsupported-format",
 	}, cfg)
 }
 
@@ -201,17 +157,6 @@ func TestLoadTOMLAppConfigExperimental(t *testing.T) {
 			Entrypoint: []string{"entrypoint"},
 			Exec:       []string{"exec"},
 		},
-		RawDefinition: map[string]any{
-			"app": "foo",
-			"experimental": map[string]any{
-				"cmd":          "cmd",
-				"entrypoint":   "entrypoint",
-				"exec":         "exec",
-				"kill_timeout": int64(3),
-				"metrics_path": "/foo",
-				"metrics_port": int64(9000),
-			},
-		},
 	}, cfg)
 }
 
@@ -227,13 +172,6 @@ func TestLoadTOMLAppConfigMountsArray(t *testing.T) {
 			Source:      "pg_data",
 			Destination: "/data",
 		}},
-		RawDefinition: map[string]any{
-			"app": "foo",
-			"mounts": []any{map[string]any{
-				"source":      "pg_data",
-				"destination": "/data",
-			}},
-		},
 	}, cfg)
 }
 
@@ -241,8 +179,6 @@ func TestLoadTOMLAppConfigFormatQuirks(t *testing.T) {
 	const path = "./testdata/format-quirks.toml"
 	cfg, err := LoadConfig(path)
 	require.NoError(t, err)
-	// Nullify cfg.RawDefinition because Compute section is apps v2 only
-	cfg.RawDefinition = nil
 
 	assert.Equal(t, &Config{
 		configFilePath:   "./testdata/format-quirks.toml",
@@ -341,52 +277,6 @@ func TestLoadTOMLAppConfigOldFormat(t *testing.T) {
 				},
 			},
 		},
-		RawDefinition: map[string]any{
-			"app": "foo",
-			"build": map[string]any{
-				"build_target": "thalayer",
-			},
-			"env": map[string]any{
-				"FOO": "STRING",
-				"BAR": int64(123),
-			},
-			"experimental": map[string]any{},
-			"mount": map[string]any{
-				"source":      "data",
-				"destination": "/data",
-			},
-			"metrics": map[string]any{
-				"port": int64(9999),
-				"path": "/metrics",
-			},
-			"processes": []any{map[string]any{}},
-			"services": []any{map[string]any{
-				"internal_port": "8080",
-				"ports": []any{
-					map[string]any{"port": "80", "handlers": []any{"http"}},
-				},
-				"concurrency": "12,23",
-				"tcp_checks": []any{
-					map[string]any{"interval": int64(10000), "timeout": int64(2000)},
-					map[string]any{"interval": "20s", "timeout": "3s"},
-				},
-				"http_checks": []any{
-					map[string]any{
-						"interval": int64(30000),
-						"timeout":  int64(4000),
-						"headers": []any{
-							map[string]any{"name": "origin", "value": "http://localhost:8000"},
-						},
-					},
-					map[string]any{
-						"interval":     "20s",
-						"timeout":      "3s",
-						"grace_period": "",
-						"headers":      map[string]any{"fly-healthcheck": int64(1), "astring": "string", "metoo": true},
-					},
-				},
-			}},
-		},
 	}, cfg)
 }
 
@@ -400,18 +290,6 @@ func TestLoadTOMLAppConfigOldProcesses(t *testing.T) {
 		Processes: map[string]string{
 			"web":    "./web",
 			"worker": "./worker",
-		},
-		RawDefinition: map[string]any{
-			"processes": []any{
-				map[string]any{
-					"name":    "web",
-					"command": "./web",
-				},
-				map[string]any{
-					"name":    "worker",
-					"command": "./worker",
-				},
-			},
 		},
 	}, cfg)
 }
@@ -431,17 +309,6 @@ func TestLoadTOMLAppConfigOldChecksFormat(t *testing.T) {
 				HTTPPath: api.Pointer("/flycheck/pg"),
 			},
 		},
-		RawDefinition: map[string]any{
-			"app": "foo",
-			"checks": map[string]any{
-				"pg": map[string]any{
-					"type":    "http",
-					"port":    int64(5500),
-					"path":    "/flycheck/pg",
-					"headers": []any{},
-				},
-			},
-		},
 	}, cfg)
 }
 
@@ -449,9 +316,6 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 	const path = "./testdata/full-reference.toml"
 	cfg, err := LoadConfig(path)
 	require.NoError(t, err)
-
-	// Nullify cfg.RawDefinition because it won't mutate per test in TestLoadTOMLAppConfigOldFormat
-	cfg.RawDefinition = nil
 
 	assert.Equal(t, &Config{
 		configFilePath:   "./testdata/full-reference.toml",

--- a/internal/appconfig/setters.go
+++ b/internal/appconfig/setters.go
@@ -1,21 +1,15 @@
 package appconfig
 
 // ** IMPORTANT **
-// The main purpose of the functions in this file is to serve as a compatibility layer between
-// V1 and V2 applications, considering Nomad apps (V1) uses RawDefinition for its configuration
-// While V2 uses the fields in Config struct
-//
 // This methods are mainly called by `fly launch` with information provided by scanners
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/superfly/flyctl/api"
 )
 
 func (c *Config) SetInternalPort(port int) {
-	c.v1SetInternalPort(port)
 	switch {
 	case c.HTTPService != nil:
 		c.HTTPService.InternalPort = port
@@ -24,17 +18,7 @@ func (c *Config) SetInternalPort(port int) {
 	}
 }
 
-func (c *Config) v1SetInternalPort(port int) {
-	if raw, ok := c.RawDefinition["services"]; ok {
-		services, _ := ensureArrayOfMap(raw)
-		if len(services) > 0 {
-			services[0]["internal_port"] = port
-		}
-	}
-}
-
 func (c *Config) SetHttpCheck(path string, headers map[string]string) {
-	c.v1SetHttpCheck(path)
 	switch {
 	case c.HTTPService != nil:
 		if c.Checks == nil {
@@ -66,26 +50,7 @@ func (c *Config) SetHttpCheck(path string, headers map[string]string) {
 	}
 }
 
-func (c *Config) v1SetHttpCheck(path string) {
-	if raw, ok := c.RawDefinition["services"]; ok {
-		services, _ := ensureArrayOfMap(raw)
-		if len(services) > 0 {
-			services[0]["http_checks"] = []map[string]interface{}{{
-				"interval":        10000,
-				"grace_period":    "5s",
-				"method":          "get",
-				"path":            path,
-				"protocol":        "http",
-				"restart_limit":   0,
-				"timeout":         2000,
-				"tls_skip_verify": false,
-			}}
-		}
-	}
-}
-
 func (c *Config) SetConcurrency(soft int, hard int) {
-	c.v1SetConcurrency(soft, hard)
 	concurrency := &api.MachineServiceConcurrency{
 		Type:      "connections",
 		HardLimit: hard,
@@ -100,88 +65,34 @@ func (c *Config) SetConcurrency(soft int, hard int) {
 	}
 }
 
-func (c *Config) v1SetConcurrency(soft int, hard int) {
-	if raw, ok := c.RawDefinition["services"]; ok {
-		services, _ := ensureArrayOfMap(raw)
-		if len(services) > 0 {
-			services[0]["concurrency"] = map[string]any{
-				"hard_limit": hard,
-				"soft_limit": soft,
-				"type":       "connections",
-			}
-		}
-	}
-}
-
 func (c *Config) SetReleaseCommand(cmd string) {
-	c.v1SetReleaseCommand(cmd)
 	if c.Deploy == nil {
 		c.Deploy = &Deploy{}
 	}
 	c.Deploy.ReleaseCommand = cmd
 }
 
-func (c *Config) v1SetReleaseCommand(cmd string) {
-	if raw, ok := c.RawDefinition["deploy"]; ok {
-		if cast, ok := raw.(map[string]string); ok {
-			cast["release_command"] = cmd
-		} else if cast, ok := raw.(map[string]any); ok {
-			cast["release_command"] = cmd
-		}
-	} else {
-		c.RawDefinition["deploy"] = map[string]string{"release_command": cmd}
-	}
-}
-
 func (c *Config) SetDockerCommand(cmd string) {
-	c.v1SetDockerCommand(cmd)
 	if c.Experimental == nil {
 		c.Experimental = &Experimental{}
 	}
 	c.Experimental.Cmd = []string{cmd}
 }
 
-func (c *Config) v1SetDockerCommand(cmd string) {
-	if raw, ok := c.RawDefinition["experimental"]; ok {
-		if cast, ok := raw.(map[string]string); ok {
-			cast["cmd"] = cmd
-		} else if cast, ok := raw.(map[string]any); ok {
-			cast["cmd"] = cmd
-		}
-	} else {
-		c.RawDefinition["experimental"] = map[string]string{"cmd": cmd}
-	}
-}
-
 func (c *Config) SetKillSignal(signal string) {
-	c.RawDefinition["kill_signal"] = signal
 	if signal != "" {
 		c.KillSignal = &signal
 	}
 }
 
 func (c *Config) SetDockerEntrypoint(entrypoint string) {
-	c.v1SetDockerEntrypoint(entrypoint)
 	if c.Experimental == nil {
 		c.Experimental = &Experimental{}
 	}
 	c.Experimental.Entrypoint = []string{entrypoint}
 }
 
-func (c *Config) v1SetDockerEntrypoint(entrypoint string) {
-	if raw, ok := c.RawDefinition["experimental"]; ok {
-		if cast, ok := raw.(map[string]string); ok {
-			cast["entrypoint"] = entrypoint
-		} else if cast, ok := raw.(map[string]any); ok {
-			cast["entrypoint"] = entrypoint
-		}
-	} else {
-		c.RawDefinition["experimental"] = map[string]string{"entrypoint": entrypoint}
-	}
-}
-
 func (c *Config) SetEnvVariable(name, value string) {
-	c.v1SetEnvVariable(name, value)
 	if c.Env == nil {
 		c.Env = make(map[string]string)
 	}
@@ -189,69 +100,19 @@ func (c *Config) SetEnvVariable(name, value string) {
 }
 
 func (c *Config) SetEnvVariables(vals map[string]string) {
-	c.v1SetEnvVariables(vals)
 	for k, v := range vals {
 		c.SetEnvVariable(k, v)
 	}
 }
 
-func (c *Config) v1SetEnvVariable(name, value string) {
-	c.v1SetEnvVariables(map[string]string{name: value})
-}
-
-func (c *Config) v1SetEnvVariables(vals map[string]string) {
-	env := c.v1GetEnvVariables()
-	for k, v := range vals {
-		env[k] = v
-	}
-	c.RawDefinition["env"] = env
-}
-
-func (c *Config) v1GetEnvVariables() map[string]string {
-	env := map[string]string{}
-
-	if rawEnv, ok := c.RawDefinition["env"]; ok {
-		// we get map[string]interface{} when unmarshaling toml, and map[string]string from SetEnvVariables.
-		// Support them both :vomit:
-		switch castEnv := rawEnv.(type) {
-		case map[string]string:
-			env = castEnv
-		case map[string]interface{}:
-			for k, v := range castEnv {
-				if stringVal, ok := v.(string); ok {
-					env[k] = stringVal
-				} else {
-					env[k] = fmt.Sprintf("%v", v)
-				}
-			}
-		}
-	}
-
-	return env
-}
-
 func (c *Config) SetProcess(name, value string) {
-	c.v1SetProcess(name, value)
 	if c.Processes == nil {
 		c.Processes = make(map[string]string)
 	}
 	c.Processes[name] = value
 }
 
-func (c *Config) v1SetProcess(name, value string) {
-	if raw, ok := c.RawDefinition["processes"]; ok {
-		if cast, ok := raw.(map[string]string); ok {
-			cast[name] = value
-		} else if cast, ok := raw.(map[string]any); ok {
-			cast[name] = value
-		}
-	} else {
-		c.RawDefinition["processes"] = map[string]string{name: value}
-	}
-}
-
 func (c *Config) SetStatics(statics []Static) {
-	c.RawDefinition["statics"] = statics
 	c.Statics = make([]Static, 0, len(statics))
 	for _, static := range statics {
 		c.Statics = append(c.Statics, Static{
@@ -263,6 +124,5 @@ func (c *Config) SetStatics(statics []Static) {
 }
 
 func (c *Config) SetMounts(volumes []Mount) {
-	c.RawDefinition["mounts"] = volumes
 	c.Mounts = volumes
 }

--- a/internal/appconfig/setters_test.go
+++ b/internal/appconfig/setters_test.go
@@ -34,28 +34,6 @@ func TestSettersWithService(t *testing.T) {
 			HTTPTLSSkipVerify: api.Pointer(false),
 		}},
 	}})
-	assert.Equal(t, map[string]any{
-		"app": "setters",
-		"services": []any{map[string]any{
-			"internal_port": 1234,
-			"protocol":      "tcp",
-			"concurrency": map[string]any{
-				"type":       "connections",
-				"hard_limit": 34,
-				"soft_limit": 12,
-			},
-			"http_checks": []map[string]any{{
-				"interval":        10000,
-				"grace_period":    "5s",
-				"method":          "get",
-				"path":            "/status",
-				"protocol":        "http",
-				"restart_limit":   0,
-				"timeout":         2000,
-				"tls_skip_verify": false,
-			}},
-		}},
-	}, cfg.RawDefinition)
 }
 
 func TestSettersWithHTTPService(t *testing.T) {
@@ -88,7 +66,6 @@ func TestSettersWithHTTPService(t *testing.T) {
 			HTTPTLSSkipVerify: api.Pointer(false),
 		},
 	})
-	// No need to test RawDefinition because http_service is machines only
 }
 
 func TestSettersWithouServices(t *testing.T) {
@@ -98,7 +75,6 @@ func TestSettersWithouServices(t *testing.T) {
 	cfg.SetConcurrency(12, 34)
 	assert.Nil(t, cfg.Services, nil)
 	assert.Nil(t, cfg.HTTPService, nil)
-	assert.Equal(t, cfg.RawDefinition, map[string]any{})
 }
 
 func TestSetEnvVariable(t *testing.T) {
@@ -110,13 +86,6 @@ func TestSetEnvVariable(t *testing.T) {
 		"b": "2",
 		"c": "3",
 	})
-	assert.Equal(t, cfg.RawDefinition, map[string]any{
-		"env": map[string]string{
-			"a": "1",
-			"b": "2",
-			"c": "3",
-		},
-	})
 }
 
 func TestReleaseCommand(t *testing.T) {
@@ -124,11 +93,6 @@ func TestReleaseCommand(t *testing.T) {
 	cfg.SetReleaseCommand("/bin/app/run migrate")
 	assert.Equal(t, cfg.Deploy, &Deploy{
 		ReleaseCommand: "/bin/app/run migrate",
-	})
-	assert.Equal(t, cfg.RawDefinition, map[string]any{
-		"deploy": map[string]string{
-			"release_command": "/bin/app/run migrate",
-		},
 	})
 }
 
@@ -141,13 +105,6 @@ func TestReleaseCommand_DeploySectionExists(t *testing.T) {
 		ReleaseCommand: "/bin/app/run migrate",
 		Strategy:       "immediate",
 	})
-	assert.Equal(t, cfg.RawDefinition, map[string]any{
-		"app": "setters",
-		"deploy": map[string]any{
-			"release_command": "/bin/app/run migrate",
-			"strategy":        "immediate",
-		},
-	})
 }
 
 func TestSetDocker(t *testing.T) {
@@ -157,12 +114,6 @@ func TestSetDocker(t *testing.T) {
 	assert.Equal(t, cfg.Experimental, &Experimental{
 		Entrypoint: []string{"/entry"},
 		Cmd:        []string{"/cmd"},
-	})
-	assert.Equal(t, cfg.RawDefinition, map[string]any{
-		"experimental": map[string]string{
-			"entrypoint": "/entry",
-			"cmd":        "/cmd",
-		},
 	})
 }
 
@@ -177,14 +128,6 @@ func TestSetDocker_ExperimentalSectionExists(t *testing.T) {
 		Cmd:        []string{"/cmd"},
 		Exec:       []string{"/exec"},
 	})
-	assert.Equal(t, cfg.RawDefinition, map[string]any{
-		"app": "setters",
-		"experimental": map[string]any{
-			"entrypoint": "/entry",
-			"cmd":        "/cmd",
-			"exec":       "/exec",
-		},
-	})
 }
 
 func TestSetProcesses(t *testing.T) {
@@ -194,12 +137,6 @@ func TestSetProcesses(t *testing.T) {
 	assert.Equal(t, cfg.Experimental, &Experimental{
 		Entrypoint: []string{"/entry"},
 		Cmd:        []string{"/cmd"},
-	})
-	assert.Equal(t, cfg.RawDefinition, map[string]any{
-		"experimental": map[string]string{
-			"entrypoint": "/entry",
-			"cmd":        "/cmd",
-		},
 	})
 }
 
@@ -214,14 +151,6 @@ func TestSetProcesses_SectionExists(t *testing.T) {
 		"back": "run-back",
 		"foo":  "bar",
 	})
-	assert.Equal(t, cfg.RawDefinition, map[string]any{
-		"app": "setters",
-		"processes": map[string]any{
-			"app":  "run-web",
-			"back": "run-back",
-			"foo":  "bar",
-		},
-	})
 }
 
 func TestSetStatics(t *testing.T) {
@@ -230,27 +159,16 @@ func TestSetStatics(t *testing.T) {
 	assert.Equal(t, cfg.Statics, []Static{
 		{GuestPath: "/guest", UrlPrefix: "/prefix"},
 	})
-	assert.Equal(t, cfg.RawDefinition, map[string]any{
-		"statics": []Static{
-			{GuestPath: "/guest", UrlPrefix: "/prefix"},
-		},
-	})
 }
 
 func TestSetVolumes(t *testing.T) {
 	cfg := NewConfig()
 	cfg.SetMounts([]Mount{{Source: "data", Destination: "/data"}})
 	assert.Equal(t, cfg.Mounts, []Mount{{Source: "data", Destination: "/data"}})
-	assert.Equal(t, cfg.RawDefinition, map[string]any{
-		"mounts": []Mount{
-			{Source: "data", Destination: "/data"},
-		},
-	})
 }
 
 func TestSetKillSignal(t *testing.T) {
 	cfg := NewConfig()
 	cfg.SetKillSignal("TERM")
 	assert.Equal(t, cfg.KillSignal, api.Pointer("TERM"))
-	assert.Equal(t, cfg.RawDefinition, map[string]any{"kill_signal": "TERM"})
 }

--- a/internal/appconfig/testdata/always-invalid-v2.toml
+++ b/internal/appconfig/testdata/always-invalid-v2.toml
@@ -19,7 +19,6 @@ app = "unsupported-format"
 
 [[services]]
   internal_port = "8080"
-  # Single numerical concurrency is not valid, even for nomad
-  # but we are testing here that this file can't be parsed into V2 Config
-  # yet its RawDefinition is usable for v1 apps
+  # Single numerical concurrency is not valid
+  # but we are testing here that this file can't be parsed
   concurrency = 20

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/shlex"
 	"github.com/logrusorgru/aurora"
 	"github.com/superfly/flyctl/api"
-	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/sentry"
 )
@@ -23,78 +22,10 @@ var (
 )
 
 func (cfg *Config) Validate(ctx context.Context) (err error, extra_info string) {
-	appName := NameFromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
-
 	if cfg == nil {
 		return errors.New("App config file not found"), ""
 	}
 
-	extra_info = fmt.Sprintf("Validating %s\n", cfg.ConfigFilePath())
-
-	platformVersion := cfg.platformVersion
-	if platformVersion == "" {
-		app, err := apiClient.GetAppBasic(ctx, appName)
-		switch {
-		case err == nil:
-			platformVersion = app.PlatformVersion
-			extra_info += fmt.Sprintf("Platform: %s\n", platformVersion)
-		case strings.Contains(err.Error(), "Could not find App"):
-			platformVersion = NomadPlatform
-			extra_info += fmt.Sprintf("WARNING: Failed to fetch platform version: %s\n", err)
-		default:
-			return err, extra_info
-		}
-	} else {
-		extra_info += fmt.Sprintf("Platform: %s\n", platformVersion)
-	}
-
-	switch platformVersion {
-	case MachinesPlatform:
-		platErr, platExtra := cfg.ValidateForMachinesPlatform(ctx)
-		return platErr, extra_info + platExtra
-	case NomadPlatform:
-		platErr, platExtra := cfg.ValidateForNomadPlatform(ctx)
-		return platErr, extra_info + platExtra
-	case "", DetachedPlatform:
-		return nil, ""
-	default:
-		return fmt.Errorf("Unknown platform version '%s' for app '%s'", platformVersion, appName), extra_info
-	}
-}
-
-func (cfg *Config) ValidateForNomadPlatform(ctx context.Context) (err error, extra_info string) {
-	if extra, _ := cfg.validateBuildStrategies(); extra != "" {
-		extra_info += extra
-	}
-
-	appName := NameFromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
-	serverCfg, err := apiClient.ValidateConfig(ctx, appName, cfg.SanitizedDefinition())
-	if err != nil {
-		return err, extra_info
-	}
-
-	if _, haveHTTPService := cfg.RawDefinition["http_service"]; haveHTTPService {
-		// TODO: eventually make this fail validation
-		msg := fmt.Sprintf("%s the http_service section is ignored for Nomad apps", aurora.Yellow("WARN"))
-		extra_info += msg + "\n"
-		sentry.CaptureException(errors.New(msg))
-	}
-
-	if serverCfg.Valid {
-		extra_info += fmt.Sprintf("%s Configuration is valid\n", aurora.Green("✓"))
-		return nil, extra_info
-	} else {
-		for _, errStr := range serverCfg.Errors {
-			extra_info += fmt.Sprintf("   %s%s\n", aurora.Red("✘"), errStr)
-		}
-		extra_info += "\n"
-		return errors.New("App configuration is not valid"), extra_info
-	}
-}
-
-func (cfg *Config) ValidateForMachinesPlatform(ctx context.Context) (err error, extra_info string) {
 	validators := []func() (string, error){
 		cfg.validateBuildStrategies,
 		cfg.validateDeploySection,
@@ -106,6 +37,8 @@ func (cfg *Config) ValidateForMachinesPlatform(ctx context.Context) (err error, 
 		cfg.validateMounts,
 	}
 
+	extra_info = fmt.Sprintf("Validating %s\n", cfg.ConfigFilePath())
+
 	for _, vFunc := range validators {
 		info, vErr := vFunc()
 		extra_info += info
@@ -114,8 +47,8 @@ func (cfg *Config) ValidateForMachinesPlatform(ctx context.Context) (err error, 
 		}
 	}
 
-	if vErr := cfg.EnsureV2Config(); vErr != nil {
-		err = vErr
+	if cfg.v2UnmarshalError != nil {
+		err = cfg.v2UnmarshalError
 	}
 
 	if err != nil {

--- a/internal/command/apps/open.go
+++ b/internal/command/apps/open.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -47,11 +46,6 @@ func runOpen(ctx context.Context) error {
 	iostream := iostreams.FromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 
-	app, err := client.FromContext(ctx).API().GetAppCompact(ctx, appName)
-	if err != nil {
-		return fmt.Errorf("failed retrieving app %s: %w", appName, err)
-	}
-
 	flapsClient, err := flaps.NewFromAppName(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("could not create flaps client: %w", err)
@@ -60,7 +54,8 @@ func runOpen(ctx context.Context) error {
 
 	appConfig := appconfig.ConfigFromContext(ctx)
 	if appConfig == nil {
-		if appConfig, err = appconfig.FromAppCompact(ctx, app); err != nil {
+		appConfig, err = appconfig.FromRemoteApp(ctx, appName)
+		if err != nil {
 			return errors.New("The app config could not be found")
 		}
 	}

--- a/internal/command/config/env.go
+++ b/internal/command/config/env.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
@@ -48,12 +47,7 @@ func runEnv(ctx context.Context) error {
 		return err
 	}
 
-	app, err := apiClient.GetAppCompact(ctx, appName)
-	if err != nil {
-		return fmt.Errorf("failed to get app: %w", err)
-	}
-
-	flapsClient, err := flaps.New(ctx, app)
+	flapsClient, err := flaps.NewFromAppName(ctx, appName)
 	if err != nil {
 		return err
 	}

--- a/internal/command/config/env.go
+++ b/internal/command/config/env.go
@@ -64,21 +64,8 @@ func runEnv(ctx context.Context) error {
 		return err
 	}
 
-	if cfg.ForMachines() {
-		envRows := lo.Map(lo.Entries(cfg.Env), func(e lo.Entry[string, string], _ int) []string {
-			return []string{e.Key, e.Value}
-		})
-		return render.Table(io.Out, "Environment Variables", envRows, "Name", "Value")
-	} else {
-		vars, ok := cfg.RawDefinition["env"].(map[string]any)
-		if !ok {
-			return nil
-		}
-
-		envRows := lo.Map(lo.Entries(vars), func(e lo.Entry[string, any], _ int) []string {
-			return []string{e.Key, fmt.Sprintf("%s", e.Value)}
-		})
-
-		return render.Table(io.Out, "Environment Variables", envRows, "Name", "Value")
-	}
+	envRows := lo.Map(lo.Entries(cfg.Env), func(e lo.Entry[string, string], _ int) []string {
+		return []string{e.Key, e.Value}
+	})
+	return render.Table(io.Out, "Environment Variables", envRows, "Name", "Value")
 }

--- a/internal/command/config/save.go
+++ b/internal/command/config/save.go
@@ -111,9 +111,7 @@ func keepPrevSections(ctx context.Context, currentCfg *appconfig.Config, configP
 		}
 	}
 
-	// Inherit the [build] section from the old config.
-	// This is the only section from definition.SanitizedDefinition()
-	// that is supported by the nomad platform and not synthesized.
+	// Inherit the [build] section from the local config.
 	currentCfg.Build = oldCfg.Build
 
 	return nil

--- a/internal/command/config/validate.go
+++ b/internal/command/config/validate.go
@@ -22,10 +22,7 @@ ensure it is correct and meaningful to the platform.`
 		command.RequireAppName,
 	)
 	cmd.Args = cobra.NoArgs
-	flag.Add(cmd, flag.App(), flag.AppConfig(),
-		flag.Bool{Name: "machines", Description: "Forces apps v2 config validation"},
-		flag.Bool{Name: "nomad", Description: "Forces apps v1 config validation"},
-	)
+	flag.Add(cmd, flag.App(), flag.AppConfig())
 	return
 }
 
@@ -33,15 +30,8 @@ func runValidate(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
 	cfg := appconfig.ConfigFromContext(ctx)
 
-	switch {
-	case flag.GetBool(ctx, "machines"):
-		if err := cfg.SetMachinesPlatform(); err != nil {
-			return err
-		}
-	case flag.GetBool(ctx, "nomad"):
-		if err := cfg.SetNomadPlatform(); err != nil {
-			return err
-		}
+	if err := cfg.SetMachinesPlatform(); err != nil {
+		return err
 	}
 	err, extra_info := cfg.Validate(ctx)
 	fmt.Fprintln(io.Out, extra_info)

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -167,7 +167,7 @@ func runConsole(ctx context.Context) error {
 		}
 	}
 
-	if err, extraInfo := appConfig.ValidateForMachinesPlatform(ctx); err != nil {
+	if err, extraInfo := appConfig.Validate(ctx); err != nil {
 		fmt.Fprintln(io.ErrOut, extraInfo)
 		return err
 	}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -245,9 +245,6 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes
 	}
 
 	fmt.Fprintf(io.Out, "\nWatch your deployment at https://fly.io/apps/%s/monitoring\n\n", appName)
-	if err := appConfig.EnsureV2Config(); err != nil {
-		return fmt.Errorf("Can't deploy an invalid v2 app config: %s", err)
-	}
 	if err := deployToMachines(ctx, appConfig, appCompact, img, optionalGuest); err != nil {
 		return err
 	}

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -18,7 +18,6 @@ import (
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/watch"
 	"github.com/superfly/flyctl/iostreams"
-	"github.com/superfly/flyctl/terminal"
 )
 
 func newClone() *cobra.Command {
@@ -285,25 +284,4 @@ func runMachineClone(ctx context.Context) (err error) {
 	fmt.Fprintf(out, "Machine has been successfully cloned!\n")
 
 	return
-}
-
-func getAppConfig(ctx context.Context, appName string) (*appconfig.Config, error) {
-	cfg := appconfig.ConfigFromContext(ctx)
-	if cfg == nil {
-		terminal.Debug("no local app config detected; fetching from backend ...")
-
-		cfg, err := appconfig.FromRemoteApp(ctx, appName)
-		if err != nil {
-			return nil, fmt.Errorf("failed fetching existing app config: %w", err)
-		}
-
-		return cfg, nil
-	}
-
-	err, _ := cfg.Validate(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return cfg, nil
 }

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -3,7 +3,6 @@ package machine
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -11,10 +10,9 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/api"
-	"github.com/superfly/flyctl/client"
 	"github.com/superfly/flyctl/flaps"
+	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
-	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	mach "github.com/superfly/flyctl/internal/machine"
@@ -58,7 +56,6 @@ If the original Machine has a volume, then a new empty volume will be created an
 			Name:        "attach-volume",
 			Description: "Existing volume to attach to the new Machine in the form of <volume_id>[:/path/inside/machine]",
 		},
-		flag.ProcessGroup("Change the cloned Machine process group to what is specified here"),
 		flag.String{
 			Name:        "override-cmd",
 			Description: "Set CMD on the new Machine to this value",
@@ -93,17 +90,11 @@ func runMachineClone(ctx context.Context) (err error) {
 		appName  = appconfig.NameFromContext(ctx)
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
-		client   = client.FromContext(ctx).API()
 	)
-
-	app, err := client.GetAppCompact(ctx, appName)
-	if err != nil {
-		return err
-	}
 
 	machineID := flag.FirstArg(ctx)
 	haveMachineID := len(flag.Args(ctx)) > 0
-	source, ctx, err := selectOneMachine(ctx, app, machineID, haveMachineID)
+	source, ctx, err := selectOneMachine(ctx, appName, machineID, haveMachineID)
 	if err != nil {
 		return err
 	}
@@ -133,35 +124,7 @@ func runMachineClone(ctx context.Context) (err error) {
 
 	fmt.Fprintf(out, "Cloning Machine %s into region %s\n", colorize.Bold(source.ID), colorize.Bold(region))
 
-	targetConfig := source.Config
-	if targetProcessGroup := flag.GetProcessGroup(ctx); targetProcessGroup != "" {
-		appConfig, err := getAppConfig(ctx, appName)
-		if err != nil {
-			return fmt.Errorf("failed to get app config: %w", err)
-		}
-
-		if !slices.Contains(appConfig.ProcessNames(), targetProcessGroup) {
-			return fmt.Errorf("process group %s is not present in app configuration, add a [processes] section to fly.toml", targetProcessGroup)
-		}
-		if targetProcessGroup == api.MachineProcessGroupFlyAppReleaseCommand {
-			return fmt.Errorf("invalid process group %s, %s is reserved for internal use", targetProcessGroup, api.MachineProcessGroupFlyAppReleaseCommand)
-		}
-
-		if targetConfig.Metadata == nil {
-			targetConfig.Metadata = make(map[string]string)
-		}
-		targetConfig.Metadata[api.MachineConfigMetadataKeyFlyProcessGroup] = targetProcessGroup
-		targetConfig.Metadata[api.MachineConfigMetadataKeyFlyctlVersion] = buildinfo.Version().String()
-
-		terminal.Infof("Setting process group to %s for new Machine and updating cmd, services, and checks\n", targetProcessGroup)
-		mConfig, err := appConfig.ToMachineConfig(targetProcessGroup, nil)
-		if err != nil {
-			return fmt.Errorf("failed to get process group config: %w", err)
-		}
-		targetConfig.Init.Cmd = mConfig.Init.Cmd
-		targetConfig.Services = mConfig.Services
-		targetConfig.Checks = mConfig.Checks
-	}
+	targetConfig := helpers.Clone(source.Config)
 
 	targetConfig.Guest, err = flag.GetMachineGuest(ctx, targetConfig.Guest)
 	if err != nil {

--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -49,7 +49,7 @@ This command requires a machine to be in a stopped state unless the force flag i
 
 func runMachineDestroy(ctx context.Context) (err error) {
 	if len(flag.Args(ctx)) == 0 {
-		machine, ctx, err := selectOneMachine(ctx, nil, "", false)
+		machine, ctx, err := selectOneMachine(ctx, "", "", false)
 		if err != nil {
 			return err
 		}

--- a/internal/command/machine/exec.go
+++ b/internal/command/machine/exec.go
@@ -63,7 +63,7 @@ func runMachineExec(ctx context.Context) (err error) {
 		command = args[0]
 	}
 
-	current, ctx, err := selectOneMachine(ctx, nil, machineID, haveMachineID)
+	current, ctx, err := selectOneMachine(ctx, "", machineID, haveMachineID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/kill.go
+++ b/internal/command/machine/kill.go
@@ -41,7 +41,7 @@ func runMachineKill(ctx context.Context) (err error) {
 
 	machineID := flag.FirstArg(ctx)
 	haveMachineID := len(flag.Args(ctx)) > 0
-	current, ctx, err := selectOneMachine(ctx, nil, machineID, haveMachineID)
+	current, ctx, err := selectOneMachine(ctx, "", machineID, haveMachineID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/select.go
+++ b/internal/command/machine/select.go
@@ -24,14 +24,14 @@ var selectFlag = flag.Bool{
 	Hidden:      true,
 }
 
-func selectOneMachine(ctx context.Context, app *api.AppCompact, machineID string, haveMachineID bool) (*api.Machine, context.Context, error) {
+func selectOneMachine(ctx context.Context, appName string, machineID string, haveMachineID bool) (*api.Machine, context.Context, error) {
 	if err := checkSelectConditions(ctx, haveMachineID); err != nil {
 		return nil, nil, err
 	}
 
 	var err error
-	if app != nil {
-		ctx, err = buildContextFromApp(ctx, app)
+	if appName != "" {
+		ctx, err = buildContextFromAppName(ctx, appName)
 	} else {
 		ctx, err = buildContextFromAppNameOrMachineID(ctx, machineID)
 	}
@@ -114,8 +114,8 @@ func selectManyMachineIDs(ctx context.Context, machineIDs []string) ([]string, c
 	return machineIDs, ctx, nil
 }
 
-func buildContextFromApp(ctx context.Context, app *api.AppCompact) (context.Context, error) {
-	flapsClient, err := flaps.New(ctx, app)
+func buildContextFromAppName(ctx context.Context, appName string) (context.Context, error) {
+	flapsClient, err := flaps.NewFromAppName(ctx, appName)
 	if err != nil {
 		return nil, fmt.Errorf("could not create flaps client: %w", err)
 	}

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -58,7 +58,7 @@ func runMachineStatus(ctx context.Context) (err error) {
 
 	machineID := flag.FirstArg(ctx)
 	haveMachineID := len(flag.Args(ctx)) > 0
-	machine, ctx, err := selectOneMachine(ctx, nil, machineID, haveMachineID)
+	machine, ctx, err := selectOneMachine(ctx, "", machineID, haveMachineID)
 	if err != nil {
 		return err
 	}

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -82,7 +82,7 @@ func runUpdate(ctx context.Context) (err error) {
 
 	machineID := flag.FirstArg(ctx)
 	haveMachineID := len(flag.Args(ctx)) > 0
-	machine, ctx, err := selectOneMachine(ctx, nil, machineID, haveMachineID)
+	machine, ctx, err := selectOneMachine(ctx, "", machineID, haveMachineID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Change Summary

No need to rely on app platform version anylonger, we can avoid GQL roundtrips to grab it.

Related to: #3231 

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
