### PR TITLE
Fix `cannot apply host to transport: *otelhttp.Transport`

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -169,12 +169,11 @@ func (t DockerDaemonType) PrefersLocal() bool {
 }
 
 func NewLocalDockerClient() (*dockerclient.Client, error) {
-	c, err := dockerclient.NewClientWithOpts(dockerclient.WithAPIVersionNegotiation())
+	c, err := dockerclient.NewClientWithOpts(
+		dockerclient.FromEnv,
+		dockerclient.WithAPIVersionNegotiation(),
+	)
 	if err != nil {
-		return nil, err
-	}
-
-	if err := dockerclient.FromEnv(c); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Since https://github.com/moby/moby/pull/45652,
client.NewClientWithOpts wraps its Transport with
otelhttp.NewTransport, but *otelhttp.Transport doesn't satisfy http.Transport.

Fixes #3274

### Change Summary

What and Why:
- moby/moby upgrade brokes flyctl for some customers.
- Our way of using the client library is no longer supported.

How:

Related to:
- https://community.fly.io/t/gitlab-error-connecting-to-local-docker-daemon/18250

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
