### PR TITLE
write kubeconfig file to disk instead

### DIFF
--- a/internal/command/extensions/kubernetes/create.go
+++ b/internal/command/extensions/kubernetes/create.go
@@ -37,6 +37,10 @@ func create() (cmd *cobra.Command) {
 		},
 		flag.Org(),
 		flag.Region(),
+		flag.String{
+			Name:        "output",
+			Description: "The output path to save the kubeconfig file",
+		},
 	)
 	return cmd
 }
@@ -67,11 +71,15 @@ func runK8sCreate(ctx context.Context) (err error) {
 		return err
 	}
 
-	outFilename := fmt.Sprintf("%s.kubeconfig.yml", resp.AddOn.Name)
+	outFilename := flag.GetString(ctx, "output")
+	if outFilename == "" {
+		outFilename = fmt.Sprintf("%s.kubeconfig.yml", resp.AddOn.Name)
+	}
 	f, err := os.Create(outFilename)
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	metadata := resp.AddOn.Metadata.(map[string]interface{})
 	kubeconfig := metadata["kubeconfig"].(string)

--- a/internal/command/extensions/kubernetes/create.go
+++ b/internal/command/extensions/kubernetes/create.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
@@ -68,6 +69,17 @@ func runK8sCreate(ctx context.Context) (err error) {
 
 	metadata := resp.AddOn.Metadata.(map[string]interface{})
 
-	fmt.Fprintf(io.Out, "Use the following kubeconfig to connect to your cluster:\n\n%s", metadata["kubeconfig"])
+	outFilename := fmt.Sprintf("%s.kubeconfig.yml", resp.AddOn.Name)
+	f, err := os.Create(outFilename)
+	if err != nil {
+		return err
+	}
+	kubeconfig := metadata["kubeconfig"].(string)
+	_, err = f.Write([]byte(kubeconfig))
+	if err != nil {
+		return fmt.Errorf("failed to write %s to disk, error: %w", outFilename, err)
+	}
+
+	fmt.Fprintf(io.Out, "Wrote kubeconfig to file %s. Use it to connect to your cluster", outFilename)
 	return
 }

--- a/internal/command/extensions/kubernetes/create.go
+++ b/internal/command/extensions/kubernetes/create.go
@@ -67,13 +67,13 @@ func runK8sCreate(ctx context.Context) (err error) {
 		return err
 	}
 
-	metadata := resp.AddOn.Metadata.(map[string]interface{})
-
 	outFilename := fmt.Sprintf("%s.kubeconfig.yml", resp.AddOn.Name)
 	f, err := os.Create(outFilename)
 	if err != nil {
 		return err
 	}
+
+	metadata := resp.AddOn.Metadata.(map[string]interface{})
 	kubeconfig := metadata["kubeconfig"].(string)
 	if _, err := f.Write([]byte(kubeconfig)); err != nil {
 		return fmt.Errorf("failed to write kubeconfig to file %s, error: %w", outFilename, err)

--- a/internal/command/extensions/kubernetes/create.go
+++ b/internal/command/extensions/kubernetes/create.go
@@ -75,9 +75,8 @@ func runK8sCreate(ctx context.Context) (err error) {
 		return err
 	}
 	kubeconfig := metadata["kubeconfig"].(string)
-	_, err = f.Write([]byte(kubeconfig))
-	if err != nil {
-		return fmt.Errorf("failed to write %s to disk, error: %w", outFilename, err)
+	if _, err := f.Write([]byte(kubeconfig)); err != nil {
+		return fmt.Errorf("failed to write kubeconfig to file %s, error: %w", outFilename, err)
 	}
 
 	fmt.Fprintf(io.Out, "Wrote kubeconfig to file %s. Use it to connect to your cluster", outFilename)


### PR DESCRIPTION
### Change Summary

What and Why:

Writes the kubeconfig file to disk instead of printing it to screen (which is annoying to have to copy and paste).

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
