### PR TITLE
Switch to using Google DNS

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -1083,7 +1083,7 @@ func (md *machineDeployment) checkDNS(ctx context.Context) error {
 
 			m.SetQuestion(fqdn, dns.TypeA)
 			span.SetAttributes(attribute.String("v4_question", m.String()))
-			answerv4, _, err := c.Exchange(m, "9.9.9.9:53")
+			answerv4, _, err := c.Exchange(m, "8.8.8.8:53")
 			if err != nil {
 				tracing.RecordError(span, err, "failed to exchange v4")
 				return err
@@ -1095,7 +1095,7 @@ func (md *machineDeployment) checkDNS(ctx context.Context) error {
 
 			m.SetQuestion(fqdn, dns.TypeAAAA)
 			span.SetAttributes(attribute.String("v6_question", m.String()))
-			answerv6, _, err := c.Exchange(m, "9.9.9.9:53")
+			answerv6, _, err := c.Exchange(m, "8.8.8.8:53")
 			if err != nil {
 				tracing.RecordError(span, err, "failed to exchange v4")
 				return err

--- a/internal/command/doctor/app_checks.go
+++ b/internal/command/doctor/app_checks.go
@@ -190,7 +190,7 @@ func (ac *AppChecker) checkDnsRecords(ipAddresses []fly.IPAddress) {
 }
 
 func getFirstFlyDevNameserver(dnsClient *dns.Client) (string, error) {
-	const resolver = "9.9.9.9:53"
+	const resolver = "8.8.8.8:53"
 	msg := &dns.Msg{}
 	flydev := "fly.dev"
 	msg.SetQuestion(dns.Fqdn(flydev), dns.TypeNS)


### PR DESCRIPTION
### Change Summary

What and Why:
9.9.9.9 has been pretty inconsistent, which isn't good for our CLI.

How:
Switch all references to 9.9.9.9 to 8.8.8.8

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
