### PR TITLE
updated Dockerfile for Laravel 11

### DIFF
--- a/scanner/templates/laravel/Dockerfile
+++ b/scanner/templates/laravel/Dockerfile
@@ -20,10 +20,18 @@ RUN composer install --optimize-autoloader --no-dev \
     && mkdir -p storage/logs \
     && php artisan optimize:clear \
     && chown -R www-data:www-data /var/www/html \
-    && sed -i 's/protected \$proxies/protected \$proxies = "*"/g' app/Http/Middleware/TrustProxies.php \
     && echo "MAILTO=\"\"\n* * * * * www-data /usr/bin/php /var/www/html/artisan schedule:run" > /etc/cron.d/laravel \
     && cp .fly/entrypoint.sh /entrypoint \
     && chmod +x /entrypoint
+
+# Laravel 11 made changes to how trusting all proxies works, see https://laravel.com/docs/11.x/requests#trusting-all-proxies and https://laravel.com/docs/10.x/requests#trusting-all-proxies
+RUN if php artisan --version | grep -q "Laravel Framework 1[1-9]"; then \
+    sed -i='' '/->withMiddleware(function (Middleware \$middleware) {/a\
+        \$middleware->trustProxies(at: "*");\
+' bootstrap/app.php; \
+  else \
+    sed -i 's/protected \$proxies/protected \$proxies = "*"/g' app/Http/Middleware/TrustProxies.php; \
+fi
 
 # If we're using Octane...
 RUN if grep -Fq "laravel/octane" /var/www/html/composer.json; then \


### PR DESCRIPTION
### Change Summary

This solves #3371 

**What and Why:**
Laravel 11 has a new way to trust all proxies, which is needed when deploying to a public cloud like ours. This will ensure the Laravel app generates https links when running on Fly.io . 
In Laravel 10 and before: https://laravel.com/docs/10.x/requests#trusting-all-proxies 
From Laravel 11 onwards: https://laravel.com/docs/11.x/requests#trusting-all-proxies

Our dockerfile automatically makes the changes to trust all proxies, and can now make these changes for Laravel 11 onwards as well. 

**How:**
By checking the Laravel version with `php artisan --version` and based on the version, running a different `sed` command: 
```
# Laravel 11 made changes to how trusting all proxies works, see https://laravel.com/docs/11.x/requests#trusting-all-proxies and https://laravel.com/docs/10.x/requests#trusting-all-proxies
RUN if php artisan --version | grep -q "Laravel Framework 1[1-9]"; then \
    sed -i='' '/->withMiddleware(function (Middleware \$middleware) {/a\
        \$middleware->trustProxies(at: "*");\
' bootstrap/app.php; \
  else \
    sed -i 's/protected \$proxies/protected \$proxies = "*"/g' app/Http/Middleware/TrustProxies.php; \
fi
```
