### PR TITLE
Rename root cmd from "flyctl" to "fly"

### DIFF
--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -74,7 +74,7 @@ func New() *cobra.Command {
 		short = "The Fly.io command line interface"
 	)
 
-	root := command.New("flyctl", short, long, run)
+	root := command.New("fly", short, long, run)
 	root.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true


### PR DESCRIPTION
`fly --help` and friends now refer to the cli as "fly" instead of "flyctl" in auto-generated text.

There's still a bunch of "flyctl" in help text, errors, and output (like a few of the commands below) and we'll need to come back to fix those separately. Run `go run ./cmd/audit  list --description` from the root of this repo to see a few.

```
This is flyctl, the Fly.io command line interface.

Usage:
  fly [flags]
  fly [command]

Deploying apps & machines
  apps         Manage apps
  deploy       Deploy Fly applications
  launch       Create and configure a new app from source code or a Docker image
  machine      Manage Fly Machines.
  status       Show app status

Configuration & scaling
  certs        Manage certificates
  config       Manage an app's configuration
  image        Manage app image
  ips          Manage IP addresses for apps
  scale        Scale app resources
  secrets      Manage application secrets with the set and unset commands.
  volumes      Manage Fly Volumes.

Monitoring & managing things
  checks       Manage health checks
  console      Run a console in a new or existing machine
  dashboard    Open web browser on Fly Web UI for this app
  dig          Make DNS requests against Fly.io's internal DNS server
  logs         View app logs
  ping         Test connectivity with ICMP ping messages
  proxy        Proxies connections to a Fly Machine.
  releases     List app releases
  services     Show the application's services
  sftp         Get or put files from a remote VM.
  ssh          Use SSH to log into or run commands on Machines
  wireguard    Commands that manage WireGuard peer connections

Databases & extensions
  consul       Enable and manage Consul clusters
  extensions   Extensions are additional functionality that can be added to your Fly apps
  litefs-cloud LiteFS Cloud management commands
  planetscale  Provision and manage PlanetScale MySQL databases
  postgres     Manage Postgres clusters.
  redis        Launch and manage Redis databases managed by Upstash.com
  storage      Provision and manage Tigris object storage buckets

Access control
  auth         Manage authentication
  orgs         Commands for managing Fly organizations
  tokens       Manage Fly.io API tokens

Help & troubleshooting
  docs         View Fly documentation
  doctor       The DOCTOR command allows you to debug your Fly environment
  platform     Fly platform information

Additional Commands:
  agent        Commands that manage the Fly agent, a background process that manages flyctl wireguard connections
  completion   Generate the autocompletion script for the specified shell
  help         Help about any command
  jobs         Show jobs at Fly.io
  settings     Manage flyctl settings
  version      Show version information for the flyctl command

Flags:
  -t, --access-token string   Fly API Access Token
      --debug                 Print additional logs and traces
  -h, --help                  help for fly
      --verbose               Verbose output

Use "fly [command] --help" for more information about a command.
```