### PR TITLE
Remove rollback on blue/green deploy failure

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -441,9 +441,11 @@ func (md *machineDeployment) updateUsingBlueGreenStrategy(ctx context.Context, u
 	bg := BlueGreenStrategy(md, updateEntries)
 	if err := bg.Deploy(ctx); err != nil {
 		fmt.Fprintf(md.io.ErrOut, "Deployment failed after error: %s\n", err)
-		if rollbackErr := bg.Rollback(ctx, err); rollbackErr != nil {
-			fmt.Fprintf(md.io.ErrOut, "Error in rollback: %s\n", rollbackErr)
-			return rollbackErr
+
+		if strings.Contains(err.Error(), ErrDestroyBlueMachines.Error()) {
+			fmt.Fprintf(bg.io.ErrOut, "\nFailed to destroy blue machines (%s)\n", strings.Join(bg.hangingBlueMachines, ","))
+			fmt.Fprintf(bg.io.ErrOut, "\nYou can destroy them using `fly machines destroy --force <id>`")
+			return err
 		}
 		return suggestChangeWaitTimeout(err, "wait-timeout")
 	}

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -722,27 +722,6 @@ func (bg *blueGreen) Deploy(ctx context.Context) error {
 	return nil
 }
 
-func (bg *blueGreen) Rollback(ctx context.Context, err error) error {
-	ctx, span := tracing.GetTracer().Start(ctx, "rollback")
-	defer span.End()
-
-	if strings.Contains(err.Error(), ErrDestroyBlueMachines.Error()) {
-		fmt.Fprintf(bg.io.ErrOut, "\nFailed to destroy blue machines (%s)\n", strings.Join(bg.hangingBlueMachines, ","))
-		fmt.Fprintf(bg.io.ErrOut, "\nYou can destroy them using `fly machines destroy --force <id>`")
-		return nil
-	}
-
-	for _, mach := range bg.greenMachines.machines() {
-		err := mach.Destroy(ctx, true)
-		if err != nil {
-			tracing.RecordError(span, err, "failed to destroy green machine")
-			return err
-		}
-	}
-
-	return nil
-}
-
 func getZombies(ids map[string]bool) (map[string]bool, error) {
 	numbers := []int{}
 	for str := range ids {


### PR DESCRIPTION
### Change Summary

What and Why: Rollback on blue/green deploy failure can end up killing green machines if the error was caused during certain times of the blue machine shutdown.

How: Remove the code that destroys green machines during rollback.

Related to: 

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x]  n/a
