### PR TITLE
Prevent users from deploying fly tomls with duplicate service definitions

### DIFF
--- a/internal/appconfig/testdata/validate-duplicate-services-diff-processgroup.toml
+++ b/internal/appconfig/testdata/validate-duplicate-services-diff-processgroup.toml
@@ -1,22 +1,18 @@
 app = "foo"
 
-[[services]]
+[processes]
+web = "/run1"
+app = "/run2"
+
+
+[http_service]
   internal_port = 1738
-  protocol = "tcp"
-
-  [[services.ports]]
-    port = 80
-    handlers = ['http']
-    force_https = true
-
-  [services.concurrency]
-    type = "requests"
-    hard_limit = 22
-    soft_limit = 13
+  processes = ["app"]
 
 [[services]]
   internal_port = 1738
   protocol = "tcp"
+  processes = ["web"]
 
   [[services.ports]]
     port = 80

--- a/internal/appconfig/testdata/validate-duplicate-services.toml
+++ b/internal/appconfig/testdata/validate-duplicate-services.toml
@@ -1,0 +1,19 @@
+app = "foo"
+
+[[services]]
+  internal_port = 1738
+  protocol = "tcp"
+
+  [services.concurrency]
+    type = "requests"
+    hard_limit = 22
+    soft_limit = 13
+
+[[services]]
+  internal_port = 1738
+  protocol = "tcp"
+
+  [services.concurrency]
+    type = "requests"
+    hard_limit = 22
+    soft_limit = 13

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -187,17 +187,34 @@ func (cfg *Config) validateServicesSection() (extraInfo string, err error) {
 			extraInfo += validateServiceCheckDurations(check.Interval, check.Timeout, check.GracePeriod, "HTTP")
 		}
 
-		serviceCounter[fmt.Sprintf("%s-%d", service.Protocol, service.InternalPort)] += 1
+		serviceCounter[cfg.getServiceDeduplicationKey(service)] += 1
 	}
 
 	for service, count := range serviceCounter {
 		if count > 1 {
-			extraInfo += fmt.Sprintf("Service [%s] has %d duplicate definitions. To resolve this, merge them into 1 service. \n", service, count)
+			protocol, port := cfg.getServiceComponets(service)[0], cfg.getServiceComponets(service)[1]
+			extraInfo += fmt.Sprintf("Service [%s-%s] has %d duplicate definitions. To resolve this, merge them into 1 service. \n", protocol, port, count)
 			err = ValidationError
 		}
 	}
 
 	return extraInfo, err
+}
+
+func (cfg *Config) getServiceDeduplicationKey(s Service) string {
+	processes := s.Processes
+	if len(processes) == 0 {
+		processes = []string{fly.MachineProcessGroupApp}
+	}
+
+	slices.Sort(processes)
+	return fmt.Sprintf("%s+%s+%d", strings.Join(processes, ":"), s.Protocol, s.InternalPort)
+}
+
+func (cfg *Config) getServiceComponets(s string) []string {
+	components := strings.Split(s, "+")
+	return []string{components[len(components)-2], components[len(components)-1]}
+
 }
 
 func validateServiceCheckDurations(interval, timeout, gracePeriod *fly.Duration, proto string) (extraInfo string) {

--- a/internal/appconfig/validation_test.go
+++ b/internal/appconfig/validation_test.go
@@ -71,3 +71,14 @@ func TestConfig_ValidateServices(t *testing.T) {
 	err, x = cfg.ValidateGroups(ctx, []string{"success"})
 	require.NoErrorf(t, err, x)
 }
+
+func TestConfig_ValidateDuplicateServices(t *testing.T) {
+	cfg, err := LoadConfig("./testdata/validate-duplicate-services.toml")
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetMachinesPlatform())
+
+	ctx := _getValidationContext(t)
+	err, x := cfg.Validate(ctx)
+	require.Error(t, err, x)
+	require.Contains(t, x, "Service [tcp-1738] has 2 duplicate definitions. To resolve this, merge them into 1 service.")
+}

--- a/internal/appconfig/validation_test.go
+++ b/internal/appconfig/validation_test.go
@@ -82,3 +82,13 @@ func TestConfig_ValidateDuplicateServices(t *testing.T) {
 	require.Error(t, err, x)
 	require.Contains(t, x, "Service [tcp-1738] has 2 duplicate definitions. To resolve this, merge them into 1 service.")
 }
+
+func TestConfig_ValidateDuplicateServicesButDifferentProcessGroup(t *testing.T) {
+	cfg, err := LoadConfig("./testdata/validate-duplicate-services-diff-processgroup.toml")
+	require.NoError(t, err)
+	require.NoError(t, cfg.SetMachinesPlatform())
+
+	ctx := _getValidationContext(t)
+	err, x := cfg.Validate(ctx)
+	require.NoError(t, err, x)
+}


### PR DESCRIPTION
### Change Summary
Users sometimes end up defining multiple services for the same protocol & port. 
This harmless mistake would cause health-checks to fail because of only one of these services get picked by flaps.
To fix this, I'm introducing some client-side validation to flag these issues.

They would now see this warning/help text 👇 
```
Service [tcp-1738] has 2 duplicate definitions. To resolve this, merge them into 1 service.
```


References
https://community.fly.io/t/health-checks-failing-with-failed-to-get-vm/18077
https://community.fly.io/t/unable-to-perform-health-checks/19604
https://community.fly.io/t/health-checks-always-failing/19641/2
