### PR TITLE
Bump github.com/superfly/fly-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.1.4
+	github.com/superfly/fly-go v0.1.5-0.20240412130949-55269e2468c8
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.12

--- a/go.sum
+++ b/go.sum
@@ -614,8 +614,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.4 h1:CDvBjfZVrdREAUX5zy1VkkZAlCb7SMRL2fxpncbiq0o=
-github.com/superfly/fly-go v0.1.4/go.mod h1:MUKMuc5Tg+qmDmAi5jBMKcuitw4SNhrZ60fS4jqIZpQ=
+github.com/superfly/fly-go v0.1.5-0.20240412130949-55269e2468c8 h1:ZRWtri1m/n8TE1Y3vcYvBwVWgvZYP5OpEcdO/lYKhoo=
+github.com/superfly/fly-go v0.1.5-0.20240412130949-55269e2468c8/go.mod h1:MUKMuc5Tg+qmDmAi5jBMKcuitw4SNhrZ60fS4jqIZpQ=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=


### PR DESCRIPTION
The update brings new HTTPResponseOptions paramter: pristine. It tells
the proxy to not add any Fly specific headers to HTTP response.
