### PR TITLE
Consistently lease machines on state changing actions

### DIFF
--- a/internal/command/machine/cordon.go
+++ b/internal/command/machine/cordon.go
@@ -8,6 +8,7 @@ import (
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -40,16 +41,22 @@ func runMachineCordon(ctx context.Context) (err error) {
 		args = flag.Args(ctx)
 	)
 
-	machineIDs, ctx, err := selectManyMachineIDs(ctx, args)
+	machines, ctx, err := selectManyMachines(ctx, args)
 	if err != nil {
 		return err
 	}
 
+	machines, release, err := mach.AcquireLeases(ctx, machines)
+	if err != nil {
+		return err
+	}
+	defer release()
+
 	flapsClient := flaps.FromContext(ctx)
 
-	for _, machineID := range machineIDs {
-		fmt.Fprintf(io.Out, "Activating cordon on machine %s...\n", machineID)
-		if err = flapsClient.Cordon(ctx, machineID, ""); err != nil {
+	for _, machine := range machines {
+		fmt.Fprintf(io.Out, "Activating cordon on machine %s...\n", machine.ID)
+		if err = flapsClient.Cordon(ctx, machine.ID, machine.LeaseNonce); err != nil {
 			return err
 		}
 		fmt.Fprintf(io.Out, "done!\n")

--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -52,6 +53,12 @@ func runMachineDestroy(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
+		machine, release, err := mach.AcquireLease(ctx, machine)
+		if err != nil {
+			return err
+		}
+		defer release()
+
 		err = singleDestroyRun(ctx, machine)
 		if err != nil {
 			return err
@@ -61,6 +68,12 @@ func runMachineDestroy(ctx context.Context) (err error) {
 		if err != nil {
 			return err
 		}
+
+		machines, release, err := mach.AcquireLeases(ctx, machines)
+		if err != nil {
+			return err
+		}
+		defer release()
 
 		for _, machine := range machines {
 			err = singleDestroyRun(ctx, machine)

--- a/internal/command/machine/start.go
+++ b/internal/command/machine/start.go
@@ -3,13 +3,15 @@ package machine
 import (
 	"context"
 	"fmt"
-	"github.com/superfly/flyctl/internal/appconfig"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -44,37 +46,43 @@ func runMachineStart(ctx context.Context) (err error) {
 		args = flag.Args(ctx)
 	)
 
-	machineIDs, ctx, err := selectManyMachineIDs(ctx, args)
+	machines, ctx, err := selectManyMachines(ctx, args)
 	if err != nil {
 		return err
 	}
 
-	for _, machineID := range machineIDs {
-		if err = Start(ctx, machineID); err != nil {
+	machines, release, err := mach.AcquireLeases(ctx, machines)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	for _, machine := range machines {
+		if err = Start(ctx, machine); err != nil {
 			return
 		}
-		fmt.Fprintf(io.Out, "%s has been started\n", machineID)
+		fmt.Fprintf(io.Out, "%s has been started\n", machine.ID)
 	}
 	return
 }
 
-func Start(ctx context.Context, machineID string) (err error) {
-	machine, err := flaps.FromContext(ctx).Start(ctx, machineID, "")
+func Start(ctx context.Context, machine *fly.Machine) (err error) {
+	res, err := flaps.FromContext(ctx).Start(ctx, machine.ID, machine.LeaseNonce)
 	if err != nil {
 		//TODO(dov): just do the clone
 		switch {
 		case strings.Contains(err.Error(), " for machine"):
-			return fmt.Errorf("could not start machine due to lack of capacity. Try 'flyctl machine clone %s -a %s'", machineID, appconfig.NameFromContext(ctx))
+			return fmt.Errorf("could not start machine due to lack of capacity. Try 'flyctl machine clone %s -a %s'", machine.ID, appconfig.NameFromContext(ctx))
 		default:
-			if err := rewriteMachineNotFoundErrors(ctx, err, machineID); err != nil {
+			if err := rewriteMachineNotFoundErrors(ctx, err, machine.ID); err != nil {
 				return err
 			}
-			return fmt.Errorf("could not start machine %s: %w", machineID, err)
+			return fmt.Errorf("could not start machine %s: %w", machine.ID, err)
 		}
 	}
 
-	if machine.Status == "error" {
-		return fmt.Errorf("machine could not be started: %s", machine.Message)
+	if res.Status == "error" {
+		return fmt.Errorf("machine could not be started: %s", res.Message)
 	}
 	return
 }


### PR DESCRIPTION
### Change Summary

What and Why: Machines expose a lease API that is supposed to protect them from race conditions but are not using it consistently

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
