### PR TITLE
[tracing] change otel exporter from grpc to http

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.11
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.50.0
 	go.opentelemetry.io/otel v1.25.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.25.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.25.0
 	go.opentelemetry.io/otel/sdk v1.25.0
 	go.opentelemetry.io/otel/trace v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -664,8 +664,6 @@ go.opentelemetry.io/otel v1.25.0 h1:gldB5FfhRl7OJQbUHt/8s0a7cE8fbsPAtdpRaApKy4k=
 go.opentelemetry.io/otel v1.25.0/go.mod h1:Wa2ds5NOXEMkCmUou1WA7ZBfLTHWIsp034OVD7AO+Vg=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.25.0 h1:dT33yIHtmsqpixFsSQPwNeY5drM9wTcoL8h0FWF4oGM=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.25.0/go.mod h1:h95q0LBGh7hlAC08X2DhSeyIG02YQ0UyioTCVAqRPmc=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.25.0 h1:vOL89uRfOCCNIjkisd0r7SEdJF3ZJFyCNY34fdZs8eU=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.25.0/go.mod h1:8GlBGcDk8KKi7n+2S4BT/CPZQYH3erLu0/k64r1MYgo=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0 h1:digkEZCJWobwBqMwC0cwCq8/wkkRy/OowZg5OArWZrM=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0/go.mod h1:/OpE/y70qVkndM0TrxT4KBoN3RsFZP0QaofcfYrj76I=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.25.0 h1:0vZZdECYzhTt9MKQZ5qQ0V+J3MFu4MQaQ3COfugF+FQ=
