### PR TITLE
`launch`: make the relationship between scanners and determined ports more obvious

### DIFF
--- a/internal/command/launch/launch_frameworks.go
+++ b/internal/command/launch/launch_frameworks.go
@@ -203,10 +203,6 @@ func (state *launchState) scannerSetAppconfig(ctx context.Context) error {
 		return nil
 	}
 
-	if srcInfo.Port > 0 {
-		appConfig.SetInternalPort(srcInfo.Port)
-	}
-
 	if srcInfo.HttpCheckPath != "" {
 		appConfig.SetHttpCheck(srcInfo.HttpCheckPath, srcInfo.HttpCheckHeaders)
 	}

--- a/internal/command/launch/plan/plan.go
+++ b/internal/command/launch/plan/plan.go
@@ -26,7 +26,8 @@ type LaunchPlan struct {
 	// As of writing this, however, the UI does not return this field.
 	Compute []*appconfig.Compute `json:"compute"`
 
-	HttpServicePort int `json:"http_service_port,omitempty"`
+	HttpServicePort             int  `json:"http_service_port,omitempty"`
+	HttpServicePortSetByScanner bool `json:"http_service_port_set_by_scanner,omitempty"`
 
 	Postgres PostgresPlan `json:"postgres"`
 	Redis    RedisPlan    `json:"redis"`

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -182,6 +182,7 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 
 	if !copiedConfig && srcInfo.Port != 0 {
 		lp.HttpServicePort = srcInfo.Port
+		lp.HttpServicePortSetByScanner = true
 	}
 
 	planSource := &launchPlanSource{

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -180,11 +180,6 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 		FlyctlVersion:    buildinfo.Info().Version,
 	}
 
-	if !copiedConfig && srcInfo.Port != 0 {
-		lp.HttpServicePort = srcInfo.Port
-		lp.HttpServicePortSetByScanner = true
-	}
-
 	planSource := &launchPlanSource{
 		appNameSource:  appNameExplanation,
 		regionSource:   regionExplanation,
@@ -223,6 +218,7 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 		}
 		if srcInfo.Port != 0 {
 			lp.HttpServicePort = srcInfo.Port
+			lp.HttpServicePortSetByScanner = true
 		}
 	}
 

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -180,6 +180,10 @@ func buildManifest(ctx context.Context, canEnterUi bool) (*LaunchManifest, *plan
 		FlyctlVersion:    buildinfo.Info().Version,
 	}
 
+	if !copiedConfig && srcInfo.Port != 0 {
+		lp.HttpServicePort = srcInfo.Port
+	}
+
 	planSource := &launchPlanSource{
 		appNameSource:  appNameExplanation,
 		regionSource:   regionExplanation,


### PR DESCRIPTION
### Change Summary

What and Why:

This does two things.
First: when you launched an app that uses a framework scanner, that scanner would always override the port set, even if it was customized. This is unexpected behavior, and has been removed.

Second: It adds a field to the launch plan, `http_service_port_set_by_scanner`. This can be used to show a warning next to the port option in the launch UI explaining that the port in question was determined by scanning the application config, and thus should probably not be changed.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a, will fresh produce when UI side is implemented c:
