### PR TITLE
Prompt to log in when not logged in

### DIFF
--- a/internal/command/auth/auth.go
+++ b/internal/command/auth/auth.go
@@ -2,24 +2,9 @@
 package auth
 
 import (
-	"context"
-	"fmt"
-	"io"
-	"time"
-
-	"github.com/azazeal/pause"
-	"github.com/briandowns/spinner"
-	"github.com/pkg/errors"
-	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
 
-	"github.com/superfly/flyctl/iostreams"
-
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
-	"github.com/superfly/flyctl/internal/config"
-	"github.com/superfly/flyctl/internal/logger"
-	"github.com/superfly/flyctl/internal/state"
 )
 
 // New initializes and returns a new apps Command.
@@ -44,77 +29,4 @@ If you do have an account, begin with the AUTH LOGIN subcommand.
 	)
 
 	return auth
-}
-
-func runWebLogin(ctx context.Context, signup bool) (string, error) {
-	auth, err := fly.StartCLISessionWebAuth(state.Hostname(ctx), signup)
-	if err != nil {
-		return "", err
-	}
-
-	io := iostreams.FromContext(ctx)
-	if err := open.Run(auth.URL); err != nil {
-		fmt.Fprintf(io.ErrOut,
-			"failed opening browser. Copy the url (%s) into a browser and continue\n",
-			auth.URL,
-		)
-	}
-
-	logger := logger.FromContext(ctx)
-
-	colorize := io.ColorScheme()
-	fmt.Fprintf(io.Out, "Opening %s ...\n\n", colorize.Bold(auth.URL))
-
-	token, err := waitForCLISession(ctx, logger, io.ErrOut, auth.ID)
-	switch {
-	case errors.Is(err, context.DeadlineExceeded):
-		return "", errors.New("Login expired, please try again")
-	case err != nil:
-		return "", err
-	case token == "":
-		return "", errors.New("failed to log in, please try again")
-	}
-
-	return token, nil
-}
-
-// TODO: this does NOT break on interrupts
-func waitForCLISession(parent context.Context, logger *logger.Logger, w io.Writer, id string) (token string, err error) {
-	ctx, cancel := context.WithTimeout(parent, 15*time.Minute)
-	defer cancel()
-
-	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
-	s.Writer = w
-	s.Prefix = "Waiting for session..."
-	s.Start()
-
-	for ctx.Err() == nil {
-		if token, err = fly.GetAccessTokenForCLISession(ctx, id); err != nil {
-			logger.Debugf("failed retrieving token: %v", err)
-
-			pause.For(ctx, time.Second)
-
-			continue
-		}
-
-		logger.Debug("retrieved access token.")
-
-		s.FinalMSG = "Waiting for session... Done\n"
-		s.Stop()
-
-		break
-	}
-
-	return
-}
-
-func persistAccessToken(ctx context.Context, token string) (err error) {
-	path := state.ConfigFile(ctx)
-
-	if err = config.SetAccessToken(path, token); err != nil {
-		err = fmt.Errorf("failed persisting %s in %s: %w\n",
-			config.AccessTokenFileKey, path, err)
-	}
-
-	return
 }

--- a/internal/command/auth/signup.go
+++ b/internal/command/auth/signup.go
@@ -2,15 +2,11 @@ package auth
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/command/auth/webauth"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
-	"github.com/superfly/flyctl/internal/flyutil"
-	"github.com/superfly/flyctl/iostreams"
 )
 
 func newSignup() *cobra.Command {
@@ -33,17 +29,6 @@ func runSignup(ctx context.Context) error {
 	if err := webauth.SaveToken(ctx, token); err != nil {
 		return err
 	}
-
-	user, err := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{
-		AccessToken: token,
-	}).GetCurrentUser(ctx)
-	if err != nil {
-		return fmt.Errorf("failed retrieving current user: %w", err)
-	}
-
-	io := iostreams.FromContext(ctx)
-	colorize := io.ColorScheme()
-	fmt.Fprintf(io.Out, "successfully logged in as %s\n", colorize.Bold(user.Email))
 
 	return nil
 }

