### PR TITLE
Fix `fly launch --from <ssh-url>` for private repos

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"os/exec"
 	"time"
@@ -131,10 +130,6 @@ func setupFromTemplate(ctx context.Context) (context.Context, error) {
 	from := flag.GetString(ctx, "from")
 	if from == "" {
 		return ctx, nil
-	}
-
-	if _, err := url.Parse(from); err != nil {
-		return ctx, fmt.Errorf("invalid URL: `%s'. Expected https:// git repo", from)
 	}
 
 	entries, err := os.ReadDir(".")


### PR DESCRIPTION
allow cloning any URL, git will do the validation
