### PR TITLE
fix: fly deploy --regions should be honored

### DIFF
--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -40,6 +40,10 @@ func (md *machineDeployment) launchInputForLaunch(processGroup string, guest *fl
 	processGroup = mConfig.ProcessGroup()
 	region := md.appConfig.PrimaryRegion
 
+	if region == "" && len(md.onlyRegions) == 1 {
+		region = lo.Keys(md.onlyRegions)[0]
+	}
+
 	if len(mConfig.Mounts) > 0 {
 		mount0 := &mConfig.Mounts[0]
 		vol := md.popVolumeFor(mount0.Name, region)


### PR DESCRIPTION
The flag seems ignored and only primary_region in fly.toml is considered.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
