### PR TITLE
[bluegreen] detect & delete zombie machines from failed deployments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.8.4
-	github.com/superfly/fly-go v0.0.0-20240215173409-62ee9918aa58
+	github.com/superfly/fly-go v0.0.0-20240215193014-b45ae6e6b02c
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.10

--- a/go.sum
+++ b/go.sum
@@ -576,8 +576,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.0.0-20240215173409-62ee9918aa58 h1:5bMc3CTcxMXSTqXO5I401Sk5Z/R8RYp5+sRvYS28Z2s=
-github.com/superfly/fly-go v0.0.0-20240215173409-62ee9918aa58/go.mod h1:Mb+y+hXfEKzJ5guQyA/lAhyQqXWHiKULFu/4A5Ehink=
+github.com/superfly/fly-go v0.0.0-20240215193014-b45ae6e6b02c h1:S67UpSXmov8BgU0l6mA/VcxiJzCR4PKZN5JP+NjIN08=
+github.com/superfly/fly-go v0.0.0-20240215193014-b45ae6e6b02c/go.mod h1:Mb+y+hXfEKzJ5guQyA/lAhyQqXWHiKULFu/4A5Ehink=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -55,6 +55,7 @@ func Test_resolveUpdatedMachineConfig_Basic(t *testing.T) {
 			},
 		},
 	}, li)
+
 }
 
 // Test any LaunchMachineInput field that must not be set on a machine


### PR DESCRIPTION
### Change Summary
Supersedes https://github.com/superfly/flyctl/pull/2836

### Documentation

- [x] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [x] n/a
