### PR TITLE
Suggest `--wg=false` when users run into wireguard issues

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -370,7 +370,7 @@ func newRemoteDockerClient(ctx context.Context, apiClient *fly.Client, appName s
 			err = fmt.Errorf("failed building options: %w", err)
 			captureError(err)
 
-			if strings.Contains(err.Error(), "failed probing") {
+			if strings.Contains(err.Error(), "failed probing") || strings.Contains(err.Error(), "websocket") {
 				return nil, generateBrokenWGError(err)
 			}
 


### PR DESCRIPTION
### Change Summary
This is to drive adoption of the wg-less feature and more importantly, unblock users.
When we detect they're running into wireguard issues during deploys, we suggest the "--wg=false" flag
