### PR TITLE
Handle unwritable gem installation directories gracefully.

### DIFF
--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -250,7 +250,7 @@ func RailsCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan) e
 		// "touch" fly.toml
 		file, err := os.Create(flyToml)
 		if err != nil {
-			log.Fatal(err)
+			log.Panic(err)
 		}
 		file.Close()
 

--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -188,27 +188,47 @@ Once ready: run 'fly deploy' to deploy your Rails app.
 
 func RailsCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan) error {
 	// install dockerfile-rails gem, if not already included
+	writable := false
 	gemfile, err := os.ReadFile("Gemfile")
 	if err != nil {
 		panic(err)
 	} else if !strings.Contains(string(gemfile), "dockerfile-rails") {
-		cmd := exec.Command(bundle, "add", "dockerfile-rails",
-			"--optimistic", "--group", "development", "--skip-install")
-		cmd.Stdin = nil
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-
-		if err := cmd.Run(); err != nil {
-			return errors.Wrap(err, "Failed to add dockerfile-rails gem, exiting")
+		// check for writable gem installation directory
+		out, err := exec.Command("gem", "environment").Output()
+		if err == nil {
+			regexp := regexp.MustCompile(`INSTALLATION DIRECTORY: (.*)\n`)
+			for _, match := range regexp.FindAllStringSubmatch(string(out), -1) {
+				// Testing to see if a directory is writable is OS dependent, so
+				// we use a brute force method: attempt it and see if it works.
+				file, err := os.CreateTemp(match[1], ".flyctl.probe")
+				if err == nil {
+					writable = true
+					defer os.Remove(file.Name())
+					defer file.Close()
+				}
+			}
 		}
 
-		cmd = exec.Command(bundle, "install", "--quiet")
-		cmd.Stdin = nil
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+		// install dockerfile-rails gem if the gem installation directory is writable
+		if writable {
+			cmd := exec.Command(bundle, "add", "dockerfile-rails",
+				"--optimistic", "--group", "development", "--skip-install")
+			cmd.Stdin = nil
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
 
-		if err := cmd.Run(); err != nil {
-			return errors.Wrap(err, "Failed to install dockerfile-rails gem, exiting")
+			if err := cmd.Run(); err != nil {
+				return errors.Wrap(err, "Failed to add dockerfile-rails gem, exiting")
+			}
+
+			cmd = exec.Command(bundle, "install", "--quiet")
+			cmd.Stdin = nil
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+
+			if err := cmd.Run(); err != nil {
+				return errors.Wrap(err, "Failed to install dockerfile-rails gem, exiting")
+			}
 		}
 	}
 
@@ -249,6 +269,10 @@ func RailsCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan) e
 	_, err = os.Stat("Dockerfile")
 	if !errors.Is(err, fs.ErrNotExist) {
 		args = append(args, "--skip")
+
+		if !writable {
+			return errors.Wrap(err, "No Dockerfile found and unable to install dockerfile-rails gem")
+		}
 	}
 
 	// add postgres


### PR DESCRIPTION
See: https://community.fly.io/t/rails-7-applications-do-not-need-a-dockerfile-rails-gem/18738/11

Background: while installing and running the dockerfile-rails gem has been working quite well for some time, this fails in locked down environments such as a docker container for a Ruby image when running as an unpriviledged user.

The purpose of dockerfile-rails (in addition to creating a Dockerfile in the first place) is twofold:

 * Make adjustments to fly.toml to do things like allocate a volume for sqlite and run sidekiq in a process.
 * Be available make assisting people who have failed first deploys or make later changes.

While both of these are good reasons to install the gem when possible, neither of them are sufficient reason to fail a fly launch if the installation won't succeed and a Dockerfile is present; which generally will be the case for Rails 7.1 onward.

As to what to do should the gem installation directory be locked down and no Dockerfile is present - should this come up, the recommendation will be to install dockerfile-rails manually and run it before re-attempting fly launch.