### PR TITLE
Watch config file for token changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/ejcx/sshcert v1.1.0
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/getsentry/sentry-go v0.27.0
 	github.com/go-logr/logr v1.4.1
 	github.com/gofrs/flock v0.8.1
@@ -156,7 +157,6 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/gdamore/tcell/v2 v2.7.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
@@ -252,4 +252,7 @@ require (
 	gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 // indirect
 )
 
-replace github.com/loadsmart/calver-go => github.com/ndarilek/calver-go v0.0.0-20230710153822-893bbd83a936
+replace (
+	github.com/loadsmart/calver-go => github.com/ndarilek/calver-go v0.0.0-20230710153822-893bbd83a936
+	github.com/nats-io/nats.go => github.com/btoews/nats.go v0.0.0-20240401180931-476bea7f4158
+)

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,11 @@ go 1.21.7
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
+	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161
 	github.com/Khan/genqlient v0.6.0
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
+	github.com/Microsoft/go-winio v0.6.1
+	github.com/PuerkitoBio/rehttp v1.4.0
 	github.com/alecthomas/chroma v0.10.0
 	github.com/avast/retry-go/v4 v4.5.1
 	github.com/azazeal/pause v1.3.0
@@ -13,12 +16,16 @@ require (
 	github.com/briandowns/spinner v1.23.0
 	github.com/buildpacks/pack v0.33.2
 	github.com/cavaliergopher/grab/v3 v3.0.1
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/chzyer/readline v1.5.1
 	github.com/cli/safeexec v1.0.1
 	github.com/docker/docker v25.0.3+incompatible
+	github.com/docker/go-connections v0.5.0
+	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/ejcx/sshcert v1.1.0
 	github.com/getsentry/sentry-go v0.27.0
+	github.com/go-logr/logr v1.4.1
 	github.com/gofrs/flock v0.8.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
@@ -47,6 +54,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.6
+	github.com/r3labs/diff v1.1.0
 	github.com/samber/lo v1.39.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/sourcegraph/conc v0.3.0
@@ -62,13 +70,20 @@ require (
 	github.com/vektah/gqlparser v1.3.1
 	github.com/vektah/gqlparser/v2 v2.5.11
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.50.0
+	go.opentelemetry.io/otel v1.25.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.25.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.25.0
+	go.opentelemetry.io/otel/sdk v1.25.0
+	go.opentelemetry.io/otel/trace v1.25.0
 	golang.org/x/crypto v0.22.0
 	golang.org/x/exp v0.0.0-20231219160207-73b9e39aefca
+	golang.org/x/mod v0.17.0
 	golang.org/x/net v0.24.0
 	golang.org/x/sync v0.7.0
+	golang.org/x/sys v0.19.0
 	golang.org/x/term v0.19.0
+	golang.org/x/text v0.14.0
+	golang.org/x/time v0.5.0
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 	google.golang.org/grpc v1.63.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -77,28 +92,8 @@ require (
 )
 
 require (
-	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.4 // indirect
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
-	github.com/containerd/console v1.0.4 // indirect
-	github.com/containerd/ttrpc v1.2.2 // indirect
-	github.com/docker/go-metrics v0.0.1 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/in-toto/in-toto-golang v0.5.0 // indirect
-	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
-	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/locker v1.0.1 // indirect
-	github.com/prometheus/client_golang v1.17.0 // indirect
-	github.com/prometheus/client_model v0.5.0 // indirect
-	github.com/prometheus/common v0.44.0 // indirect
-	github.com/prometheus/procfs v0.12.0 // indirect
-	github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect
-	github.com/shibumi/go-pathspec v1.3.0 // indirect
-)
-
-require (
 	dario.cat/mergo v1.0.0 // indirect
+	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.29 // indirect
@@ -126,6 +121,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.7.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.24.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.21.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.18.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.7 // indirect
@@ -133,129 +129,127 @@ require (
 	github.com/aws/smithy-go v1.19.0 // indirect
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20231213181459-b0fcec718dc6 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/buildpacks/imgutil v0.0.0-20240118145509-e94a1b7de8a9 // indirect
+	github.com/buildpacks/lifecycle v0.18.5 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/containerd/console v1.0.4 // indirect
+	github.com/containerd/containerd v1.7.13 // indirect
+	github.com/containerd/continuity v0.4.3 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
+	github.com/containerd/ttrpc v1.2.2 // indirect
 	github.com/containerd/typeurl/v2 v2.1.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/docker/cli v25.0.3+incompatible // indirect
+	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.0 // indirect
+	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/fatih/color v1.15.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/gdamore/tcell/v2 v2.7.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/go-git/go-git/v5 v5.11.0 // indirect
-	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/gogo/googleapis v1.4.1 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/go-containerregistry v0.19.0 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/heroku/color v0.0.6 // indirect
+	github.com/in-toto/in-toto-golang v0.5.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/klauspost/compress v1.17.4 // indirect
 	github.com/kr/fs v0.1.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/magiconair/properties v1.8.7 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/ioprogress v0.0.0-20180201004757-6a23b12fa88e // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/moby/docker-image-spec v1.3.1 // indirect
+	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/sys/sequential v0.5.0 // indirect
 	github.com/moby/sys/signal v0.7.0 // indirect
 	github.com/moby/sys/user v0.1.0 // indirect
 	github.com/moby/term v0.5.0 // indirect
+	github.com/nats-io/nkeys v0.4.7 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencontainers/image-spec v1.1.0-rc5 // indirect
 	github.com/opencontainers/selinux v1.11.0 // indirect
+	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/prometheus/client_golang v1.17.0 // indirect
+	github.com/prometheus/client_model v0.5.0 // indirect
+	github.com/prometheus/common v0.44.0 // indirect
+	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rivo/tview v0.0.0-20220307222120-9994674d60a8 // indirect
+	github.com/rivo/uniseg v0.4.3 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/secure-systems-lab/go-securesystemslib v0.4.0 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect
+	github.com/shibumi/go-pathspec v1.3.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.2.1 // indirect
+	github.com/spf13/afero v1.11.0 // indirect
+	github.com/spf13/cast v1.6.0 // indirect
+	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/superfly/ltx v0.3.12 // indirect
+	github.com/tonistiigi/fsutil v0.0.0-20240301111122-7525a1af2bb5 // indirect
+	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
+	github.com/tonistiigi/vt100 v0.0.0-20230623042737-f9a4f7ef6531 // indirect
 	github.com/vbatts/tar-split v0.11.5 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.25.0 // indirect
 	go.opentelemetry.io/otel/metric v1.25.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.1.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/tools v0.17.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
+	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240401170217-c3f982113cda // indirect
-	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 // indirect
-)
-
-require (
-	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161
-	github.com/Microsoft/go-winio v0.6.1
-	github.com/PuerkitoBio/rehttp v1.4.0
-	github.com/buildpacks/lifecycle v0.18.5 // indirect
-	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/containerd/containerd v1.7.13 // indirect
-	github.com/containerd/continuity v0.4.3 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/go-connections v0.5.0
-	github.com/docker/go-units v0.5.0
-	github.com/fatih/color v1.15.0 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
-	github.com/gogo/googleapis v1.4.1 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/klauspost/compress v1.17.4 // indirect
-	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/magiconair/properties v1.8.7 // indirect
-	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/nats-io/nkeys v0.4.7 // indirect
-	github.com/nats-io/nuid v1.0.1 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0-rc5 // indirect
-	github.com/pborman/uuid v1.2.0 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/r3labs/diff v1.1.0
-	github.com/rivo/uniseg v0.4.3 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
-	github.com/spf13/afero v1.11.0 // indirect
-	github.com/spf13/cast v1.6.0 // indirect
-	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/tonistiigi/fsutil v0.0.0-20240301111122-7525a1af2bb5 // indirect
-	github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea // indirect
-	github.com/tonistiigi/vt100 v0.0.0-20230623042737-f9a4f7ef6531 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.1 // indirect
-	go.opentelemetry.io/otel v1.25.0
-	go.opentelemetry.io/otel/sdk v1.25.0
-	go.opentelemetry.io/otel/trace v1.25.0
-	go.opentelemetry.io/proto/otlp v1.1.0 // indirect
-	golang.org/x/mod v0.17.0
-	golang.org/x/sys v0.19.0
-	golang.org/x/text v0.14.0
-	golang.org/x/time v0.5.0
-	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 // indirect
 )
 
 replace github.com/loadsmart/calver-go => github.com/ndarilek/calver-go v0.0.0-20230710153822-893bbd83a936

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/bradleyjkemp/cupaloy/v2 v2.6.0 h1:knToPYa2xtfg42U3I6punFEjaGFKWQRXJwj
 github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1lps46Enkdqw6aRX0=
 github.com/briandowns/spinner v1.23.0 h1:alDF2guRWqa/FOZZYWjlMIx2L6H0wyewPxo/CH4Pt2A=
 github.com/briandowns/spinner v1.23.0/go.mod h1:rPG4gmXeN3wQV/TsAY4w8lPdIM6RX3yqeBQJSrbXjuE=
+github.com/btoews/nats.go v0.0.0-20240401180931-476bea7f4158 h1:dyIdqIvZvxRjekfXZL+ZD3FdJzQS5gq/I7IFSyQ/aNg=
+github.com/btoews/nats.go v0.0.0-20240401180931-476bea7f4158/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
 github.com/buildpacks/imgutil v0.0.0-20240118145509-e94a1b7de8a9 h1:kxe31xfMWJAIAzDfGQ3lL0j8QSSRfEHyLg7dRWIHA8I=
 github.com/buildpacks/imgutil v0.0.0-20240118145509-e94a1b7de8a9/go.mod h1:PsazEB9yz+NG/cgm0Z1oQ0Xq6rD/U7eNMt5Su41afYY=
 github.com/buildpacks/lifecycle v0.18.5 h1:lfoUX8jYCUZ2/Tr2AopaRjinqDivkNkcTChzysQTo00=
@@ -472,8 +474,6 @@ github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7P
 github.com/muesli/termenv v0.15.2 h1:GohcuySI0QmI3wN8Ok9PtKGkgkFIk7y6Vpb5PvrY+Wo=
 github.com/muesli/termenv v0.15.2/go.mod h1:Epx+iuz8sNs7mNKhxzH4fWXGNpZwUaJKRS1noLXviQ8=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nats-io/nats.go v1.34.1 h1:syWey5xaNHZgicYBemv0nohUPPmaLteiBEUT6Q5+F/4=
-github.com/nats-io/nats.go v1.34.1/go.mod h1:Ubdu4Nh9exXdSz0RVWRFBbRfrbSxOYd26oF0wkWclB8=
 github.com/nats-io/nkeys v0.4.7 h1:RwNJbbIdYCoClSDNY7QVKZlyb/wfT6ugvFCiKy6vDvI=
 github.com/nats-io/nkeys v0.4.7/go.mod h1:kqXRgRDPlGy7nGaEDMuYzmiJCIAAWDK0IMBtDmGD0nc=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -2,9 +2,7 @@ package preparers
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -33,19 +31,10 @@ type Preparer func(context.Context) (context.Context, error)
 func LoadConfig(ctx context.Context) (context.Context, error) {
 	logger := logger.FromContext(ctx)
 
-	cfg := config.New()
-
-	// Apply config from the config file, if it exists
-	path := filepath.Join(state.ConfigDirectory(ctx), config.FileName)
-	if err := cfg.ApplyFile(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+	cfg, err := config.Load(ctx, filepath.Join(state.ConfigDirectory(ctx), config.FileName))
+	if err != nil {
 		return nil, err
 	}
-
-	// Apply config from the environment, overriding anything from the file
-	cfg.ApplyEnv()
-
-	// Finally, apply command line options, overriding any previous setting
-	cfg.ApplyFlags(flagctx.FromContext(ctx))
 
 	logger.Debug("config initialized.")
 

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -557,9 +557,11 @@ func RequireSession(ctx context.Context) (context.Context, error) {
 // updateMacaroons prune any invalid/expired macaroons and fetch needed third
 // party discharges
 func updateMacaroons(ctx context.Context) (context.Context, error) {
-	log := logger.FromContext(ctx)
-
-	toks := config.Tokens(ctx)
+	var (
+		log  = logger.FromContext(ctx)
+		cfg  = config.FromContext(ctx)
+		toks = cfg.Tokens
+	)
 
 	updated, err := toks.Update(ctx,
 		tokens.WithUserURLCallback(tryOpenUserURL),
@@ -570,14 +572,32 @@ func updateMacaroons(ctx context.Context) (context.Context, error) {
 		log.Debug(err)
 	}
 
-	if !updated || toks.FromConfigFile == "" {
+	if toks.FromConfigFile == "" {
 		return ctx, nil
 	}
 
-	if err := config.SetAccessToken(toks.FromConfigFile, toks.All()); err != nil {
-		log.Warn("Failed to persist authentication token.")
-		log.Debug(err)
+	if updated {
+		if err := config.SetAccessToken(toks.FromConfigFile, toks.All()); err != nil {
+			log.Warn("Failed to persist authentication token.")
+			log.Debug(err)
+		}
 	}
+
+	sub, err := cfg.Watch(ctx)
+	if err != nil {
+		log.Warn("Failed to watch config file for changes.")
+		log.Debug(err)
+		return ctx, nil
+	}
+
+	go func() {
+		for newCfg := range sub {
+			if cfg.Tokens.All() != newCfg.Tokens.All() {
+				log.Debug("Authentication tokens updated from config file.")
+				cfg.Tokens.Replace(newCfg.Tokens)
+			}
+		}
+	}()
 
 	return ctx, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -252,6 +252,13 @@ func (cfg *Config) Watch(ctx context.Context) (chan *Config, error) {
 				cfg.subs = nil
 			}()
 
+			var (
+				notifyCtx        context.Context
+				cancelNotify     context.CancelFunc  = func() {}
+				cancelLastNotify *context.CancelFunc = &cancelNotify
+			)
+			defer func() { (*cancelLastNotify)() }()
+
 			for {
 				select {
 				case e, open := <-watch.Events:
@@ -263,7 +270,17 @@ func (cfg *Config) Watch(ctx context.Context) (chan *Config, error) {
 						continue
 					}
 
-					go cfg.notifySubs(ctx)
+					// Debounce change notifications: notifySubs sleeps for 50ms
+					// before notifying subs. If we get another change before
+					// that, we preempt the previous notification attempt. This
+					// is necessary because we receive multiple notifications
+					// for a single config change on windows and the first event
+					// fires before the change is available to be read.
+					(*cancelLastNotify)()
+					notifyCtx, cancelNotify = context.WithCancel(ctx)
+					cancelLastNotify = &cancelNotify
+
+					go cfg.notifySubs(notifyCtx)
 				case err := <-watch.Errors:
 					cfg.mu.Lock()
 					defer cfg.mu.Unlock()
@@ -302,6 +319,13 @@ func (cfg *Config) Unwatch(sub chan *Config) {
 }
 
 func (cfg *Config) notifySubs(ctx context.Context) {
+	// sleep for 50ms to facilitate debouncing (described above)
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(50 * time.Millisecond):
+	}
+
 	newCfg, err := Load(ctx, cfg.path)
 	if err != nil {
 		return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,13 +1,20 @@
 package config
 
 import (
+	"context"
+	"errors"
+	"io/fs"
 	"sync"
+	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/pflag"
 
 	"github.com/superfly/fly-go/tokens"
 	"github.com/superfly/flyctl/internal/env"
+	"github.com/superfly/flyctl/internal/flag/flagctx"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
+	"github.com/superfly/flyctl/internal/task"
 )
 
 const (
@@ -47,7 +54,12 @@ const (
 //
 // Instances of Config are safe for concurrent use.
 type Config struct {
-	mu sync.RWMutex
+	mu   sync.RWMutex
+	path string
+
+	watchOnce sync.Once
+	watchErr  error
+	subs      map[chan *Config]struct{}
 
 	// APIBaseURL denotes the base URL of the API.
 	APIBaseURL string
@@ -93,22 +105,34 @@ type Config struct {
 	MetricsToken string
 }
 
-// New returns a new instance of Config populated with default values.
-func New() *Config {
-	return &Config{
+func Load(ctx context.Context, path string) (*Config, error) {
+	cfg := &Config{
 		APIBaseURL:     defaultAPIBaseURL,
 		FlapsBaseURL:   defaultFlapsBaseURL,
 		RegistryHost:   defaultRegistryHost,
 		MetricsBaseURL: defaultMetricsBaseURL,
 		Tokens:         new(tokens.Tokens),
 	}
+
+	// Apply config from the config file, if it exists
+	if err := cfg.applyFile(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+
+	// Apply config from the environment, overriding anything from the file
+	cfg.applyEnv()
+
+	// Finally, apply command line options, overriding any previous setting
+	cfg.applyFlags(flagctx.FromContext(ctx))
+
+	return cfg, nil
 }
 
-// ApplyEnv sets the properties of cfg which may be set via environment
+// applyEnv sets the properties of cfg which may be set via environment
 // variables to the values these variables contain.
 //
-// ApplyEnv does not change the dirty state of config.
-func (cfg *Config) ApplyEnv() {
+// applyEnv does not change the dirty state of config.
+func (cfg *Config) applyEnv() {
 	cfg.mu.Lock()
 	defer cfg.mu.Unlock()
 
@@ -131,11 +155,13 @@ func (cfg *Config) ApplyEnv() {
 	cfg.SendMetrics = env.IsTruthy(SendMetricsEnvKey) || cfg.SendMetrics
 }
 
-// ApplyFile sets the properties of cfg which may be set via configuration file
+// applyFile sets the properties of cfg which may be set via configuration file
 // to the values the file at the given path contains.
-func (cfg *Config) ApplyFile(path string) (err error) {
+func (cfg *Config) applyFile(path string) (err error) {
 	cfg.mu.Lock()
 	defer cfg.mu.Unlock()
+
+	cfg.path = path
 
 	var w struct {
 		AccessToken  string `yaml:"access_token"`
@@ -158,9 +184,9 @@ func (cfg *Config) ApplyFile(path string) (err error) {
 	return
 }
 
-// ApplyFlags sets the properties of cfg which may be set via command line flags
+// applyFlags sets the properties of cfg which may be set via command line flags
 // to the values the flags of the given FlagSet may contain.
-func (cfg *Config) ApplyFlags(fs *pflag.FlagSet) {
+func (cfg *Config) applyFlags(fs *pflag.FlagSet) {
 	cfg.mu.Lock()
 	defer cfg.mu.Unlock()
 
@@ -186,6 +212,117 @@ func (cfg *Config) ApplyFlags(fs *pflag.FlagSet) {
 
 func (cfg *Config) MetricsBaseURLIsProduction() bool {
 	return cfg.MetricsBaseURL == defaultMetricsBaseURL
+}
+
+func (cfg *Config) Watch(ctx context.Context) (chan *Config, error) {
+	cfg.watchOnce.Do(func() {
+		watch, err := fsnotify.NewWatcher()
+		if err != nil {
+			cfg.watchErr = err
+			return
+		}
+
+		if err := watch.Add(cfg.path); err != nil {
+			cfg.watchErr = err
+			return
+		}
+
+		cfg.subs = make(map[chan *Config]struct{})
+
+		task.FromContext(ctx).Run(func(ctx context.Context) {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			cleanupDone := make(chan struct{})
+			defer func() { <-cleanupDone }()
+
+			go func() {
+				defer close(cleanupDone)
+
+				<-ctx.Done()
+
+				cfg.mu.Lock()
+				defer cfg.mu.Unlock()
+
+				cfg.watchErr = errors.Join(cfg.watchErr, ctx.Err(), watch.Close())
+
+				for sub := range cfg.subs {
+					close(sub)
+				}
+				cfg.subs = nil
+			}()
+
+			for {
+				select {
+				case e, open := <-watch.Events:
+					if !open {
+						return
+					}
+
+					if !e.Has(fsnotify.Write) {
+						continue
+					}
+
+					go cfg.notifySubs(ctx)
+				case err := <-watch.Errors:
+					cfg.mu.Lock()
+					defer cfg.mu.Unlock()
+
+					cfg.watchErr = errors.Join(cfg.watchErr, err)
+
+					return
+				case <-ctx.Done():
+					return
+				}
+			}
+		})
+	})
+
+	cfg.mu.Lock()
+	defer cfg.mu.Unlock()
+
+	if cfg.watchErr != nil {
+		return nil, cfg.watchErr
+	}
+
+	sub := make(chan *Config)
+	cfg.subs[sub] = struct{}{}
+
+	return sub, nil
+}
+
+func (cfg *Config) Unwatch(sub chan *Config) {
+	cfg.mu.Lock()
+	defer cfg.mu.Unlock()
+
+	if cfg.subs != nil {
+		delete(cfg.subs, sub)
+		close(sub)
+	}
+}
+
+func (cfg *Config) notifySubs(ctx context.Context) {
+	newCfg, err := Load(ctx, cfg.path)
+	if err != nil {
+		return
+	}
+
+	cfg.mu.RLock()
+	defer cfg.mu.RUnlock()
+
+	// just in case we have a slow subscriber
+	timer := time.NewTimer(100 * time.Millisecond)
+	defer timer.Stop()
+
+	for sub := range cfg.subs {
+		select {
+		case sub <- newCfg:
+		case <-timer.C:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 func applyStringFlags(fs *pflag.FlagSet, flags map[string]*string) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/flyctl/flyctl"
+	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/logger"
+	"github.com/superfly/flyctl/internal/task"
+)
+
+func TestConfigWatch(t *testing.T) {
+	cfgDirWas, cfgDirWasSet := os.LookupEnv("FLY_CONFIG_DIR")
+	os.Setenv("FLY_CONFIG_DIR", t.TempDir())
+	flyctl.InitConfig()
+	t.Cleanup(func() {
+		if cfgDirWasSet {
+			os.Setenv("FLY_CONFIG_DIR", cfgDirWas)
+		} else {
+			os.Unsetenv("FLY_CONFIG_DIR")
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ctx = logger.NewContext(ctx, logger.New(io.Discard, logger.Error, false))
+	ctx = flagctx.NewContext(ctx, new(pflag.FlagSet))
+
+	tm := task.New()
+	tm.Start(ctx)
+	ctx = task.WithContext(ctx, tm)
+
+	path := path.Join(t.TempDir(), "config.yml")
+
+	require.NoError(t, os.WriteFile(path, []byte(`access_token: fo1_foo`), 0644))
+	cfg, err := Load(ctx, path)
+	require.NoError(t, err)
+	require.Equal(t, "fo1_foo", cfg.Tokens.All())
+
+	c1, err := cfg.Watch(ctx)
+	require.NoError(t, err)
+
+	c2, err := cfg.Watch(ctx)
+	require.NoError(t, err)
+
+	cfgs, errs := getConfigChanges(c1, c2)
+	require.Equal(t, 2, len(errs))
+	require.Equal(t, 0, len(cfgs))
+
+	require.NoError(t, os.WriteFile(path, []byte(`access_token: fo1_bar`), 0644))
+
+	cfgs, errs = getConfigChanges(c1, c2)
+	require.Equal(t, 0, len(errs))
+	require.Equal(t, 2, len(cfgs))
+	require.Equal(t, cfgs[0], cfgs[1])
+	require.Equal(t, "fo1_bar", cfgs[0].Tokens.All())
+
+	cfg.Unwatch(c1)
+
+	require.NoError(t, os.WriteFile(path, []byte(`access_token: fo1_baz`), 0644))
+
+	cfgs, errs = getConfigChanges(c2)
+	require.Equal(t, 0, len(errs))
+	require.Equal(t, 1, len(cfgs))
+	require.Equal(t, "fo1_baz", cfgs[0].Tokens.All())
+
+	shutdown := make(chan struct{})
+	go func() {
+		defer close(shutdown)
+		tm.Shutdown()
+	}()
+	select {
+	case <-shutdown:
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("slow shutdown")
+	}
+
+	_, open := <-c1
+	require.False(t, open)
+	_, open = <-c2
+	require.False(t, open)
+
+	_, err = cfg.Watch(ctx)
+	assert.Error(t, err)
+	require.EqualError(t, err, context.Canceled.Error())
+}
+
+func getConfigChanges(chans ...chan *Config) ([]*Config, []error) {
+	var (
+		cfgs []*Config
+		errs []error
+		m    sync.Mutex
+		wg   sync.WaitGroup
+	)
+
+	for _, ch := range chans {
+		ch := ch
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer m.Unlock()
+
+			select {
+			case cfg, open := <-ch:
+				m.Lock()
+				if open {
+					cfgs = append(cfgs, cfg)
+				} else {
+					errs = append(errs, errors.New("closed"))
+				}
+			case <-time.After(50 * time.Millisecond):
+				m.Lock()
+				errs = append(errs, errors.New("timeout"))
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	return cfgs, errs
+}

--- a/logs/nats.go
+++ b/logs/nats.go
@@ -75,7 +75,12 @@ func newNatsClient(ctx context.Context, dialer agent.Dialer, orgSlug string) (*n
 	natsIP := net.IP(natsIPBytes[:])
 
 	url := fmt.Sprintf("nats://[%s]:4223", natsIP.String())
-	conn, err := nats.Connect(url, nats.SetCustomDialer(&natsDialer{dialer, ctx}), nats.UserInfo(orgSlug, config.Tokens(ctx).NATS()))
+	toks := config.Tokens(ctx)
+	conn, err := nats.Connect(
+		url,
+		nats.SetCustomDialer(&natsDialer{dialer, ctx}),
+		nats.UserInfoHandler(func() (string, string) { return orgSlug, toks.NATS() }),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed connecting to nats: %w", err)
 	}


### PR DESCRIPTION
### Change Summary

What and Why:

The macaroons that flyctl gets have a short lifespan. Commands with `RequireSession` refresh macaroons that are about to expire before the command runs. Similarly, the agent checks every minute if macaroons need to be refreshed soon. This setup works great for commands that run quickly, but I've had some slower deploys fail because my macaroons expired partway through. I've also had issues with long running `fly logs` where the NATS client has to reconnect but no longer has a valid token. This PR fixes that.

How:

This PR adds an API for watching for changes to the config file. Both the agent and other commands load changes to auth tokens that are written to the config. The agent still checks periodically if tokens need to be updated, and writes those updates to the config. This way, a long running command will start using the new macaroons that were refreshed by the running agent.

I had to submit a PR to the NATS library to allow dynamically changing tokens to be used when reconnecting after an error. I'm hoping https://github.com/nats-io/nats.go/pull/1599 will merge soon so I don't need to point flyctl at my fork.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
