### PR TITLE
Revert "Rename root cmd from "flyctl" to "fly""

### DIFF
--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -74,7 +74,7 @@ func New() *cobra.Command {
 		short = "The Fly.io command line interface"
 	)
 
-	root := command.New("fly", short, long, run)
+	root := command.New("flyctl", short, long, run)
 	root.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		cmd.SilenceUsage = true
 		cmd.SilenceErrors = true


### PR DESCRIPTION
Reverts superfly/flyctl#3399

breaks docs gen!