### PR TITLE
`fly pg`: require unique zones for volumes

### DIFF
--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -185,7 +185,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 		volInput := fly.CreateVolumeRequest{
 			Name:                volumeName,
 			Encrypted:           fly.Pointer(true),
-			RequireUniqueZone:   fly.Pointer(false),
+			RequireUniqueZone:   fly.Pointer(true),
 			SnapshotID:          snapshot,
 			ComputeRequirements: machineConf.Guest,
 			ComputeImage:        machineConf.Image,


### PR DESCRIPTION
### Change Summary

**What and Why:**

Ensure that volumes end up in different zones when creating HA Fly Postgres clusters for better availability in the face of hardware failures.

**How:**

Use `"require_unique_zone": "true"` when creating the volumes.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
