### PR TITLE
Fix flaps metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.1.2
+	github.com/superfly/fly-go v0.1.3
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.10

--- a/go.sum
+++ b/go.sum
@@ -608,8 +608,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.2 h1:CnXzm2ddZfcbXW1Dv7/r4QKXfciM3nh4a2gIC4pzDQI=
-github.com/superfly/fly-go v0.1.2/go.mod h1:5WiuvjaHg5zzdCxhV5mPElADEqIAKbLMhVI18vM+OeY=
+github.com/superfly/fly-go v0.1.3 h1:lKx8hozCTtKTb4ceoXDmrFrAOu0C4eiVm9gehuYpBz0=
+github.com/superfly/fly-go v0.1.3/go.mod h1:5WiuvjaHg5zzdCxhV5mPElADEqIAKbLMhVI18vM+OeY=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/flyctl/internal/machine"
 )
 
 const (
@@ -184,6 +183,16 @@ func (c *Config) HasNonHttpAndHttpsStandardServices() bool {
 	return false
 }
 
+// IsUsingGPU returns true if any VMs have a gpu-kind set.
+func (c *Config) IsUsingGPU() bool {
+	for _, vm := range c.Compute {
+		if vm != nil && vm.MachineGuest != nil && vm.MachineGuest.GPUKind != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Config) HasUdpService() bool {
 	for _, service := range c.Services {
 		if service.Protocol == "udp" {
@@ -316,7 +325,7 @@ func (cfg *Config) MergeFiles(files []*fly.File) error {
 	mConfig := &fly.MachineConfig{
 		Files: cfgFiles,
 	}
-	machine.MergeFiles(mConfig, files)
+	fly.MergeFiles(mConfig, files)
 
 	// Persist the merged files back to the config to be used later for deploying.
 	cfg.MergedFiles = mConfig.Files

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -10,7 +10,6 @@ import (
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/buildinfo"
-	"github.com/superfly/flyctl/internal/machine"
 )
 
 func (c *Config) ToMachineConfig(processGroup string, src *fly.MachineConfig) (*fly.MachineConfig, error) {
@@ -212,7 +211,7 @@ func (c *Config) updateMachineConfig(src *fly.MachineConfig) (*fly.MachineConfig
 
 	// Files
 	mConfig.Files = nil
-	machine.MergeFiles(mConfig, c.MergedFiles)
+	fly.MergeFiles(mConfig, c.MergedFiles)
 
 	// Guest
 	if guest, err := c.toMachineGuest(); err != nil {

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -552,7 +552,7 @@ func LoadAppConfigIfPresent(ctx context.Context) (context.Context, error) {
 	// Shortcut to avoid unmarshaling and querying Web when
 	// LoadAppConfigIfPresent is chained with RequireAppName
 	if cfg := appconfig.ConfigFromContext(ctx); cfg != nil {
-		metrics.AppConfig = cfg
+		metrics.IsUsingGPU = cfg.IsUsingGPU()
 		return ctx, nil
 	}
 
@@ -564,7 +564,7 @@ func LoadAppConfigIfPresent(ctx context.Context) (context.Context, error) {
 			if err := cfg.SetMachinesPlatform(); err != nil {
 				logger.Warnf("WARNING the config file at '%s' is not valid: %s", path, err)
 			}
-			metrics.AppConfig = cfg
+			metrics.IsUsingGPU = cfg.IsUsingGPU()
 			return appconfig.WithConfig(ctx, cfg), nil // we loaded a configuration file
 		case errors.Is(err, fs.ErrNotExist):
 			logger.Debugf("no app config found at %s; skipped.", path)

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -354,7 +354,7 @@ func makeEphemeralConsoleMachine(ctx context.Context, app *fly.AppCompact, appCo
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed parsing filest: %w", err)
 	}
-	machine.MergeFiles(machConfig, machineFiles)
+	fly.MergeFiles(machConfig, machineFiles)
 
 	machConfig.Guest = guest
 

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -780,7 +780,7 @@ func determineMachineConfig(
 	if err != nil {
 		return machineConf, err
 	}
-	mach.MergeFiles(machineConf, machineFiles)
+	fly.MergeFiles(machineConf, machineFiles)
 
 	return machineConf, nil
 }

--- a/internal/machine/config.go
+++ b/internal/machine/config.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"slices"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
@@ -113,23 +112,4 @@ func configCompare(ctx context.Context, original fly.MachineConfig, new fly.Mach
 	}
 	// We know the objects are different, if we can't cleanup return the best we have got
 	return str
-}
-
-// MergeFiles merges the files parsed from the command line or fly.toml into the machine configuration.
-func MergeFiles(machineConf *fly.MachineConfig, files []*fly.File) {
-	for _, f := range files {
-		idx := slices.IndexFunc(machineConf.Files, func(i *fly.File) bool {
-			return i.GuestPath == f.GuestPath
-		})
-
-		switch {
-		case idx == -1:
-			machineConf.Files = append(machineConf.Files, f)
-			continue
-		case f.RawValue == nil && f.SecretName == nil:
-			machineConf.Files = slices.Delete(machineConf.Files, idx, idx+1)
-		default:
-			machineConf.Files = slices.Replace(machineConf.Files, idx, idx+1, f)
-		}
-	}
 }

--- a/internal/machine/ephemeral.go
+++ b/internal/machine/ephemeral.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/ctrlc"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/spinner"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/terminal"
@@ -33,7 +34,7 @@ func LaunchEphemeral(ctx context.Context, input *EphemeralInput) (*fly.Machine, 
 		return nil, nil, errors.New("ephemeral machines must be configured to auto-destroy (this is a bug)")
 	}
 
-	machine, err := flapsClient.Launch(ctx, input.LaunchInput)
+	machine, err := flapsutil.Launch(ctx, flapsClient, input.LaunchInput)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
### Change Summary

What and Why: Some metrics were removed when transitioning to the `fly-go` library. This fixes them.

How: Added helper functions to `flapsutil` so that they can appropriately wrap the timing functions and utilize defer.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
