### PR TITLE
Add release command for Postgres and MySQL dbs

### DIFF
--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -108,8 +108,9 @@ a Postgres database.
 `
 	}
 
-	// Add migration task if we find ecto
-	if checksPass(sourceDir, dirContains("mix.exs", "ecto")) {
+	// Add migration task if we find one of the dependencies that would run migrations.
+	// They are listed here: https://github.com/elixir-ecto/ecto?tab=readme-ov-file#usage
+	if checksPass(sourceDir, dirContains("mix.exs", "postgrex", "myxql", "tds")) {
 		s.ReleaseCmd = "/app/bin/migrate"
 	}
 


### PR DESCRIPTION
This changes the scanner code to look for the dependencies for Postgres and MySQL specifically. Before this, it was looking for Ecto on its own, which includes SQLite. SQLite fails to run the migrate command which meant that deploys were failing for apps that were using SQLite.

For context: https://flyio.slack.com/archives/C04FTKNE0R5/p1713971879644689