### PR TITLE
Add file-local, file-literal, and file-secret flags.

### DIFF
--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -135,6 +135,18 @@ func New() *cobra.Command {
 			Default:     true,
 			Hidden:      true,
 		},
+		flag.StringArray{
+			Name:        "file-local",
+			Description: "Set of files to write to the Machine, in the form of /path/inside/machine=<local/path> pairs. Can be specified multiple times.",
+		},
+		flag.StringArray{
+			Name:        "file-literal",
+			Description: "Set of literals to write to the Machine, in the form of /path/inside/machine=VALUE pairs, where VALUE is the base64-encoded raw content. Can be specified multiple times.",
+		},
+		flag.StringArray{
+			Name:        "file-secret",
+			Description: "Set of secrets to write to the Machine, in the form of /path/inside/machine=SECRET pairs, where SECRET is the name of the secret. The content of the secret must be base64 encoded. Can be specified multiple times.",
+		},
 		flag.VMSizeFlags,
 	)
 


### PR DESCRIPTION
The code is already in place to implement these options:

https://github.com/superfly/flyctl/blob/8f631803e7d17e2d135216b1dda9242f0f15a371/internal/command/console/console.go#L337-L341