### PR TITLE
Goreleaser: update deprecated field

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -96,7 +96,7 @@ changelog:
       - "^test:"
 
 brews:
-  - tap:
+  - repository:
       owner: superfly
       name: homebrew-tap
     folder: Formula


### PR DESCRIPTION
### Change Summary

What and Why: Update goreleaser configuration

How: tap was replaced by repository

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
