### PR TITLE
Made Django scanner handle pure ASGI projects.

### DIFF
--- a/scanner/django.go
+++ b/scanner/django.go
@@ -134,6 +134,18 @@ This module is used on Dockerfile to start the Gunicorn server process.
 		}
 	}
 
+	if checksPass(sourceDir, dirContains("requirements.txt", "gunicorn")) ||
+		checksPass(sourceDir, dirContains("Pipfile", "gunicorn")) ||
+		checksPass(sourceDir, dirContains("pyproject.toml", "gunicorn")) {
+		vars["hasGunicorn"] = true
+	}
+
+	if checksPass(sourceDir, dirContains("requirements.txt", "daphne")) ||
+		checksPass(sourceDir, dirContains("Pipfile", "daphne")) ||
+		checksPass(sourceDir, dirContains("pyproject.toml", "daphne")) {
+		vars["hasDaphne"] = true
+	}
+
 	asgiFiles, err := zglob.Glob(`./**/asgi.py`)
 
 	if err == nil && len(asgiFiles) > 0 {
@@ -161,7 +173,7 @@ This module is used on Dockerfile to start the Gunicorn server process.
 Multiple asgi.py files were found in your Django application:
 [%s]
 Before proceeding, make sure '%s' is the module containing a ASGI application object named 'application'. If not, update your Dockefile.
-This module is used on Dockerfile to start the Gunicorn server process.
+This module is used on Dockerfile to start the Daphne server process.
 `, strings.Join(asgiFilesProject, ", "), dirPath)
 			}
 		}

--- a/scanner/django.go
+++ b/scanner/django.go
@@ -134,6 +134,39 @@ This module is used on Dockerfile to start the Gunicorn server process.
 		}
 	}
 
+	asgiFiles, err := zglob.Glob(`./**/asgi.py`)
+
+	if err == nil && len(asgiFiles) > 0 {
+		var asgiFilesProject []string
+		for _, asgiPath := range asgiFiles {
+			// When using a virtual environment to manage the dependencies (e.g. venv),
+			// the 'site-packages/' folder is created within the virtual environment
+			// folder. This folder contains all the (dependencies) packages installed
+			// within the virtual environment.
+			// Exclude dependencies matches that contain 'site-packages'.
+			if !strings.Contains(asgiPath, "site-packages") {
+				asgiFilesProject = append(asgiFilesProject, asgiPath)
+			}
+		}
+
+		if len(asgiFilesProject) > 0 {
+			asgiFilesLen := len(asgiFilesProject)
+			dirPath, _ := path.Split(asgiFilesProject[asgiFilesLen-1])
+			dirName := path.Base(dirPath)
+			vars["asgiName"] = dirName
+			vars["asgiFound"] = true
+			if asgiFilesLen > 1 {
+				// Warning: multiple asgi.py files found.
+				s.DeployDocs = s.DeployDocs + fmt.Sprintf(`
+Multiple asgi.py files were found in your Django application:
+[%s]
+Before proceeding, make sure '%s' is the module containing a ASGI application object named 'application'. If not, update your Dockefile.
+This module is used on Dockerfile to start the Gunicorn server process.
+`, strings.Join(asgiFilesProject, ", "), dirPath)
+			}
+		}
+	}
+
 	// check if settings.py file exists
 	allSettingsFiles, err := zglob.Glob(`./**/settings.py`)
 

--- a/scanner/templates/django/Dockerfile
+++ b/scanner/templates/django/Dockerfile
@@ -47,7 +47,11 @@ RUN python manage.py collectstatic --noinput
 {{ end }}
 EXPOSE 8000
 
-{{ if .wsgiFound -}}
+{{ if and .wsgiFound .hasGunicorn -}}
+CMD ["gunicorn", "--bind", ":8000", "--workers", "2", "{{ .wsgiName }}.wsgi"]
+{{ else if and .asgiFound .hasDaphne -}}
+CMD ["daphne", "-b", "0.0.0.0", "-p", "8000", "{{ .asgiName }}.asgi:application"]
+{{ else if .wsgiFound -}}
 CMD ["gunicorn", "--bind", ":8000", "--workers", "2", "{{ .wsgiName }}.wsgi"]
 {{ else if .asgiFound -}}
 CMD ["daphne", "-b", "0.0.0.0", "-p", "8000", "{{ .asgiName }}.asgi:application"]

--- a/scanner/templates/django/Dockerfile
+++ b/scanner/templates/django/Dockerfile
@@ -49,6 +49,8 @@ EXPOSE 8000
 
 {{ if .wsgiFound -}}
 CMD ["gunicorn", "--bind", ":8000", "--workers", "2", "{{ .wsgiName }}.wsgi"]
+{{ else if .asgiFound -}}
+CMD ["daphne", "-b", "0.0.0.0", "-p", "8000", "{{ .asgiName }}.asgi:application"]
 {{ else -}}
 # TODO: replace demo.wsgi with <project_name>.wsgi
 CMD ["gunicorn", "--bind", ":8000", "--workers", "2", "demo.wsgi"]


### PR DESCRIPTION
### Change Summary

#### What and Why:

Django scanner should generate a valid command for pure ASGI projects without WSGI applications.

#### How:

When `wsgi.py` doesn't exist and `asgi.py` does, generate command to start `daphne` web server pointing to the ASGi application.  

---

### Documentation

- [x] Fresh Produce