### PR TITLE
use wg flag in m run command

### DIFF
--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -42,6 +42,7 @@ func New() *cobra.Command {
 		flag.App(),
 		flag.AppConfig(),
 		flag.Region(),
+		flag.Wireguard(),
 		flag.String{
 			Name:        "machine",
 			Description: "Run the console in the existing machine with the specified ID",

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -224,6 +224,7 @@ func newRun() *cobra.Command {
 		cmd,
 		runOrCreateFlags,
 		sharedFlags,
+		flag.Wireguard(),
 		flag.String{
 			Name:        "user",
 			Description: "Used with --shell. The username, if we're shelling into the Machine now.",


### PR DESCRIPTION
### Change Summary
`getBool(name)` returns `false`, if nothing is set on ctx. Except that trips the `!connectOverWireguard` check, because it expects the default value to be true. Adding this flag sets the proper default.
