### PR TITLE
Toggle volume AutoBackupEnabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
-	github.com/superfly/fly-go v0.0.0-20240215193014-b45ae6e6b02c
+	github.com/superfly/fly-go v0.0.0-20240216135825-98eaf7a53661
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.10

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
-	github.com/superfly/fly-go v0.0.0-20240216135825-98eaf7a53661
+	github.com/superfly/fly-go v0.0.0-20240216161738-ca39fa12b183
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.10

--- a/go.sum
+++ b/go.sum
@@ -576,8 +576,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.0.0-20240216135825-98eaf7a53661 h1:yVsammRmHaMwCTwHkSDHMr54VDFlslWxF4ydxUe7iNw=
-github.com/superfly/fly-go v0.0.0-20240216135825-98eaf7a53661/go.mod h1:Mb+y+hXfEKzJ5guQyA/lAhyQqXWHiKULFu/4A5Ehink=
+github.com/superfly/fly-go v0.0.0-20240216161738-ca39fa12b183 h1:qHPTNfw83l27Xs4y69r97+Jnzd75sl5dCqHdFS/FHsc=
+github.com/superfly/fly-go v0.0.0-20240216161738-ca39fa12b183/go.mod h1:Mb+y+hXfEKzJ5guQyA/lAhyQqXWHiKULFu/4A5Ehink=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/go.sum
+++ b/go.sum
@@ -578,6 +578,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/fly-go v0.0.0-20240215193014-b45ae6e6b02c h1:S67UpSXmov8BgU0l6mA/VcxiJzCR4PKZN5JP+NjIN08=
 github.com/superfly/fly-go v0.0.0-20240215193014-b45ae6e6b02c/go.mod h1:Mb+y+hXfEKzJ5guQyA/lAhyQqXWHiKULFu/4A5Ehink=
+github.com/superfly/fly-go v0.0.0-20240216135825-98eaf7a53661 h1:yVsammRmHaMwCTwHkSDHMr54VDFlslWxF4ydxUe7iNw=
+github.com/superfly/fly-go v0.0.0-20240216135825-98eaf7a53661/go.mod h1:Mb+y+hXfEKzJ5guQyA/lAhyQqXWHiKULFu/4A5Ehink=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/go.sum
+++ b/go.sum
@@ -576,8 +576,6 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.0.0-20240215193014-b45ae6e6b02c h1:S67UpSXmov8BgU0l6mA/VcxiJzCR4PKZN5JP+NjIN08=
-github.com/superfly/fly-go v0.0.0-20240215193014-b45ae6e6b02c/go.mod h1:Mb+y+hXfEKzJ5guQyA/lAhyQqXWHiKULFu/4A5Ehink=
 github.com/superfly/fly-go v0.0.0-20240216135825-98eaf7a53661 h1:yVsammRmHaMwCTwHkSDHMr54VDFlslWxF4ydxUe7iNw=
 github.com/superfly/fly-go v0.0.0-20240216135825-98eaf7a53661/go.mod h1:Mb+y+hXfEKzJ5guQyA/lAhyQqXWHiKULFu/4A5Ehink=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=

--- a/internal/command/volumes/update.go
+++ b/internal/command/volumes/update.go
@@ -89,9 +89,9 @@ func runUpdate(ctx context.Context) error {
 	}
 
 	if flag.GetString(ctx, "scheduled-snapshots") == "true" {
-		input.AutoBackupEnabled = api.BoolPointer(true)
+		input.AutoBackupEnabled = fly.BoolPointer(true)
 	} else if flag.GetString(ctx, "scheduled-snapshots") == "false" {
-		input.AutoBackupEnabled = api.BoolPointer(false)
+		input.AutoBackupEnabled = fly.BoolPointer(false)
 	} else if flag.GetString(ctx, "scheduled-snapshots") != "" {
 		return fmt.Errorf("--scheduled-snapshots=VALUE must be either `true` or `false`")
 	}

--- a/internal/command/volumes/update.go
+++ b/internal/command/volumes/update.go
@@ -41,9 +41,9 @@ func newUpdate() *cobra.Command {
 			Name:        "snapshot-retention",
 			Description: "Snapshot retention in days (min 5)",
 		},
-		flag.String{
+		flag.Bool{
 			Name:        "scheduled-snapshots",
-			Description: "Disable/Enable scheduled snapshots. --scheduled-snapshots=(true/false)",
+			Description: "Disable/Enable scheduled snapshots",
 		},
 	)
 
@@ -88,12 +88,8 @@ func runUpdate(ctx context.Context) error {
 		SnapshotRetention: snapshotRetention,
 	}
 
-	if flag.GetString(ctx, "scheduled-snapshots") == "true" {
-		input.AutoBackupEnabled = fly.BoolPointer(true)
-	} else if flag.GetString(ctx, "scheduled-snapshots") == "false" {
-		input.AutoBackupEnabled = fly.BoolPointer(false)
-	} else if flag.GetString(ctx, "scheduled-snapshots") != "" {
-		return fmt.Errorf("--scheduled-snapshots=VALUE must be either `true` or `false`")
+	if flag.IsSpecified(ctx, "scheduled-snapshots") {
+		input.AutoBackupEnabled = fly.BoolPointer(flag.GetBool(ctx, "scheduled-snapshots"))
 	}
 
 	updatedVolume, err := flapsClient.UpdateVolume(ctx, volumeID, input)

--- a/internal/command/volumes/update.go
+++ b/internal/command/volumes/update.go
@@ -41,6 +41,10 @@ func newUpdate() *cobra.Command {
 			Name:        "snapshot-retention",
 			Description: "Snapshot retention in days (min 5)",
 		},
+		flag.Bool{
+			Name:        "auto-backup-enabled",
+			Description: "Disable/Enable scheduled snapshots",
+		},
 	)
 
 	flag.Add(cmd, flag.JSONOutput())
@@ -79,9 +83,15 @@ func runUpdate(ctx context.Context) error {
 		snapshotRetention = fly.Pointer(flag.GetInt(ctx, "snapshot-retention"))
 	}
 
+	var autoBackupEnabled *bool
+	if flag.GetInt(ctx, "snapshot-retention") != 0 {
+		autoBackupEnabled = api.Pointer(flag.GetBool(ctx, "auto-backup-enabled"))
+	}
+
 	out := iostreams.FromContext(ctx).Out
 	input := fly.UpdateVolumeRequest{
 		SnapshotRetention: snapshotRetention,
+		AutoBackupEnabled: autoBackupEnabled,
 	}
 
 	updatedVolume, err := flapsClient.UpdateVolume(ctx, volumeID, input)

--- a/internal/command/volumes/volumes.go
+++ b/internal/command/volumes/volumes.go
@@ -63,6 +63,7 @@ func printVolume(w io.Writer, vol *fly.Volume, appName string) error {
 	fmt.Fprintf(&buf, "%20s: %t\n", "Encrypted", vol.Encrypted)
 	fmt.Fprintf(&buf, "%20s: %s\n", "Created at", vol.CreatedAt.Format(time.RFC822))
 	fmt.Fprintf(&buf, "%20s: %d\n", "Snapshot retention", vol.SnapshotRetention)
+	fmt.Fprintf(&buf, "%20s: %t\n", "Scheduled snapshots", vol.AutoBackupEnabled)
 
 	_, err := buf.WriteTo(w)
 


### PR DESCRIPTION
### Change Summary

What and Why: You can set AutoBackupEnabled when creating a volume (via API) but you can't do anything through flyctl.

How: Updating flaps to enable toggling

Related to: Internal PRs

---

### Documentation

Soon ™️ (building this PR to use the updated API)

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