@@ -681,8 +679,6 @@ go.opentelemetry.io/proto/otlp v1.1.0/go.mod h1:GpBHCBWiqvVLDqmHZsoMM3C5ySeKTC7e
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
-go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=
 go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTVQ=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,7 +24,6 @@ import (
 	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/internal/task"
-	"github.com/superfly/flyctl/internal/tracing"
 	"golang.org/x/term"
 
 	"github.com/superfly/flyctl/iostreams"
@@ -61,14 +60,6 @@ func Run(ctx context.Context, io *iostreams.IOStreams, args ...string) int {
 
 	httptracing.Init()
 	defer httptracing.Finish()
-
-	tp, err := tracing.InitTraceProvider(ctx)
-	if err != nil {
-		fmt.Fprintf(io.ErrOut, "failed to initialize tracing library: =%v", err)
-		return 127
-	}
-
-	defer tp.Shutdown(ctx)
 
 	cmd := root.New()
 	cmd.SetOut(io.Out)

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -136,20 +135,4 @@ func ApplyAliases(ctx context.Context) (context.Context, error) {
 		}
 	}
 	return ctx, err
-}
-
-// This method sets the user auth token as an environment variable called FLY_OTEL_AUTH_KEY
-// Why is this necessary? It's quite difficult to get the auth token when we initialize the tracer.
-// There's no assurance it will exist at the time of creation, so we use this preparer to set it
-// And then in the tracer, we use a GRPC interceptor to pull it out when sending the traces.
-// *Another approach would be to load the config in the interceptor, and pull the tokens from it.
-// except it only came to my mind after writing this so let's stick with this for now.
-func SetOtelAuthenticationKey(ctx context.Context) (context.Context, error) {
-	token := config.Tokens(ctx).Flaps()
-	if token == "" {
-		token = os.Getenv("FLY_API_TOKEN")
-	}
-
-	os.Setenv("FLY_OTEL_AUTH_KEY", token)
-	return ctx, nil
 }

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -67,7 +67,6 @@ var commonPreparers = []preparers.Preparer{
 var authPreparers = []preparers.Preparer{
 	preparers.InitClient,
 	killOldAgent,
-	preparers.SetOtelAuthenticationKey,
 }
 
 func sendOsMetric(ctx context.Context, state string) {

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -6,26 +6,26 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 
 	"github.com/go-logr/logr"
 	"github.com/superfly/flyctl/internal/buildinfo"
+	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/iostreams"
 )
+
+var tp *sdktrace.TracerProvider
 
 const (
 	tracerName       = "github.com/superfly/flyctl"
@@ -40,10 +40,10 @@ func getCollectorUrl() string {
 	}
 
 	if buildinfo.IsDev() {
-		return "fly-otel-collector-dev.fly.dev:4317"
+		return "fly-otel-collector-dev.fly.dev"
 	}
 
-	return "fly-otel-collector-prod.fly.dev:4317"
+	return "fly-otel-collector-prod.fly.dev"
 }
 
 func GetTracer() trace.Tracer {
@@ -87,19 +87,19 @@ func CMDSpan(ctx context.Context, appName, spanName string, opts ...trace.SpanSt
 	return GetTracer().Start(ctx, spanName, startOpts...)
 }
 
-func attachToken(
-	ctx context.Context,
-	method string,
-	req, reply any,
-	cc *grpc.ClientConn,
-	invoker grpc.UnaryInvoker,
-	opts ...grpc.CallOption,
-) error {
-	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", os.Getenv("FLY_OTEL_AUTH_KEY"))
-	return invoker(ctx, method, req, reply, cc, opts...)
+func getToken(ctx context.Context) string {
+	token := config.Tokens(ctx).Flaps()
+	if token == "" {
+		token = os.Getenv("FLY_API_TOKEN")
+	}
+	return token
 }
 
 func InitTraceProvider(ctx context.Context) (*sdktrace.TracerProvider, error) {
+	if tp != nil {
+		return tp, nil
+	}
+
 	var exporter sdktrace.SpanExporter
 	switch {
 	case os.Getenv("LOG_LEVEL") == "trace":
@@ -108,24 +108,22 @@ func InitTraceProvider(ctx context.Context) (*sdktrace.TracerProvider, error) {
 			return nil, err
 		}
 		exporter = stdoutExp
+
 	default:
-		grpcExpOpt := []otlptracegrpc.Option{
-			otlptracegrpc.WithEndpoint(getCollectorUrl()),
-			otlptracegrpc.WithDialOption(
-				grpc.WithUnaryInterceptor(attachToken),
-			),
+
+		opts := []otlptracehttp.Option{
+			otlptracehttp.WithEndpoint(getCollectorUrl() + ":4318"),
+			otlptracehttp.WithInsecure(),
+			otlptracehttp.WithHeaders(map[string]string{
+				"authorization": getToken(ctx),
+			}),
 		}
-		grpcExpOpt = append(grpcExpOpt, otlptracegrpc.WithInsecure())
-
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
-
-		grpcExporter, err := otlptracegrpc.New(ctx, grpcExpOpt...)
+		httpExporter, err := otlptracehttp.New(ctx, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to telemetry collector")
 		}
 
-		exporter = grpcExporter
+		exporter = httpExporter
 	}
 
 	resourceAttrs := []attribute.KeyValue{
@@ -141,7 +139,7 @@ func InitTraceProvider(ctx context.Context) (*sdktrace.TracerProvider, error) {
 		resourceAttrs...,
 	)
 
-	tp := sdktrace.NewTracerProvider(
+	tp = sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(resource),
 	)


### PR DESCRIPTION
### Change Summary
We are having some reliability/consistency issues with traces we are ingesting. Some spans never make it to the collector, mostly because grpc on the open internet is a bit of a weird story and so it breaks for some users. (speculation)

This PR swaps out the old exporter for a new one, which will hopefully improve delivery reliability.
I also moved the trace provider outside the CLI package because the otelhttp exporter doesn't support dynamic headers and it's really hard to decently get access to the token (no pun intended) in the cli.go package.

The trace provider is now closer to whichever command is being run and is stored in a global variable internally so duplicate calls don't create 2 providers :))

Improvments
- [x]  change flyctl exporter from using grpc to http (this will massively improve delivery reliability for the traces)
- [x]  sometimes traces/spans never make it to honeycomb (i suspect grpc exporter and uptime of collector)
- [x]   [log](https://github.com/superfly/fly-go/pull/40) trace-id on errors (for easier lookups)
- [ ]  heavily sample machine lease spans (they make up about 80% of spans in a trace and are mostly useless)
- [ ]  run more instances of the otel collector (availability)
- [ ] add metrics to the collector (so we can monitor it's health and behaviour, eg how many spans it's dropping)