### PR TITLE
`launch`: allow empty tigris bucket names

### DIFF
--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -38,7 +38,7 @@ type ExtensionParams struct {
 
 	// Surely there's a nicer way to do this, but this gets `fly launch` unblocked on launching exts
 	OverrideRegion string
-	OverrideName   string
+	OverrideName   *string
 }
 
 // Common flags that should be used for all extension commands
@@ -96,20 +96,23 @@ func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension 
 
 	// Prompt to name the provisioned resource, or use the target app name like in Sentry's case
 	if provider.SelectName {
-		name = params.OverrideName
 
-		if name == "" {
-			name = flag.GetString(ctx, "name")
-		}
-
-		if name == "" {
-			if provider.NameSuffix != "" && targetApp.Name != "" {
-				name = targetApp.Name + "-" + provider.NameSuffix
+		if override := params.OverrideName; override != nil {
+			name = *override
+		} else {
+			if name == "" {
+				name = flag.GetString(ctx, "name")
 			}
-			err = prompt.String(ctx, &name, "Choose a name, use the default, or leave blank to generate one:", name, false)
 
-			if err != nil {
-				return
+			if name == "" {
+				if provider.NameSuffix != "" && targetApp.Name != "" {
+					name = targetApp.Name + "-" + provider.NameSuffix
+				}
+				err = prompt.String(ctx, &name, "Choose a name, use the default, or leave blank to generate one:", name, false)
+
+				if err != nil {
+					return
+				}
 			}
 		}
 	} else {

--- a/internal/command/launch/launch_databases.go
+++ b/internal/command/launch/launch_databases.go
@@ -168,7 +168,7 @@ func (state *launchState) createSupabasePostgres(ctx context.Context) error {
 		AppName:        state.Plan.AppName,
 		Organization:   org,
 		Provider:       "supabase",
-		OverrideName:   postgresPlan.GetDbName(state.Plan),
+		OverrideName:   fly.Pointer(postgresPlan.GetDbName(state.Plan)),
 		OverrideRegion: postgresPlan.GetRegion(state.Plan),
 	}
 
@@ -229,7 +229,7 @@ func (state *launchState) createTigrisObjectStorage(ctx context.Context) error {
 		Provider:       "tigris",
 		Organization:   org,
 		AppName:        state.Plan.AppName,
-		OverrideName:   tigrisPlan.Name,
+		OverrideName:   fly.Pointer(tigrisPlan.Name),
 		OverrideRegion: state.Plan.RegionCode,
 		Options: gql.AddOnOptions{
 			"public":     tigrisPlan.Public,


### PR DESCRIPTION
### Change Summary

What and Why: When provisioning an addon, `OverrideName` is a string pointer now, which means we can check against `nil` instead of an empty string. This means we can intentionally provide an empty string from launch to imply "generate a name, please!"

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
