### PR TITLE
Use correct windows path syntax to dockerfile-laravel executable for …

### DIFF
--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -10,11 +10,11 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
-
+	
 	"github.com/blang/semver"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/command/launch/plan"
@@ -140,7 +140,8 @@ func LaravelCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan,
 	}
 
 	// check if executable is available
-	_, err = os.Stat("vendor/bin/dockerfile-laravel")
+	vendorPath := filepath.Join("vendor", "bin", "dockerfile-laravel")
+	_, err = os.Stat(vendorPath)
 	if os.IsNotExist(err) {
 		installed = false
 	}
@@ -159,12 +160,6 @@ func LaravelCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan,
 		}
 	}
 
-	// Use correct path syntax to executable based on runtime!
-	vendorPath := "vendor/bin/dockerfile-laravel"
-	if runtime.GOOS == "windows" {
-		vendorPath = "vendor\\bin\\dockerfile-laravel"
-	}
-	
 	args := []string{vendorPath, "generate"}
 	if dockerfileExists {
 		args = append(args, "--skip")

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -14,7 +14,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	
+
 	"github.com/blang/semver"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/command/launch/plan"

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -158,7 +159,13 @@ func LaravelCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan,
 		}
 	}
 
-	args := []string{"vendor/bin/dockerfile-laravel", "generate"}
+	// Use correct path syntax to executable based on runtime!
+	vendorPath := "vendor/bin/dockerfile-laravel"
+	if runtime.GOOS == "windows" {
+		vendorPath = "vendor\\bin\\dockerfile-laravel"
+	}
+	
+	args := []string{vendorPath, "generate"}
 	if dockerfileExists {
 		args = append(args, "--skip")
 	}


### PR DESCRIPTION
…windows runtime

### Change Summary

**What and Why:**
Use the windows syntax for path to dockerfile-laravel executable when runtime is windows. The executable would otherwise not be found!

**How:**
- Detect if runtime is windows
- use "\\" for windows, "/" for others as separator between folders

**ALSO, TIL:**
To generate a flyctl executable for windows locally, when building, "GOOS" can be set:
```
 GOOS=windows GOARCH=amd64 go build -o bin/flyctl_win.exe .
```

**Related to:**
"Error: failed to generate Dockerfile: exit status 1" _- Error can be replicated by running fly launch on a windows runtime._
https://flyio.slack.com/archives/C042W39VAMB/p1713464639271189
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
