### PR TITLE
Add the --http-failover flag for remote Docker builders

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -37,6 +37,7 @@ var CommonFlags = flag.Set{
 	flag.LocalOnly(),
 	flag.Push(),
 	flag.Wireguard(),
+	flag.HttpFailover(),
 	flag.Detach(),
 	flag.Strategy(),
 	flag.Dockerfile(),
@@ -248,10 +249,12 @@ func run(ctx context.Context) error {
 }
 
 func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes bool) (err error) {
+	ctx, span := tracing.GetTracer().Start(ctx, "deploy_with_config")
 	io := iostreams.FromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	apiClient := fly.ClientFromContext(ctx)
 	appCompact, err := apiClient.GetAppCompact(ctx, appName)
+
 	if err != nil {
 		return err
 	}
@@ -262,16 +265,24 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes
 			fmt.Fprintln(io.ErrOut, warning)
 		}
 	}
-	useWG := flag.GetWireguard(ctx)
+
+	httpFailover := flag.GetHTTPFailover(ctx)
+	usingWireguard := flag.GetWireguard(ctx)
+
 	// Fetch an image ref or build from source to get the final image reference to deploy
-	img, err := determineImage(ctx, appConfig, useWG)
-	if err != nil && useWG {
-		return fmt.Errorf("failed to fetch an image or build from source: %w", err)
-	} else if err != nil {
-		img, err = determineImage(ctx, appConfig, true)
-		if err != nil {
+	img, err := determineImage(ctx, appConfig, usingWireguard)
+	if err != nil {
+		if usingWireguard && !httpFailover {
 			return fmt.Errorf("failed to fetch an image or build from source: %w", err)
+		} else {
+			span.SetAttributes(attribute.String("builder.failover_error", err.Error()))
+			span.AddEvent("using http failover")
+			img, err = determineImage(ctx, appConfig, true)
+			if err != nil {
+				return fmt.Errorf("failed to fetch an image or build from source: %w", err)
+			}
 		}
+
 	}
 
 	if flag.GetBuildOnly(ctx) {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -254,7 +254,6 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes
 	appName := appconfig.NameFromContext(ctx)
 	apiClient := fly.ClientFromContext(ctx)
 	appCompact, err := apiClient.GetAppCompact(ctx, appName)
-
 	if err != nil {
 		return err
 	}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -262,11 +262,16 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes
 			fmt.Fprintln(io.ErrOut, warning)
 		}
 	}
-
+	useWG := flag.GetWireguard(ctx)
 	// Fetch an image ref or build from source to get the final image reference to deploy
-	img, err := determineImage(ctx, appConfig)
-	if err != nil {
+	img, err := determineImage(ctx, appConfig, useWG)
+	if err != nil && useWG {
 		return fmt.Errorf("failed to fetch an image or build from source: %w", err)
+	} else if err != nil {
+		img, err = determineImage(ctx, appConfig, true)
+		if err != nil {
+			return fmt.Errorf("failed to fetch an image or build from source: %w", err)
+		}
 	}
 
 	if flag.GetBuildOnly(ctx) {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/superfly/flyctl/internal/tracing"
 	"github.com/superfly/flyctl/iostreams"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var defaultMaxConcurrent = 16
@@ -249,8 +250,7 @@ func run(ctx context.Context) error {
 }
 
 func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes bool) (err error) {
-	ctx, span := tracing.GetTracer().Start(ctx, "deploy_with_config")
-	defer span.End()
+	span := trace.SpanFromContext(ctx)
 
 	io := iostreams.FromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -48,7 +48,7 @@ func multipleDockerfile(ctx context.Context, appConfig *appconfig.Config) error 
 
 // determineImage picks the deployment strategy, builds the image and returns a
 // DeploymentImage struct
-func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgsrc.DeploymentImage, err error) {
+func determineImage(ctx context.Context, appConfig *appconfig.Config, useWG bool) (img *imgsrc.DeploymentImage, err error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "determine_image")
 	defer span.End()
 
@@ -65,7 +65,7 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config) (img *imgs
 		terminal.Warnf("%s\n", err.Error())
 	}
 
-	resolver := imgsrc.NewResolver(daemonType, client, appConfig.AppName, io, flag.GetWireguard(ctx))
+	resolver := imgsrc.NewResolver(daemonType, client, appConfig.AppName, io, useWG)
 
 	var imageRef string
 	if imageRef, err = fetchImageRef(ctx, appConfig); err != nil {

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -422,7 +422,7 @@ func HttpFailover() Bool {
 	return Bool{
 		Name:        httpFailover,
 		Description: "Determines whether to failover to plain internet(https) communication with remote builders if wireguard fails",
-		// TODO: Determine this based on feature flag
+		// TODO(billy): Determine this based on feature flag
 		Default: false,
 	}
 }

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -416,6 +416,21 @@ func GetWireguard(ctx context.Context) bool {
 	return GetBool(ctx, wireguard)
 }
 
+const httpFailover = "http-failover"
+
+func HttpFailover() Bool {
+	return Bool{
+		Name:        httpFailover,
+		Description: "Determines whether to failover to plain internet(https) communication with remote builders if wireguard fails",
+		// TODO: Determine this based on feature flag
+		Default: false,
+	}
+}
+
+func GetHTTPFailover(ctx context.Context) bool {
+	return GetBool(ctx, httpFailover)
+}
+
 const localOnlyName = "local-only"
 
 // RemoteOnly returns a boolean flag for deploying remotely


### PR DESCRIPTION
### Change Summary

What and Why:
I added the --http-failover flag, which will automatically retry to determine an image if we have any issues connecting to our org's builder.

How:

Related to:

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
