### PR TITLE
Track builder regions so we can easily group failures by region

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -255,4 +255,5 @@ require (
 replace (
 	github.com/loadsmart/calver-go => github.com/ndarilek/calver-go v0.0.0-20230710153822-893bbd83a936
 	github.com/nats-io/nats.go => github.com/btoews/nats.go v0.0.0-20240401180931-476bea7f4158
+	github.com/superfly/fly-go => ../fly-go
 )

--- a/go.sum
+++ b/go.sum
@@ -614,8 +614,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.7 h1:nZHw+pvuNN/wTnQZ3dqYN73QuR5DEgjPwpjMjkrAFEM=
-github.com/superfly/fly-go v0.1.7/go.mod h1:0wgmVsqPPDgPSTsZA0L0zI5uajxx86KfuBoPQT87B1E=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -221,7 +221,8 @@ func newRemoteDockerClient(ctx context.Context, apiClient *fly.Client, appName s
 	var host string
 	var app *fly.App
 	var machine *fly.GqlMachine
-	machine, app, err = remoteBuilderMachine(ctx, apiClient, appName)
+	// var headers http.Header
+	machine, app, _, err = remoteBuilderMachine(ctx, apiClient, appName)
 	if err != nil {
 		tracing.RecordError(span, err, "failed to init remote builder machine")
 		return nil, err
@@ -266,7 +267,7 @@ func newRemoteDockerClient(ctx context.Context, apiClient *fly.Client, appName s
 			}
 
 			fmt.Fprintln(streams.Out, streams.ColorScheme().Yellow("🔧 creating fresh remote builder, (this might take a while ...)"))
-			machine, app, err = remoteBuilderMachine(ctx, apiClient, appName)
+			machine, app, _, err = remoteBuilderMachine(ctx, apiClient, appName)
 			if err != nil {
 				tracing.RecordError(span, err, "failed to init remote builder machine")
 				return nil, err
@@ -680,7 +681,7 @@ func EagerlyEnsureRemoteBuilder(ctx context.Context, apiClient *fly.Client, orgS
 		return
 	}
 
-	_, app, err := apiClient.EnsureRemoteBuilder(ctx, org.ID, "")
+	_, app, _, err := apiClient.EnsureRemoteBuilder(ctx, org.ID, "")
 	if err != nil {
 		terminal.Debugf("error ensuring remote builder for organization: %s", err)
 		return
@@ -689,9 +690,9 @@ func EagerlyEnsureRemoteBuilder(ctx context.Context, apiClient *fly.Client, orgS
 	terminal.Debugf("remote builder %s is being prepared", app.Name)
 }
 
-func remoteBuilderMachine(ctx context.Context, apiClient *fly.Client, appName string) (*fly.GqlMachine, *fly.App, error) {
+func remoteBuilderMachine(ctx context.Context, apiClient *fly.Client, appName string) (*fly.GqlMachine, *fly.App, http.Header, error) {
 	if v := os.Getenv("FLY_REMOTE_BUILDER_HOST"); v != "" {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	return apiClient.EnsureRemoteBuilder(ctx, "", appName)

--- a/internal/build/imgsrc/nixpacks_builder.go
+++ b/internal/build/imgsrc/nixpacks_builder.go
@@ -130,7 +130,7 @@ func (*nixpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFact
 			return nil, "", err
 		}
 
-		machine, app, err := remoteBuilderMachine(ctx, dockerFactory.apiClient, dockerFactory.appName)
+		machine, app, _, err := remoteBuilderMachine(ctx, dockerFactory.apiClient, dockerFactory.appName)
 		if err != nil {
 			build.BuilderInitFinish()
 			build.BuildFinish()


### PR DESCRIPTION
### Change Summary
I want to be able to confidently go into honeycomb and group builder failures by region.
Depends on https://github.com/superfly/fly-go/pull/53