### PR TITLE
[golang] Use a base image that sets CGO_ENABLED=1 

### DIFF
--- a/scanner/templates/go/Dockerfile
+++ b/scanner/templates/go/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 COPY . .
-RUN CGO_ENABLED=1 go build -v -o /run-app .
+RUN go build -v -o /run-app .
 
 
 FROM debian:bookworm

--- a/scanner/templates/go/Dockerfile
+++ b/scanner/templates/go/Dockerfile
@@ -1,14 +1,14 @@
 ARG GO_VERSION=1
-FROM golang:${GO_VERSION}-alpine as builder
+FROM golang:${GO_VERSION}-bookworm as builder
 
 WORKDIR /usr/src/app
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 COPY . .
-RUN go build -v -o /run-app .
+RUN CGO_ENABLED=1 go build -v -o /run-app .
 
 
-FROM alpine:latest
+FROM debian:bookworm
 
 COPY --from=builder /run-app /usr/local/bin/
 CMD ["run-app"]


### PR DESCRIPTION
[golang] Use a base image that sets CGO_ENABLED=1 

### Change Summary

What and Why:

How:

Related to:

Fly discourse: /t/non-buildpack-go-behavior-differences/4975/8

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
