### PR TITLE
`fly launch`: support launching Supabase databases

### DIFF
--- a/internal/command/launch/describe_plan.go
+++ b/internal/command/launch/describe_plan.go
@@ -16,19 +16,21 @@ import (
 
 const descriptionNone = "<none>"
 
-func describePostgresPlan(ctx context.Context, p plan.PostgresPlan, org *fly.Organization) (string, error) {
+func describePostgresPlan(launchPlan *plan.LaunchPlan) (string, error) {
 
-	switch provider := p.Provider().(type) {
+	switch provider := launchPlan.Postgres.Provider().(type) {
 	case *plan.FlyPostgresPlan:
-		return describeFlyPostgresPlan(ctx, provider, org)
+		return describeFlyPostgresPlan(provider)
+	case *plan.SupabasePostgresPlan:
+		return describeSupabasePostgresPlan(provider, launchPlan)
 	}
 	return descriptionNone, nil
 }
 
-func describeFlyPostgresPlan(ctx context.Context, p *plan.FlyPostgresPlan, org *fly.Organization) (string, error) {
+func describeFlyPostgresPlan(p *plan.FlyPostgresPlan) (string, error) {
 
 	nodePlural := lo.Ternary(p.Nodes == 1, "", "s")
-	nodesStr := fmt.Sprintf("%d Node%s", p.Nodes, nodePlural)
+	nodesStr := fmt.Sprintf("(Fly Postgres) %d Node%s", p.Nodes, nodePlural)
 
 	guestStr := p.VmSize
 	if p.VmRam > 0 {
@@ -46,6 +48,11 @@ func describeFlyPostgresPlan(ctx context.Context, p *plan.FlyPostgresPlan, org *
 	}
 
 	return strings.Join(info, ", "), nil
+}
+
+func describeSupabasePostgresPlan(p *plan.SupabasePostgresPlan, launchPlan *plan.LaunchPlan) (string, error) {
+
+	return fmt.Sprintf("(Supabase) %s in %s", p.GetDbName(launchPlan), p.GetRegion(launchPlan)), nil
 }
 
 func describeRedisPlan(ctx context.Context, p plan.RedisPlan, org *fly.Organization) (string, error) {

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -26,6 +26,10 @@ func (state *launchState) Launch(ctx context.Context) error {
 
 	state.updateConfig(ctx)
 
+	if err := state.validateExtensions(ctx); err != nil {
+		return err
+	}
+
 	org, err := state.Org(ctx)
 	if err != nil {
 		return err

--- a/internal/command/launch/plan/postgres.go
+++ b/internal/command/launch/plan/postgres.go
@@ -61,3 +61,17 @@ type SupabasePostgresPlan struct {
 	DbName string `json:"db_name"`
 	Region string `json:"region"`
 }
+
+func (p *SupabasePostgresPlan) GetDbName(plan *LaunchPlan) string {
+	if p.DbName == "" {
+		return plan.AppName + "-db"
+	}
+	return p.DbName
+}
+
+func (p *SupabasePostgresPlan) GetRegion(plan *LaunchPlan) string {
+	if p.Region == "" {
+		return plan.RegionCode
+	}
+	return p.Region
+}

--- a/internal/command/launch/plan/postgres.go
+++ b/internal/command/launch/plan/postgres.go
@@ -5,7 +5,8 @@ import (
 )
 
 type PostgresPlan struct {
-	FlyPostgres *FlyPostgresPlan `json:"fly_postgres"`
+	FlyPostgres      *FlyPostgresPlan      `json:"fly_postgres"`
+	SupabasePostgres *SupabasePostgresPlan `json:"supabase_postgres"`
 }
 
 func (p *PostgresPlan) Provider() any {
@@ -15,11 +16,15 @@ func (p *PostgresPlan) Provider() any {
 	if p.FlyPostgres != nil {
 		return p.FlyPostgres
 	}
+	if p.SupabasePostgres != nil {
+		return p.SupabasePostgres
+	}
 	return nil
 }
 
 func DefaultPostgres(plan *LaunchPlan) PostgresPlan {
 	return PostgresPlan{
+		// TODO: Once supabase is GA, we want to default to Supabase
 		FlyPostgres: &FlyPostgresPlan{
 			// NOTE: Until Legacy Launch is removed, we have to maintain
 			//       "%app_name%-db" as the app name for the database.
@@ -50,4 +55,9 @@ func (p *FlyPostgresPlan) Guest() *fly.MachineGuest {
 		guest.MemoryMB = p.VmRam
 	}
 	return &guest
+}
+
+type SupabasePostgresPlan struct {
+	DbName string `json:"db_name"`
+	Region string `json:"region"`
 }

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -105,7 +105,7 @@ func (state *launchState) PlanSummary(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	postgresStr, err := describePostgresPlan(ctx, state.Plan.Postgres, org)
+	postgresStr, err := describePostgresPlan(state.Plan)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
### Change Summary

What and Why: Adds support for launching Supabase databases to `fly launch`. They aren't currently the default, but this allows future updates to the Launch UI to provide Supabase as an option for Postgres databases.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a - Self documenting, as this is currently only exposed via UI.
