### PR TITLE
bump fly-go with its recent fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.1.2-0.20240315204608-e08276378316
+	github.com/superfly/fly-go v0.1.2
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.10

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.1.1
+	github.com/superfly/fly-go v0.1.2-0.20240315204608-e08276378316
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.10

--- a/go.sum
+++ b/go.sum
@@ -608,8 +608,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.2-0.20240315204608-e08276378316 h1:IsWrDumG8q1UUfa98JMQB6GmYngFZqiluZQRMuC/3NM=
-github.com/superfly/fly-go v0.1.2-0.20240315204608-e08276378316/go.mod h1:5WiuvjaHg5zzdCxhV5mPElADEqIAKbLMhVI18vM+OeY=
+github.com/superfly/fly-go v0.1.2 h1:CnXzm2ddZfcbXW1Dv7/r4QKXfciM3nh4a2gIC4pzDQI=
+github.com/superfly/fly-go v0.1.2/go.mod h1:5WiuvjaHg5zzdCxhV5mPElADEqIAKbLMhVI18vM+OeY=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/go.sum
+++ b/go.sum
@@ -608,8 +608,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.1 h1:8HelSk7lrQqUR3MUnCqRC/PIaBaYTz8S7Vuo41cL2zE=
-github.com/superfly/fly-go v0.1.1/go.mod h1:Mb+y+hXfEKzJ5guQyA/lAhyQqXWHiKULFu/4A5Ehink=
+github.com/superfly/fly-go v0.1.2-0.20240315204608-e08276378316 h1:IsWrDumG8q1UUfa98JMQB6GmYngFZqiluZQRMuC/3NM=
+github.com/superfly/fly-go v0.1.2-0.20240315204608-e08276378316/go.mod h1:5WiuvjaHg5zzdCxhV5mPElADEqIAKbLMhVI18vM+OeY=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=


### PR DESCRIPTION
### Change Summary

What and Why: There are [coming changes](https://github.com/superfly/fly-go/pull/18) in fly-go that would like to test for regressions in flyctl testsuite

How: bump fly-go dep

Related to: https://github.com/superfly/fly-go/pull/18

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
