### PR TITLE
force git tag clobbering

### DIFF
--- a/tools/version/relmeta/repo.go
+++ b/tools/version/relmeta/repo.go
@@ -148,7 +148,7 @@ func (r *gitRepo) gitDirty() (bool, error) {
 
 func (r *gitRepo) RefreshTags() error {
 	originName := "origin"
-	_, err := r.runGit("fetch", "--tags", originName)
+	_, err := r.runGit("fetch", "--tags", "--force", originName)
 	return err
 }
 


### PR DESCRIPTION
### Change Summary

Fix pre-release build pipeline by forcing tag clobbering

<img width="705" alt="image" src="https://github.com/superfly/flyctl/assets/37369/3cd43298-b24a-4d28-9992-0759a26ac7c0">

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
