### PR TITLE
Unify token updating code

### DIFF
--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -14,9 +14,7 @@ import (
 
 	"github.com/azazeal/pause"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/tokens"
 	"github.com/superfly/flyctl/agent"
-	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/sentry"
 	"github.com/superfly/flyctl/internal/wireguard"
@@ -136,20 +134,6 @@ func (s *server) serve(parent context.Context, l net.Listener) (err error) {
 
 		return nil
 	})
-
-	if toks := config.Tokens(ctx); len(toks.MacaroonTokens) != 0 {
-		eg.Go(func() error {
-			if f := toks.FromConfigFile; f == "" {
-				s.print("monitoring for token expiration")
-				s.updateMacaroonsInMemory(ctx)
-			} else {
-				s.print("monitoring for token changes and expiration")
-				s.updateMacaroonsInFile(ctx, f)
-			}
-
-			return nil
-		})
-	}
 
 	eg.Go(func() (err error) {
 		s.printf("OK %d", os.Getpid())
@@ -377,84 +361,10 @@ func (s *server) clean(ctx context.Context) {
 	}
 }
 
-// updateMacaroons prunes expired macaroons and attempts to fetch discharge
-// tokens as necessary.
-func (s *server) updateMacaroonsInMemory(ctx context.Context) {
-	toks := config.Tokens(ctx)
-
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
-
-	var lastErr error
-
-	for {
-		if _, err := toks.Update(ctx, tokens.WithDebugger(s)); err != nil && err != lastErr {
-			s.print("failed upgrading authentication tokens:", err)
-			lastErr = err
-		}
-
-		select {
-		case <-ticker.C:
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-// updateMacaroons prunes expired tokens and fetches discharge tokens as
-// necessary. Those updates are written back to the config file.
-func (s *server) updateMacaroonsInFile(ctx context.Context, path string) {
-	configToks := config.Tokens(ctx)
-
-	ticker := time.NewTicker(time.Minute)
-	defer ticker.Stop()
-
-	var lastErr error
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-
-		// the tokens in the config are continually updated as the config file
-		// changes. We do our updates on a copy of the tokens so we can still
-		// tell if the tokens in the config changed out from under us.
-		configToksBefore := configToks.All()
-		localToks := tokens.Parse(configToksBefore)
-
-		updated, err := localToks.Update(ctx, tokens.WithDebugger(s))
-		if err != nil && err != lastErr {
-			s.print("failed upgrading authentication tokens:", err)
-			lastErr = err
-
-			// Don't continue loop here! It might only be partial failure
-		}
-
-		// the consequences of a race here (agent and foreground command both
-		// fetching updates simultaneously) are low, so don't bother with a lock
-		// file.
-		if updated && configToks.All() == configToksBefore {
-			if err := config.SetAccessToken(path, localToks.All()); err != nil {
-				s.print("Failed to persist authentication token:", err)
-				s.updateMacaroonsInMemory(ctx)
-				return
-			}
-
-			s.print("Authentication tokens upgraded")
-		}
-	}
-}
-
 func (s *server) print(v ...interface{}) {
 	s.Logger.Print(v...)
 }
 
 func (s *server) printf(format string, v ...interface{}) {
 	s.Logger.Printf(format, v...)
-}
-
-func (s *server) Debug(v ...any) {
-	s.Logger.Print(v...)
 }

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.1.4
+	github.com/superfly/fly-go v0.1.5-0.20240410210341-005ba5f365fe
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.12

--- a/go.sum
+++ b/go.sum
@@ -614,8 +614,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.4 h1:CDvBjfZVrdREAUX5zy1VkkZAlCb7SMRL2fxpncbiq0o=
-github.com/superfly/fly-go v0.1.4/go.mod h1:MUKMuc5Tg+qmDmAi5jBMKcuitw4SNhrZ60fS4jqIZpQ=
+github.com/superfly/fly-go v0.1.5-0.20240410210341-005ba5f365fe h1:3rCZVlHF1R1a7AOuiqPqWOA0m0c6eT79DJ8PtP+40IE=
+github.com/superfly/fly-go v0.1.5-0.20240410210341-005ba5f365fe/go.mod h1:MUKMuc5Tg+qmDmAi5jBMKcuitw4SNhrZ60fS4jqIZpQ=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/command/agent/run.go
+++ b/internal/command/agent/run.go
@@ -50,13 +50,10 @@ func run(ctx context.Context) error {
 	}
 	defer closeLogger()
 
-	apiClient := fly.ClientFromContext(ctx)
-	if !apiClient.Authenticated() {
+	if config.Tokens(ctx).GraphQL() == "" {
 		logger.Println(fly.ErrNoAuthToken)
 		return fly.ErrNoAuthToken
 	}
-
-	config.MonitorTokens(ctx, config.Tokens(ctx), nil)
 
 	unlock, err := lock(ctx, logger)
 	if err != nil {
@@ -67,7 +64,6 @@ func run(ctx context.Context) error {
 	opt := server.Options{
 		Socket:           socketPath(ctx),
 		Logger:           logger,
-		Client:           apiClient,
 		Background:       logPath != "",
 		ConfigFile:       state.ConfigFile(ctx),
 		ConfigWebsockets: viper.GetBool(flyctl.ConfigWireGuardWebsockets),

--- a/internal/config/tokens_test.go
+++ b/internal/config/tokens_test.go
@@ -1,0 +1,198 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/tokens"
+	"github.com/superfly/flyctl/internal/logger"
+	"github.com/superfly/macaroon"
+	"github.com/superfly/macaroon/flyio"
+	"github.com/superfly/macaroon/resset"
+)
+
+func TestFetchOrgTokens(t *testing.T) {
+	ctx := logger.NewContext(context.Background(), logger.New(os.Stdout, logger.Debug, true))
+
+	// no tokens
+	created, err := doFetchOrgTokens(ctx, &tokens.Tokens{}, nil, nil)
+	require.False(t, created)
+	require.NoError(t, err)
+
+	// no macaroons
+	created, err = doFetchOrgTokens(ctx, &tokens.Tokens{UserTokens: []string{"hi"}}, nil, nil)
+	require.False(t, created)
+	require.NoError(t, err)
+
+	// no user token
+	created, err = doFetchOrgTokens(ctx, &tokens.Tokens{MacaroonTokens: []string{"hi"}}, nil, nil)
+	require.False(t, created)
+	require.NoError(t, err)
+
+	// basic case
+	toks := fakeTokens(t, "fo1_hi", 1)
+	fetchOrgs := fakeOrgFetcher(map[uint64]string{1: "org1", 2: "org2"}, nil)
+	mintToken := fakeOrgTokenMinter(t, "org2", 2)
+	created, err = doFetchOrgTokens(ctx, toks, fetchOrgs, mintToken)
+	require.True(t, created)
+	require.NoError(t, err)
+	assertTokenOrgs(t, toks, 1, 2)
+
+	// fetchOrgs error
+	toks = fakeTokens(t, "fo1_hi", 1)
+	foErr := errors.New("my error")
+	fetchOrgs = fakeOrgFetcher(nil, foErr)
+	created, err = doFetchOrgTokens(ctx, toks, fetchOrgs, nil)
+	require.False(t, created)
+	require.ErrorIs(t, err, foErr)
+
+	// partial success
+	toks = fakeTokens(t, "fo1_hi", 1)
+	fetchOrgs = fakeOrgFetcher(map[uint64]string{1: "org1", 2: "org2", 3: "org3"}, nil)
+	fotErr := errors.New("my error")
+	mintToken = fakeTokenMinter(
+		fakeTokenHeader(t, "", 2),
+		fotErr,
+	)
+	created, err = doFetchOrgTokens(ctx, toks, fetchOrgs, mintToken)
+	require.True(t, created)
+	require.ErrorIs(t, err, fotErr)
+	assertTokenOrgs(t, toks, 1, 2)
+
+	// prune tokens for orgs that user isn't member of
+	toks = fakeTokens(t, "fo1_hi", 1, 2)
+	fetchOrgs = fakeOrgFetcher(map[uint64]string{1: "org1"}, nil)
+	created, err = doFetchOrgTokens(ctx, toks, fetchOrgs, nil)
+	require.True(t, created)
+	require.NoError(t, err)
+	assertTokenOrgs(t, toks, 1)
+}
+
+func fakeOrgFetcher(orgs map[uint64]string, err error) orgFetcher {
+	return func(context.Context, *fly.Client) (map[uint64]string, error) { return orgs, err }
+}
+
+func fakeOrgTokenMinter(tb testing.TB, expectedGraphID string, oid uint64) tokenMinter {
+	tb.Helper()
+	return func(_ context.Context, _ *fly.Client, graphID string) (string, error) {
+		require.Equal(tb, expectedGraphID, graphID)
+		return fakeTokenHeader(tb, "", oid), nil
+	}
+}
+
+func fakeTokenMinter(hdrsOrErrors ...any) tokenMinter {
+	return func(context.Context, *fly.Client, string) (string, error) {
+		if len(hdrsOrErrors) == 0 {
+			panic("unexpected call to fakeTokenMinter")
+		}
+
+		hdrOrErr := hdrsOrErrors[0]
+		hdrsOrErrors = hdrsOrErrors[1:]
+
+		switch hoe := hdrOrErr.(type) {
+		case error:
+			return "", hoe
+		case string:
+			return hoe, nil
+		default:
+			panic("unexpected type")
+		}
+	}
+}
+
+var (
+	permKID = []byte("hello")
+	permK   = macaroon.NewSigningKey()
+	authK   = macaroon.NewEncryptionKey()
+)
+
+func fakeTokens(tb testing.TB, userToken string, oids ...uint64) *tokens.Tokens {
+	tb.Helper()
+
+	return tokens.Parse(fakeTokenHeader(tb, userToken, oids...))
+}
+
+func fakeTokenHeader(tb testing.TB, userToken string, oids ...uint64) string {
+	tb.Helper()
+
+	macs := fakeMacaroons(tb, oids...)
+	toks := make([][]byte, 0, len(macs))
+	for _, m := range macs {
+		tok, err := m.Encode()
+		require.NoError(tb, err)
+		toks = append(toks, tok)
+	}
+
+	hdr := macaroon.ToAuthorizationHeader(toks...)
+
+	if userToken != "" {
+		if len(toks) > 0 {
+			hdr += "," + userToken
+		} else {
+			hdr += userToken
+		}
+	}
+
+	return hdr
+}
+
+func fakeMacaroons(tb testing.TB, oids ...uint64) []*macaroon.Macaroon {
+	tb.Helper()
+
+	toks := make([]*macaroon.Macaroon, 0, len(oids)*2)
+	for _, oid := range oids {
+		perm := fakePermissionToken(tb, &flyio.Organization{ID: oid, Mask: resset.ActionAll})
+		auth := fakeAuthToken(tb, perm)
+		toks = append(toks, perm, auth)
+	}
+
+	return toks
+}
+
+func fakePermissionToken(tb testing.TB, cavs ...macaroon.Caveat) *macaroon.Macaroon {
+	tb.Helper()
+
+	perm, err := macaroon.New(permKID, flyio.LocationPermission, permK)
+	require.NoError(tb, err)
+	require.NoError(tb, perm.Add(cavs...))
+	return perm
+}
+
+func fakeAuthToken(tb testing.TB, perm *macaroon.Macaroon) *macaroon.Macaroon {
+	tb.Helper()
+
+	require.NoError(tb, perm.Add3P(authK, flyio.LocationAuthentication))
+	ticket, err := perm.ThirdPartyTicket(flyio.LocationAuthentication)
+	require.NoError(tb, err)
+	_, auth, err := macaroon.DischargeTicket(authK, flyio.LocationAuthentication, ticket)
+	require.NoError(tb, err)
+	return auth
+}
+
+func assertTokenOrgs(tb testing.TB, toks *tokens.Tokens, expectedOIDs ...uint64) {
+	tb.Helper()
+
+	actualOIDs := make([]uint64, 0, len(expectedOIDs))
+	for _, mt := range toks.MacaroonTokens {
+		mtoks, err := macaroon.Parse(mt)
+		require.NoError(tb, err)
+		require.Equal(tb, 1, len(mtoks))
+		macs, _, _, _, err := macaroon.FindPermissionAndDischargeTokens(mtoks, flyio.LocationPermission)
+		require.NoError(tb, err)
+		if len(macs) != 1 {
+			continue
+		}
+		oid, err := flyio.OrganizationScope(&macs[0].UnsafeCaveats)
+		require.NoError(tb, err)
+		actualOIDs = append(actualOIDs, oid)
+	}
+
+	slices.Sort(expectedOIDs)
+	slices.Sort(actualOIDs)
+	require.Equal(tb, expectedOIDs, actualOIDs)
+}


### PR DESCRIPTION
There's a lot of stuff we need to do to make macaroon tokens work well in flyctl:

- Prune expired/invalid tokens
- Fetch and refresh the user's discharge tokens
- Fetch new macaroons when the user is added to an org (we weren't doing this)
- Prune macaroons when the user is removed from an org (we were just letting them expire after 10 minutes)

This was complicated further by wanting to keep tokens in sync between the flyctl agent and any foreground processes. Long running commands were also winding up with expired tokens because we were only doing a lot of this work when the command started.

This PR centralizes all of this logic and runs it both in foreground flyctl processes as well as in the background agent. When flyctl makes changes to its set of tokens, it writes those back to the config file (so long as flyctl wasn't started with `FLY_AUTH_TOKEN`). This should allow everything to stay nicely up to date and synced between processes.

There was also some annoyance (/cc @jipperinbham) when running commands with `FLY_AUTH_TOKEN`. The background agent and foreground commands would often end up running with a different set of tokens and one or the other would run into authorization errors. I'm adding a new `set-token` RPC to the fly agent in this PR. Clients send this command before sending other commands, letting the agent know what tokens to use for the session.

TODO:
- Make sure `send-token` command fails nicely when sent to old agent
- Store agent tunnels by "raw slug" instead of "slug" to avoid confusion between multiple `personal` orgs when using different tokens.

PS: There's been a lot of churn in the tokens code in flyctl. Sorry about that. I'd been trying to avoid writing this big PR, but half measure weren't cutting it.