### PR TITLE
Reduce threshold required to show alternative suggestion

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -561,7 +561,7 @@ func waitForDaemon(parent context.Context, client *dockerclient.Client) (up bool
 				brokenTunnelErrors++
 			}
 
-			if brokenTunnelErrors >= 20 {
+			if brokenTunnelErrors >= 7 {
 				return false, err
 			}
 
@@ -596,7 +596,7 @@ func waitForDaemon(parent context.Context, client *dockerclient.Client) (up bool
 }
 
 func clientPing(parent context.Context, client *dockerclient.Client) (types.Ping, error) {
-	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
+	ctx, cancel := context.WithTimeout(parent, 3*time.Second)
 	defer cancel()
 
 	return client.Ping(ctx)

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -588,7 +588,7 @@ func heartbeat(ctx context.Context, client *dockerclient.Client, req *http.Reque
 	ctx, span := tracing.GetTracer().Start(ctx, "heartbeat")
 	defer span.End()
 
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	resp, err := client.HTTPClient().Do(req.Clone(ctx))


### PR DESCRIPTION
### Change Summary
Looking at this [trace](https://ui.honeycomb.io/fly/environments/prod/datasets/flyctl/result/cZ7biaMaJRY), the user had to wait (2 * 200) seconds before the application exited. 

With these new thresholds, you should get suggestions after ~21 seconds of retries (7 retries in total)