### PR TITLE
docs: Fixed the storage destroy help text

### DIFF
--- a/internal/command/extensions/tigris/destroy.go
+++ b/internal/command/extensions/tigris/destroy.go
@@ -21,7 +21,7 @@ func destroy() (cmd *cobra.Command) {
 		long = `Permanently destroy a Tigris object storage bucket`
 
 		short = long
-		usage = "destroy [name]"
+		usage = "destroy [storage-bucket-name]"
 	)
 
 	cmd = command.New(usage, short, long, runDestroy, command.RequireSession, command.LoadAppNameIfPresent)


### PR DESCRIPTION
### Change Summary

What and Why:
Clarified the storage destroy sub command help text to include bucket name.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
