### PR TITLE
Show worker status in `fly m ls`, `fly vol ls`

### DIFF
--- a/internal/command/volumes/list.go
+++ b/internal/command/volumes/list.go
@@ -68,5 +68,5 @@ func runList(ctx context.Context) error {
 		return render.JSON(out, volumes)
 	}
 
-	return renderTable(ctx, volumes, app, out)
+	return renderTable(ctx, volumes, app, out, true)
 }


### PR DESCRIPTION
### Change Summary

**What and Why:**

Expose worker status information in `fly m ls` and `fly vol ls`, so that users have better visibility into host issues. This also suppresses unset fields for Machines with unreachable workers in `fly m ls` so that the (potentially confusing) default values are not shown. (Most notably, this eliminates the strange 1970 dates shown in the "created" and "last updated" columns.)

If a worker is unreachable, then it looks like this:

```
ID                   	STATE  	NAME    	SIZE	REGION	ZONE	ENCRYPTED	ATTACHED VM	CREATED AT   
vol_rd9kkvvz39ox01wn*	created	test_vol	1GB 	ord 	ed69 	false    	           	22 hours ago	

* The workers hosting these volumes could not be reached.
```

**How:**

Use the `worker_status` field recently added to Machines and volumes in the Machines API.

---

### Documentation

- [x] Fresh Produce (one has been drafted)
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
