### PR TITLE
Add FailureCallback for Laravel Scanner, displaying advise on upgrading to latest flyctl version

### DIFF
--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -135,7 +135,7 @@ func LaravelCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan,
 			requireDev, ok := composerJson["require-dev"].(map[string]interface{})
 			if ok && requireDev["fly-apps/dockerfile-laravel"] != nil {
 				installed = true
-			}
+			} 
 		}
 	}
 
@@ -191,6 +191,24 @@ Now: run 'fly deploy' to deploy your %s app.
 
 	return nil
 }
+
+func LaravelFailureCallback(err error) error {
+	suggestion := flyerr.GetErrorSuggestion(err)
+
+	if suggestion == "" {
+		err = flyerr.GenericErr{
+			Err: err.Error(),
+			Suggest: "\nWoops! It seems there's been a hiccup in launching your awesome Laravel app!\n
+			No worries! Please make sure you're running the latest `flyctl` launcher by running: `fly version update` and try again. \n
+			If the issue persists, kindly drop a post in our community forum, under the Laravel category: https://community.fly.io/c/laravel/22. \n
+			Thank you for your patience, and remember, at Fly.io, we're with you through every step in your Laravel app's deployment journery, so drop by with that community post!
+			",
+		}
+	}
+
+	return err
+}
+
 
 func extractPhpVersion() (string, error) {
 	/* Example Output:


### PR DESCRIPTION
### Change Summary

What and Why:
Include a  FailureCallback for the Laravel scanner. There are cases when launch fails for Laravel apps. Sometimes these issues are already fixed in more recent versions of flyctl, so display advise prompting user to upgrade their flyctl scanner to latest version.

How:
Include a FailureCallback function for Laravel scanner at LaravelFailureCallback. Set the `flyerr.GenericErr.Suggest` value to string prompting for version upgrade.

Very similar to [Rails Callback!](https://github.com/superfly/flyctl/commit/3d22858019b7d8e8119b78a5d91c3662c0f7a9ef#diff-7f4ac514b3eafe0f18cd70007458daf86d683bd66e931882d6d8ef07446b047eR76-R351) Thanks for pointing this out @rubys !


TODO: 
Create a docs page in Laravel section of Fly.io docs to include a list of common launch issues and their fixes. similar to https://fly.io/docs/rails/getting-started/existing/#common-initial-deployment-issues
THEN finalize this PR with a link to that new page.
 
Related to:
Launch errors for Laravel apps

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
