### PR TITLE
`fly vol snapshots ls`  works for deleted volumes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.1.7
+	github.com/superfly/fly-go v0.1.8
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.13

--- a/go.sum
+++ b/go.sum
@@ -614,8 +614,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.7 h1:nZHw+pvuNN/wTnQZ3dqYN73QuR5DEgjPwpjMjkrAFEM=
-github.com/superfly/fly-go v0.1.7/go.mod h1:0wgmVsqPPDgPSTsZA0L0zI5uajxx86KfuBoPQT87B1E=
+github.com/superfly/fly-go v0.1.8 h1:4YlEh4GPCZ8Z5OT8lQugsHiwX90U/F+gMSQvGOrGxlI=
+github.com/superfly/fly-go v0.1.8/go.mod h1:0wgmVsqPPDgPSTsZA0L0zI5uajxx86KfuBoPQT87B1E=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/test/preflight/fly_volume_test.go
+++ b/test/preflight/fly_volume_test.go
@@ -91,7 +91,6 @@ func TestFlyVolume_CreateFromDestroyedVolSnapshot(t *testing.T) {
 	createRes := f.Fly("vol create -s 1 -a %s -r %s --yes --json test_destroy", appName, f.PrimaryRegion())
 	var vol *fly.Volume
 	createRes.StdOutJSON(&vol)
-	// create and then destroy a machine
 	f.Fly("m run --org %s -a %s -r %s -v %s:/data --build-remote-only nginx", f.OrgSlug(), appName, f.PrimaryRegion(), vol.ID)
 	machine := f.MachinesList(appName)[0]
 	require.Eventually(f, func() bool {

--- a/test/preflight/fly_volume_test.go
+++ b/test/preflight/fly_volume_test.go
@@ -84,3 +84,67 @@ func TestFlyVolumeLs(t *testing.T) {
 	require.Contains(f, lsAllIds, v1.ID)
 	require.Contains(f, lsAllIds, v2.ID)
 }
+
+func TestFlyVolume_CreateFromDestroyedVolSnapshot(t *testing.T) {
+	f := testlib.NewTestEnvFromEnv(t)
+	appName := f.CreateRandomAppMachines()
+	createRes := f.Fly("vol create -s 1 -a %s -r %s --yes --json test_destroy", appName, f.PrimaryRegion())
+	var vol *fly.Volume
+	createRes.StdOutJSON(&vol)
+	// create and then destroy a machine
+	f.Fly("m run --org %s -a %s -r %s -v %s:/data --build-remote-only nginx", f.OrgSlug(), appName, f.PrimaryRegion(), vol.ID)
+	machine := f.MachinesList(appName)[0]
+	require.Eventually(f, func() bool {
+		machines := f.MachinesList(appName)
+		return len(machines) == 1 && machines[0].State == "started"
+	}, 1*time.Minute, 1*time.Second, "machine %s never started", machine.ID)
+	f.Fly("m destroy --force %s", machine.ID)
+	require.Eventually(f, func() bool {
+		return len(f.MachinesList(appName)) == 0
+	}, 1*time.Minute, 1*time.Second, "machine %s never destroyed", machine.ID)
+	f.Fly("vol snapshot create --json %s", vol.ID)
+	var snapshot *fly.VolumeSnapshot
+	require.Eventually(f, func() bool {
+		lsRes := f.Fly("vol snapshot ls --json %s", vol.ID)
+		var ls []*fly.VolumeSnapshot
+		lsRes.StdOutJSON(&ls)
+		for _, s := range ls {
+			if time.Since(s.CreatedAt) < 1*time.Hour && s.Status == "created" {
+				snapshot = s
+				return true
+			}
+		}
+		return false
+	}, 1*time.Minute, 1*time.Second, "snapshot never made it to created state")
+	f.Fly("vol destroy -y %s", vol.ID)
+	require.Eventually(f, func() bool {
+		lsRes := f.Fly("vol ls -a %s --all --json", appName)
+		var ls []*fly.Volume
+		lsRes.StdOutJSON(&ls)
+		if len(ls) == 1 {
+			return ls[0].State == "pending_destroy"
+		}
+		return false
+	}, 1*time.Minute, 1*time.Second, "volume %s never made it to pending_destroy state", vol.ID)
+	ls := f.Fly("vol snapshot ls --json %s", vol.ID)
+	var snapshots2 []*fly.VolumeSnapshot
+	ls.StdOutJSON(&snapshots2)
+	require.Len(f, snapshots2, 1)
+	require.Equal(f, snapshot.ID, snapshots2[0].ID)
+	require.Equal(f, snapshot.Size, snapshots2[0].Size)
+	require.Equal(f, snapshot.CreatedAt, snapshots2[0].CreatedAt)
+	fromDestroyedRes := f.Fly("vol create -s 1 -a %s -r %s --yes --json --snapshot-id %s test", appName, f.PrimaryRegion(), snapshot.ID)
+	var fromDestroyed *fly.Volume
+	fromDestroyedRes.StdOutJSON(&fromDestroyed)
+	require.Eventually(f, func() bool {
+		lsRes := f.Fly("vol ls -a %s --all --json", appName)
+		var ls []*fly.Volume
+		lsRes.StdOutJSON(&ls)
+		for _, s := range ls {
+			if s.State == "created" {
+				return true
+			}
+		}
+		return false
+	}, 1*time.Minute, 1*time.Second, "final volume %s never made it to created state", vol.ID)
+}


### PR DESCRIPTION
### Change Summary

Previously, running `fly vol snapshots ls` would fail when provided the volume id of a deleted volume. We want to show snapshots from deleted volumes, because it enabled folks to create a new volume from those snapshots.

Update `fly vol snapshots ls` to work for destroyed volumes using the graphql api to retrieve the snapshots, instead of the flaps api. The one downside of doing it this way is the returned snapshots won't include status, but that seems like an ok tradeoff.

Related to: https://github.com/superfly/fly-go/pull/51

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
