### PR TITLE
Detach the context in case of an interrupt

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -45,6 +45,8 @@ func (md *machineDeployment) DeployMachinesApp(ctx context.Context) error {
 
 	ctx = flaps.NewContext(ctx, md.flapsClient)
 
+	onInterruptContext := context.WithoutCancel(ctx)
+
 	if err := md.updateReleaseInBackend(ctx, "running"); err != nil {
 		tracing.RecordError(span, err, "failed to update release")
 		return fmt.Errorf("failed to set release status to 'running': %w", err)
@@ -65,7 +67,7 @@ func (md *machineDeployment) DeployMachinesApp(ctx context.Context) error {
 		// Provide an extra second to try to update the release status.
 		status = "interrupted"
 		var cancel func()
-		ctx, cancel = context.WithTimeout(ctx, time.Second)
+		ctx, cancel = context.WithTimeout(onInterruptContext, time.Second)
 		defer cancel()
 	default:
 		status = "failed"


### PR DESCRIPTION
### Change Summary

What and Why: Detach the context used to update the release status in case the deployment is interrupted.

the bug manifests as a graphql context cancelled error:
```
-------
Updating existing machines in 'app' with rolling strategy
^C
-------

-------
 ✖ [1/2] Machine 148e75eb913789 [app] update canceled while it was in progress
   [2/2] Waiting for job
-------
INFO detected canceled context and allowing 500ms to release machine leases
INFO detected canceled context and allowing 500ms to release machine 148e75eb913789 [app] lease
INFO detected canceled context and allowing 500ms to release machine 6e82746a7923d8 [app] lease

WARN failed to set final release status after deployment failure: Post "https://api.fly.io/graphql": context canceled

WARN DNS checks failed: context canceled

```

With this fix:
```
-------
 ✖ [1/2] Machine 148e75eb913789 [app] update canceled while it was in progress
   [2/2] Waiting for job
-------
INFO detected canceled context and allowing 500ms to release machine leases

INFO detected canceled context and allowing 500ms to release machine 148e75eb913789 [app] lease

INFO detected canceled context and allowing 500ms to release machine 6e82746a7923d8 [app] lease

Checking DNS configuration for flo2.fly.dev
```

Related to: https://github.com/superfly/flyctl/pull/3345

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
