### PR TITLE
Trim generated name before appending new generated name

### DIFF
--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -408,11 +408,15 @@ func validateAppName(appName string) error {
 func determineAppName(ctx context.Context, appConfig *appconfig.Config, configPath string) (string, string, error) {
 	delimiter := "-"
 	findUniqueAppName := func(prefix string) (string, bool) {
+		// Remove any existing haikus so we don't keep adding to the end.
+		b := haikunator.Haikunator().Delimiter(delimiter)
+		prefix = b.TrimSuffix(prefix)
+
 		if prefix != "" {
 			prefix += delimiter
 		}
 		for i := 1; i < 10; i++ {
-			outName := prefix + haikunator.Haikunator().Delimiter(delimiter).String()
+			outName := prefix + b.String()
 			if taken, _ := appNameTaken(ctx, outName); !taken {
 				return outName, true
 			}

--- a/internal/haikunator/haikunator.go
+++ b/internal/haikunator/haikunator.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/superfly/flyctl/helpers"
+	"golang.org/x/exp/slices"
 )
 
 var adjectives = strings.Fields(`
@@ -20,6 +21,7 @@ var adjectives = strings.Fields(`
 	young holy solitary fragrant aged snowy proud floral
 	restless divine polished ancient purple lively nameless
 `)
+
 var nouns = strings.Fields(`
 	waterfall river breeze moon rain wind sea morning
 	snow lake sunset pine shadow leaf dawn glitter forest
@@ -31,59 +33,78 @@ var nouns = strings.Fields(`
 	frost voice paper frog smoke star
 `)
 
-type builder struct {
+type Builder struct {
 	tokRange  int
 	delimiter string
+
+	RandN func(max int) int
 }
 
-type Builder interface {
-	TokenRange(r int) Builder
-	Delimiter(d string) Builder
-	Build() string
-	String() string
-}
-
-func randN(max int) int {
-	ret, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
-	if err != nil {
-		// Fallback to "insecure" random
-		// it doesn't really matter, this is not security critical
-		return rand2.Intn(max) // skipcq: GSC-G404
-	}
-	return int(ret.Int64())
-}
-
-func choose(list []string) string {
-	return list[randN(len(list))]
-}
-
-func Haikunator() Builder {
-	return &builder{
+func Haikunator() *Builder {
+	return &Builder{
 		tokRange:  9999,
 		delimiter: "-",
+
+		RandN: func(max int) int {
+			ret, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+			if err != nil {
+				// Fallback to "insecure" random
+				// it doesn't really matter, this is not security critical
+				return rand2.Intn(max) // skipcq: GSC-G404
+			}
+			return int(ret.Int64())
+		},
 	}
 }
 
-func (b *builder) TokenRange(r int) Builder {
+func (b *Builder) choose(list []string) string {
+	return list[b.RandN(len(list))]
+}
+
+func (b *Builder) TokenRange(r int) *Builder {
 	newB := helpers.Clone(b)
 	newB.tokRange = r
 	return newB
 }
-func (b *builder) Delimiter(d string) Builder {
+
+func (b *Builder) Delimiter(d string) *Builder {
 	newB := helpers.Clone(b)
 	newB.delimiter = d
 	return newB
 }
-func (b *builder) Build() string {
+
+func (b *Builder) Build() string {
 	sections := []string{
-		choose(adjectives),
-		choose(nouns),
+		b.choose(adjectives),
+		b.choose(nouns),
 	}
 	if b.tokRange > 0 {
-		sections = append(sections, strconv.Itoa(randN(b.tokRange)))
+		sections = append(sections, strconv.Itoa(b.RandN(b.tokRange)))
 	}
 	return strings.Join(sections, b.delimiter)
 }
-func (b *builder) String() string {
+
+func (b *Builder) String() string {
 	return b.Build()
+}
+
+// TrimSuffix removes a haiku name at the end of s, if it exists.
+// Otherwise returns the original string.
+func (b *Builder) TrimSuffix(s string) string {
+	a := strings.Split(s, b.delimiter)
+	if len(a) < 3 {
+		return s
+	}
+
+	adjective, noun, num := a[len(a)-3], a[len(a)-2], a[len(a)-1]
+	if !slices.Contains(adjectives, adjective) {
+		return s
+	}
+	if !slices.Contains(nouns, noun) {
+		return s
+	}
+	if _, err := strconv.Atoi(num); err != nil {
+		return s
+	}
+	return strings.Join(a[:len(a)-3], b.delimiter)
 }

--- a/internal/haikunator/haikunator_test.go
+++ b/internal/haikunator/haikunator_test.go
@@ -1,0 +1,58 @@
+package haikunator_test
+
+import (
+	"testing"
+
+	"github.com/superfly/flyctl/internal/haikunator"
+)
+
+func TestHaikunator_Build(t *testing.T) {
+	t.Run("Rand", func(t *testing.T) {
+		b := haikunator.Haikunator().Delimiter("-")
+		if b.Build() == "" {
+			t.Fatal("expected haiku")
+		}
+	})
+
+	t.Run("Deterministic", func(t *testing.T) {
+		b := haikunator.Haikunator().Delimiter("-")
+		b.RandN = func(max int) int { return 0 }
+		if got, want := b.Build(), "autumn-waterfall-0"; got != want {
+			t.Fatalf("name=%s, want %s", got, want)
+		}
+	})
+}
+
+func TestHaikunator_TrimSuffix(t *testing.T) {
+	b := haikunator.Haikunator().Delimiter("-")
+
+	t.Run("HaikuOnly", func(t *testing.T) {
+		if got, want := b.TrimSuffix("rough-snowflake-1234"), ""; got != want {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("HaikuSuffix", func(t *testing.T) {
+		if got, want := b.TrimSuffix("foobar-rough-snowflake-1234"), "foobar"; got != want {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("NoAdjective", func(t *testing.T) {
+		if got, want := b.TrimSuffix("foo-snowflake-1234"), "foo-snowflake-1234"; got != want {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("NoNoun", func(t *testing.T) {
+		if got, want := b.TrimSuffix("rough-foo-1234"), "rough-foo-1234"; got != want {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("NoNumber", func(t *testing.T) {
+		if got, want := b.TrimSuffix("rough-snowflake-1234x"), "rough-snowflake-1234x"; got != want {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+}


### PR DESCRIPTION
### Change Summary

What and Why: The name generation used to keep concatenating to the end so you could end up with a ridiculously long name.

How: This adds a `haikunator.Builder.TrimSuffix()` to remove any existing generated name from the end before regenerating.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
