### PR TITLE
track gpu and cpu kinds for deployments

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -213,6 +213,19 @@ func run(ctx context.Context) error {
 		return err
 	}
 
+	gpuKinds := []string{}
+	for _, compute := range appConfig.Compute {
+		gpuKinds = append(gpuKinds, compute.GPUKind)
+	}
+
+	cpuKinds := []string{}
+	for _, compute := range appConfig.Compute {
+		cpuKinds = append(cpuKinds, compute.CPUKind)
+	}
+
+	span.SetAttributes(attribute.StringSlice("gpu.kinds", gpuKinds))
+	span.SetAttributes(attribute.StringSlice("cpu.kinds", cpuKinds))
+
 	return DeployWithConfig(ctx, appConfig, flag.GetYes(ctx), nil)
 }
 


### PR DESCRIPTION
### Change Summary
Allow us to group deployments by CPU and GPU kinds

