### PR TITLE
Make the DNS checks warn, rather than fail the deploy

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -81,7 +81,7 @@ func (md *machineDeployment) DeployMachinesApp(ctx context.Context) error {
 
 	if !md.skipDNSChecks {
 		if err := md.checkDNS(ctx); err != nil {
-			return err
+			terminal.Warnf("DNS checks failed: %v\n", err)
 		}
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why:
We sometimes fail deploys unnecessarily when DNS checks fail. It's better to just warn the user that there may be an issue, so that they can continue debugging if need be, rather than failing the deployment completely.

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
