### PR TITLE
Lower the Postgres default disk size to 1 GB

### DIFF
--- a/internal/command/launch/plan/postgres.go
+++ b/internal/command/launch/plan/postgres.go
@@ -34,7 +34,7 @@ func DefaultPostgres(plan *LaunchPlan) PostgresPlan {
 			VmSize:     "shared-cpu-1x",
 			VmRam:      1024,
 			Nodes:      1,
-			DiskSizeGB: 10,
+			DiskSizeGB: 1,
 		},
 	}
 }


### PR DESCRIPTION
### Change Summary

What and Why:

A 10 GB default disk size hinders `fly launch` by requiring a credit card, which introduces friction for anyone just interested in trying fly.io out for the first time.

In addition, this matches up with the lowest tier development Postgres settings provided by the Launch UI: 
> Development - Single node, 1x shared CPU, 256MB RAM, 1GB disk

[More info here.](https://flyio.discourse.team/t/making-the-rails-speedrun-more-credible/5512/18?u=clouvet) 

Related to:

https://github.com/superfly/flyctl/pull/3455

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
