### PR TITLE
Get otel internal logger to respect log levels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/go-git/go-git/v5 v5.11.0 // indirect
-	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"time"
@@ -20,7 +21,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/go-logr/logr"
 	"github.com/superfly/flyctl/internal/buildinfo"
+	"github.com/superfly/flyctl/iostreams"
 )
 
 const (
@@ -151,5 +154,32 @@ func InitTraceProvider(ctx context.Context) (*sdktrace.TracerProvider, error) {
 		),
 	)
 
+	otel.SetLogger(otelLogger(ctx))
+
 	return tp, nil
+}
+
+func otelLogger(ctx context.Context) logr.Logger {
+	io := iostreams.FromContext(ctx)
+
+	var level slog.Level
+	switch os.Getenv("LOG_LEVEL") {
+	case "debug":
+		level = slog.LevelDebug
+	case "info":
+		level = slog.LevelInfo
+	case "warn":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	default:
+		level = slog.LevelInfo
+	}
+
+	opts := &slog.HandlerOptions{
+		Level: level,
+	}
+	handler := slog.NewTextHandler(io.ErrOut, opts)
+
+	return logr.FromSlogHandler(handler)
 }


### PR DESCRIPTION
### Change Summary

What and Why: The recently added otel based tracing was polluting build logs with details that might not be relevant to the user
because the internal otel log did not respect our log level.

How: I'm using the std libray slog to give `otel.SetLogger` a logger that respects the log level set by LOG_LEVEL environment variable.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
