### PR TITLE
Enable scanners to modify/append to error messages via a callback

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -127,10 +127,18 @@ func run(ctx context.Context) (err error) {
 	startTime := time.Now()
 	var status metrics.LaunchStatusPayload
 	metrics.Started(ctx, "launch")
+
+	var state *launchState = nil
+
 	defer func() {
 		if err != nil {
 			status.Error = err.Error()
+
+			if state != nil && state.sourceInfo != nil && state.sourceInfo.FailureCallback != nil {
+				err = errors.New(state.sourceInfo.FailureCallback(status.Error))
+			}
 		}
+
 		status.Duration = time.Since(startTime)
 		metrics.LaunchStatus(ctx, "launch", status)
 	}()
@@ -192,7 +200,7 @@ func run(ctx context.Context) (err error) {
 	status.ScannerFamily = launchManifest.Plan.ScannerFamily
 	status.FlyctlVersion = launchManifest.Plan.FlyctlVersion.String()
 
-	state, err := stateFromManifest(ctx, *launchManifest, cache)
+	state, err = stateFromManifest(ctx, *launchManifest, cache)
 	if err != nil {
 		return err
 	}

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -135,7 +135,7 @@ func run(ctx context.Context) (err error) {
 			status.Error = err.Error()
 
 			if state != nil && state.sourceInfo != nil && state.sourceInfo.FailureCallback != nil {
-				err = errors.New(state.sourceInfo.FailureCallback(status.Error))
+				err = state.sourceInfo.FailureCallback(err)
 			}
 		}
 

--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/internal/command/launch/plan"
+	"github.com/superfly/flyctl/internal/flyerr"
 )
 
 var healthcheck_channel = make(chan string)
@@ -330,11 +331,16 @@ func RailsCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan) e
 	return nil
 }
 
-func RailsFailureCallback(msg string) string {
-	if !strings.Contains(msg, "https://") {
-		msg += "\n\nSee https://fly.io/docs/rails/getting-started/existing/#common-initial-deployment-issues\n" +
-			"for suggestions on how to resolve common deployment issues."
+func RailsFailureCallback(err error) error {
+	suggestion := flyerr.GetErrorSuggestion(err)
+
+	if suggestion == "" {
+		err = flyerr.GenericErr{
+			Err: err.Error(),
+			Suggest: "\nSee https://fly.io/docs/rails/getting-started/existing/#common-initial-deployment-issues\n" +
+				"for suggestions on how to resolve common deployment issues.",
+		}
 	}
 
-	return msg
+	return err
 }

--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -72,6 +72,7 @@ func configureRails(sourceDir string, config *ScannerConfig) (*SourceInfo, error
 	s := &SourceInfo{
 		Family:               "Rails",
 		Callback:             RailsCallback,
+		FailureCallback:      RailsFailureCallback,
 		Port:                 3000,
 		ConsoleCommand:       "/rails/bin/rails console",
 		AutoInstrumentErrors: true,
@@ -327,4 +328,13 @@ func RailsCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan) e
 	}
 
 	return nil
+}
+
+func RailsFailureCallback(msg string) string {
+	if !strings.Contains(msg, "https://") {
+		msg += "\n\nSee https://fly.io/docs/rails/getting-started/existing/#common-initial-deployment-issues\n" +
+			"for suggestions on how to resolve common deployment issues."
+	}
+
+	return msg
 }

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -79,6 +79,7 @@ type SourceInfo struct {
 	ConsoleCommand               string
 	MergeConfig                  *MergeConfigStruct
 	AutoInstrumentErrors         bool
+	FailureCallback              func(msg string) string
 }
 
 type SourceFile struct {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -79,7 +79,7 @@ type SourceInfo struct {
 	ConsoleCommand               string
 	MergeConfig                  *MergeConfigStruct
 	AutoInstrumentErrors         bool
-	FailureCallback              func(msg string) string
+	FailureCallback              func(err error) error
 }
 
 type SourceFile struct {


### PR DESCRIPTION
This should help with the movement from launch SkipDeploy=true where DeployDocs would suggest reading materials before deployment to SkipDeploy=false and the link to the reading materials only shows up on failure.

The callbacks are passsed the actual error message, so over time it may even be possible to provide (or point to) specific advice for common errors.