### PR TITLE
`fly console`: use all of console group's `[[vm]]` section

### DIFF
--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -352,7 +352,7 @@ func makeEphemeralConsoleMachine(ctx context.Context, app *fly.AppCompact, appCo
 
 	machineFiles, err := command.FilesFromCommand(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed parsing filest: %w", err)
+		return nil, nil, fmt.Errorf("failed parsing files: %w", err)
 	}
 	fly.MergeFiles(machConfig, machineFiles)
 


### PR DESCRIPTION
### Change Summary

**What and Why:**

We currently check for the `[[vm]]` section that applies to the `console` process group and then access the raw `memory_mb` field as it is in `fly.toml`, which may be unset (causing a `nil`-pointer dereference). Furthermore, we ignore the `memory` field, which allows for a human-friendly suffix. (#3203 reported both of these.)

It seems best to just make `fly console` use *all* of the `[[vm]]` section, including e.g. the `size`.

To avoid changing too much behavior, it will *not* fall back to a default `[[vm]]` section. (But maybe we do want this?)

Also, the minimum/maximum memory check/adjuster was written when `fly console` accepted *only* flags to determine the Machine size, which explains the checks for `--vm-memory` and `--vm-size` when deciding whether to operate or whether to print anything. With the additional features it's gained since then, I think it makes sense just to run it unconditionally. (I still think that being able to type `--vm-cpus` and have the memory automatically increased is kind of convenient, so I decided not to remove it.)

**How:**

Use `appconfig.ToMachineConfig` to parse the `[[vm]]` section, rather than accessing the raw values. Then use `flag.GetMachineGuest` to easily merge the `fly.toml` configuration and any command-line overrides.

**Related to:**

* Feature introduced in #3172
* Fixes #3203

---

### Documentation

This may be worth posting about on the community forum, especially because it means that you can run console Machines with GPUs(!).
