### PR TITLE
More flags for fine-tuning deploy

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -184,6 +184,11 @@ func New() (cmd *cobra.Command) {
 			Description: "Do not create Machines for new process groups",
 			Default:     false,
 		},
+		flag.Bool{
+			Name:        "skip-release-command",
+			Description: "Do not run the release command during deployment.",
+			Default:     false,
+		},
 	)
 
 	return
@@ -415,6 +420,7 @@ func deployToMachines(
 		SkipSmokeChecks:       flag.GetDetach(ctx) || !flag.GetBool(ctx, "smoke-checks"),
 		SkipHealthChecks:      flag.GetDetach(ctx),
 		SkipDNSChecks:         flag.GetDetach(ctx) || !flag.GetBool(ctx, "dns-checks"),
+		SkipReleaseCommand:    flag.GetBool(ctx, "skip-release-command"),
 		WaitTimeout:           waitTimeout,
 		StopSignal:            flag.GetString(ctx, "signal"),
 		ReleaseCmdTimeout:     releaseCmdTimeout,

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"github.com/superfly/flyctl/terminal"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/exp/maps"
 )
 
 const (
@@ -62,11 +64,13 @@ type MachineDeploymentArgs struct {
 	AllocPublicIP         bool
 	UpdateOnly            bool
 	Files                 []*fly.File
-	ExcludeRegions        map[string]interface{}
-	OnlyRegions           map[string]interface{}
+	ExcludeRegions        map[string]bool
+	OnlyRegions           map[string]bool
+	ExcludeMachines       map[string]bool
+	OnlyMachines          map[string]bool
+	ProcessGroups         map[string]bool
 	MaxConcurrent         int
 	VolumeInitialSize     int
-	ProcessGroups         map[string]interface{}
 	RestartPolicy         *fly.MachineRestartPolicy
 	RestartMaxRetries     int
 }
@@ -102,11 +106,13 @@ type machineDeployment struct {
 	increasedAvailability bool
 	listenAddressChecked  sync.Map
 	updateOnly            bool
-	excludeRegions        map[string]interface{}
-	onlyRegions           map[string]interface{}
+	excludeRegions        map[string]bool
+	onlyRegions           map[string]bool
+	excludeMachines       map[string]bool
+	onlyMachines          map[string]bool
+	processGroups         map[string]bool
 	maxConcurrent         int
 	volumeInitialSize     int
-	processGroups         map[string]interface{}
 }
 
 func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (MachineDeployment, error) {
@@ -223,6 +229,8 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		machineGuest:          args.Guest,
 		excludeRegions:        args.ExcludeRegions,
 		onlyRegions:           args.OnlyRegions,
+		excludeMachines:       args.ExcludeMachines,
+		onlyMachines:          args.OnlyMachines,
 		maxConcurrent:         maxConcurrent,
 		volumeInitialSize:     args.VolumeInitialSize,
 		processGroups:         args.ProcessGroups,
@@ -287,7 +295,8 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 		return err
 	}
 
-	if len(machines) == 0 {
+	nMachines := len(machines)
+	if nMachines == 0 {
 		terminal.Debug("Found no machines that are part of Fly Apps Platform. Checking for active machines...")
 		activeMachines, err := md.flapsClient.ListActive(ctx)
 		if err != nil {
@@ -300,35 +309,60 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 		}
 	}
 
-	if len(md.onlyRegions) > 0 {
-		var onlyRegionMachines []*fly.Machine
-		for _, m := range machines {
-			if _, present := md.onlyRegions[m.Region]; present {
-				onlyRegionMachines = append(onlyRegionMachines, m)
+	filtersApplied := map[string]struct{}{}
+	machines = slices.DeleteFunc(machines, func(m *fly.Machine) bool {
+		if len(md.onlyRegions) > 0 {
+			filtersApplied["--regions"] = struct{}{}
+
+			if !md.onlyRegions[m.Region] {
+				return true
 			}
 		}
-		fmt.Fprintf(md.io.ErrOut, "--regions filter applied, deploying to %d/%d machines\n", len(onlyRegionMachines), len(machines))
-		machines = onlyRegionMachines
-	}
-	if len(md.excludeRegions) > 0 {
-		var excludeRegionMachines []*fly.Machine
-		for _, m := range machines {
-			if _, present := md.excludeRegions[m.Region]; !present {
-				excludeRegionMachines = append(excludeRegionMachines, m)
+
+		if len(md.excludeRegions) > 0 {
+			filtersApplied["--exclude-regions"] = struct{}{}
+
+			if md.excludeRegions[m.Region] {
+				return true
 			}
 		}
-		fmt.Fprintf(md.io.ErrOut, "--exclude-regions filter applied, deploying to %d/%d machines\n", len(excludeRegionMachines), len(machines))
-		machines = excludeRegionMachines
-	}
-	if len(md.processGroups) > 0 {
-		var processGroupMachines []*fly.Machine
-		for _, m := range machines {
-			if _, present := md.processGroups[m.ProcessGroup()]; present {
-				processGroupMachines = append(processGroupMachines, m)
+
+		if len(md.onlyMachines) > 0 {
+			filtersApplied["--only-machines"] = struct{}{}
+
+			if !md.onlyMachines[m.ID] {
+				return true
 			}
 		}
-		fmt.Fprintf(md.io.ErrOut, "--process-groups filter applied, deploying to %d/%d machines\n", len(processGroupMachines), len(machines))
-		machines = processGroupMachines
+
+		if len(md.excludeMachines) > 0 {
+			filtersApplied["--exclude-machines"] = struct{}{}
+
+			if md.excludeMachines[m.ID] {
+				return true
+			}
+		}
+
+		if len(md.processGroups) > 0 {
+			filtersApplied["--process-groups"] = struct{}{}
+
+			if !md.processGroups[m.ProcessGroup()] {
+				return true
+			}
+		}
+
+		return false
+	})
+
+	if len(filtersApplied) > 0 {
+		s := ""
+		if len(filtersApplied) > 1 {
+			s = "s"
+		}
+
+		filtersAppliedStr := strings.Join(maps.Keys(filtersApplied), "/")
+
+		fmt.Fprintf(md.io.ErrOut, "%s filter%s applied, deploying to %d/%d machines\n", filtersAppliedStr, s, len(machines), nMachines)
 	}
 
 	for _, m := range machines {
@@ -633,8 +667,8 @@ func determineAppConfigForMachines(ctx context.Context, envFromFlags []string, p
 func (md *machineDeployment) ProcessNames() (names []string) {
 	names = md.appConfig.ProcessNames()
 	if len(md.processGroups) > 0 {
-		names = lo.Filter(names, func(name string, _ int) bool {
-			return md.processGroups[name] != nil
+		names = slices.DeleteFunc(names, func(name string) bool {
+			return !md.processGroups[name]
 		})
 	}
 	return

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -50,6 +50,7 @@ type MachineDeploymentArgs struct {
 	SkipSmokeChecks       bool
 	SkipHealthChecks      bool
 	SkipDNSChecks         bool
+	SkipReleaseCommand    bool
 	MaxUnavailable        *float64
 	RestartOnly           bool
 	WaitTimeout           *time.Duration
@@ -88,6 +89,7 @@ type machineDeployment struct {
 	skipSmokeChecks       bool
 	skipHealthChecks      bool
 	skipDNSChecks         bool
+	skipReleaseCommand    bool
 	maxUnavailable        float64
 	restartOnly           bool
 	waitTimeout           time.Duration
@@ -208,6 +210,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 		skipSmokeChecks:       args.SkipSmokeChecks,
 		skipHealthChecks:      args.SkipHealthChecks,
 		skipDNSChecks:         args.SkipDNSChecks,
+		skipReleaseCommand:    args.SkipReleaseCommand,
 		restartOnly:           args.RestartOnly,
 		maxUnavailable:        maxUnavailable,
 		waitTimeout:           waitTimeout,

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -258,8 +258,10 @@ func (md *machineDeployment) deployMachinesApp(ctx context.Context) error {
 	ctx, span := tracing.GetTracer().Start(ctx, "deploy_new_machines")
 	defer span.End()
 
-	if err := md.runReleaseCommand(ctx); err != nil {
-		return fmt.Errorf("release command failed - aborting deployment. %w", err)
+	if !md.skipReleaseCommand {
+		if err := md.runReleaseCommand(ctx); err != nil {
+			return fmt.Errorf("release command failed - aborting deployment. %w", err)
+		}
 	}
 
 	if err := md.machineSet.AcquireLeases(ctx, md.leaseTimeout); err != nil {

--- a/internal/flag/context.go
+++ b/internal/flag/context.go
@@ -3,6 +3,7 @@ package flag
 import (
 	"context"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -89,6 +90,21 @@ func GetStringSlice(ctx context.Context, name string) []string {
 		return []string{}
 	} else {
 		return v
+	}
+}
+
+// GetStringSlice returns the values of the named string flag ctx carries. Can
+// be comma separated or passed "by repeated flags": `--flag x,y` is equivalent
+// to `--flag x --flag y`. Strings are trimmed of extra whitespace and empty
+// strings are removed.
+func GetNonEmptyStringSlice(ctx context.Context, name string) []string {
+	if v, err := FromContext(ctx).GetStringSlice(name); err != nil {
+		return []string{}
+	} else {
+		for i := range v {
+			v[i] = strings.TrimSpace(v[i])
+		}
+		return slices.DeleteFunc(v, func(s string) bool { return s == "" })
 	}
 }
 


### PR DESCRIPTION
### Change Summary

What and Why:

This PR adds `--skip-release-command` and `--only-machines`/`--exclude-machines` flags to `fly deploy`.

Being able to deploy to a subset of machines allows users to conduct their own blue/green deploys at their own pace. I will find it very useful to be able to deploy to a single machine in a big app for half an hour to see if things break.

Being able to skip release commands is useful in this situation also, where you wouldn't, for example, want to run database migrations when testing a small change.

How:

Added flags.

Related to:

Apropos of nothing

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
