### PR TITLE
Have fly launch stop parsing for arguments at a double dash

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"html/template"
 	"os"
 	"runtime/debug"
+	"slices"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/env"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/internal/metrics"
@@ -71,6 +73,19 @@ func Run(ctx context.Context, io *iostreams.IOStreams, args ...string) int {
 	cmd := root.New()
 	cmd.SetOut(io.Out)
 	cmd.SetErr(io.ErrOut)
+
+	// Special case for the launch command, support `flyctl launch args -- [subargs]`
+	// Where the arguments after `--` are passed to the scanner/dockerfile generator.
+	// This isn't supported natively by cobra, so we have to manually split the args
+	// See: https://github.com/spf13/cobra/issues/739
+	if len(args) > 0 && args[0] == "launch" {
+		index := slices.Index(args, "--")
+		if index >= 0 {
+			ctx = flag.WithExtraArgs(ctx, args[index+1:])
+			args = args[0:index]
+		}
+	}
+
 	cmd.SetArgs(args)
 	cmd.SilenceErrors = true
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -82,7 +82,7 @@ func Run(ctx context.Context, io *iostreams.IOStreams, args ...string) int {
 		index := slices.Index(args, "--")
 		if index >= 0 {
 			ctx = flag.WithExtraArgs(ctx, args[index+1:])
-			args = args[0:index]
+			args = args[:index]
 		}
 	}
 

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -22,8 +22,8 @@ import (
 
 func New() (cmd *cobra.Command) {
 	const (
-		long  = `Create and configure a new app from source code or a Docker image`
-		short = long
+		long  = `Create and configure a new app from source code or a Docker image.  Options passed after double dashes ("--") will be passed to the language specific scanner/dockerfile generator.`
+		short = `Create and configure a new app from source code or a Docker image`
 	)
 
 	cmd = command.New("launch", short, long, run, command.RequireSession, command.LoadAppConfigIfPresent)

--- a/internal/command/launch/launch_frameworks.go
+++ b/internal/command/launch/launch_frameworks.go
@@ -128,7 +128,7 @@ func (state *launchState) scannerRunCallback(ctx context.Context) error {
 		return nil
 	}
 
-	err := state.sourceInfo.Callback(state.Plan.AppName, state.sourceInfo, state.Plan)
+	err := state.sourceInfo.Callback(state.Plan.AppName, state.sourceInfo, state.Plan, flag.ExtraArgsFromContext(ctx))
 
 	if state.sourceInfo.MergeConfig != nil {
 		if err == nil {

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -3,6 +3,7 @@ package flag
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"time"
 
@@ -10,6 +11,8 @@ import (
 	"github.com/superfly/flyctl/internal/flag/completion"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
 )
+
+type extraArgsContextKey struct{}
 
 func makeAlias[T any](template T, name string) T {
 	var ret T
@@ -587,4 +590,20 @@ func BpVolume() StringSlice {
 Repeat for each volume in order (comma-separated lists not accepted)
 `,
 	}
+}
+
+// WithExtraArgs derives a context that carries extraArgs from ctx.
+func WithExtraArgs(ctx context.Context, extraArgs []string) context.Context {
+	return context.WithValue(ctx, extraArgsContextKey{}, extraArgs)
+}
+
+// ExtraArgsFromContext returns the extraArgs ctx carries.
+func ExtraArgsFromContext(ctx context.Context) []string {
+	if extraArgs, ok := ctx.Value(extraArgsContextKey{}).([]string); ok {
+		return extraArgs
+	}
+
+	fmt.Printf("unable to get extra args from context\n")
+
+	return []string{}
 }

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -3,7 +3,6 @@ package flag
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"time"
 
@@ -602,8 +601,6 @@ func ExtraArgsFromContext(ctx context.Context) []string {
 	if extraArgs, ok := ctx.Value(extraArgsContextKey{}).([]string); ok {
 		return extraArgs
 	}
-
-	fmt.Printf("unable to get extra args from context\n")
 
 	return []string{}
 }

--- a/scanner/jsFramework.go
+++ b/scanner/jsFramework.go
@@ -243,7 +243,7 @@ func configureJsFramework(sourceDir string, config *ScannerConfig) (*SourceInfo,
 	return srcInfo, nil
 }
 
-func JsFrameworkCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan) error {
+func JsFrameworkCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan, flags []string) error {
 	// create temporary fly.toml for merge purposes
 	flyToml := "fly.toml"
 	_, err := os.Stat(flyToml)
@@ -352,6 +352,11 @@ func JsFrameworkCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchP
 			xcmdpath, err = filepath.Abs(xcmdpath)
 			if err != nil {
 				return fmt.Errorf("failure finding %s executable in PATH", xcmd)
+			}
+
+			// add additional flags from launch command
+			if len(flags) > 0 {
+				args = append(args, flags...)
 			}
 
 			// execute (via npx, bunx, or bun x) the docker module

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -76,7 +76,7 @@ func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 	return s, nil
 }
 
-func LaravelCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan) error {
+func LaravelCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan, flags []string) error {
 	// create temporary fly.toml for merge purposes
 	flyToml := "fly.toml"
 	_, err := os.Stat(flyToml)
@@ -141,6 +141,12 @@ func LaravelCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan)
 	if dockerfileExists {
 		args = append(args, "--skip")
 	}
+
+	// add additional flags from launch command
+	if len(flags) > 0 {
+		args = append(args, flags...)
+	}
+
 	fmt.Printf("Running: %s\n", strings.Join(args, " "))
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Stdin = os.Stdin

--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -116,7 +116,7 @@ a Postgres database.
 	return s, nil
 }
 
-func PhoenixCallback(appName string, _ *SourceInfo, plan *plan.LaunchPlan) error {
+func PhoenixCallback(appName string, _ *SourceInfo, plan *plan.LaunchPlan, flags []string) error {
 	envEExPath := "rel/env.sh.eex"
 	envEExContents := `
 # configure node for distributed erlang with IPV6 support

--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -188,7 +188,7 @@ Once ready: run 'fly deploy' to deploy your Rails app.
 	return s, nil
 }
 
-func RailsCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan) error {
+func RailsCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan, flags []string) error {
 	// install dockerfile-rails gem, if not already included
 	writable := false
 	gemfile, err := os.ReadFile("Gemfile")
@@ -288,6 +288,11 @@ func RailsCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan) e
 	// add redis
 	if redis := plan.Redis.Provider(); redis != nil {
 		args = append(args, "--redis")
+	}
+
+	// add additional flags from launch command
+	if len(flags) > 0 {
+		args = append(args, flags...)
 	}
 
 	// run command

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -73,7 +73,7 @@ type SourceInfo struct {
 	DatabaseDesired              DatabaseKind
 	RedisDesired                 bool
 	Concurrency                  map[string]int
-	Callback                     func(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan) error
+	Callback                     func(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan, flags []string) error
 	HttpCheckPath                string
 	HttpCheckHeaders             map[string]string
 	ConsoleCommand               string


### PR DESCRIPTION
The purpose of this is to pass the remainder of the arguments to the language or framework specific scanner to do with as it wishes. To start with, the framework scanners that include dockerfile generators will pass the remaining arguments onto their respective dockerfile generator.  Other scanners may find other uses.

Note that the chosen argument scanner, cobra, does not support this at this time so the arguments are removed and retained before being passed to cobra.