### PR TITLE
Remove fly-go client package

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -19,7 +19,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/agent/internal/proto"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/buildinfo"
@@ -501,8 +500,7 @@ func arrayEqual(a, b []string) bool {
 }
 
 func gqlGetInstances(ctx context.Context, orgSlug, appName string) instancesResult {
-	flyClient := client.FromContext(ctx)
-	gqlClient := flyClient.API().GenqClient
+	gqlClient := api.ClientFromContext(ctx).GenqClient
 	_ = `# @genqlient
 	query AgentGetInstances($appName: String!) {
 		app(name: $appName) {

--- a/flypg/cmd.go
+++ b/flypg/cmd.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/command/ssh"
 	"github.com/superfly/flyctl/internal/flag"
@@ -32,7 +31,7 @@ type Command struct {
 }
 
 func NewCommand(ctx context.Context, app *api.AppCompact) (*Command, error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	agentclient, err := agent.Establish(ctx, client)
 	if err != nil {

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -9,7 +9,6 @@ import (
 	"github.com/superfly/flyctl/ssh"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/flapsutil"
@@ -67,7 +66,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 	var (
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
-		client   = client.FromContext(ctx).API()
+		client   = api.ClientFromContext(ctx)
 	)
 
 	// Ensure machines can be started when scaling to zero is enabled

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
-	github.com/superfly/fly-go v0.0.0-20240214205541-ecdc587e2e86
+	github.com/superfly/fly-go v0.0.0-20240214220226-766b16e140d3
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.10

--- a/go.sum
+++ b/go.sum
@@ -576,8 +576,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.0.0-20240214205541-ecdc587e2e86 h1:6S/rzeDE9ZUnrW3G9tFjPLCydJWlObxBWz21O2o+ibA=
-github.com/superfly/fly-go v0.0.0-20240214205541-ecdc587e2e86/go.mod h1:Mb+y+hXfEKzJ5guQyA/lAhyQqXWHiKULFu/4A5Ehink=
+github.com/superfly/fly-go v0.0.0-20240214220226-766b16e140d3 h1:jKQBnVfFPcYA+BBoz+JLBWqYTV5jRmc+hFMHDT5/JF0=
+github.com/superfly/fly-go v0.0.0-20240214220226-766b16e140d3/go.mod h1:Mb+y+hXfEKzJ5guQyA/lAhyQqXWHiKULFu/4A5Ehink=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/appconfig/remote.go
+++ b/internal/appconfig/remote.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/machine"
@@ -13,7 +12,7 @@ import (
 )
 
 func FromRemoteApp(ctx context.Context, appName string) (*Config, error) {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	cfg, err := getAppV2ConfigFromReleases(ctx, apiClient, appName)
 	if cfg == nil {

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -18,7 +18,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	dockerclient "github.com/docker/docker/client"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/config"
@@ -310,7 +309,7 @@ func (r *Resolver) createBuildGql(ctx context.Context, strategiesAvailable []str
 	ctx, span := tracing.GetTracer().Start(ctx, "web.create_build")
 	defer span.End()
 
-	gqlClient := client.FromContext(ctx).API().GenqClient
+	gqlClient := api.ClientFromContext(ctx).GenqClient
 	_ = `# @genqlient
 	mutation ResolverCreateBuild($input:CreateBuildInput!) {
 		createBuild(input:$input) {
@@ -513,7 +512,7 @@ func (r *Resolver) finishBuild(ctx context.Context, build *build, failed bool, l
 		terminal.Debug("Skipping FinishBuild() gql call, because CreateBuild() failed.\n")
 		return nil, nil
 	}
-	gqlClient := client.FromContext(ctx).API().GenqClient
+	gqlClient := api.ClientFromContext(ctx).GenqClient
 	_ = `# @genqlient
 	mutation ResolverFinishBuild($input:FinishBuildInput!) {
 		finishBuild(input:$input) {

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/config"
@@ -63,14 +62,14 @@ func InitClient(ctx context.Context) (context.Context, error) {
 	api.SetInstrumenter(instrument.ApiAdapter)
 	api.SetTransport(otelhttp.NewTransport(http.DefaultTransport))
 
-	c := client.NewClientWithOptions(&client.NewClientOpts{
-		Tokens:        cfg.Tokens,
-		ClientName:    buildinfo.Name(),
-		ClientVersion: buildinfo.Version().String(),
+	c := api.NewClientFromOptions(api.ClientOptions{
+		Name:    buildinfo.Name(),
+		Version: buildinfo.Version().String(),
+		Tokens:  cfg.Tokens,
 	})
 	logger.Debug("client initialized.")
 
-	return client.NewContext(ctx, c), nil
+	return api.NewContextWithClient(ctx, c), nil
 }
 
 func DetermineConfigDir(ctx context.Context) (context.Context, error) {

--- a/internal/command/agent/agent.go
+++ b/internal/command/agent/agent.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/agent"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/state"
@@ -48,7 +48,7 @@ func New() (cmd *cobra.Command) {
 }
 
 func establish(ctx context.Context) (ac *agent.Client, err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	if ac, err = agent.Establish(ctx, client); err != nil {
 		err = fmt.Errorf("failed establishing connection to agent: %w", err)

--- a/internal/command/agent/instances.go
+++ b/internal/command/agent/instances.go
@@ -10,7 +10,6 @@ import (
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/iostreams"
 
-	apiClient "github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
@@ -39,7 +38,7 @@ func runInstances(ctx context.Context) (err error) {
 	}
 
 	slug := flag.FirstArg(ctx)
-	apiClient := apiClient.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	var org *api.Organization
 	if org, err = apiClient.GetOrganizationBySlug(ctx, slug); err != nil {

--- a/internal/command/agent/run.go
+++ b/internal/command/agent/run.go
@@ -11,10 +11,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/agent/server"
 	"github.com/superfly/flyctl/flyctl"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/filemu"
 	"github.com/superfly/flyctl/internal/flag"
@@ -46,11 +46,10 @@ func run(ctx context.Context) error {
 	}
 	defer closeLogger()
 
-	apiClient := client.FromContext(ctx)
+	apiClient := api.ClientFromContext(ctx)
 	if !apiClient.Authenticated() {
-		logger.Println(client.ErrNoAuthToken)
-
-		return client.ErrNoAuthToken
+		logger.Println(api.ErrNoAuthToken)
+		return api.ErrNoAuthToken
 	}
 
 	unlock, err := lock(ctx, logger)
@@ -62,7 +61,7 @@ func run(ctx context.Context) error {
 	opt := server.Options{
 		Socket:           socketPath(ctx),
 		Logger:           logger,
-		Client:           apiClient.API(),
+		Client:           apiClient,
 		Background:       logPath != "",
 		ConfigFile:       state.ConfigFile(ctx),
 		ConfigWebsockets: viper.GetBool(flyctl.ConfigWireGuardWebsockets),

--- a/internal/command/apps/apps.go
+++ b/internal/command/apps/apps.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/command"
@@ -49,7 +48,7 @@ The LIST command will list all currently registered applications.
 
 // BuildContext is a helper that builds out commonly required context requirements
 func BuildContext(ctx context.Context, app *api.AppCompact) (context.Context, error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	agentclient, err := agent.Establish(ctx, client)
 	if err != nil {

--- a/internal/command/apps/create.go
+++ b/internal/command/apps/create.go
@@ -10,7 +10,6 @@ import (
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -69,7 +68,7 @@ func RunCreate(ctx context.Context) (err error) {
 		aName         = flag.FirstArg(ctx)
 		fName         = flag.GetString(ctx, "name")
 		fGenerateName = flag.GetBool(ctx, "generate-name")
-		apiClient     = client.FromContext(ctx).API()
+		apiClient     = api.ClientFromContext(ctx)
 	)
 
 	var name string

--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/flag/completion"
 
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/prompt"
@@ -44,7 +44,7 @@ func RunDestroy(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
 	appName := flag.FirstArg(ctx)
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	if !flag.GetYes(ctx) {
 		const msg = "Destroying an app is not reversible."

--- a/internal/command/apps/list.go
+++ b/internal/command/apps/list.go
@@ -10,7 +10,6 @@ import (
 	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -40,7 +39,7 @@ be shown with its name, owner and when it was last deployed.
 }
 
 func runList(ctx context.Context) (err error) {
-	client := client.FromContext(ctx)
+	client := api.ClientFromContext(ctx)
 	cfg := config.FromContext(ctx)
 	org, err := getOrg(ctx)
 	if err != nil {
@@ -49,9 +48,9 @@ func runList(ctx context.Context) (err error) {
 
 	var apps []api.App
 	if org != nil {
-		apps, err = client.API().GetAppsForOrganization(ctx, org.ID)
+		apps, err = client.GetAppsForOrganization(ctx, org.ID)
 	} else {
-		apps, err = client.API().GetApps(ctx, nil)
+		apps, err = client.GetApps(ctx, nil)
 	}
 
 	if err != nil {
@@ -65,7 +64,7 @@ func runList(ctx context.Context) (err error) {
 		return
 	}
 
-	var verbose = flag.GetBool(ctx, "verbose")
+	verbose := flag.GetBool(ctx, "verbose")
 
 	rows := make([][]string, 0, len(apps))
 	for _, app := range apps {
@@ -92,7 +91,7 @@ func runList(ctx context.Context) (err error) {
 }
 
 func getOrg(ctx context.Context) (*api.Organization, error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	orgName := flag.GetOrg(ctx)
 

--- a/internal/command/apps/move.go
+++ b/internal/command/apps/move.go
@@ -8,7 +8,6 @@ import (
 	"github.com/superfly/flyctl/internal/flag/completion"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/logger"
@@ -51,7 +50,7 @@ organization the current user belongs to.
 func RunMove(ctx context.Context) error {
 	var (
 		appName  = flag.FirstArg(ctx)
-		client   = client.FromContext(ctx).API()
+		client   = api.ClientFromContext(ctx)
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
 		logger   = logger.FromContext(ctx)
@@ -96,7 +95,7 @@ Please confirm whether you wish to restart this app now.`
 
 func runMoveAppOnMachines(ctx context.Context, app *api.AppCompact, targetOrg *api.Organization) error {
 	var (
-		client           = client.FromContext(ctx).API()
+		client           = api.ClientFromContext(ctx)
 		io               = iostreams.FromContext(ctx)
 		skipHealthChecks = flag.GetBool(ctx, "skip-health-checks")
 	)

--- a/internal/command/apps/releases.go
+++ b/internal/command/apps/releases.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
@@ -50,7 +49,7 @@ including type, when, success/fail and which user triggered the release.
 func runReleases(ctx context.Context) error {
 	var (
 		appName = appconfig.NameFromContext(ctx)
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 		out     = iostreams.FromContext(ctx).Out
 	)
 

--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -52,7 +51,7 @@ func newRestart() *cobra.Command {
 func runRestart(ctx context.Context) error {
 	var (
 		appName = flag.FirstArg(ctx)
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 	)
 
 	if appName == "" {

--- a/internal/command/auth/login.go
+++ b/internal/command/auth/login.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/command"
@@ -82,11 +81,11 @@ func runLogin(ctx context.Context) error {
 		return err
 	}
 
-	user, err := client.NewClientWithOptions(&client.NewClientOpts{
-		Token:         token,
-		ClientName:    buildinfo.Name(),
-		ClientVersion: buildinfo.Version().String(),
-	}).API().GetCurrentUser(ctx)
+	user, err := api.NewClientFromOptions(api.ClientOptions{
+		AccessToken: token,
+		Name:        buildinfo.Name(),
+		Version:     buildinfo.Version().String(),
+	}).GetCurrentUser(ctx)
 	if err != nil {
 		return fmt.Errorf("failed retrieving current user: %w", err)
 	}

--- a/internal/command/auth/logout.go
+++ b/internal/command/auth/logout.go
@@ -6,16 +6,15 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/gql"
-	"github.com/superfly/flyctl/iostreams"
-
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/state"
+	"github.com/superfly/flyctl/iostreams"
 )
 
 func newLogout() *cobra.Command {
@@ -32,8 +31,8 @@ To continue interacting with Fly, the user will need to log in again.
 func runLogout(ctx context.Context) (err error) {
 	log := logger.FromContext(ctx)
 
-	if c := client.FromContext(ctx); c.Authenticated() {
-		resp, err := gql.LogOut(ctx, c.API().GenqClient)
+	if c := api.ClientFromContext(ctx); c.Authenticated() {
+		resp, err := gql.LogOut(ctx, c.GenqClient)
 		if err != nil || !resp.LogOut.Ok {
 			log.Warnf("Unable to revoke token")
 		}

--- a/internal/command/auth/signup.go
+++ b/internal/command/auth/signup.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/iostreams"
@@ -33,11 +33,11 @@ func runSignup(ctx context.Context) error {
 		return err
 	}
 
-	user, err := client.NewClientWithOptions(&client.NewClientOpts{
-		Token:         token,
-		ClientName:    buildinfo.Name(),
-		ClientVersion: buildinfo.Version().String(),
-	}).API().GetCurrentUser(ctx)
+	user, err := api.NewClientFromOptions(api.ClientOptions{
+		AccessToken: token,
+		Name:        buildinfo.Name(),
+		Version:     buildinfo.Version().String(),
+	}).GetCurrentUser(ctx)
 	if err != nil {
 		return fmt.Errorf("failed retrieving current user: %w", err)
 	}

--- a/internal/command/auth/whoami.go
+++ b/internal/command/auth/whoami.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -30,7 +30,7 @@ authenticated and in use.
 }
 
 func runWhoAmI(ctx context.Context) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	user, err := client.GetCurrentUser(ctx)
 	if err != nil {

--- a/internal/command/certificates/root.go
+++ b/internal/command/certificates/root.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
@@ -138,7 +137,7 @@ Displays results in the same format as the SHOW command.`
 
 func runCertificatesList(ctx context.Context) error {
 	appName := appconfig.NameFromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	certs, err := apiClient.GetAppCertificates(ctx, appName)
 	if err != nil {
@@ -149,7 +148,7 @@ func runCertificatesList(ctx context.Context) error {
 }
 
 func runCertificatesShow(ctx context.Context) error {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	hostname := flag.FirstArg(ctx)
 
@@ -168,7 +167,7 @@ func runCertificatesShow(ctx context.Context) error {
 }
 
 func runCertificatesCheck(ctx context.Context) error {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	hostname := flag.FirstArg(ctx)
 
@@ -187,7 +186,7 @@ func runCertificatesCheck(ctx context.Context) error {
 }
 
 func runCertificatesAdd(ctx context.Context) error {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	hostname := flag.FirstArg(ctx)
 
@@ -202,7 +201,7 @@ func runCertificatesAdd(ctx context.Context) error {
 func runCertificatesRemove(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	hostname := flag.FirstArg(ctx)
 
@@ -242,7 +241,7 @@ func reportNextStepCert(ctx context.Context, hostname string, cert *api.AppCerti
 
 	colorize := io.ColorScheme()
 	appName := appconfig.NameFromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	alternateHostname := getAlternateHostname(hostname)
 
 	// These are the IPs we have for the app

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/fly-go/api/tokens"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/cache"
@@ -499,8 +499,8 @@ func ExcludeFromMetrics(ctx context.Context) (context.Context, error) {
 
 // RequireSession is a Preparer which makes sure a session exists.
 func RequireSession(ctx context.Context) (context.Context, error) {
-	if !client.FromContext(ctx).Authenticated() {
-		return nil, client.ErrNoAuthToken
+	if !api.ClientFromContext(ctx).Authenticated() {
+		return nil, api.ErrNoAuthToken
 	}
 
 	return updateMacaroons(ctx)
@@ -517,7 +517,6 @@ func updateMacaroons(ctx context.Context) (context.Context, error) {
 		tokens.WithUserURLCallback(tryOpenUserURL),
 		tokens.WithDebugger(log),
 	)
-
 	if err != nil {
 		log.Warn("Failed to upgrade authentication token. Command may fail.")
 		log.Debug(err)

--- a/internal/command/command_run.go
+++ b/internal/command/command_run.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/iostreams"
 	"golang.org/x/exp/slices"
@@ -31,7 +30,7 @@ import (
 
 func DetermineImage(ctx context.Context, appName string, imageOrPath string) (img *imgsrc.DeploymentImage, err error) {
 	var (
-		client = client.FromContext(ctx).API()
+		client = api.ClientFromContext(ctx)
 		io     = iostreams.FromContext(ctx)
 		cfg    = appconfig.ConfigFromContext(ctx)
 	)
@@ -370,7 +369,7 @@ func DetermineMounts(ctx context.Context, mounts []api.MachineMount, region stri
 }
 
 func getUnattachedVolumes(ctx context.Context, regionCode string) (map[string][]api.Volume, error) {
-	apiclient := client.FromContext(ctx).API()
+	apiclient := api.ClientFromContext(ctx)
 	flapsClient := flaps.FromContext(ctx)
 
 	if regionCode == "" {

--- a/internal/command/config/env.go
+++ b/internal/command/config/env.go
@@ -6,7 +6,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -32,7 +31,7 @@ secrets and another for config file defined environment variables.`
 }
 
 func runEnv(ctx context.Context) error {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/cmdutil"
@@ -158,7 +157,7 @@ func runConsole(ctx context.Context) error {
 	var (
 		io        = iostreams.FromContext(ctx)
 		appName   = appconfig.NameFromContext(ctx)
-		apiClient = client.FromContext(ctx).API()
+		apiClient = api.ClientFromContext(ctx)
 	)
 
 	app, err := apiClient.GetAppCompact(ctx, appName)
@@ -303,7 +302,7 @@ func getMachineByID(ctx context.Context) (*api.Machine, func(), error) {
 }
 
 func makeEphemeralConsoleMachine(ctx context.Context, app *api.AppCompact, appConfig *appconfig.Config, guest *api.MachineGuest) (*api.Machine, func(), error) {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	currentRelease, err := apiClient.GetAppCurrentReleaseMachines(ctx, app.Name)
 	if err != nil {
 		return nil, nil, err

--- a/internal/command/consul/attach.go
+++ b/internal/command/consul/attach.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/secrets"
@@ -40,7 +40,7 @@ func newAttach() *cobra.Command {
 
 func runAttach(ctx context.Context) error {
 	var (
-		apiClient  = client.FromContext(ctx).API()
+		apiClient  = api.ClientFromContext(ctx)
 		appName    = appconfig.NameFromContext(ctx)
 		secretName = flag.GetString(ctx, "variable-name")
 	)

--- a/internal/command/consul/detach.go
+++ b/internal/command/consul/detach.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/secrets"
@@ -36,7 +36,7 @@ func newDetach() *cobra.Command {
 
 func runDetach(ctx context.Context) error {
 	var (
-		apiClient  = client.FromContext(ctx).API()
+		apiClient  = api.ClientFromContext(ctx)
 		appName    = appconfig.NameFromContext(ctx)
 		secretName = flag.GetString(ctx, "variable-name")
 	)

--- a/internal/command/curl/curl.go
+++ b/internal/command/curl/curl.go
@@ -19,7 +19,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -77,7 +76,7 @@ func run(ctx context.Context) error {
 }
 
 func fetchRegionCodes(ctx context.Context) (codes []string, err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	var regions []api.Region
 	if regions, _, err = client.PlatformRegions(ctx); err != nil {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -10,7 +10,6 @@ import (
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
@@ -194,7 +193,7 @@ func run(ctx context.Context) error {
 	}
 	ctx = flaps.NewContext(ctx, flapsClient)
 
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	ctx, span := tracing.CMDSpan(ctx, appName, "cmd.deploy")
 	defer span.End()
@@ -231,7 +230,7 @@ func run(ctx context.Context) error {
 func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes bool) (err error) {
 	io := iostreams.FromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	appCompact, err := apiClient.GetAppCompact(ctx, appName)
 	if err != nil {
 		return err

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/dustin/go-humanize"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
 	"github.com/superfly/flyctl/internal/cmdutil"
@@ -55,7 +55,7 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgs
 	tb := render.NewTextBlock(ctx, "Building image")
 	daemonType := imgsrc.NewDockerDaemonType(!flag.GetRemoteOnly(ctx), !flag.GetLocalOnly(ctx), env.IsCI(), flag.GetBool(ctx, "nixpacks"))
 
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 
 	span.SetAttributes(attribute.String("daemon_type", daemonType.String()))

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -14,7 +14,6 @@ import (
 	"github.com/morikuni/aec"
 	"github.com/samber/lo"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -181,7 +180,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	}
 
 	io := iostreams.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	maxUnavailable := DefaultMaxUnavailable
 	if appConfig.Deploy != nil && appConfig.Deploy.MaxUnavailable != nil {

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -17,7 +17,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/sourcegraph/conc/pool"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/helpers"
 	machcmd "github.com/superfly/flyctl/internal/command/machine"
@@ -1040,7 +1039,7 @@ func (md *machineDeployment) checkDNS(ctx context.Context) error {
 	ctx, span := tracing.GetTracer().Start(ctx, "check_dns")
 	defer span.End()
 
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	ipAddrs, err := client.GetIPAddresses(ctx, md.appConfig.AppName)
 	if err != nil {
 		tracing.RecordError(span, err, "failed to get ip addresses")

--- a/internal/command/dig/dig.go
+++ b/internal/command/dig/dig.go
@@ -14,10 +14,10 @@ import (
 	"github.com/miekg/dns"
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -63,7 +63,7 @@ attached to the current app (you can pass an app in with -a <appname>).`
 
 func run(ctx context.Context) error {
 	var (
-		client = client.FromContext(ctx).API()
+		client = api.ClientFromContext(ctx)
 		io     = iostreams.FromContext(ctx)
 
 		err error

--- a/internal/command/dnsrecords/root.go
+++ b/internal/command/dnsrecords/root.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -78,7 +78,7 @@ func newDNSRecordsImport() *cobra.Command {
 
 func runDNSRecordsList(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	name := flag.FirstArg(ctx)
 
@@ -117,7 +117,7 @@ func runDNSRecordsList(ctx context.Context) error {
 
 func runDNSRecordsExport(ctx context.Context) error {
 	name := flag.FirstArg(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	domain, err := apiClient.GetDomain(ctx, name)
 	if err != nil {
@@ -153,7 +153,7 @@ func runDNSRecordsExport(ctx context.Context) error {
 
 func runDNSRecordsImport(ctx context.Context) error {
 	name := flag.FirstArg(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	var filename string
 

--- a/internal/command/doctor/app_checks.go
+++ b/internal/command/doctor/app_checks.go
@@ -12,7 +12,6 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/miekg/dns"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
@@ -41,7 +40,7 @@ func NewAppChecker(ctx context.Context, jsonOutput bool, color *iostreams.ColorS
 		return nil, nil
 	}
 
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	appCompact, err := apiClient.GetAppCompact(ctx, appName)
 	if err != nil {
 		return nil, err

--- a/internal/command/doctor/diag/diag.go
+++ b/internal/command/doctor/diag/diag.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/command"
@@ -107,7 +107,7 @@ add the --force flag to send us best-effort diagnostics.`)
 
 	zip.Close()
 
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	url, err := client.CreateDoctorUrl(context.Background())
 	if err != nil {

--- a/internal/command/doctor/doctor.go
+++ b/internal/command/doctor/doctor.go
@@ -7,12 +7,12 @@ import (
 
 	dockerclient "github.com/docker/docker/client"
 	"github.com/spf13/cobra"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/flag/completion"
 
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/doctor/diag"
@@ -218,7 +218,7 @@ This is likely a platform issue, please contact support.
 }
 
 func runAuth(ctx context.Context) (err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	if _, err = client.GetCurrentUser(ctx); err != nil {
 		err = fmt.Errorf("can't verify access token: %w", err)

--- a/internal/command/doctor/wireguard.go
+++ b/internal/command/doctor/wireguard.go
@@ -8,14 +8,14 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/command/dig"
 	"github.com/superfly/flyctl/internal/command/ping"
 )
 
 func runPersonalOrgPing(ctx context.Context, orgSlug string) (err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	ac, err := agent.DefaultClient(ctx)
 	if err != nil {
@@ -59,7 +59,7 @@ func runPersonalOrgPing(ctx context.Context, orgSlug string) (err error) {
 }
 
 func runPersonalOrgCheckDns(ctx context.Context, orgSlug string) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	ac, err := agent.DefaultClient(ctx)
 	if err != nil {
@@ -82,7 +82,7 @@ func runPersonalOrgCheckDns(ctx context.Context, orgSlug string) error {
 }
 
 func runPersonalOrgCheckFlaps(ctx context.Context, orgSlug string) error {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	// Set up the agent connection
 	ac, err := agent.DefaultClient(ctx)

--- a/internal/command/domains/root.go
+++ b/internal/command/domains/root.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -102,7 +101,7 @@ func newDomainsRegister() *cobra.Command {
 
 func runDomainsList(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	args := flag.Args(ctx)
 	var orgSlug string
@@ -139,7 +138,7 @@ func runDomainsList(ctx context.Context) error {
 
 func runDomainsShow(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	name := flag.FirstArg(ctx)
 
 	domain, err := apiClient.GetDomain(ctx, name)
@@ -181,7 +180,7 @@ func runDomainsShow(ctx context.Context) error {
 
 func runDomainsCreate(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	var org *api.Organization
 	var name string

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -12,7 +12,6 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/skratchdot/open-golang/open"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag"
@@ -41,7 +40,7 @@ var SharedFlags = flag.Set{
 }
 
 func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension Extension, err error) {
-	client := client.FromContext(ctx).API().GenqClient
+	client := api.ClientFromContext(ctx).GenqClient
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
 
@@ -220,7 +219,7 @@ func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension 
 }
 
 func AgreeToProviderTos(ctx context.Context, provider gql.ExtensionProviderData) error {
-	client := client.FromContext(ctx).API().GenqClient
+	client := api.ClientFromContext(ctx).GenqClient
 	out := iostreams.FromContext(ctx).Out
 
 	// Internal providers like kubernetes don't need ToS agreement
@@ -266,7 +265,7 @@ func AgreeToProviderTos(ctx context.Context, provider gql.ExtensionProviderData)
 
 func WaitForProvision(ctx context.Context, name string) error {
 	io := iostreams.FromContext(ctx)
-	client := client.FromContext(ctx).API().GenqClient
+	client := api.ClientFromContext(ctx).GenqClient
 
 	s := spinner.New(spinner.CharSets[9], 200*time.Millisecond)
 	s.Writer = io.ErrOut
@@ -320,7 +319,7 @@ func GetExcludedRegions(ctx context.Context, provider gql.ExtensionProviderData)
 
 func OpenOrgDashboard(ctx context.Context, orgSlug string, providerName string) (err error) {
 	var (
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	resp, err := gql.GetAddOnProvider(ctx, client, providerName)
@@ -361,7 +360,7 @@ func openUrl(ctx context.Context, url string) (err error) {
 
 func OpenDashboard(ctx context.Context, extensionName string) (err error) {
 	var (
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	result, err := gql.GetAddOn(ctx, client, extensionName)
@@ -383,7 +382,7 @@ func OpenDashboard(ctx context.Context, extensionName string) (err error) {
 }
 
 func Discover(ctx context.Context, provider gql.AddOnType) (addOn *gql.AddOnData, app *gql.AppData, err error) {
-	client := client.FromContext(ctx).API().GenqClient
+	client := api.ClientFromContext(ctx).GenqClient
 	appName := appconfig.NameFromContext(ctx)
 
 	if len(flag.Args(ctx)) == 1 {
@@ -418,7 +417,7 @@ func Discover(ctx context.Context, provider gql.AddOnType) (addOn *gql.AddOnData
 func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *Extension) (err error) {
 	var (
 		io              = iostreams.FromContext(ctx)
-		client          = client.FromContext(ctx).API().GenqClient
+		client          = api.ClientFromContext(ctx).GenqClient
 		setSecrets bool = true
 	)
 
@@ -482,7 +481,7 @@ func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *E
 }
 
 func AgreedToProviderTos(ctx context.Context, providerName string) (bool, error) {
-	client := client.FromContext(ctx).API().GenqClient
+	client := api.ClientFromContext(ctx).GenqClient
 
 	tosResp, err := gql.AgreedToProviderTos(ctx, client, providerName)
 

--- a/internal/command/extensions/kubernetes/create.go
+++ b/internal/command/extensions/kubernetes/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -38,7 +38,7 @@ func create() (cmd *cobra.Command) {
 
 func runK8sCreate(ctx context.Context) (err error) {
 	io := iostreams.FromContext(ctx)
-	client := client.FromContext(ctx).API().GenqClient
+	client := api.ClientFromContext(ctx).GenqClient
 	appName := appconfig.NameFromContext(ctx)
 	targetOrg, err := orgs.OrgFromFlagOrSelect(ctx)
 	if err != nil {

--- a/internal/command/extensions/kubernetes/destroy.go
+++ b/internal/command/extensions/kubernetes/destroy.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
@@ -64,7 +64,7 @@ func runDestroy(ctx context.Context) (err error) {
 
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	_, err = gql.DeleteAddOn(ctx, client, extension.Name)

--- a/internal/command/extensions/kubernetes/list.go
+++ b/internal/command/extensions/kubernetes/list.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/render"
 )
@@ -29,7 +29,7 @@ func list() (cmd *cobra.Command) {
 func runList(ctx context.Context) (err error) {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	response, err := gql.ListAddOns(ctx, client, "kubernetes")

--- a/internal/command/extensions/planetscale/destroy.go
+++ b/internal/command/extensions/planetscale/destroy.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
@@ -42,7 +42,6 @@ func runDestroy(ctx context.Context) (err error) {
 	colorize := io.ColorScheme()
 
 	extension, _, err := extensions_core.Discover(ctx, gql.AddOnTypePlanetscale)
-
 	if err != nil {
 		return err
 	}
@@ -65,7 +64,7 @@ func runDestroy(ctx context.Context) (err error) {
 
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	_, err = gql.DeleteAddOn(ctx, client, extension.Name)

--- a/internal/command/extensions/planetscale/list.go
+++ b/internal/command/extensions/planetscale/list.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
@@ -37,7 +37,7 @@ func list() (cmd *cobra.Command) {
 func runList(ctx context.Context) (err error) {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	response, err := gql.ListAddOns(ctx, client, "planetscale")

--- a/internal/command/extensions/supabase/destroy.go
+++ b/internal/command/extensions/supabase/destroy.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
@@ -42,7 +42,6 @@ func runDestroy(ctx context.Context) (err error) {
 	colorize := io.ColorScheme()
 
 	extension, _, err := extensions_core.Discover(ctx, gql.AddOnTypeSupabase)
-
 	if err != nil {
 		return err
 	}
@@ -65,7 +64,7 @@ func runDestroy(ctx context.Context) (err error) {
 
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	_, err = gql.DeleteAddOn(ctx, client, extension.Name)

--- a/internal/command/extensions/supabase/list.go
+++ b/internal/command/extensions/supabase/list.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
@@ -37,7 +37,7 @@ func list() (cmd *cobra.Command) {
 func runList(ctx context.Context) (err error) {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	response, err := gql.ListAddOns(ctx, client, "supabase")

--- a/internal/command/extensions/tigris/destroy.go
+++ b/internal/command/extensions/tigris/destroy.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
@@ -42,7 +42,6 @@ func runDestroy(ctx context.Context) (err error) {
 	colorize := io.ColorScheme()
 
 	extension, _, err := extensions_core.Discover(ctx, gql.AddOnTypeTigris)
-
 	if err != nil {
 		return err
 	}
@@ -65,7 +64,7 @@ func runDestroy(ctx context.Context) (err error) {
 
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	_, err = gql.DeleteAddOn(ctx, client, extension.Name)

--- a/internal/command/extensions/tigris/list.go
+++ b/internal/command/extensions/tigris/list.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
@@ -37,7 +37,7 @@ func list() (cmd *cobra.Command) {
 func runList(ctx context.Context) (err error) {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	response, err := gql.ListAddOns(ctx, client, "tigris")

--- a/internal/command/extensions/tigris/update.go
+++ b/internal/command/extensions/tigris/update.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
@@ -40,7 +40,7 @@ func update() (cmd *cobra.Command) {
 }
 
 func runUpdate(ctx context.Context) (err error) {
-	client := client.FromContext(ctx).API().GenqClient
+	client := api.ClientFromContext(ctx).GenqClient
 
 	id := flag.FirstArg(ctx)
 	response, err := gql.GetAddOn(ctx, client, id)

--- a/internal/command/image/show.go
+++ b/internal/command/image/show.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -45,7 +44,7 @@ func newShow() *cobra.Command {
 
 func runShow(ctx context.Context) error {
 	var (
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 
@@ -61,7 +60,7 @@ func showMachineImage(ctx context.Context, app *api.AppCompact) error {
 	var (
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
-		client   = client.FromContext(ctx).API()
+		client   = api.ClientFromContext(ctx)
 		cfg      = config.FromContext(ctx)
 	)
 

--- a/internal/command/image/update.go
+++ b/internal/command/image/update.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
@@ -49,7 +49,7 @@ The update will perform a rolling restart against each VM, which may result in a
 func runUpdate(ctx context.Context) error {
 	var (
 		appName = appconfig.NameFromContext(ctx)
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 	)
 
 	app, err := client.GetAppCompact(ctx, appName)

--- a/internal/command/image/update_machines.go
+++ b/internal/command/image/update_machines.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/flag"
@@ -257,7 +256,7 @@ func machineRole(machine *api.Machine) (role string) {
 
 func resolveImage(ctx context.Context, machine api.Machine) (string, error) {
 	var (
-		client = client.FromContext(ctx).API()
+		client = api.ClientFromContext(ctx)
 		image  = flag.GetString(ctx, "image")
 	)
 

--- a/internal/command/ips/allocate.go
+++ b/internal/command/ips/allocate.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/orgs"
@@ -111,7 +110,7 @@ func runAllocateIPAddressV6(ctx context.Context) (err error) {
 }
 
 func runAllocateIPAddress(ctx context.Context, addrType string, org *api.Organization, network string) (err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	appName := appconfig.NameFromContext(ctx)
 

--- a/internal/command/ips/list.go
+++ b/internal/command/ips/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
@@ -37,7 +37,7 @@ func newList() *cobra.Command {
 
 func runIPAddressesList(ctx context.Context) error {
 	cfg := config.FromContext(ctx)
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
 
 	appName := appconfig.NameFromContext(ctx)

--- a/internal/command/ips/release.go
+++ b/internal/command/ips/release.go
@@ -6,7 +6,7 @@ import (
 	"net"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -33,7 +33,7 @@ func newRelease() *cobra.Command {
 }
 
 func runReleaseIPAddress(ctx context.Context) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	appName := appconfig.NameFromContext(ctx)
 

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag"
@@ -132,7 +131,7 @@ func (state *launchState) updateConfig(ctx context.Context) {
 
 // createApp creates the fly.io app for the plan
 func (state *launchState) createApp(ctx context.Context) (*api.App, error) {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	org, err := state.Org(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/command/launch/launch_databases.go
+++ b/internal/command/launch/launch_databases.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/command/postgres"
 	"github.com/superfly/flyctl/internal/command/redis"
@@ -50,7 +49,7 @@ func (state *launchState) createDatabases(ctx context.Context) error {
 func (state *launchState) createFlyPostgres(ctx context.Context) error {
 	var (
 		pgPlan    = state.Plan.Postgres.FlyPostgres
-		apiClient = client.FromContext(ctx).API()
+		apiClient = api.ClientFromContext(ctx)
 		io        = iostreams.FromContext(ctx)
 	)
 
@@ -153,7 +152,7 @@ func (state *launchState) createUpstashRedis(ctx context.Context) error {
 
 	var readReplicaRegions []api.Region
 	{
-		client := client.FromContext(ctx).API()
+		client := api.ClientFromContext(ctx)
 		regions, _, err := client.PlatformRegions(ctx)
 		if err != nil {
 			return err

--- a/internal/command/launch/launch_frameworks.go
+++ b/internal/command/launch/launch_frameworks.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/samber/lo"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag"
@@ -112,7 +112,7 @@ func (state *launchState) scannerCreateSecrets(ctx context.Context) error {
 	}
 
 	if len(secrets) > 0 {
-		apiClient := client.FromContext(ctx).API()
+		apiClient := api.ClientFromContext(ctx)
 		_, err := apiClient.SetSecrets(ctx, state.Plan.AppName, secrets)
 		if err != nil {
 			return err

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command/launch/plan"
 )
 
@@ -48,7 +47,7 @@ func cacheGrab[T any](cache map[string]interface{}, key string, cb func() (T, er
 }
 
 func (state *launchState) Org(ctx context.Context) (*api.Organization, error) {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	return cacheGrab(state.cache, "org,"+state.Plan.OrgSlug, func() (*api.Organization, error) {
 		return apiClient.GetOrganizationBySlug(ctx, state.Plan.OrgSlug)
 	})
@@ -56,7 +55,7 @@ func (state *launchState) Org(ctx context.Context) (*api.Organization, error) {
 
 func (state *launchState) Region(ctx context.Context) (api.Region, error) {
 
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	regions, err := cacheGrab(state.cache, "regions", func() ([]api.Region, error) {
 		regions, _, err := apiClient.PlatformRegions(ctx)
 		if err != nil {

--- a/internal/command/lfsc/clusters_create.go
+++ b/internal/command/lfsc/clusters_create.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -40,7 +40,7 @@ func newClustersCreate() *cobra.Command {
 }
 
 func runClustersCreate(ctx context.Context) error {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	orgID, err := getOrgID(ctx)
 	if err != nil {

--- a/internal/command/lfsc/lfsc.go
+++ b/internal/command/lfsc/lfsc.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -82,7 +82,7 @@ func regionFlag() flag.String {
 
 // newLFSCClient returns an lfsc.Client with a temporary auth token.
 func newLFSCClient(ctx context.Context, clusterName string) (*lfsc.Client, error) {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	// Determine the org via flag or environment variable first.
 	// If neither is available, use the local app's org, if available.
@@ -110,7 +110,7 @@ func newLFSCClient(ctx context.Context, clusterName string) (*lfsc.Client, error
 }
 
 func getOrgID(ctx context.Context) (string, error) {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	if slug := flag.GetOrg(ctx); slug != "" {
 		org, err := apiClient.GetOrganizationBySlug(ctx, slug)

--- a/internal/command/lfsc/regions.go
+++ b/internal/command/lfsc/regions.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -33,7 +33,7 @@ func newRegions() (cmd *cobra.Command) {
 }
 
 func runRegions(ctx context.Context) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	flyRegions, _, err := client.PlatformRegions(ctx)
 	if err != nil {

--- a/internal/command/logs/logs.go
+++ b/internal/command/logs/logs.go
@@ -15,7 +15,6 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/logs"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
@@ -65,7 +64,7 @@ Use --no-tail to only fetch the logs in the buffer.
 }
 
 func run(ctx context.Context) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	opts := &logs.LogOptions{
 		AppName:    appconfig.NameFromContext(ctx),

--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -84,7 +83,7 @@ func singleDestroyRun(ctx context.Context, machine *api.Machine) error {
 	appName := appconfig.NameFromContext(ctx)
 
 	// This is used for the deletion hook below.
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("could not get app '%s': %w", appName, err)

--- a/internal/command/machine/proxy.go
+++ b/internal/command/machine/proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -35,7 +35,7 @@ func newProxy() *cobra.Command {
 }
 
 func runMachineProxy(ctx context.Context) error {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	orgSlug := flag.GetOrg(ctx)
 
 	if orgSlug == "" {

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -13,7 +13,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/cmdutil"
@@ -286,7 +285,7 @@ func runMachineCreate(ctx context.Context) error {
 func runMachineRun(ctx context.Context) error {
 	var (
 		appName  = appconfig.NameFromContext(ctx)
-		client   = client.FromContext(ctx).API()
+		client   = api.ClientFromContext(ctx)
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
 		err      error

--- a/internal/command/machine/select.go
+++ b/internal/command/machine/select.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag"
@@ -138,7 +137,7 @@ func buildContextFromAppNameOrMachineID(ctx context.Context, machineIDs ...strin
 		// NOTE: assuming that we validated the command line arguments
 		// correctly, we must have at least one machine ID when no app
 		// is set.
-		client := client.FromContext(ctx).API()
+		client := api.ClientFromContext(ctx)
 		var gqlMachine *api.GqlMachine
 		gqlMachine, err = client.GetMachine(ctx, machineIDs[0])
 		if err != nil {

--- a/internal/command/orgs/create.go
+++ b/internal/command/orgs/create.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -43,12 +43,10 @@ organization later.
 }
 
 func runCreate(ctx context.Context) error {
-
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
 	user, err := client.GetCurrentUser(ctx)
-
 	if err != nil {
 		return err
 	}
@@ -62,7 +60,6 @@ func runCreate(ctx context.Context) error {
 
 		if name == "" {
 			confirmed, err := prompt.Confirm(ctx, "Do you still want to create the organization?")
-
 			if err != nil {
 				return err
 			}
@@ -87,7 +84,6 @@ func runCreate(ctx context.Context) error {
 	}
 
 	org, err := client.CreateOrganization(ctx, name)
-
 	if err != nil {
 		return fmt.Errorf("failed creating organization: %w", err)
 	}
@@ -95,7 +91,6 @@ func runCreate(ctx context.Context) error {
 	if io := iostreams.FromContext(ctx); config.FromContext(ctx).JSONOutput {
 		_ = render.JSON(io.Out, org)
 	} else {
-
 		fmt.Fprintf(io.Out, "Your organization %s (%s) was created successfully. Visit %s to add a credit card and enable deployment.\n", org.Name, org.Slug, colorize.Green(fmt.Sprintf("https://fly.io/dashboard/%s/billing", org.Slug)))
 	}
 

--- a/internal/command/orgs/delete.go
+++ b/internal/command/orgs/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/prompt"
@@ -59,7 +58,7 @@ func runDelete(ctx context.Context) error {
 		}
 	}
 
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	if _, err := client.DeleteOrganization(ctx, org.ID); err != nil {
 		return fmt.Errorf("failed deleting organization %s", err)
 	}

--- a/internal/command/orgs/invite.go
+++ b/internal/command/orgs/invite.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -36,7 +35,7 @@ sent, and the user will be pending until they respond.
 }
 
 func runInvite(ctx context.Context) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	org, err := OrgFromEnvVarOrFirstArgOrSelect(ctx, api.AdminOnly)
 	if err != nil {

--- a/internal/command/orgs/list.go
+++ b/internal/command/orgs/list.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -32,7 +32,7 @@ func newList() *cobra.Command {
 }
 
 func runList(ctx context.Context) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	orgs, err := client.GetOrganizations(ctx)
 	if err != nil {

--- a/internal/command/orgs/orgs.go
+++ b/internal/command/orgs/orgs.go
@@ -10,7 +10,6 @@ import (
 	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/prompt"
@@ -77,7 +76,7 @@ func slugFromArgOrSelect(ctx context.Context, orgSlug string, filters ...api.Org
 		return
 	}
 
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	var orgs []api.Organization
 	if orgs, err = client.GetOrganizations(ctx, filters...); err != nil {
@@ -118,7 +117,7 @@ func OrgFromFlagOrSelect(ctx context.Context, filters ...api.OrganizationFilter)
 }
 
 func OrgFromSlug(ctx context.Context, slug string) (*api.Organization, error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	org, err := client.GetOrganizationBySlug(ctx, slug)
 	if err != nil {

--- a/internal/command/orgs/remove.go
+++ b/internal/command/orgs/remove.go
@@ -10,7 +10,6 @@ import (
 	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 )
 
@@ -32,7 +31,7 @@ invitation to join (if not, see orgs revoke).
 }
 
 func runRemove(ctx context.Context) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	selectedOrg, err := OrgFromEnvVarOrFirstArgOrSelect(ctx, api.AdminOnly)
 	if err != nil {
 		return nil

--- a/internal/command/orgs/show.go
+++ b/internal/command/orgs/show.go
@@ -8,7 +8,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -37,7 +37,7 @@ associated member. Details full list of members and roles.
 }
 
 func runShow(ctx context.Context) (err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	selectedOrg, err := OrgFromEnvVarOrFirstArgOrSelect(ctx)
 	if err != nil {
 		return err

--- a/internal/command/ping/ping.go
+++ b/internal/command/ping/ping.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -75,7 +75,7 @@ The target argument can be either a ".internal" DNS name in our network
 }
 
 func run(ctx context.Context) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	var (
 		err  error

--- a/internal/command/platform/regions.go
+++ b/internal/command/platform/regions.go
@@ -8,9 +8,9 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -38,7 +38,7 @@ func newRegions() (cmd *cobra.Command) {
 }
 
 func runRegions(ctx context.Context) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	regions, _, err := client.PlatformRegions(ctx)
 	if err != nil {

--- a/internal/command/postgres/add_flycast.go
+++ b/internal/command/postgres/add_flycast.go
@@ -7,7 +7,6 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
@@ -41,7 +40,7 @@ func newAddFlycast() *cobra.Command {
 
 func runAddFlycast(ctx context.Context) error {
 	var (
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 

--- a/internal/command/postgres/attach.go
+++ b/internal/command/postgres/attach.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/helpers"
@@ -74,7 +73,7 @@ func runAttach(ctx context.Context) error {
 	var (
 		pgAppName = flag.FirstArg(ctx)
 		appName   = appconfig.NameFromContext(ctx)
-		client    = client.FromContext(ctx).API()
+		client    = api.ClientFromContext(ctx)
 	)
 
 	pgApp, err := client.GetAppCompact(ctx, pgAppName)
@@ -126,7 +125,7 @@ func runAttach(ctx context.Context) error {
 // AttachCluster is mean't to be called from an external package.
 func AttachCluster(ctx context.Context, params AttachParams) error {
 	var (
-		client = client.FromContext(ctx).API()
+		client = api.ClientFromContext(ctx)
 
 		pgAppName = params.PgAppName
 		appName   = params.AppName
@@ -198,7 +197,7 @@ func machineAttachCluster(ctx context.Context, params AttachParams, flycast *str
 
 func runAttachCluster(ctx context.Context, leaderIP string, params AttachParams, flycast *string) error {
 	var (
-		client = client.FromContext(ctx).API()
+		client = api.ClientFromContext(ctx)
 		dialer = agent.DialerFromContext(ctx)
 		io     = iostreams.FromContext(ctx)
 

--- a/internal/command/postgres/barman.go
+++ b/internal/command/postgres/barman.go
@@ -10,7 +10,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -93,7 +92,7 @@ func newCreateBarman() *cobra.Command {
 func runBarmanCreate(ctx context.Context) error {
 	var (
 		io      = iostreams.FromContext(ctx)
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 
@@ -445,7 +444,7 @@ func runBarmanRecover(ctx context.Context) error {
 }
 
 func runConsole(ctx context.Context, cmd string) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 
 	app, err := client.GetAppCompact(ctx, appName)

--- a/internal/command/postgres/config_show.go
+++ b/internal/command/postgres/config_show.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -44,7 +43,7 @@ func newConfigShow() (cmd *cobra.Command) {
 
 func runConfigShow(ctx context.Context) error {
 	var (
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 

--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -9,7 +9,6 @@ import (
 	"github.com/r3labs/diff"
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -90,7 +89,7 @@ func newConfigUpdate() (cmd *cobra.Command) {
 
 func runConfigUpdate(ctx context.Context) error {
 	var (
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 

--- a/internal/command/postgres/connect.go
+++ b/internal/command/postgres/connect.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mattn/go-colorable"
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -59,7 +58,7 @@ func newConnect() *cobra.Command {
 
 func runConnect(ctx context.Context) error {
 	var (
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/command"
@@ -98,7 +97,7 @@ func newCreate() *cobra.Command {
 func run(ctx context.Context) (err error) {
 	var (
 		appName  = flag.GetString(ctx, "name")
-		client   = client.FromContext(ctx).API()
+		client   = api.ClientFromContext(ctx)
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
 	)
@@ -266,7 +265,7 @@ func run(ctx context.Context) (err error) {
 // CreateCluster creates a Postgres cluster with an optional name. The name will be prompted for if not supplied.
 func CreateCluster(ctx context.Context, org *api.Organization, region *api.Region, params *ClusterParams) (err error) {
 	var (
-		client = client.FromContext(ctx).API()
+		client = api.ClientFromContext(ctx)
 		io     = iostreams.FromContext(ctx)
 	)
 

--- a/internal/command/postgres/db.go
+++ b/internal/command/postgres/db.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -61,7 +60,7 @@ func newListDbs() *cobra.Command {
 
 func runListDbs(ctx context.Context) error {
 	var (
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 

--- a/internal/command/postgres/detach.go
+++ b/internal/command/postgres/detach.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -42,7 +41,7 @@ func newDetach() *cobra.Command {
 
 func runDetach(ctx context.Context) error {
 	var (
-		client = client.FromContext(ctx).API()
+		client = api.ClientFromContext(ctx)
 
 		pgAppName = flag.FirstArg(ctx)
 		appName   = appconfig.NameFromContext(ctx)
@@ -96,7 +95,7 @@ func runMachineDetach(ctx context.Context, app *api.AppCompact, pgApp *api.AppCo
 // TODO - This process needs to be re-written to suppport non-interactive terminals.
 func detachAppFromPostgres(ctx context.Context, leaderIP string, app *api.AppCompact, pgApp *api.AppCompact) error {
 	var (
-		client = client.FromContext(ctx).API()
+		client = api.ClientFromContext(ctx)
 		dialer = agent.DialerFromContext(ctx)
 		io     = iostreams.FromContext(ctx)
 	)

--- a/internal/command/postgres/events.go
+++ b/internal/command/postgres/events.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -88,7 +88,7 @@ func newListEvents() *cobra.Command {
 
 func runListEvents(ctx context.Context) error {
 	var (
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 

--- a/internal/command/postgres/failover.go
+++ b/internal/command/postgres/failover.go
@@ -11,7 +11,6 @@ import (
 	"github.com/mattn/go-colorable"
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flypg"
@@ -53,7 +52,7 @@ func runFailover(ctx context.Context) (err error) {
 		MinPostgresStandaloneVersion = "0.0.7"
 
 		io      = iostreams.FromContext(ctx)
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 

--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mattn/go-colorable"
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -75,7 +74,7 @@ func newImport() *cobra.Command {
 
 func runImport(ctx context.Context) error {
 	var (
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 
 		sourceURI = flag.FirstArg(ctx)

--- a/internal/command/postgres/list.go
+++ b/internal/command/postgres/list.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -32,7 +31,7 @@ func newList() *cobra.Command {
 
 func runList(ctx context.Context) (err error) {
 	var (
-		client = client.FromContext(ctx).API()
+		client = api.ClientFromContext(ctx)
 		io     = iostreams.FromContext(ctx)
 		cfg    = config.FromContext(ctx)
 	)

--- a/internal/command/postgres/restart.go
+++ b/internal/command/postgres/restart.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -50,7 +49,7 @@ func newRestart() *cobra.Command {
 func runRestart(ctx context.Context) error {
 	var (
 		appName = appconfig.NameFromContext(ctx)
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 	)
 
 	app, err := client.GetAppCompact(ctx, appName)

--- a/internal/command/postgres/users.go
+++ b/internal/command/postgres/users.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -63,7 +62,7 @@ func newListUsers() *cobra.Command {
 
 func runListUsers(ctx context.Context) error {
 	var (
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 

--- a/internal/command/proxy/proxy.go
+++ b/internal/command/proxy/proxy.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -56,7 +56,7 @@ connects to the first Machine address returned by an internal DNS query on the a
 }
 
 func run(ctx context.Context) (err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 
 	orgSlug := flag.GetOrg(ctx)

--- a/internal/command/redis/attach.go
+++ b/internal/command/redis/attach.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 )
 
 func AttachDatabase(ctx context.Context, db *gql.AddOn, appName string) (err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 	s := map[string]string{}
 	s["REDIS_URL"] = db.PublicUrl

--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -12,7 +12,6 @@ import (
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/prompt"
@@ -187,7 +186,7 @@ type RedisConfiguration struct {
 }
 
 func ProvisionDatabase(ctx context.Context, org *api.Organization, config RedisConfiguration) (addOn *gql.AddOn, err error) {
-	client := client.FromContext(ctx).API().GenqClient
+	client := api.ClientFromContext(ctx).GenqClient
 
 	var readRegionCodes []string
 
@@ -221,7 +220,7 @@ func ProvisionDatabase(ctx context.Context, org *api.Organization, config RedisC
 
 func DeterminePlan(ctx context.Context, org *api.Organization) (*gql.ListAddOnPlansAddOnPlansAddOnPlanConnectionNodesAddOnPlan, error) {
 
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	// All new databases are pay-as-you-go
 	planId := redisPlanPayAsYouGo

--- a/internal/command/redis/dashboard.go
+++ b/internal/command/redis/dashboard.go
@@ -7,7 +7,7 @@ import (
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -32,7 +32,7 @@ func newDashboard() (cmd *cobra.Command) {
 func runDashboard(ctx context.Context) (err error) {
 	var (
 		io     = iostreams.FromContext(ctx)
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	orgSlug := flag.FirstArg(ctx)

--- a/internal/command/redis/destroy.go
+++ b/internal/command/redis/destroy.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/prompt"
@@ -58,7 +58,7 @@ func runDestroy(ctx context.Context) (err error) {
 
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	name := flag.FirstArg(ctx)

--- a/internal/command/redis/list.go
+++ b/internal/command/redis/list.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
@@ -36,7 +36,7 @@ func newList() (cmd *cobra.Command) {
 func runList(ctx context.Context) (err error) {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	response, err := gql.ListAddOns(ctx, client, "redis")

--- a/internal/command/redis/plans.go
+++ b/internal/command/redis/plans.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -32,7 +32,7 @@ func newPlans() (cmd *cobra.Command) {
 func runPlans(ctx context.Context) (err error) {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	_ = `# @genqlient

--- a/internal/command/redis/proxy.go
+++ b/internal/command/redis/proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
@@ -46,7 +46,7 @@ func runProxy(ctx context.Context) (err error) {
 }
 
 func getRedisProxyParams(ctx context.Context, localProxyPort string) (*proxy.ConnectParams, string, error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	var index int
 	var options []string

--- a/internal/command/redis/redis.go
+++ b/internal/command/redis/redis.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 )
@@ -36,7 +36,7 @@ func New() (cmd *cobra.Command) {
 }
 
 func GetExcludedRegions(ctx context.Context) (excludedRegions []string, err error) {
-	client := client.FromContext(ctx).API().GenqClient
+	client := api.ClientFromContext(ctx).GenqClient
 
 	response, err := gql.GetAddOnProvider(ctx, client, "upstash_redis")
 

--- a/internal/command/redis/reset_password.go
+++ b/internal/command/redis/reset_password.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 )
@@ -33,7 +33,7 @@ func newReset() (cmd *cobra.Command) {
 func runReset(ctx context.Context) (err error) {
 	var (
 		io       = iostreams.FromContext(ctx)
-		client   = client.FromContext(ctx).API().GenqClient
+		client   = api.ClientFromContext(ctx).GenqClient
 		colorize = io.ColorScheme()
 		out      = io.Out
 	)

--- a/internal/command/redis/status.go
+++ b/internal/command/redis/status.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -36,7 +36,7 @@ func runStatus(ctx context.Context) (err error) {
 	var (
 		io     = iostreams.FromContext(ctx)
 		name   = flag.FirstArg(ctx)
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	response, err := gql.GetAddOn(ctx, client, name)

--- a/internal/command/redis/update.go
+++ b/internal/command/redis/update.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/prompt"
@@ -37,7 +37,7 @@ func newUpdate() (cmd *cobra.Command) {
 func runUpdate(ctx context.Context) (err error) {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = client.FromContext(ctx).API().GenqClient
+		client = api.ClientFromContext(ctx).GenqClient
 	)
 
 	id := flag.FirstArg(ctx)

--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -8,7 +8,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/agent"
@@ -190,7 +190,7 @@ func run(ctx context.Context) error {
 	cmd.Printf("  %s\n", "flyctl [command]")
 	cmd.Println()
 
-	if !client.FromContext(ctx).Authenticated() {
+	if !api.ClientFromContext(ctx).Authenticated() {
 		msg := `It doesn't look like you're logged in. Try "fly auth signup" to create an account, or "fly auth login" to log in to an existing account.`
 		cmd.Println(text.Wrap(msg, 80))
 		cmd.Println()

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -9,7 +9,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/sourcegraph/conc/pool"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -25,7 +24,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 	io := iostreams.FromContext(ctx)
 	flapsClient := flaps.FromContext(ctx)
 	ctx = appconfig.WithConfig(ctx, appConfig)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	machines, _, err := flapsClient.ListFlyAppsMachines(ctx)
 	if err != nil {

--- a/internal/command/secrets/deploy.go
+++ b/internal/command/secrets/deploy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -33,7 +33,7 @@ func newDeploy() (cmd *cobra.Command) {
 }
 
 func runDeploy(ctx context.Context) (err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {

--- a/internal/command/secrets/import.go
+++ b/internal/command/secrets/import.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -30,7 +30,7 @@ func newImport() (cmd *cobra.Command) {
 }
 
 func runImport(ctx context.Context) (err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {

--- a/internal/command/secrets/list.go
+++ b/internal/command/secrets/list.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
@@ -37,7 +37,7 @@ actual value of the secret is only available to the application.`
 }
 
 func runList(ctx context.Context) (err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
 	secrets, err := client.GetAppSecrets(ctx, appName)

--- a/internal/command/secrets/set.go
+++ b/internal/command/secrets/set.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/cmdutil"
@@ -34,7 +33,7 @@ func newSet() (cmd *cobra.Command) {
 }
 
 func runSet(ctx context.Context) (err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
@@ -67,7 +66,7 @@ func runSet(ctx context.Context) (err error) {
 }
 
 func SetSecretsAndDeploy(ctx context.Context, app *api.AppCompact, secrets map[string]string, stage bool, detach bool) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	if _, err := client.SetSecrets(ctx, app.Name, secrets); err != nil {
 		return err
 	}

--- a/internal/command/secrets/unset.go
+++ b/internal/command/secrets/unset.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -30,7 +29,7 @@ func newUnset() (cmd *cobra.Command) {
 }
 
 func runUnset(ctx context.Context) (err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
@@ -41,7 +40,7 @@ func runUnset(ctx context.Context) (err error) {
 }
 
 func UnsetSecretsAndDeploy(ctx context.Context, app *api.AppCompact, secrets []string, stage bool, detach bool) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	if _, err := client.UnsetSecrets(ctx, app.Name, secrets); err != nil {
 		return err
 	}

--- a/internal/command/ssh/connect.go
+++ b/internal/command/ssh/connect.go
@@ -11,7 +11,6 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/pkg/errors"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/iostreams"
@@ -102,7 +101,7 @@ func Connect(p *ConnectParams, addr string) (*ssh.Client, error) {
 }
 
 func singleUseSSHCertificate(ctx context.Context, org api.OrganizationImpl, appNames []string) (*api.IssuedCertificate, ed25519.PrivateKey, error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	hours := 1
 
 	pub, priv, err := ed25519.GenerateKey(nil)

--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -14,7 +14,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -133,7 +132,7 @@ func captureError(ctx context.Context, err error, app *api.AppCompact) {
 }
 
 func runConsole(ctx context.Context) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 
 	if !quiet(ctx) {

--- a/internal/command/ssh/issue.go
+++ b/internal/command/ssh/issue.go
@@ -20,7 +20,6 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/orgs"
 	"github.com/superfly/flyctl/internal/flag"
@@ -77,7 +76,7 @@ validity.`
 }
 
 func runSSHIssue(ctx context.Context) (err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
 
 	org, err := orgs.OrgFromEnvVarOrFirstArgOrSelect(ctx)

--- a/internal/command/ssh/log.go
+++ b/internal/command/ssh/log.go
@@ -7,7 +7,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/orgs"
 	"github.com/superfly/flyctl/internal/config"
@@ -34,7 +34,7 @@ func newLog() *cobra.Command {
 }
 
 func runLog(ctx context.Context) (err error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	jsonOutput := config.FromContext(ctx).JSONOutput
 	out := iostreams.FromContext(ctx).Out
 

--- a/internal/command/ssh/sftp.go
+++ b/internal/command/ssh/sftp.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/pkg/sftp"
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -87,7 +87,7 @@ func newGet() *cobra.Command {
 }
 
 func newSFTPConnection(ctx context.Context) (*sftp.Client, error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 
 	app, err := client.GetAppCompact(ctx, appName)

--- a/internal/command/status/machines.go
+++ b/internal/command/status/machines.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/command/postgres"
 	"github.com/superfly/flyctl/internal/config"
@@ -77,7 +76,7 @@ func RenderMachineStatus(ctx context.Context, app *api.AppCompact, out io.Writer
 	var (
 		io         = iostreams.FromContext(ctx)
 		colorize   = io.ColorScheme()
-		client     = client.FromContext(ctx).API()
+		client     = api.ClientFromContext(ctx)
 		jsonOutput = config.FromContext(ctx).JSONOutput
 	)
 
@@ -222,7 +221,7 @@ func RenderMachineStatus(ctx context.Context, app *api.AppCompact, out io.Writer
 func renderMachineJSONStatus(ctx context.Context, app *api.AppCompact, machines []*api.Machine) error {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = client.FromContext(ctx).API()
+		client = api.ClientFromContext(ctx)
 	)
 
 	versionQuery := `
@@ -275,7 +274,7 @@ func renderPGStatus(ctx context.Context, app *api.AppCompact, machines []*api.Ma
 	var (
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
-		client   = client.FromContext(ctx).API()
+		client   = api.ClientFromContext(ctx)
 	)
 
 	if len(machines) > 0 {

--- a/internal/command/status/status.go
+++ b/internal/command/status/status.go
@@ -14,9 +14,9 @@ import (
 	"github.com/inancgumus/screen"
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/iostreams"
 
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
@@ -85,7 +85,7 @@ func runOnce(ctx context.Context) error {
 func once(ctx context.Context, out io.Writer) (err error) {
 	var (
 		appName = appconfig.NameFromContext(ctx)
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 	)
 
 	app, err := client.GetAppCompact(ctx, appName)

--- a/internal/command/tokens/create.go
+++ b/internal/command/tokens/create.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command/orgs"
@@ -194,7 +193,7 @@ func makeToken(ctx context.Context, apiClient *api.Client, orgID string, expiry 
 
 func runOrg(ctx context.Context) error {
 	var token string
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	expiry := ""
 	if expiryDuration := flag.GetDuration(ctx, "expiry"); expiryDuration != 0 {
@@ -226,7 +225,7 @@ func runOrg(ctx context.Context) error {
 func runOrgRead(ctx context.Context) error {
 	var (
 		token          string
-		apiClient      = client.FromContext(ctx).API()
+		apiClient      = api.ClientFromContext(ctx)
 		expiry         = ""
 		expiryDuration = flag.GetDuration(ctx, "expiry")
 		perm           []byte
@@ -321,7 +320,7 @@ func runOrgRead(ctx context.Context) error {
 
 func runDeploy(ctx context.Context) (err error) {
 	var token string
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	expiry := ""
 	if expiryDuration := flag.GetDuration(ctx, "expiry"); expiryDuration != 0 {
@@ -356,7 +355,7 @@ func runDeploy(ctx context.Context) (err error) {
 
 func runLiteFSCloud(ctx context.Context) (err error) {
 	var token string
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	expiry := ""
 	if expiryDuration := flag.GetDuration(ctx, "expiry"); expiryDuration != 0 {

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/orgs"
@@ -41,7 +41,7 @@ func newList() *cobra.Command {
 }
 
 func runList(ctx context.Context) (err error) {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
 	var rows [][]string
 

--- a/internal/command/tokens/revoke.go
+++ b/internal/command/tokens/revoke.go
@@ -3,8 +3,9 @@ package tokens
 import (
 	"context"
 	"fmt"
+
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 )
@@ -24,7 +25,7 @@ func newRevoke() *cobra.Command {
 }
 
 func runRevoke(ctx context.Context) (err error) {
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	args := flag.Args(ctx)
 	for _, id := range args {

--- a/internal/command/volumes/create.go
+++ b/internal/command/volumes/create.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -82,7 +81,7 @@ func newCreate() *cobra.Command {
 func runCreate(ctx context.Context) error {
 	var (
 		cfg    = config.FromContext(ctx)
-		client = client.FromContext(ctx).API()
+		client = api.ClientFromContext(ctx)
 
 		volumeName = flag.FirstArg(ctx)
 		appName    = appconfig.NameFromContext(ctx)

--- a/internal/command/volumes/destroy.go
+++ b/internal/command/volumes/destroy.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -42,7 +41,7 @@ func newDestroy() *cobra.Command {
 func runDestroy(ctx context.Context) error {
 	var (
 		io     = iostreams.FromContext(ctx)
-		client = client.FromContext(ctx).API()
+		client = api.ClientFromContext(ctx)
 		volIDs = flag.Args(ctx)
 	)
 

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -55,7 +55,7 @@ func runExtend(ctx context.Context) error {
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
 		appName  = appconfig.NameFromContext(ctx)
-		client   = client.FromContext(ctx).API()
+		client   = api.ClientFromContext(ctx)
 		volID    = flag.FirstArg(ctx)
 	)
 

--- a/internal/command/volumes/fork.go
+++ b/internal/command/volumes/fork.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -67,7 +66,7 @@ func runFork(ctx context.Context) error {
 		cfg     = config.FromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 		volID   = flag.FirstArg(ctx)
-		client  = client.FromContext(ctx).API()
+		client  = api.ClientFromContext(ctx)
 	)
 
 	flapsClient, err := flapsutil.NewClientWithOptions(ctx, flaps.NewClientOpts{

--- a/internal/command/volumes/list.go
+++ b/internal/command/volumes/list.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -41,7 +41,7 @@ func newList() *cobra.Command {
 
 func runList(ctx context.Context) error {
 	cfg := config.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	appName := appconfig.NameFromContext(ctx)
 

--- a/internal/command/volumes/lsvd/setup.go
+++ b/internal/command/volumes/lsvd/setup.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -31,7 +31,7 @@ func newSetup() *cobra.Command {
 
 func runSetup(ctx context.Context) error {
 	appName := appconfig.NameFromContext(ctx)
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 
 	secrets, err := client.GetAppSecrets(ctx, appName)

--- a/internal/command/volumes/show.go
+++ b/internal/command/volumes/show.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -41,7 +40,7 @@ func newShow() (cmd *cobra.Command) {
 
 func runShow(ctx context.Context) error {
 	cfg := config.FromContext(ctx)
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	volumeID := flag.FirstArg(ctx)
 

--- a/internal/command/volumes/snapshots/create.go
+++ b/internal/command/volumes/snapshots/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -28,7 +28,7 @@ func newCreate() *cobra.Command {
 }
 
 func create(ctx context.Context) error {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	volumeId := flag.FirstArg(ctx)
 

--- a/internal/command/volumes/snapshots/list.go
+++ b/internal/command/volumes/snapshots/list.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -51,7 +51,7 @@ func runList(ctx context.Context) error {
 	var (
 		io     = iostreams.FromContext(ctx)
 		cfg    = config.FromContext(ctx)
-		client = client.FromContext(ctx).API()
+		client = api.ClientFromContext(ctx)
 	)
 
 	volID := flag.FirstArg(ctx)

--- a/internal/command/volumes/update.go
+++ b/internal/command/volumes/update.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -51,7 +50,7 @@ func newUpdate() *cobra.Command {
 func runUpdate(ctx context.Context) error {
 	var (
 		cfg      = config.FromContext(ctx)
-		client   = client.FromContext(ctx).API()
+		client   = api.ClientFromContext(ctx)
 		volumeID = flag.FirstArg(ctx)
 	)
 

--- a/internal/command/wireguard/others.go
+++ b/internal/command/wireguard/others.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
@@ -43,7 +42,7 @@ func orgByArg(ctx context.Context) (*api.Organization, error) {
 		return org, nil
 	}
 
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	return apiClient.GetOrganizationBySlug(ctx, args[0])
 }
 

--- a/internal/command/wireguard/tokens.go
+++ b/internal/command/wireguard/tokens.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/internal/wireguard"
@@ -20,7 +19,7 @@ import (
 
 func runWireguardTokenList(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	org, err := orgByArg(ctx)
 	if err != nil {
@@ -49,7 +48,7 @@ func runWireguardTokenList(ctx context.Context) error {
 
 func runWireguardTokenCreate(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	org, err := orgByArg(ctx)
 	if err != nil {
@@ -102,7 +101,7 @@ and 'pubkey' (the public key of the gateway), which you can inject into a
 
 func runWireguardTokenDelete(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	org, err := orgByArg(ctx)
 	if err != nil {

--- a/internal/command/wireguard/wireguard.go
+++ b/internal/command/wireguard/wireguard.go
@@ -8,7 +8,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/config"
@@ -22,7 +22,7 @@ import (
 
 func runWireguardList(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	org, err := orgByArg(ctx)
 	if err != nil {
@@ -105,7 +105,7 @@ func runWireguardReset(ctx context.Context) error {
 		return err
 	}
 
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 	agentclient, err := agent.Establish(ctx, apiClient)
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func runWireguardReset(ctx context.Context) error {
 
 func runWireguardCreate(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	org, err := orgByArg(ctx)
 	if err != nil {
@@ -174,7 +174,7 @@ func runWireguardCreate(ctx context.Context) error {
 
 func runWireguardRemove(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := client.FromContext(ctx).API()
+	apiClient := api.ClientFromContext(ctx)
 
 	org, err := orgByArg(ctx)
 	if err != nil {

--- a/internal/flag/completion/completions.go
+++ b/internal/flag/completion/completions.go
@@ -9,7 +9,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
 )
 
@@ -19,10 +18,8 @@ func CompleteApps(
 	args []string,
 	partial string,
 ) ([]string, error) {
-
 	var (
-		client    = client.FromContext(ctx)
-		clientApi = client.API()
+		client = api.ClientFromContext(ctx)
 
 		apps []api.App
 		err  error
@@ -34,14 +31,14 @@ func CompleteApps(
 	orgFlag := cmd.Flag(flagnames.Org)
 	if orgFlag != nil && orgFlag.Changed {
 		var org *api.Organization
-		org, err = clientApi.GetOrganizationBySlug(ctx, orgFlag.Value.String())
+		org, err = client.GetOrganizationBySlug(ctx, orgFlag.Value.String())
 		if err != nil {
 			return nil, err
 		}
-		apps, err = clientApi.GetAppsForOrganization(ctx, org.ID)
+		apps, err = client.GetAppsForOrganization(ctx, org.ID)
 		orgFiltered = true
 	} else {
-		apps, err = clientApi.GetApps(ctx, nil)
+		apps, err = client.GetApps(ctx, nil)
 	}
 	if err != nil {
 		return nil, err
@@ -68,14 +65,13 @@ func CompleteOrgs(
 	args []string,
 	partial string,
 ) ([]string, error) {
-
-	clientApi := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	format := func(org api.Organization) string {
 		return fmt.Sprintf("%s\t%s", org.Slug, org.Name)
 	}
 
-	orgs, err := clientApi.GetOrganizations(ctx)
+	orgs, err := client.GetOrganizations(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -96,15 +92,14 @@ func CompleteRegions(
 	args []string,
 	partial string,
 ) ([]string, error) {
-
-	clientApi := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	format := func(org api.Region) string {
 		return fmt.Sprintf("%s\t%s", org.Code, org.Name)
 	}
 
 	// TODO(ali): Do we need to worry about which ones are marked as "gateway"?
-	regions, reqRegion, err := clientApi.PlatformRegions(ctx)
+	regions, reqRegion, err := client.PlatformRegions(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/flapsutil/flapsutil.go
+++ b/internal/flapsutil/flapsutil.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/buildinfo"
@@ -24,7 +23,7 @@ func NewClientWithOptions(ctx context.Context, opts flaps.NewClientOpts) (*flaps
 			return nil, fmt.Errorf("failed to resolve org for app '%s': %w", opts.AppName, err)
 		}
 
-		client := client.FromContext(ctx).API()
+		client := api.ClientFromContext(ctx)
 		agentclient, err := agent.Establish(ctx, client)
 		if err != nil {
 			return nil, fmt.Errorf("error establishing agent: %w", err)
@@ -64,7 +63,7 @@ func resolveOrgSlugForApp(ctx context.Context, app *api.AppCompact, appName stri
 func resolveApp(ctx context.Context, app *api.AppCompact, appName string) (*api.AppCompact, error) {
 	var err error
 	if app == nil {
-		client := client.FromContext(ctx).API()
+		client := api.ClientFromContext(ctx)
 		app, err = client.GetAppCompact(ctx, appName)
 	}
 	return app, err

--- a/internal/metrics/token.go
+++ b/internal/metrics/token.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/config"
@@ -18,11 +18,11 @@ func queryMetricsToken(ctx context.Context) (string, error) {
 	// We use this over the context API client because we're trying to
 	// authenticate the human user, not the specific credentials they're using.
 	cfg := config.FromContext(ctx)
-	apiClient := client.NewClientWithOptions(&client.NewClientOpts{
-		Tokens:        cfg.Tokens,
-		ClientName:    buildinfo.Name(),
-		ClientVersion: buildinfo.Version().String(),
-	}).API()
+	apiClient := api.NewClientFromOptions(api.ClientOptions{
+		Name:    buildinfo.Name(),
+		Version: buildinfo.Version().String(),
+		Tokens:  cfg.Tokens,
+	})
 
 	personal, err := apiClient.GetOrganizationBySlug(ctx, "personal")
 	if err != nil {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -16,7 +16,6 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/superfly/fly-go/api"
-	"github.com/superfly/fly-go/client"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/future"
@@ -205,7 +204,7 @@ var errOrgSlugRequired = NonInteractiveError("org slug must be specified when no
 // Org returns the Organization the user has passed in via flag or prompts the
 // user for one.
 func Org(ctx context.Context) (*api.Organization, error) {
-	client := client.FromContext(ctx).API()
+	client := api.ClientFromContext(ctx)
 
 	orgs, err := client.GetOrganizations(ctx)
 	if err != nil {
@@ -279,7 +278,7 @@ var regionsFuture *future.Future[RegionInfo]
 func PlatformRegions(ctx context.Context) *future.Future[RegionInfo] {
 	regionsOnce.Do(func() {
 		regionsFuture = future.Spawn(func() (RegionInfo, error) {
-			client := client.FromContext(ctx).API()
+			client := api.ClientFromContext(ctx)
 			regions, defaultRegion, err := client.PlatformRegions(ctx)
 			regionInfo := RegionInfo{
 				Regions:       regions,

--- a/proxy/connect.go
+++ b/proxy/connect.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/superfly/fly-go/client"
+	"github.com/superfly/fly-go/api"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/ip"
@@ -54,7 +54,7 @@ func Start(ctx context.Context, p *ConnectParams) error {
 func NewServer(ctx context.Context, p *ConnectParams) (*Server, error) {
 	var (
 		io            = iostreams.FromContext(ctx)
-		client        = client.FromContext(ctx).API()
+		client        = api.ClientFromContext(ctx)
 		orgSlug       = p.OrganizationSlug
 		localBindAddr = p.BindAddr
 		localPort     = p.Ports[0]


### PR DESCRIPTION
### Change Summary

What and Why: The `client` package in fly-go was simply a wrapper for the `api` package.

How: Refactor calls to `client` to `api` instead.

Related to: https://github.com/superfly/fly-go/pull/1

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
