### PR TITLE
Add Filament Cache Command through Laravel Scanner's Dockerfile Template

### DIFF
--- a/scanner/templates/laravel/.fly/scripts/caches.sh
+++ b/scanner/templates/laravel/.fly/scripts/caches.sh
@@ -3,3 +3,9 @@
 /usr/bin/php /var/www/html/artisan config:cache --no-ansi -q
 /usr/bin/php /var/www/html/artisan route:cache --no-ansi -q
 /usr/bin/php /var/www/html/artisan view:cache --no-ansi -q
+
+# Filament v3.2 Performance Improvement with commands 
+if grep "filament/filament.*:.*3\.2" "/var/www/html/composer.json"; then 
+    /usr/bin/php /var/www/html/artisan icons:cache --no-ansi -q
+    /usr/bin/php /var/www/html/artisan filament:cache-components --no-ansi -q
+fi

--- a/scanner/templates/laravel/Dockerfile
+++ b/scanner/templates/laravel/Dockerfile
@@ -40,6 +40,11 @@ RUN if grep -Fq "laravel/octane" /var/www/html/composer.json; then \
         ln -sf /etc/nginx/sites-available/default-octane /etc/nginx/sites-enabled/default; \
     fi
 
+# If we're using Filament...
+RUN if grep -Fq "filament/filament" /var/www/html/composer.json; then \
+        php artisan icons:cache && php artisan filament:cache-components; \
+    fi
+    
 # Multi-stage build: Build static assets
 # This allows us to not include Node within the final container
 FROM node:${NODE_VERSION} as node_modules_go_brrr

--- a/scanner/templates/laravel/Dockerfile
+++ b/scanner/templates/laravel/Dockerfile
@@ -39,11 +39,6 @@ RUN if grep -Fq "laravel/octane" /var/www/html/composer.json; then \
         rm /etc/nginx/sites-enabled/default; \
         ln -sf /etc/nginx/sites-available/default-octane /etc/nginx/sites-enabled/default; \
     fi
-
-# If we're using Filament...
-RUN if grep -Fq "filament/filament" /var/www/html/composer.json; then \
-        php artisan icons:cache && php artisan filament:cache-components; \
-    fi
     
 # Multi-stage build: Build static assets
 # This allows us to not include Node within the final container


### PR DESCRIPTION

### Change Summary

**What and Why:** 
What: Run Filament Cache command when Filament is installed for a Laravel application

Why: Thanks to [community post](https://community.fly.io/t/am-i-holding-it-wrong-laravel-performance-on-fly-io/18503/15), it was discovered that Laravel apps with Filament installed get really low requests per second( I tested, and got 5 requests per second ). This can be improved by running [Filament's cache commands. ](https://filamentphp.com/docs/3.x/panels/installation#improving-filament-panel-performance)

**How:**
Revise Laravel's Dockerfile template to run the Filament cache commands when  "filament/filament" is detected in the composer.json file

**Related to:**
[Community post](https://community.fly.io/t/am-i-holding-it-wrong-laravel-performance-on-fly-io/18503)
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
