### PR TITLE
Avoid losing context state by passing original context

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -65,7 +65,7 @@ func (md *machineDeployment) DeployMachinesApp(ctx context.Context) error {
 		// Provide an extra second to try to update the release status.
 		status = "interrupted"
 		var cancel func()
-		ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+		ctx, cancel = context.WithTimeout(ctx, time.Second)
 		defer cancel()
 	default:
 		status = "failed"


### PR DESCRIPTION
### Change Summary

What and Why: Panic while doing dns checks do to flaps/fly api client missing from the context.Context.

How: 

Related to: https://flyio.sentry.io/issues/4981226661/?alert_rule_id=7865765&alert_type=issue&environment=production&notification_uuid=ba5aa509-c317-4e92-9fe7-994160a84f1a&project=4492967&referrer=slack

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
