### PR TITLE
SkipDeploy on Rails launch if build secrets detected

### DIFF
--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -178,7 +178,7 @@ func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension 
 			return extension, err
 		}
 
-		detectedPlatform, err = scanner.Scan(absDir, &scanner.ScannerConfig{})
+		detectedPlatform, err = scanner.Scan(absDir, &scanner.ScannerConfig{Colorize: io.ColorScheme()})
 
 		if err != nil {
 			return extension, err

--- a/internal/command/launch/sourceinfo.go
+++ b/internal/command/launch/sourceinfo.go
@@ -23,6 +23,7 @@ func determineSourceInfo(ctx context.Context, appConfig *appconfig.Config, copyC
 	scannerConfig := &scanner.ScannerConfig{
 		ExistingPort: appConfig.InternalPort(),
 		Mode:         "launch",
+		Colorize:     io.ColorScheme(),
 	}
 	// Detect if --copy-config and --now flags are set. If so, limited set of
 	// fly.toml file updates. Helpful for deploying PRs when the project is

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command/launch/plan"
+	"github.com/superfly/flyctl/iostreams"
 )
 
 //go:embed templates templates/*/.dockerignore templates/**/.fly
@@ -94,6 +95,7 @@ type Volume = appconfig.Mount
 type ScannerConfig struct {
 	Mode         string
 	ExistingPort int
+	Colorize     *iostreams.ColorScheme
 }
 
 func Scan(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {


### PR DESCRIPTION
Instead, provide deploy docs guiding the user to how to remediate the issue.

Also, pass the color scheme to the scanner so that colorized outputs are possible.### Documentation.

Once deployed, fresh produce is warranted.