### PR TITLE
Builder region

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.1.8
+	github.com/superfly/fly-go v0.1.10
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.13

--- a/go.sum
+++ b/go.sum
@@ -614,8 +614,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.8 h1:4YlEh4GPCZ8Z5OT8lQugsHiwX90U/F+gMSQvGOrGxlI=
-github.com/superfly/fly-go v0.1.8/go.mod h1:0wgmVsqPPDgPSTsZA0L0zI5uajxx86KfuBoPQT87B1E=
+github.com/superfly/fly-go v0.1.10 h1:QXx1SyvbqeKrhAjQFfiqgCHUZy2KgHc94i/BvQ3BoK0=
+github.com/superfly/fly-go v0.1.10/go.mod h1:0wgmVsqPPDgPSTsZA0L0zI5uajxx86KfuBoPQT87B1E=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -710,7 +710,8 @@ func EagerlyEnsureRemoteBuilder(ctx context.Context, apiClient *fly.Client, orgS
 		return
 	}
 
-	_, app, err := apiClient.EnsureRemoteBuilder(ctx, org.ID, "")
+	region := os.Getenv("FLY_REMOTE_BUILDER_REGION")
+	_, app, err := apiClient.EnsureRemoteBuilder(ctx, org.ID, "", region)
 	if err != nil {
 		terminal.Debugf("error ensuring remote builder for organization: %s", err)
 		return
@@ -724,7 +725,8 @@ func remoteBuilderMachine(ctx context.Context, apiClient *fly.Client, appName st
 		return nil, nil, nil
 	}
 
-	return apiClient.EnsureRemoteBuilder(ctx, "", appName)
+	region := os.Getenv("FLY_REMOTE_BUILDER_REGION")
+	return apiClient.EnsureRemoteBuilder(ctx, "", appName, region)
 }
 
 func (d *dockerClientFactory) IsRemote() bool {


### PR DESCRIPTION
### Change Summary

What and Why: Recent problems pushing images from `ams` to the region motivates this change.

How: Allow to force the region by setting FLY_REMOTE_BUILDER_REGION envvar

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
