### PR TITLE
Disable zombie reaping for blue/green deployments

### DIFF
--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -602,12 +602,14 @@ func (bg *blueGreen) Deploy(ctx context.Context) error {
 		return ErrOrgLimit
 	}
 
-	fmt.Fprintf(bg.io.ErrOut, "\nCleanup Previous Deployment\n")
+	/*
+		fmt.Fprintf(bg.io.ErrOut, "\nCleanup Previous Deployment\n")
 
-	err = bg.DeleteZombiesFromPreviousDeployment(ctx)
-	if err != nil {
-		return err
-	}
+		err = bg.DeleteZombiesFromPreviousDeployment(ctx)
+		if err != nil {
+			return err
+		}
+	*/
 
 	bg.attachCustomTopLevelChecks()
 
@@ -734,7 +736,7 @@ func getZombies(ids map[string]bool) (map[string]bool, error) {
 
 	sort.Ints(numbers)
 
-	delete(ids, fmt.Sprint(numbers[0]))
+	delete(ids, fmt.Sprint(numbers[len(numbers)-1]))
 	return ids, nil
 }
 


### PR DESCRIPTION
### Change Summary

What and Why: Previously, we attempted to reap old machines from partial blue/green deployments, however, the logic was removing all newer machines which isn't always what we want. It can also remove all previously deployed machines if any machines are missing a `fly_bluegreen_deployment_tag`.

How: I'm disabling the reaping functionality until we can go through it more thoroughly.

Related to: https://github.com/superfly/flyctl/pull/3295

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
