### PR TITLE
Add testflight test for wireguardless deployments

### DIFF
--- a/test/preflight/fly_deploy_test.go
+++ b/test/preflight/fly_deploy_test.go
@@ -156,6 +156,33 @@ func TestFlyDeployNodeAppWithRemoteBuilder(t *testing.T) {
 	require.Contains(t, string(body), fmt.Sprintf("Hello, World! %s", f.ID()))
 }
 
+func TestFlyDeployNodeAppWithRemoteBuilderWithoutWireguard(t *testing.T) {
+	f := testlib.NewTestEnvFromEnv(t)
+	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node", []string{})
+	require.NoError(t, err)
+
+	flyTomlPath := fmt.Sprintf("%s/fly.toml", f.WorkDir())
+
+	appName := f.CreateRandomAppMachines()
+	require.NotEmpty(t, appName)
+
+	err = testlib.OverwriteConfig(flyTomlPath, map[string]any{
+		"app":    appName,
+		"region": f.PrimaryRegion(),
+		"env": map[string]string{
+			"TEST_ID": f.ID(),
+		},
+	})
+	require.NoError(t, err)
+
+	f.Fly("deploy --remote-only --ha=false --wg=false")
+
+	body, err := testlib.RunHealthCheck(fmt.Sprintf("https://%s.fly.dev", appName))
+	require.NoError(t, err)
+
+	require.Contains(t, string(body), fmt.Sprintf("Hello, World! %s", f.ID()))
+}
+
 func TestFlyDeployBasicNodeWithWGEnabled(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
 	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node", []string{})


### PR DESCRIPTION
### Change Summary
The [wireguardless](https://github.com/superfly/flyctl/pull/3314) feature comes in very handy when you wg config is borked.
To make it work, flyctl + web + remote-builders need to work together as one happy family. 
This integration test ensures we are aware when it's broken :)
