### PR TITLE
Sort extension secrets by key

### DIFF
--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -455,15 +455,18 @@ func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *E
 		setSecrets = false
 	}
 
+	keys := lo.Keys(secrets)
+	sort.Strings(keys)
+
 	if setSecrets {
 		extension.SetsSecrets = true
 		fmt.Fprintf(io.Out, "Setting the following secrets on %s:\n", app.Name)
 		input := gql.SetSecretsInput{
 			AppId: app.Id,
 		}
-		for key, value := range secrets {
-			input.Secrets = append(input.Secrets, gql.SecretInput{Key: key, Value: value.(string)})
-			fmt.Println(key)
+		for _, key := range keys {
+			input.Secrets = append(input.Secrets, gql.SecretInput{Key: key, Value: secrets[key].(string)})
+			fmt.Fprintln(io.Out, key)
 		}
 
 		fmt.Fprintln(io.Out)
@@ -475,9 +478,6 @@ func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *E
 		}
 	} else {
 		fmt.Fprintf(io.Out, "Set the following secrets on your target app.\n")
-
-		keys := lo.Keys(secrets)
-		sort.Strings(keys)
 
 		for _, key := range keys {
 			fmt.Fprintf(io.Out, "%s: %s\n", key, secrets[key].(string))

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"sort"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -472,12 +473,19 @@ func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *E
 			return err
 		}
 	} else {
-		fmt.Fprintf(io.Out, "Set one or more of the following secrets on your target app.\n")
-		for key, value := range secrets {
-			fmt.Println(key + ": " + value.(string))
-		}
-	}
+		fmt.Fprintf(io.Out, "Set the following secrets on your target app.\n")
+		var keys []string
 
+		for key := range secrets {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			fmt.Println(key + ": " + secrets[key].(string))
+		}
+
+	}
 	return err
 }
 

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/samber/lo"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/superfly/flyctl/api"
 	"github.com/superfly/flyctl/client"
@@ -474,15 +475,12 @@ func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *E
 		}
 	} else {
 		fmt.Fprintf(io.Out, "Set the following secrets on your target app.\n")
-		var keys []string
 
-		for key := range secrets {
-			keys = append(keys, key)
-		}
+		keys := lo.Keys(secrets)
 		sort.Strings(keys)
 
 		for _, key := range keys {
-			fmt.Println(key + ": " + secrets[key].(string))
+			fmt.Fprintf(io.Out, "%s: %s\n", key, secrets[key].(string))
 		}
 
 	}


### PR DESCRIPTION
Extension secrets should always show up in the same order. For now, that will be alphabetical.

Based on feedback from this article: https://benhoyt.com/writings/flyio-and-tigris/?moving

