### PR TITLE
Add snapshot retention to mount section of fly.toml

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -131,7 +131,7 @@ type Mount struct {
 	Source                  string   `toml:"source,omitempty" json:"source,omitempty"`
 	Destination             string   `toml:"destination,omitempty" json:"destination,omitempty"`
 	InitialSize             string   `toml:"initial_size,omitempty" json:"initial_size,omitempty"`
-	SnapshotRetention       int      `toml:"snapshot_retention,omitempty" json:"snapshot_retention,omitempty"`
+	SnapshotRetention       *int     `toml:"snapshot_retention,omitempty" json:"snapshot_retention,omitempty"`
 	AutoExtendSizeThreshold int      `toml:"auto_extend_size_threshold,omitempty" json:"auto_extend_size_threshold,omitempty"`
 	AutoExtendSizeIncrement string   `toml:"auto_extend_size_increment,omitempty" json:"auto_extend_size_increment,omitempty"`
 	AutoExtendSizeLimit     string   `toml:"auto_extend_size_limit,omitempty" json:"auto_extend_size_limit,omitempty"`

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -131,6 +131,7 @@ type Mount struct {
 	Source                  string   `toml:"source,omitempty" json:"source,omitempty"`
 	Destination             string   `toml:"destination,omitempty" json:"destination,omitempty"`
 	InitialSize             string   `toml:"initial_size,omitempty" json:"initial_size,omitempty"`
+	SnapshotRetention       int      `toml:"snapshot_retention,omitempty" json:"snapshot_retention,omitempty"`
 	AutoExtendSizeThreshold int      `toml:"auto_extend_size_threshold,omitempty" json:"auto_extend_size_threshold,omitempty"`
 	AutoExtendSizeIncrement string   `toml:"auto_extend_size_increment,omitempty" json:"auto_extend_size_increment,omitempty"`
 	AutoExtendSizeLimit     string   `toml:"auto_extend_size_limit,omitempty" json:"auto_extend_size_limit,omitempty"`

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -279,9 +279,10 @@ func TestToDefinition(t *testing.T) {
 			},
 		},
 		"mounts": []any{map[string]any{
-			"source":       "data",
-			"destination":  "/data",
-			"initial_size": "30gb",
+			"source":             "data",
+			"destination":        "/data",
+			"initial_size":       "30gb",
+			"snapshot_retention": int64(17),
 		}},
 		"processes": map[string]any{
 			"web":  "run web",

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -188,9 +188,10 @@ func TestLoadTOMLAppConfigFormatQuirks(t *testing.T) {
 			Memory: "512",
 		}},
 		Mounts: []Mount{{
-			Source:      "data",
-			Destination: "/data",
-			InitialSize: "200",
+			Source:            "data",
+			Destination:       "/data",
+			InitialSize:       "200",
+			SnapshotRetention: 10,
 		}},
 	}, cfg)
 }
@@ -477,9 +478,10 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 		},
 
 		Mounts: []Mount{{
-			Source:      "data",
-			Destination: "/data",
-			InitialSize: "30gb",
+			Source:            "data",
+			Destination:       "/data",
+			InitialSize:       "30gb",
+			SnapshotRetention: 17,
 		}},
 
 		Processes: map[string]string{

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -191,7 +191,7 @@ func TestLoadTOMLAppConfigFormatQuirks(t *testing.T) {
 			Source:            "data",
 			Destination:       "/data",
 			InitialSize:       "200",
-			SnapshotRetention: 10,
+			SnapshotRetention: fly.Pointer(10),
 		}},
 	}, cfg)
 }
@@ -481,7 +481,7 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 			Source:            "data",
 			Destination:       "/data",
 			InitialSize:       "30gb",
-			SnapshotRetention: 17,
+			SnapshotRetention: fly.Pointer(17),
 		}},
 
 		Processes: map[string]string{

--- a/internal/appconfig/testdata/format-quirks.toml
+++ b/internal/appconfig/testdata/format-quirks.toml
@@ -7,3 +7,4 @@ memory = 512
 source = "data"
 destination = "/data"
 initial_size = 200
+snapshot_retention = 10

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -114,6 +114,7 @@ host_dedication_id = "06031957"
   source = "data"
   initial_size = "30gb"
   destination = "/data"
+  snapshot_retention = 17
 
 [[vm]]
   size = "shared-cpu-1x"

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -275,6 +275,14 @@ func (cfg *Config) validateMounts() (extraInfo string, err error) {
 			}
 		}
 
+		switch {
+		case m.SnapshotRetention == 0:
+			m.SnapshotRetention = 5
+		case m.SnapshotRetention < 1 || m.SnapshotRetention > 60:
+			extraInfo += fmt.Sprintf("mount '%s' has a snapshot_retention value which is not between 1 and 60 days\n", m.Source)
+			err = ValidationError
+		}
+
 		var autoExtendSizeIncrement, autoExtendSizeLimit int
 		var vErr error
 		if m.AutoExtendSizeIncrement != "" {

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -275,11 +275,8 @@ func (cfg *Config) validateMounts() (extraInfo string, err error) {
 			}
 		}
 
-		switch {
-		case m.SnapshotRetention == 0:
-			m.SnapshotRetention = 5
-		case m.SnapshotRetention < 1 || m.SnapshotRetention > 60:
-			extraInfo += fmt.Sprintf("mount '%s' has a snapshot_retention value which is not between 1 and 60 days\n", m.Source)
+		if m.SnapshotRetention != nil && (*m.SnapshotRetention < 1 || *m.SnapshotRetention > 60) {
+			extraInfo += fmt.Sprintf("mount '%s' has a snapshot_retention value which is not between 1 and 60 days inclusive\n", m.Source)
 			err = ValidationError
 		}
 

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -145,7 +145,7 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 				Encrypted:           fly.Pointer(true),
 				ComputeRequirements: guest,
 				ComputeImage:        md.img,
-				SnapshotRetention:   fly.Pointer(m.SnapshotRetention),
+				SnapshotRetention:   m.SnapshotRetention,
 			}
 
 			vol, err := md.flapsClient.CreateVolume(ctx, input)

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -145,6 +145,7 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 				Encrypted:           fly.Pointer(true),
 				ComputeRequirements: guest,
 				ComputeImage:        md.img,
+				SnapshotRetention:   fly.Pointer(m.SnapshotRetention),
 			}
 
 			vol, err := md.flapsClient.CreateVolume(ctx, input)


### PR DESCRIPTION
### Change Summary

Add snapshot_retention to the mounts section of fly.toml, so you can customize how long we retain volume snapshots from the app.

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
