### PR TITLE
Cordon and gracefully shutdown old machines during blue-green deploy

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -143,6 +143,11 @@ var CommonFlags = flag.Set{
 		Name:        "process-groups",
 		Description: "Deploy to machines only in these process groups",
 	},
+	flag.String{
+		Name:        "signal",
+		Shorthand:   "s",
+		Description: "Signal to stop the machine with for bluegreen strategy (default: SIGINT)",
+	},
 }
 
 func New() (cmd *cobra.Command) {
@@ -379,6 +384,7 @@ func deployToMachines(
 		SkipHealthChecks:       flag.GetDetach(ctx),
 		SkipDNSChecks:          flag.GetDetach(ctx) || !flag.GetBool(ctx, "dns-checks"),
 		WaitTimeout:            waitTimeout,
+		StopSignal:             flag.GetString(ctx, "signal"),
 		ReleaseCmdTimeout:      releaseCmdTimeout,
 		LeaseTimeout:           leaseTimeout,
 		MaxUnavailable:         maxUnavailable,

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -53,6 +53,7 @@ type MachineDeploymentArgs struct {
 	MaxUnavailable         *float64
 	RestartOnly            bool
 	WaitTimeout            *time.Duration
+	StopSignal             string
 	LeaseTimeout           *time.Duration
 	ReleaseCmdTimeout      *time.Duration
 	Guest                  *fly.MachineGuest
@@ -88,6 +89,7 @@ type machineDeployment struct {
 	maxUnavailable         float64
 	restartOnly            bool
 	waitTimeout            time.Duration
+	stopSignal             string
 	leaseTimeout           time.Duration
 	leaseDelayBetween      time.Duration
 	releaseCmdTimeout      time.Duration
@@ -206,6 +208,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		restartOnly:            args.RestartOnly,
 		maxUnavailable:         maxUnavailable,
 		waitTimeout:            waitTimeout,
+		stopSignal:             args.StopSignal,
 		leaseTimeout:           leaseTimeout,
 		leaseDelayBetween:      leaseDelayBetween,
 		releaseCmdTimeout:      releaseCmdTimeout,

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -26,7 +26,9 @@ type LeasableMachine interface {
 	StartBackgroundLeaseRefresh(context.Context, time.Duration, time.Duration)
 	Update(context.Context, fly.LaunchMachineInput) error
 	Start(context.Context) error
+	Stop(context.Context, string) error
 	Destroy(context.Context, bool) error
+	Cordon(context.Context) error
 	WaitForState(context.Context, string, time.Duration, bool) error
 	WaitForSmokeChecksToPass(context.Context) error
 	WaitForHealthchecksToPass(context.Context, time.Duration) error
@@ -71,6 +73,19 @@ func (lm *leasableMachine) Update(ctx context.Context, input fly.LaunchMachineIn
 	return nil
 }
 
+func (lm *leasableMachine) Stop(ctx context.Context, signal string) error {
+	if lm.IsDestroyed() {
+		return fmt.Errorf("cannon stop machine %s that was already destroyed", lm.machine.ID)
+	}
+
+	input := fly.StopMachineInput{
+		ID:     lm.machine.ID,
+		Signal: signal,
+	}
+
+	return lm.flapsClient.Stop(ctx, input, lm.leaseNonce)
+}
+
 func (lm *leasableMachine) Destroy(ctx context.Context, kill bool) error {
 	if lm.IsDestroyed() {
 		return nil
@@ -85,6 +100,14 @@ func (lm *leasableMachine) Destroy(ctx context.Context, kill bool) error {
 	}
 	lm.destroyed = true
 	return nil
+}
+
+func (lm *leasableMachine) Cordon(ctx context.Context) error {
+	if lm.IsDestroyed() {
+		return fmt.Errorf("cannon cordon machine %s that was already destroyed", lm.machine.ID)
+	}
+
+	return lm.flapsClient.Cordon(ctx, lm.machine.ID, lm.leaseNonce)
 }
 
 func (lm *leasableMachine) FormattedMachineId() string {


### PR DESCRIPTION
If flyctl destroys the old machines immediatelly after uncordoning the
new ones, fly-proxy doesn't have any time to learn about the new machines
and has nowhere to send the requests.

So this patch modifies the procedure to first cordon the old machines.

Even with this in place, we need to gracefully shutdown the old machines
in order to let the app properly terminate existing connections by handling
SIGTERM.
