### PR TITLE
Lower the default volume size

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -33,7 +33,7 @@ const (
 	DefaultReleaseCommandTimeout  = 5 * time.Minute
 	DefaultLeaseTtl               = 13 * time.Second
 	DefaultMaxUnavailable         = 0.33
-	DefaultVolumeInitialSizeGB    = 3
+	DefaultVolumeInitialSizeGB    = 1
 	DefaultGPUVolumeInitialSizeGB = 100
 )
 

--- a/internal/command/volumes/create.go
+++ b/internal/command/volumes/create.go
@@ -22,10 +22,9 @@ import (
 func newCreate() *cobra.Command {
 	const (
 		short = "Create a new volume for an app."
-
+		long  = "Volumes are persistent storage for Fly Machines. Learn how to add a volume to your app: https://fly.io/docs/apps/volume-storage/"
 		usage = "create <volumename>"
 	)
-	long := fmt.Sprintf("Volumes are persistent storage for Fly Machines. The default size is %d GB. Learn how to add a volume to your app: https://fly.io/docs/apps/volume-storage/", deploy.DefaultVolumeInitialSizeGB)
 
 	cmd := command.New(usage, short, long, runCreate,
 		command.RequireSession,
@@ -41,7 +40,7 @@ func newCreate() *cobra.Command {
 			Name:        "size",
 			Shorthand:   "s",
 			Default:     deploy.DefaultVolumeInitialSizeGB,
-			Description: fmt.Sprintf("The size of volume in gigabytes. The default is %d.", deploy.DefaultGPUVolumeInitialSizeGB),
+			Description: "The size of volume in gigabytes",
 		},
 		flag.Int{
 			Name:        "snapshot-retention",

--- a/internal/command/volumes/create.go
+++ b/internal/command/volumes/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/command/deploy"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
@@ -22,12 +23,9 @@ func newCreate() *cobra.Command {
 	const (
 		short = "Create a new volume for an app."
 
-		long = short + ` Volumes are persistent storage for
-		Fly Machines. The default size is 3 GB. Learn how to add a volume to
-		your app: https://fly.io/docs/apps/volume-storage/`
-
 		usage = "create <volumename>"
 	)
+	long := fmt.Sprintf("Volumes are persistent storage for Fly Machines. The default size is %d GB. Learn how to add a volume to your app: https://fly.io/docs/apps/volume-storage/", deploy.DefaultVolumeInitialSizeGB)
 
 	cmd := command.New(usage, short, long, runCreate,
 		command.RequireSession,
@@ -42,8 +40,8 @@ func newCreate() *cobra.Command {
 		flag.Int{
 			Name:        "size",
 			Shorthand:   "s",
-			Default:     3,
-			Description: "The size of volume in gigabytes. The default is 3.",
+			Default:     deploy.DefaultVolumeInitialSizeGB,
+			Description: fmt.Sprintf("The size of volume in gigabytes. The default is %d.", deploy.DefaultGPUVolumeInitialSizeGB),
 		},
 		flag.Int{
 			Name:        "snapshot-retention",


### PR DESCRIPTION
### Change Summary

What and Why:
See more information [here](https://flyio.discourse.team/t/making-the-rails-speedrun-more-credible/5512/14)

How:
We lowered the default volume size constant to 1GB.

Related to:

---

### Documentation

- [x] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a
