### PR TITLE
Update deprecated buildpack

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,4 +199,4 @@
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
-   limitations under the License.
+   limitations under the  License.


### PR DESCRIPTION
### Change Summary

heroku/buildpacks:20 was recently deprecated and now `pack` builds error when trying to use it.

This commit updates all uses of that buildpack to heroku/buildpacks:22 which is still supported.

What and Why:
Builds result in this error:
ERROR: This builder image (heroku/buildpacks:20) has been sunset,
  since it uses legacy shimmed classic Heroku buildpacks, rather than
  Heroku's next-generation Cloud Native Buildpacks.
  
  As such, this image is no longer supported and will soon stop receiving
  security updates.
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
