### PR TITLE
Extract and show toml decode errors.

### DIFF
--- a/internal/appconfig/serde.go
+++ b/internal/appconfig/serde.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -107,6 +108,11 @@ func (c *Config) marshalTOML() ([]byte, error) {
 func unmarshalTOML(buf []byte) (*Config, error) {
 	cfgMap := map[string]any{}
 	if err := toml.Unmarshal(buf, &cfgMap); err != nil {
+		var derr *toml.DecodeError
+		if errors.As(err, &derr) {
+			row, col := derr.Position()
+			return nil, fmt.Errorf("row %d column %d\n%s", row, col, derr.String())
+		}
 		return nil, err
 	}
 	cfg, err := applyPatches(cfgMap)


### PR DESCRIPTION
See: https://github.com/pelletier/go-toml?tab=readme-ov-file#contextualized-errors

Adapted from:

https://github.com/pelletier/go-toml/blob/2e087bdf5f676bd8c3cf0ea9ed3e8bf1fdc6a72c/cmd/tomljson/main.go#L51-L58

---

Example output.  Before:

```
% fly machine list
Error: failed loading app config from /Users/rubys/git/showcase/fly.toml: toml: expected character =
```

After:

```
% ~/git/flyctl/bin/flyctl machine list
Error: failed loading app config from /Users/rubys/git/showcase/fly.toml: row 4 column 3
1| # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
2| #
3|
4| x app = "smooth"
 |   ~ expected character =
5| primary_region = "iad"
6| swap_size_mb = 2048
7|
```