### PR TITLE
Remove AppCompact.ImageDetails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.0.0-20240216161738-ca39fa12b183
+	github.com/superfly/fly-go v0.1.1
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.10

--- a/go.sum
+++ b/go.sum
@@ -608,8 +608,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.0.0-20240216161738-ca39fa12b183 h1:qHPTNfw83l27Xs4y69r97+Jnzd75sl5dCqHdFS/FHsc=
-github.com/superfly/fly-go v0.0.0-20240216161738-ca39fa12b183/go.mod h1:Mb+y+hXfEKzJ5guQyA/lAhyQqXWHiKULFu/4A5Ehink=
+github.com/superfly/fly-go v0.1.1 h1:8HelSk7lrQqUR3MUnCqRC/PIaBaYTz8S7Vuo41cL2zE=
+github.com/superfly/fly-go v0.1.1/go.mod h1:Mb+y+hXfEKzJ5guQyA/lAhyQqXWHiKULFu/4A5Ehink=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=


### PR DESCRIPTION
### Change Summary

What and Why: The `image_details` field in the GraphQL call can be slow if it needs to resolve from the underlying registry. We also don't use the field in `flyctl`.

How: Upgrade `fly-go` to use https://github.com/superfly/fly-go/pull/16

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
