### PR TITLE
Add experimental `kernel_args` field in fly.toml.

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -27,7 +27,7 @@ func NewConfig() *Config {
 }
 
 // Config wraps the properties of app configuration.
-// NOTE: If you any new setting here, please also add a value for it at testdata/rull-reference.toml
+// NOTE: If you any new setting here, please also add a value for it at testdata/full-reference.toml
 type Config struct {
 	AppName        string        `toml:"app,omitempty" json:"app,omitempty"`
 	PrimaryRegion  string        `toml:"primary_region,omitempty" json:"primary_region,omitempty"`
@@ -147,6 +147,7 @@ type Experimental struct {
 	AutoRollback bool     `toml:"auto_rollback,omitempty" json:"auto_rollback,omitempty"`
 	EnableConsul bool     `toml:"enable_consul,omitempty" json:"enable_consul,omitempty"`
 	EnableEtcd   bool     `toml:"enable_etcd,omitempty" json:"enable_etcd,omitempty"`
+	KernelArgs   []string `toml:"kernel_args,omitempty" json:"kernel_args,omitempty"`
 }
 
 type Compute struct {

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -289,5 +289,9 @@ func (c *Config) toMachineGuest() (*fly.MachineGuest, error) {
 		}
 	}
 
+	if c.Experimental != nil {
+		guest.KernelArgs = c.Experimental.KernelArgs
+	}
+
 	return guest, nil
 }

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -13,6 +13,7 @@ host_dedication_id = "06031957"
   auto_rollback = true
   enable_consul = true
   enable_etcd = true
+  kernel_args = ["LOG_FILTER=debug"]
 
 [build]
   builder = "dockerfile"


### PR DESCRIPTION
### Change Summary
Add a `kernel_args` field to the `[experimental]` section in fly.toml.

This is useful, for instance, when debugging an issue that requires bumping init's log level but without having to update the machine to add it in later.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x ] n/a
