### PR TITLE
`fly launch`: support creating Tigris Object Storage

### DIFF
--- a/internal/command/launch/launch_databases.go
+++ b/internal/command/launch/launch_databases.go
@@ -8,6 +8,7 @@ import (
 	"github.com/samber/lo"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/flypg"
+	"github.com/superfly/flyctl/gql"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/command/postgres"
 	"github.com/superfly/flyctl/internal/command/redis"
@@ -38,6 +39,14 @@ func (state *launchState) createDatabases(ctx context.Context) error {
 		if err != nil {
 			// TODO(Ali): Make error printing here better.
 			fmt.Fprintf(iostreams.FromContext(ctx).ErrOut, "Error provisioning Upstash Redis: %s\n", err)
+		}
+	}
+
+	if state.Plan.ObjectStorage.TigrisObjectStorage != nil {
+		err := state.createTigrisObjectStorage(ctx)
+		if err != nil {
+			// TODO(Ali): Make error printing here better.
+			fmt.Fprintf(iostreams.FromContext(ctx).ErrOut, "Error creating Tigris object storage: %s\n", err)
 		}
 	}
 
@@ -205,4 +214,37 @@ func (state *launchState) createUpstashRedis(ctx context.Context) error {
 		return err
 	}
 	return redis.AttachDatabase(ctx, db, state.Plan.AppName)
+}
+
+func (state *launchState) createTigrisObjectStorage(ctx context.Context) error {
+
+	tigrisPlan := state.Plan.ObjectStorage.TigrisObjectStorage
+
+	org, err := state.Org(ctx)
+	if err != nil {
+		return err
+	}
+
+	params := extensions_core.ExtensionParams{
+		Provider:       "tigris",
+		Organization:   org,
+		AppName:        state.Plan.AppName,
+		OverrideName:   tigrisPlan.Name,
+		OverrideRegion: state.Plan.RegionCode,
+		Options: gql.AddOnOptions{
+			"public":     tigrisPlan.Public,
+			"accelerate": tigrisPlan.Accelerate,
+			"website": map[string]interface{}{
+				"domain_name": tigrisPlan.WebsiteDomainName,
+			},
+		},
+	}
+
+	_, err = extensions_core.ProvisionExtension(ctx, params)
+
+	if err != nil {
+		return err
+	}
+
+	return err
 }

--- a/internal/command/launch/plan/object_storage.go
+++ b/internal/command/launch/plan/object_storage.go
@@ -20,16 +20,8 @@ func DefaultObjectStorage(plan *LaunchPlan) ObjectStoragePlan {
 	}
 }
 
-type TigrisShadowBucketConfig struct {
-	Region       string `json:"region"`
-	Name         string `json:"name"`
-	Endpoint     string `json:"endpoint"`
-	WriteThrough bool   `json:"write_through"`
-}
-
 type TigrisObjectStoragePlan struct {
-	Name               string                    `json:"name"`
-	Public             bool                      `json:"public"`
-	Accelerate         bool                      `json:"accelerate"`
-	ShadowBucketConfig *TigrisShadowBucketConfig `json:"shadow_bucket"`
+	Name       string `json:"name"`
+	Public     bool   `json:"public"`
+	Accelerate bool   `json:"accelerate"`
 }

--- a/internal/command/launch/plan/object_storage.go
+++ b/internal/command/launch/plan/object_storage.go
@@ -21,7 +21,8 @@ func DefaultObjectStorage(plan *LaunchPlan) ObjectStoragePlan {
 }
 
 type TigrisObjectStoragePlan struct {
-	Name       string `json:"name"`
-	Public     bool   `json:"public"`
-	Accelerate bool   `json:"accelerate"`
+	Name              string `json:"name"`
+	Public            bool   `json:"public"`
+	Accelerate        bool   `json:"accelerate"`
+	WebsiteDomainName string `json:"website_domain_name"`
 }

--- a/internal/command/launch/plan/object_storage.go
+++ b/internal/command/launch/plan/object_storage.go
@@ -1,0 +1,35 @@
+package plan
+
+type ObjectStoragePlan struct {
+	TigrisObjectStorage *TigrisObjectStoragePlan `json:"tigris_object_storage"`
+}
+
+func (p *ObjectStoragePlan) Provider() any {
+	if p == nil {
+		return nil
+	}
+	if p.TigrisObjectStorage != nil {
+		return p.TigrisObjectStorage
+	}
+	return nil
+}
+
+func DefaultObjectStorage(plan *LaunchPlan) ObjectStoragePlan {
+	return ObjectStoragePlan{
+		TigrisObjectStorage: &TigrisObjectStoragePlan{},
+	}
+}
+
+type TigrisShadowBucketConfig struct {
+	Region       string `json:"region"`
+	Name         string `json:"name"`
+	Endpoint     string `json:"endpoint"`
+	WriteThrough bool   `json:"write_through"`
+}
+
+type TigrisObjectStoragePlan struct {
+	Name               string                    `json:"name"`
+	Public             bool                      `json:"public"`
+	Accelerate         bool                      `json:"accelerate"`
+	ShadowBucketConfig *TigrisShadowBucketConfig `json:"shadow_bucket"`
+}

--- a/internal/command/launch/plan/plan.go
+++ b/internal/command/launch/plan/plan.go
@@ -33,10 +33,6 @@ type LaunchPlan struct {
 	Sentry        bool              `json:"sentry"`
 	ObjectStorage ObjectStoragePlan `json:"object_storage"`
 
-	// We don't want to send the actual credentials back and forth, so this
-	// indicates to the UI whether the user specified shadow bucket credentials via the command line.
-	ObjectStorageHasShadowBucketCredentials bool `json:"object_storage_has_shadow_bucket_credentials"`
-
 	ScannerFamily string          `json:"scanner_family"`
 	FlyctlVersion version.Version `json:"flyctl_version"`
 }

--- a/internal/command/launch/plan/plan.go
+++ b/internal/command/launch/plan/plan.go
@@ -28,9 +28,14 @@ type LaunchPlan struct {
 
 	HttpServicePort int `json:"http_service_port,omitempty"`
 
-	Postgres PostgresPlan `json:"postgres"`
-	Redis    RedisPlan    `json:"redis"`
-	Sentry   bool         `json:"sentry"`
+	Postgres      PostgresPlan      `json:"postgres"`
+	Redis         RedisPlan         `json:"redis"`
+	Sentry        bool              `json:"sentry"`
+	ObjectStorage ObjectStoragePlan `json:"object_storage"`
+
+	// We don't want to send the actual credentials back and forth, so this
+	// indicates to the UI whether the user specified shadow bucket credentials via the command line.
+	ObjectStorageHasShadowBucketCredentials bool `json:"object_storage_has_shadow_bucket_credentials"`
 
 	ScannerFamily string          `json:"scanner_family"`
 	FlyctlVersion version.Version `json:"flyctl_version"`


### PR DESCRIPTION
### Change Summary

What and Why: Adds support for creating object storage via the Tigris Data extension.
Note: this currently doesn't support shadow buckets (aka s3 passthrough). That would either require a) a ton of CLI flags specific to tigris object storage, or b) passing an S3 access key from the UI to the CLI, neither of which I'm happy with. it should be fine for now, though, because shadow buckets are mostly a transitional tool, and therefore less likely to be needed on an initial launch.

How: adds object storage to the launch plan. If it's filled out in the plan, attempts to provision the extension between app creation and initial deploy.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a - should be documented when support for this in the UI lands
