### PR TITLE
Remove AWS_ACCESS_KEY_ID warning on deploy

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -244,7 +244,7 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes
 
 	for _, potentialSecretSubstr := range commonSecretSubstrings {
 		for env := range appConfig.Env {
-			if strings.Contains(env, potentialSecretSubstr) {
+			if strings.Contains(env, potentialSecretSubstr) && env != "AWS_ACCESS_KEY_ID" {
 				warning := fmt.Sprintf("%s %s may be a potentially sensitive environment variable. Consider setting it as a secret, and removing it from the [env] section: https://fly.io/docs/reference/secrets/\n", aurora.Yellow("WARN"), env)
 				fmt.Fprintln(io.ErrOut, warning)
 			}


### PR DESCRIPTION
### Change Summary

What and Why: Having `AWS_ACCESS_KEY_ID` in the `[env]` section triggers a warning even though the access key id is not a secret. We should remove the warning.

How: Whitelist the key in the "potentially sensitive" variables check.

Fixes: https://github.com/superfly/flyctl/issues/3375

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
