### PR TITLE
Overwrite uploads in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           name: flyctl
           path: dist/default_linux_amd64_v1/flyctl
+          overwrite: true
 
   preflight:
     needs: test_build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           name: checksums
           path: dist/checksums.txt
+          overwrite: true
 
   sync_docs:
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
           name: build-artifacts
           path: |
             release.json
+          overwrite: true
 
   build:
     needs: meta
@@ -116,6 +117,7 @@ jobs:
             dist/**/*.zip
             dist/**/*.tar.gz
           retention-days: 1
+          overwrite: true
       - name: Upload to flypkgs
         env:
           FLYPKGS_API_TOKEN: ${{ secrets.FLYPKGS_API_TOKEN }}


### PR DESCRIPTION
### Change Summary

What and Why: CI can fail due to a GitHub Actions race condition. 

How: Set `overwrite` to `true` for `upload-artifact`

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
