### PR TITLE
[bluegreen] Improve reliability of bluegreen deployments

### DIFF
--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -35,6 +35,8 @@ type LeasableMachine interface {
 	WaitForEventTypeAfterType(context.Context, string, string, time.Duration, bool) (*fly.MachineEvent, error)
 	FormattedMachineId() string
 	GetMinIntervalAndMinGracePeriod() (time.Duration, time.Duration)
+	SetMetadata(ctx context.Context, k, v string) error
+	GetMetadata(ctx context.Context) (map[string]string, error)
 }
 
 type leasableMachine struct {
@@ -496,4 +498,12 @@ func (lm *leasableMachine) GetMinIntervalAndMinGracePeriod() (time.Duration, tim
 	}
 
 	return minInterval, minGracePeriod
+}
+
+func (lm *leasableMachine) GetMetadata(ctx context.Context) (map[string]string, error) {
+	return lm.flapsClient.GetMetadata(ctx, lm.machine.ID)
+}
+
+func (lm *leasableMachine) SetMetadata(ctx context.Context, k, v string) error {
+	return lm.flapsClient.SetMetadata(ctx, lm.machine.ID, k, v)
 }


### PR DESCRIPTION
### Change Summary
This change builds on the work done in https://github.com/superfly/flyctl/pull/3437

Once this PR is merged, bluegreen deployments will
- Detect multiple image versions in app (this will 100% put a stop to 700+ machines)
- Suggest how to easily unblock app for deployments (guide users to fix their issues)
- Add new flag to `fly machines destroy` to help delete machines by image version (automate 90% of the 'fixing' process)
- Properly bluegreen handle deployments with autostop/autostart machines (improve ux)

### Demo
![Screenshot 2024-04-17 at 18 52 23](https://github.com/superfly/flyctl/assets/24861123/62f456c6-e476-4ede-80e8-1fad5174e060)

![Screenshot 2024-04-17 at 18 52 07](https://github.com/superfly/flyctl/assets/24861123/d376b266-199e-416c-a12a-d0fecd1f56ed)

### Documentation
- [x] Fresh Produce
