### PR TITLE
Remove redundant volume error wrapping

### DIFF
--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -148,7 +148,7 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 
 			vol, err := md.flapsClient.CreateVolume(ctx, input)
 			if err != nil {
-				return fmt.Errorf("failed creating volume: %w", err)
+				return err
 			}
 
 			md.volumes[m.Source] = append(md.volumes[m.Source], *vol)

--- a/internal/command/volumes/create.go
+++ b/internal/command/volumes/create.go
@@ -146,7 +146,7 @@ func runCreate(ctx context.Context) error {
 	for i := 0; i < count; i++ {
 		volume, err := flapsClient.CreateVolume(ctx, input)
 		if err != nil {
-			return fmt.Errorf("failed creating volume: %w", err)
+			return err
 		}
 
 		if cfg.JSONOutput {


### PR DESCRIPTION
### Change Summary

What and Why: This error is already wrapped with more context in the flaps package: https://github.com/superfly/fly-go/blob/fcbcb1c70cccc7a610c16a2ea75c4a2f3f6de251/flaps/flaps_volumes.go#L51
              I do think http client packages should just return the errors and let the caller add context though. But this is the easier change.
How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
