### PR TITLE
Parallelize deletion of old machines in blue/green deploy

### DIFF
--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -13,6 +13,7 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/conc/pool"
 	"go.opentelemetry.io/otel/attribute"
 
 	fly "github.com/superfly/fly-go"
@@ -507,44 +508,35 @@ func (bg *blueGreen) DestroyBlueMachines(ctx context.Context) error {
 	ctx, span := tracing.GetTracer().Start(ctx, "destroy_blue_machines")
 	defer span.End()
 
-	const parallelism = 16
-
-	ch := make(chan *machineUpdateEntry, len(bg.blueMachines))
-	for _, gm := range bg.blueMachines {
-		ch <- gm
-	}
-	close(ch)
+	p := pool.New().
+		WithErrors().
+		WithFirstError().
+		WithMaxGoroutines(16)
 
 	var mu sync.Mutex
-	var wg sync.WaitGroup
-	for i := 0; i < parallelism; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			for gm := range ch {
-				if bg.isAborted() {
-					return
-				}
-
-				err := gm.leasableMachine.Destroy(ctx, true)
-				if err != nil {
-					mu.Lock()
-					bg.hangingBlueMachines = append(bg.hangingBlueMachines, gm.launchInput.ID)
-					mu.Unlock()
-					continue
-				}
-
-				mu.Lock()
-				fmt.Fprintf(bg.io.ErrOut, "  Machine %s destroyed\n", bg.colorize.Bold(gm.leasableMachine.FormattedMachineId()))
-				mu.Unlock()
+	for _, gm := range bg.blueMachines {
+		p.Go(func() error {
+			if bg.isAborted() {
+				return ErrAborted
 			}
-		}()
+
+			err := gm.leasableMachine.Destroy(ctx, true)
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if err != nil {
+				bg.hangingBlueMachines = append(bg.hangingBlueMachines, gm.launchInput.ID)
+				return nil
+			}
+
+			fmt.Fprintf(bg.io.ErrOut, "  Machine %s destroyed\n", bg.colorize.Bold(gm.leasableMachine.FormattedMachineId()))
+			return nil
+		})
 	}
 
-	wg.Wait()
-	if bg.isAborted() {
-		return ErrAborted
+	if err := p.Wait(); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -507,18 +507,46 @@ func (bg *blueGreen) DestroyBlueMachines(ctx context.Context) error {
 	ctx, span := tracing.GetTracer().Start(ctx, "destroy_blue_machines")
 	defer span.End()
 
-	for _, gm := range bg.blueMachines {
-		if bg.isAborted() {
-			return ErrAborted
-		}
-		err := gm.leasableMachine.Destroy(ctx, true)
-		if err != nil {
-			bg.hangingBlueMachines = append(bg.hangingBlueMachines, gm.launchInput.ID)
-			continue
-		}
+	const parallelism = 16
 
-		fmt.Fprintf(bg.io.ErrOut, "  Machine %s destroyed\n", bg.colorize.Bold(gm.leasableMachine.FormattedMachineId()))
+	ch := make(chan *machineUpdateEntry, len(bg.blueMachines))
+	for _, gm := range bg.blueMachines {
+		ch <- gm
 	}
+	close(ch)
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for i := 0; i < parallelism; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for gm := range ch {
+				if bg.isAborted() {
+					return
+				}
+
+				err := gm.leasableMachine.Destroy(ctx, true)
+				if err != nil {
+					mu.Lock()
+					bg.hangingBlueMachines = append(bg.hangingBlueMachines, gm.launchInput.ID)
+					mu.Unlock()
+					continue
+				}
+
+				mu.Lock()
+				fmt.Fprintf(bg.io.ErrOut, "  Machine %s destroyed\n", bg.colorize.Bold(gm.leasableMachine.FormattedMachineId()))
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+	if bg.isAborted() {
+		return ErrAborted
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### Change Summary

What and Why: Machines are destroyed serially, which can take a while. We should destroy them faster.

How: Run deletions in multiple goroutines. There is a hardcoded limit for parallelism that we may want to expand later but we also don't want users to overload the API for very large deployments.

Related to: https://github.com/superfly/flyctl/issues/3328

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
