### PR TITLE
hint volume creation with machine's image

### DIFF
--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -144,6 +144,7 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 				SizeGb:              fly.Pointer(initialSize),
 				Encrypted:           fly.Pointer(true),
 				ComputeRequirements: guest,
+				ComputeImage:        md.img,
 			}
 
 			vol, err := md.flapsClient.CreateVolume(ctx, input)

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -218,6 +218,7 @@ func runMachineClone(ctx context.Context) (err error) {
 				SnapshotID:          snapshotID,
 				RequireUniqueZone:   fly.Pointer(flag.GetBool(ctx, "volume-requires-unique-zone")),
 				ComputeRequirements: targetConfig.Guest,
+				ComputeImage:        targetConfig.Image,
 			}
 			vol, err = flapsClient.CreateVolume(ctx, volInput)
 			if err != nil {

--- a/internal/command/scale/machine_defaults.go
+++ b/internal/command/scale/machine_defaults.go
@@ -131,5 +131,6 @@ func (d *defaultValues) CreateVolumeRequest(mConfig *fly.MachineConfig, region s
 		RequireUniqueZone:   fly.Pointer(false),
 		SnapshotID:          d.snapshotID,
 		ComputeRequirements: mConfig.Guest,
+		ComputeImage:        mConfig.Image,
 	}
 }

--- a/internal/command/volumes/fork.go
+++ b/internal/command/volumes/fork.go
@@ -110,6 +110,7 @@ func runFork(ctx context.Context) error {
 
 	region := flag.GetString(ctx, "region")
 
+	var attachedMachineImage string
 	var attachedMachineGuest *fly.MachineGuest
 	if vol.AttachedMachine != nil {
 		m, err := flapsClient.Get(ctx, *vol.AttachedMachine)
@@ -117,6 +118,7 @@ func runFork(ctx context.Context) error {
 			return err
 		}
 		attachedMachineGuest = m.Config.Guest
+		attachedMachineImage = m.FullImageRef()
 	}
 
 	computeRequirements, err := flag.GetMachineGuest(ctx, attachedMachineGuest)
@@ -130,6 +132,7 @@ func runFork(ctx context.Context) error {
 		RequireUniqueZone:   requireUniqueZone,
 		SourceVolumeID:      &vol.ID,
 		ComputeRequirements: computeRequirements,
+		ComputeImage:        attachedMachineImage,
 		Region:              region,
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why: Hint about the docker image that is going to be used for the machine attached to new volumes, this way the placing logic have a chance to pick a host where the image is already present.  

How: Pass the image name on volume creation request.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