--- a/internal/command/auth/signup.go
+++ b/internal/command/auth/signup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/command/auth/webauth"
 
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
@@ -24,12 +25,12 @@ and sends the user to a form to provide appropriate credentials.
 }
 
 func runSignup(ctx context.Context) error {
-	token, err := runWebLogin(ctx, true)
+	token, err := webauth.RunWebLogin(ctx, true)
 	if err != nil {
 		return err
 	}
 
-	if err := persistAccessToken(ctx, token); err != nil {
+	if err := webauth.SaveToken(ctx, token); err != nil {
 		return err
 	}
 

--- a/internal/command/auth/webauth/webauth.go
+++ b/internal/command/auth/webauth/webauth.go
@@ -1,0 +1,118 @@
+package webauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/azazeal/pause"
+	"github.com/briandowns/spinner"
+	"github.com/skratchdot/open-golang/open"
+	"github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/agent"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/logger"
+	"github.com/superfly/flyctl/internal/state"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func SaveToken(ctx context.Context, token string) error {
+
+	if ac, err := agent.DefaultClient(ctx); err == nil {
+		_ = ac.Kill(ctx)
+	}
+	config.Clear(state.ConfigFile(ctx))
+
+	if err := persistAccessToken(ctx, token); err != nil {
+		return err
+	}
+
+	user, err := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{
+		AccessToken: token,
+	}).GetCurrentUser(ctx)
+	if err != nil {
+		return fmt.Errorf("failed retrieving current user: %w", err)
+	}
+
+	io := iostreams.FromContext(ctx)
+	colorize := io.ColorScheme()
+	fmt.Fprintf(io.Out, "successfully logged in as %s\n", colorize.Bold(user.Email))
+
+	return nil
+}
+
+func RunWebLogin(ctx context.Context, signup bool) (string, error) {
+	auth, err := fly.StartCLISessionWebAuth(state.Hostname(ctx), signup)
+	if err != nil {
+		return "", err
+	}
+
+	io := iostreams.FromContext(ctx)
+	if err := open.Run(auth.URL); err != nil {
+		fmt.Fprintf(io.ErrOut,
+			"failed opening browser. Copy the url (%s) into a browser and continue\n",
+			auth.URL,
+		)
+	}
+
+	logger := logger.FromContext(ctx)
+
+	colorize := io.ColorScheme()
+	fmt.Fprintf(io.Out, "Opening %s ...\n\n", colorize.Bold(auth.URL))
+
+	token, err := waitForCLISession(ctx, logger, io.ErrOut, auth.ID)
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		return "", errors.New("Login expired, please try again")
+	case err != nil:
+		return "", err
+	case token == "":
+		return "", errors.New("failed to log in, please try again")
+	}
+
+	return token, nil
+}
+
+// TODO: this does NOT break on interrupts
+func waitForCLISession(parent context.Context, logger *logger.Logger, w io.Writer, id string) (token string, err error) {
+	ctx, cancel := context.WithTimeout(parent, 15*time.Minute)
+	defer cancel()
+
+	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
+	s.Writer = w
+	s.Prefix = "Waiting for session..."
+	s.Start()
+
+	for ctx.Err() == nil {
+		if token, err = fly.GetAccessTokenForCLISession(ctx, id); err != nil {
+			logger.Debugf("failed retrieving token: %v", err)
+
+			pause.For(ctx, time.Second)
+
+			continue
+		}
+
+		logger.Debug("retrieved access token.")
+
+		s.FinalMSG = "Waiting for session... Done\n"
+		s.Stop()
+
+		break
+	}
+
+	return
+}
+
+func persistAccessToken(ctx context.Context, token string) (err error) {
+	path := state.ConfigFile(ctx)
+
+	if err = config.SetAccessToken(path, token); err != nil {
+		err = fmt.Errorf("failed persisting %s in %s: %w\n",
+			config.AccessTokenFileKey, path, err)
+	}
+
+	return
+}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -513,6 +513,7 @@ func RequireSession(ctx context.Context) (context.Context, error) {
 		io := iostreams.FromContext(ctx)
 		// Ensure we have a session, and that the user hasn't set any flags that would lead them to expect consistent output or a lack of prompts
 		if io.IsInteractive() &&
+			!env.IsCI() &&
 			!flag.GetBool(ctx, "now") &&
 			!flag.GetBool(ctx, "json") &&
 			!flag.GetBool(ctx, "quiet") &&

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -16,6 +16,8 @@ import (
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/tokens"
+	"github.com/superfly/flyctl/internal/command/auth/webauth"
+	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -60,9 +62,12 @@ var commonPreparers = []preparers.Preparer{
 	preparers.LoadConfig,
 	startQueryingForNewRelease,
 	promptAndAutoUpdate,
+	startMetrics,
+}
+
+var authPreparers = []preparers.Preparer{
 	preparers.InitClient,
 	killOldAgent,
-	startMetrics,
 	preparers.SetOtelAuthenticationKey,
 }
 
@@ -94,6 +99,11 @@ func newRunE(fn Runner, preparers ...preparers.Preparer) func(*cobra.Command, []
 
 		// run the common preparers
 		if ctx, err = prepare(ctx, commonPreparers...); err != nil {
+			return
+		}
+
+		// run the preparers that perform or require authorization
+		if ctx, err = prepare(ctx, authPreparers...); err != nil {
 			return
 		}
 
@@ -500,7 +510,44 @@ func ExcludeFromMetrics(ctx context.Context) (context.Context, error) {
 // RequireSession is a Preparer which makes sure a session exists.
 func RequireSession(ctx context.Context) (context.Context, error) {
 	if !fly.ClientFromContext(ctx).Authenticated() {
-		return nil, fly.ErrNoAuthToken
+		io := iostreams.FromContext(ctx)
+		// Ensure we have a session, and that the user hasn't set any flags that would lead them to expect consistent output or a lack of prompts
+		if io.IsInteractive() &&
+			!flag.GetBool(ctx, "now") &&
+			!flag.GetBool(ctx, "json") &&
+			!flag.GetBool(ctx, "quiet") &&
+			!flag.GetBool(ctx, "yes") {
+
+			// Ask before we start opening things
+			confirmed, err := prompt.Confirm(ctx, "You must be logged in to do this. Would you like to sign in?")
+			if err != nil {
+				return nil, err
+			}
+			if !confirmed {
+				return nil, fly.ErrNoAuthToken
+			}
+
+			// Attempt to log the user in
+			token, err := webauth.RunWebLogin(ctx, false)
+			if err != nil {
+				return nil, err
+			}
+			if err := webauth.SaveToken(ctx, token); err != nil {
+				return nil, err
+			}
+
+			// Reload the config
+			if ctx, err = prepare(ctx, preparers.LoadConfig); err != nil {
+				return nil, err
+			}
+
+			// Re-run the auth preparers to update the client with the new token
+			if ctx, err = prepare(ctx, authPreparers...); err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, fly.ErrNoAuthToken
+		}
 	}
 
 	return updateMacaroons(ctx)


### PR DESCRIPTION
### Change Summary

What and Why: In an interactive session with no flags that imply the user is expecting to run unattended, we'll prompt the user to log in, then continue running, instead of returning an error. This should make the initial launch flow for new customers smoother c:

How: Split the `auth login` command's web login bits into a `webauth` package, which the `RequireSession` preparer now uses when it's sure the user is there attending to the CLI to facilitate login. We also split preparers that load the config or expect the config to have been loaded into an `authPreparers` array so that these can be re-run if the auth token changes mid-execution.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
