### PR TITLE
Remove warning message for max_unavailable with canary deploy

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -456,7 +456,7 @@ func determineAppConfig(ctx context.Context) (cfg *appconfig.Config, err error) 
 		return nil, err
 	}
 
-	if cfg.Deploy != nil && cfg.Deploy.Strategy != "rolling" && cfg.Deploy.MaxUnavailable != nil {
+	if cfg.Deploy != nil && cfg.Deploy.Strategy != "rolling" && cfg.Deploy.Strategy != "canary" && cfg.Deploy.MaxUnavailable != nil {
 		if !config.FromContext(ctx).JSONOutput {
 			fmt.Fprintf(io.Out, "Warning: max-unavailable set for non-rolling strategy '%s', ignoring\n", cfg.Deploy.Strategy)
 		}


### PR DESCRIPTION
### Change Summary

What and Why: Canary deploys show a warning if `max_unavailable` is set, however, is this a valid setting since canary deploys have a rolling phase.

How: Update check for deploy type before warning.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
