### PR TITLE
Rename --only-regions, remove primary regions flag

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -456,11 +456,6 @@ func determineAppConfig(ctx context.Context) (cfg *appconfig.Config, err error) 
 		cfg.SetEnvVariables(parsedEnv)
 	}
 
-	// Overrides the primary region that's shown in the config.
-	if v := flag.GetString(ctx, "primary-region"); v != "" {
-		cfg.PrimaryRegion = v
-	}
-
 	// Always prefer the app name passed via --app
 	if appName != "" {
 		cfg.AppName = appName

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -118,7 +118,6 @@ var CommonFlags = flag.Set{
 	},
 	flag.StringSlice{
 		Name:        "regions",
-		Shorthand:   "r",
 		Aliases:     []string{"only-regions"},
 		Description: "Deploy to machines only in these regions. Multiple regions can be specified with comma separated values or by providing the flag multiple times. --region iad,sea --regions syd will deploy to all three iad, sea, and syd regions. Applied before --exclude-regions. V2 machines platform only.",
 	},

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -304,7 +304,7 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 				onlyRegionMachines = append(onlyRegionMachines, m)
 			}
 		}
-		fmt.Fprintf(md.io.ErrOut, "--only-regions filter applied, deploying to %d/%d machines\n", len(onlyRegionMachines), len(machines))
+		fmt.Fprintf(md.io.ErrOut, "--regions filter applied, deploying to %d/%d machines\n", len(onlyRegionMachines), len(machines))
 		machines = onlyRegionMachines
 	}
 	if len(md.excludeRegions) > 0 {

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -39,6 +39,7 @@ func New() (cmd *cobra.Command) {
 		// See a proposed 'flag grouping' feature in Viper that could help with DX: https://github.com/spf13/cobra/pull/1778
 		deploy.CommonFlags,
 
+		flag.Region(),
 		flag.Org(),
 		flag.NoDeploy(),
 		flag.Bool{
@@ -157,7 +158,7 @@ func setupFromTemplate(ctx context.Context) (context.Context, error) {
 }
 
 func run(ctx context.Context) (err error) {
-	var io = iostreams.FromContext(ctx)
+	io := iostreams.FromContext(ctx)
 
 	tp, err := tracing.InitTraceProviderWithoutApp(ctx)
 	if err != nil {


### PR DESCRIPTION
### Change Summary

This pull request removes the previous `--region` flag on `fly deploy` as it overrode the `primary-region` setting in the config, which was surprising to say the least. I was originally going to rename it to `--primary-region` but I don't see a good use case for overriding the primary region for a single deploy. We can add it back in if it's useful.

I also renamed the `--only-regions` to `--regions` but retained the `--only-regions` alias for backwards compatibility. This flag can also use the shorthand of `-r`.

Fixes: https://github.com/superfly/flyctl/issues/3509

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
