### PR TITLE
Rename "workers" to "hosts"

### DIFF
--- a/internal/command/machine/list.go
+++ b/internal/command/machine/list.go
@@ -144,7 +144,7 @@ func runMachineList(ctx context.Context) (err error) {
 
 		_ = render.Table(io.Out, appName, rows, "ID", "Name", "State", "Region", "Image", "IP Address", "Volume", "Created", "Last Updated", "App Platform", "Process Group", "Size")
 		if unreachableMachines {
-			fmt.Fprintln(io.Out, "* The workers hosting these Machines could not be reached.")
+			fmt.Fprintln(io.Out, "* These Machines' hosts could not be reached.")
 		}
 	}
 	return nil

--- a/internal/command/volumes/volumes.go
+++ b/internal/command/volumes/volumes.go
@@ -125,7 +125,7 @@ func renderTable(ctx context.Context, volumes []fly.Volume, app *fly.AppBasic, o
 		return err
 	}
 	if showWorkerStatus && unreachableVolumes {
-		fmt.Fprintln(out, "* The workers hosting these volumes could not be reached.")
+		fmt.Fprintln(out, "* These volumes' hosts could not be reached.")
 	}
 	return nil
 }


### PR DESCRIPTION
Follow-on to #3485 after internal discussion about what to call this in the public UI.
