### PR TITLE
Explain Redis billing at provisioning time and allow provisioning in all regions

### DIFF
--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -86,7 +86,7 @@ func runCreate(ctx context.Context) (err error) {
 		return err
 	}
 
-	primaryRegion, err := prompt.Region(ctx, !org.PaidPlan, prompt.RegionParams{
+	primaryRegion, err := prompt.Region(ctx, false, prompt.RegionParams{
 		Message:             "Choose a primary region (can't be changed later)",
 		ExcludedRegionCodes: excludedRegions,
 	})
@@ -100,7 +100,7 @@ func runCreate(ctx context.Context) (err error) {
 	if flag.GetBool(ctx, "enable-eviction") {
 		enableEviction = true
 	} else if !flag.GetBool(ctx, "disable-eviction") {
-		fmt.Fprintf(io.Out, "\nUpstash Redis can evict objects when memory is full. This is useful when caching in Redis. This setting can be changed later.\nLearn more at https://fly.io/docs/reference/redis/#memory-limits-and-object-eviction-policies\n")
+		fmt.Fprintf(io.Out, "\nUpstash Redis can evict objects when memory is full. This is useful when caching in Redis. This setting can be changed later.\nLearn more at https://fly.io/docs/reference/redis/#memory-limits-and-object-eviction-policies\n\n")
 
 		enableEviction, err = prompt.Confirm(ctx, "Would you like to enable eviction?")
 		if err != nil {
@@ -129,7 +129,7 @@ func Create(ctx context.Context, org *fly.Organization, name string, region *fly
 		readRegions = &[]fly.Region{}
 
 		if !disallowReplicas {
-			readRegions, err = prompt.MultiRegion(ctx, "Optionally, choose one or more replica regions (can be changed later):", !org.PaidPlan, []string{}, excludedRegions, "replica-regions")
+			readRegions, err = prompt.MultiRegion(ctx, "Optionally, choose one or more replica regions (can be changed later):", false, []string{}, excludedRegions, "replica-regions")
 
 			if err != nil {
 				return
@@ -170,9 +170,9 @@ func Create(ctx context.Context, org *fly.Organization, name string, region *fly
 		return
 	}
 
-	fmt.Fprintf(io.Out, "\nYour Upstash Redis database %s is ready. Check the pricing details at https://upstash.com/pricing.\n", colorize.Green(addOn.Name))
-	fmt.Fprintf(io.Out, "Apps in the %s org can connect to Redis at %s\n", colorize.Green(org.Slug), colorize.Green(addOn.PublicUrl))
-	fmt.Fprintf(io.Out, "If you have redis-cli installed, use %s to get a Redis console.\n", colorize.Green("fly redis connect"))
+	fmt.Fprintf(io.Out, "\nYour database %s is ready. Apps in the %s org can connect to Redis at %s\n", colorize.Green(addOn.Name), colorize.Green(org.Slug), colorize.Green(addOn.PublicUrl))
+	fmt.Fprintf(io.Out, "\nIf you have redis-cli installed, use %s to get a Redis console.\n", colorize.Green("fly redis connect"))
+	fmt.Fprintf(io.Out, "\nYour database is billed at %s. If you're using Sidekiq or BullMQ, which poll Redis frequently, consider switching to a fixed-price plan. See https://fly.io/docs/reference/redis/#pricing\n", colorize.Green("$0.2 per 100K commands"))
 
 	return addOn, err
 }

--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -172,7 +172,7 @@ func Create(ctx context.Context, org *fly.Organization, name string, region *fly
 
 	fmt.Fprintf(io.Out, "\nYour database %s is ready. Apps in the %s org can connect to Redis at %s\n", colorize.Green(addOn.Name), colorize.Green(org.Slug), colorize.Green(addOn.PublicUrl))
 	fmt.Fprintf(io.Out, "\nIf you have redis-cli installed, use %s to get a Redis console.\n", colorize.Green("fly redis connect"))
-	fmt.Fprintf(io.Out, "\nYour database is billed at %s. If you're using Sidekiq or BullMQ, which poll Redis frequently, consider switching to a fixed-price plan. See https://fly.io/docs/reference/redis/#pricing\n", colorize.Green("$0.2 per 100K commands"))
+	fmt.Fprintf(io.Out, "\nYour database is billed at %s. If you're using Sidekiq or BullMQ, which poll Redis frequently, consider switching to a fixed-price plan. See https://fly.io/docs/reference/redis/#pricing\n", colorize.Green("$0.20 per 100K commands"))
 
 	return addOn, err
 }

--- a/internal/command/redis/update.go
+++ b/internal/command/redis/update.go
@@ -55,7 +55,7 @@ func runUpdate(ctx context.Context) (err error) {
 	}
 	excludedRegions = append(excludedRegions, addOn.PrimaryRegion)
 
-	readRegions, err := prompt.MultiRegion(ctx, "Choose replica regions, or unselect to remove replica regions:", !addOn.Organization.PaidPlan, addOn.ReadRegions, excludedRegions, "replica-regions")
+	readRegions, err := prompt.MultiRegion(ctx, "Choose replica regions, or unselect to remove replica regions:", false, addOn.ReadRegions, excludedRegions, "replica-regions")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
```

Your database bold-wave-318 is ready. Apps in the fly-ephemeral org can connect to Redis at redis://default:a0c10d31340141d6ab4a84030bc6b059@fly-bold-wave-318.upstash.io:6379

If you have redis-cli installed, use fly redis connect to get a Redis console.

Your database is billed at $0.2 per 100K commands. If you're using Sidekiq or BullMQ, which poll Redis frequently, consider switching to a fixed-price plan. See https://fly.io/docs/reference/redis/#plans
```