### PR TITLE
Deduplicate env warning

### DIFF
--- a/internal/command/deploy/common_secrets.go
+++ b/internal/command/deploy/common_secrets.go
@@ -1,4 +1,21 @@
 package deploy
 
+import "strings"
+
 // some common secrets
 var commonSecretSubstrings = []string{"KEY", "PRIVATE", "DATABASE_URL", "PASSWORD", "SECRET"}
+
+func containsCommonSecretSubstring(s string) bool {
+	// Allowlist for strings which contain a substring but are not secrets.
+	switch s {
+	case "AWS_ACCESS_KEY_ID":
+		return false
+	}
+
+	for _, substr := range commonSecretSubstrings {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -242,12 +242,10 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes
 		return err
 	}
 
-	for _, potentialSecretSubstr := range commonSecretSubstrings {
-		for env := range appConfig.Env {
-			if strings.Contains(env, potentialSecretSubstr) && env != "AWS_ACCESS_KEY_ID" {
-				warning := fmt.Sprintf("%s %s may be a potentially sensitive environment variable. Consider setting it as a secret, and removing it from the [env] section: https://fly.io/docs/reference/secrets/\n", aurora.Yellow("WARN"), env)
-				fmt.Fprintln(io.ErrOut, warning)
-			}
+	for env := range appConfig.Env {
+		if containsCommonSecretSubstring(env) {
+			warning := fmt.Sprintf("%s %s may be a potentially sensitive environment variable. Consider setting it as a secret, and removing it from the [env] section: https://fly.io/docs/reference/secrets/\n", aurora.Yellow("WARN"), env)
+			fmt.Fprintln(io.ErrOut, warning)
 		}
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why: Potentially sensitive environment variables that had two matching substrings (e.g. `AWS_SECRET_ACCESS_KEY`) would show a warning twice. It should only show once.

How: Change the loop order of the substring checks.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
