### PR TITLE
Fix GraphQL debug logging

### DIFF
--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -13,9 +13,9 @@ import (
 	"github.com/spf13/pflag"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/helpers"
-	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/instrument"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/state"
@@ -62,11 +62,7 @@ func InitClient(ctx context.Context) (context.Context, error) {
 	fly.SetInstrumenter(instrument.ApiAdapter)
 	fly.SetTransport(otelhttp.NewTransport(http.DefaultTransport))
 
-	c := fly.NewClientFromOptions(fly.ClientOptions{
-		Name:    buildinfo.Name(),
-		Version: buildinfo.Version().String(),
-		Tokens:  cfg.Tokens,
-	})
+	c := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{Tokens: cfg.Tokens})
 	logger.Debug("client initialized.")
 
 	return fly.NewContextWithClient(ctx, c), nil

--- a/internal/command/auth/login.go
+++ b/internal/command/auth/login.go
@@ -8,10 +8,10 @@ import (
 
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
-	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/state"
 	"github.com/superfly/flyctl/iostreams"
@@ -81,10 +81,8 @@ func runLogin(ctx context.Context) error {
 		return err
 	}
 
-	user, err := fly.NewClientFromOptions(fly.ClientOptions{
+	user, err := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{
 		AccessToken: token,
-		Name:        buildinfo.Name(),
-		Version:     buildinfo.Version().String(),
 	}).GetCurrentUser(ctx)
 	if err != nil {
 		return fmt.Errorf("failed retrieving current user: %w", err)

--- a/internal/command/auth/signup.go
+++ b/internal/command/auth/signup.go
@@ -7,8 +7,8 @@ import (
 	"github.com/spf13/cobra"
 
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -33,10 +33,8 @@ func runSignup(ctx context.Context) error {
 		return err
 	}
 
-	user, err := fly.NewClientFromOptions(fly.ClientOptions{
+	user, err := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{
 		AccessToken: token,
-		Name:        buildinfo.Name(),
-		Version:     buildinfo.Version().String(),
 	}).GetCurrentUser(ctx)
 	if err != nil {
 		return fmt.Errorf("failed retrieving current user: %w", err)

--- a/internal/flyutil/flyutil.go
+++ b/internal/flyutil/flyutil.go
@@ -1,0 +1,22 @@
+package flyutil
+
+import (
+	"context"
+
+	"github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/buildinfo"
+	"github.com/superfly/flyctl/internal/logger"
+)
+
+func NewClientFromOptions(ctx context.Context, opts fly.ClientOptions) *fly.Client {
+	if opts.Name == "" {
+		opts.Name = buildinfo.Name()
+	}
+	if opts.Version == "" {
+		opts.Version = buildinfo.Version().String()
+	}
+	if v := logger.MaybeFromContext(ctx); v != nil && opts.Logger == nil {
+		opts.Logger = v
+	}
+	return fly.NewClientFromOptions(opts)
+}

--- a/internal/metrics/token.go
+++ b/internal/metrics/token.go
@@ -7,8 +7,8 @@ import (
 
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
-	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/state"
 	"github.com/superfly/flyctl/terminal"
 )
@@ -18,10 +18,8 @@ func queryMetricsToken(ctx context.Context) (string, error) {
 	// We use this over the context API client because we're trying to
 	// authenticate the human user, not the specific credentials they're using.
 	cfg := config.FromContext(ctx)
-	apiClient := fly.NewClientFromOptions(fly.ClientOptions{
-		Name:    buildinfo.Name(),
-		Version: buildinfo.Version().String(),
-		Tokens:  cfg.Tokens,
+	apiClient := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{
+		Tokens: cfg.Tokens,
 	})
 
 	personal, err := apiClient.GetOrganizationBySlug(ctx, "personal")

--- a/scripts/clean-up-preflight-apps/main.go
+++ b/scripts/clean-up-preflight-apps/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/shlex"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
-	"github.com/superfly/flyctl/internal/buildinfo"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -25,10 +25,8 @@ func main() {
 func run() error {
 	var (
 		ctx       = context.TODO()
-		apiClient = fly.NewClientFromOptions(fly.ClientOptions{
+		apiClient = flyutil.NewClientFromOptions(ctx, fly.ClientOptions{
 			AccessToken: os.Getenv("FLY_PREFLIGHT_TEST_ACCESS_TOKEN"),
-			Name:        buildinfo.Name(),
-			Version:     buildinfo.Version().String(),
 			BaseURL:     "https://api.fly.io",
 			Logger:      logger.FromEnv(iostreams.System().ErrOut),
 		})


### PR DESCRIPTION
### Change Summary

What and Why: Using `LOG_LEVEL=debug` only printed Machine API calls and not GraphQL.

How: Added a `flyutil` package to wrap `fly.NewClientWithOptions()` so we can default the logger.

Related to: https://github.com/superfly/flyctl/pull/3284

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
