### PR TITLE
Fixes --json support for "postgres users list".

### DIFF
--- a/internal/command/postgres/users.go
+++ b/internal/command/postgres/users.go
@@ -32,7 +32,6 @@ func newUsers() *cobra.Command {
 		newListUsers(),
 	)
 
-	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }
 
@@ -55,6 +54,7 @@ func newListUsers() *cobra.Command {
 		cmd,
 		flag.App(),
 		flag.AppConfig(),
+		flag.JSONOutput(),
 	)
 
 	return cmd


### PR DESCRIPTION
### Change Summary

What and Why:

``--json`` flag should be available on `flyctl postgres users list`, not on the `flyctl postgres users`.

Before:

```
$ flyctl postgres users list -a <<some_app>> --json
...
Error: unknown flag: --json
```

After:

```
$ flyctl postgres users list -a <<some_app>> --json
[
    {
        "Username": "my_fancy_user",
        "Superuser": true,
        "Databases": [
            "some_app_db",
            "postgres",
            "repmgr"
        ]
    },
    ....
]
```

### Documentation

I guess it should update automatically.