### PR TITLE
Fix flaps debug logging

### DIFF
--- a/internal/flapsutil/flapsutil.go
+++ b/internal/flapsutil/flapsutil.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/logger"
 )
 
 func NewClientWithOptions(ctx context.Context, opts flaps.NewClientOpts) (*flaps.Client, error) {
@@ -47,6 +48,10 @@ func NewClientWithOptions(ctx context.Context, opts flaps.NewClientOpts) (*flaps
 
 	if opts.Tokens == nil {
 		opts.Tokens = config.Tokens(ctx)
+	}
+
+	if v := logger.MaybeFromContext(ctx); v != nil {
+		opts.Logger = v
 	}
 
 	return flaps.NewWithOptions(ctx, opts)


### PR DESCRIPTION
### Change Summary

What and Why: I broke `LOG_LEVEL=debug` when we switched to `fly-go`. This fixes it.

How: 🤦‍♂️ 

Related to: https://github.com/superfly/flyctl/pull/3284

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
