### PR TITLE
Fix docs publishing step

### DIFF
--- a/scripts/publish_docs.sh
+++ b/scripts/publish_docs.sh
@@ -14,5 +14,5 @@ if [ $? -gt 0 ]; then
   git commit -a -m "[flyctl-bot] Update docs from flyctl"
   git push -f --set-upstream origin HEAD:$BRANCH
   gh pr create -t "[flybot] Fly CLI docs update" -b "Fly CLI docs update" -B main -H $BRANCH -r jsierles
-  gh pr merge --delete-branch --merge
+  gh pr merge --delete-branch --squash
 fi


### PR DESCRIPTION
Fix docs publishing step.

It was failing with:
> GraphQL: Merge commits are not allowed on this repository. (mergePullRequest)
https://github.com/superfly/flyctl/actions/runs/8609003792/job/23592775680#step:6:282

I think that means the superfly/docs repo recently had the setting to allow merge commits disabled. Let's see if the squash commits work here...

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
