### PR TITLE
Fix initial pg machine config for scaling to zero

### DIFF
--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -51,6 +51,7 @@ type CreateClusterInput struct {
 	SnapshotID         *string
 	Manager            string
 	Autostart          bool
+	Autostop           bool
 	ScaleToZero        bool
 	ForkFrom           string
 }
@@ -72,6 +73,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 	// Ensure machines can be started when scaling to zero is enabled
 	if config.ScaleToZero {
 		config.Autostart = true
+		config.Autostop  = true
 	}
 
 	app, err := l.createApp(ctx, config)
@@ -149,6 +151,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 					},
 					Concurrency: concurrency,
 					Autostart:   &config.Autostart,
+					Autostop:    &config.Autostop,
 				},
 				{
 					Protocol:     "tcp",
@@ -164,6 +167,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 					},
 					Concurrency: concurrency,
 					Autostart:   &config.Autostart,
+					Autostop:    &config.Autostop,
 				},
 			}
 		}


### PR DESCRIPTION
### Change Summary

_What and Why:_

I was kicking the tires on [Fly Postgres](https://fly.io/docs/postgres/) and this caught my eye:

> In the single-instance “Development” config, you’ll also be given the option to activate “automatic scale to zero”. It’s not magic: it’s just [how our apps work](https://fly.io/docs/apps/scale-count/#scale-to-zero). If you have an app that connects to your database, make sure that [it also scales to zero](https://fly.io/docs/apps/scale-count/#scale-to-zero) (otherwise the connection remaining open will prevent it from “going to sleep”

But, it didn't look like my single-instance cluster was ever actually scaling down to zero.

I found [this post](https://community.fly.io/t/postgres-apps-not-scaling-to-zero/13311) on community.fly.io that recommended editing the `fly.toml` to set `auto_stop_machines = true`.

Making the change to `fly.toml` and re-deploying worked for me, so I headed to Github to make this PR.

_How:_

I looked at the changes in https://github.com/superfly/flyctl/pull/2282 and believe that setting `Autostop`  along with `Autostart` should do the trick.

I tried to look at the GraphQL schema to see if `Autostop` was a valid input, but it looks like the `config` input is as far as the schema goes:

<img width="1051" alt="image" src="https://github.com/superfly/flyctl/assets/629062/3af54c1e-63a7-4b35-bdfa-98a9ba759300">

I did not yet attempt writing an integration / "preflight" test (my Go is a bit rusty), but would happy to do so if desired.


_Related to:_

* https://community.fly.io/t/postgres-apps-not-scaling-to-zero/13311
* https://github.com/superfly/flyctl/pull/2282
* https://community.fly.io/t/scale-to-zero-postgres-for-hobby-projects/12212
