### PR TITLE
For Rails, check Dockerfile for PostgreSQL

### DIFF
--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -86,10 +86,14 @@ func configureRails(sourceDir string, config *ScannerConfig) (*SourceInfo, error
 		// mysql
 		s.DatabaseDesired = DatabaseKindMySQL
 		s.SkipDatabase = false
-	} else {
+	} else if !checksPass(sourceDir, fileExists("Dockerfile")) || checksPass(sourceDir, dirContains("Dockerfile", "libpq-dev", "postgres")) {
 		// postgresql
 		s.DatabaseDesired = DatabaseKindPostgres
 		s.SkipDatabase = false
+	} else {
+		// sqlite
+		s.DatabaseDesired = DatabaseKindSqlite
+		s.SkipDatabase = true
 	}
 
 	// enable redis if there are any action cable / anycable channels


### PR DESCRIPTION
Prior to Rails 7.1, Rails did not produce a Dockerfile, so we would produce one, and set DATABASE_URL.

Now with Rails 7.1, a Dockerfile exists, and if it isn't set up for PostgreSQL, the initial deploy will fail.  Overwriting the Dockerfile would be a bit rude, so going forward we will only default to PostgreSQL if we detect that the support is present.

Ths is a bit inconsistent with how we are handling MySQL, but the thought being is that if you intentionally chose MySQL, that likely is what you really want.