### PR TITLE
Bring back graphql client logs

### DIFF
--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -66,6 +66,7 @@ func InitClient(ctx context.Context) (context.Context, error) {
 		Name:    buildinfo.Name(),
 		Version: buildinfo.Version().String(),
 		Tokens:  cfg.Tokens,
+		Logger:  logger,
 	})
 	logger.Debug("client initialized.")
 


### PR DESCRIPTION
### Change Summary

What and Why: Debug logs from the fly graphql client were missing

How: Pass the logger as an option.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
