### PR TITLE
Detect existence of dockerfile-laravel existence in the vendor folder

### DIFF
--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -123,6 +123,12 @@ func LaravelCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan,
 		}
 	}
 
+	// check if executable is available
+	_, err = os.Stat("vendor/bin/dockerfile-laravel")
+	if os.IsNotExist(err) {
+		installed = false
+	}
+
 	// install fly-apps/dockerfile-laravel if it's not already installed
 	if !installed {
 		args := []string{"composer", "require", "--dev", "fly-apps/dockerfile-laravel"}


### PR DESCRIPTION
### Change Summary

What and Why:
Install the fly-apps/dockerfile-laravel package when `vendor/bin/dockerfile-laravel` is not found.

How:
-Detect the existence of `vendor/bin/dockerfile-laravel`. 
-Require installation of the package if not detected by setting `installed` to false so the program installs the package

Related to:
https://flyio.slack.com/archives/C06QR26SG57/p1713119019944379
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
