### PR TITLE
fly image update is not just for Postgres

### DIFF
--- a/internal/command/image/update.go
+++ b/internal/command/image/update.go
@@ -15,9 +15,9 @@ import (
 
 func newUpdate() *cobra.Command {
 	const (
-		long = `This will update the application's image to the latest available version.
-The update will perform a rolling restart against each VM, which may result in a brief service disruption.`
-		short = "Updates the app's image to the latest available version. (Fly Postgres only)"
+		long = `Update the app's image to the latest available version.
+The update will perform a rolling restart against each Machine, which may result in a brief service disruption.`
+		short = "Updates the app's image to the latest available version."
 		usage = "update"
 	)
 


### PR DESCRIPTION
### Change Summary

What and Why:

The help docs said that `fly image update` was just for Postgres is no longer true since a long time ago.

How:

Updated the help docs.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
