### PR TITLE
Remove quotes on phoenix scanner command

### DIFF
--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -82,7 +82,7 @@ func configurePhoenix(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 	}
 
 	// We found Phoenix, so lets check if its a recent version.
-	releaseCmd := exec.Command("mix", "run", "-e", "\"true = Code.ensure_loaded?(Mix.Tasks.Phx.Gen.Release)\"")
+	releaseCmd := exec.Command("mix", "run", "-e", "true = Code.ensure_loaded?(Mix.Tasks.Phx.Gen.Release)")
 	releaseCmd.Stdout = os.Stdout
 	releaseCmd.Stderr = os.Stderr
 	err = releaseCmd.Run()


### PR DESCRIPTION
go's exec.Command will take care of quoting each distinct shell argument so the escaping is unnecessary, and we've had a user report where it is causing issues: https://community.fly.io/t/syntaxerror-when-running-fly-launch-on-elixir-phoenix-project/18891
