### PR TITLE
The default is now rolling

### DIFF
--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -533,7 +533,7 @@ func Nixpacks() Bool {
 func Strategy() String {
 	return String{
 		Name:        "strategy",
-		Description: "The strategy for replacing running instances. Options are canary, rolling, bluegreen, or immediate. Default is canary, or rolling when max-per-region is set.",
+		Description: "The strategy for replacing running instances. Options are canary, rolling, bluegreen, or immediate. The default strategy is rolling.",
 	}
 }
 


### PR DESCRIPTION
### Change Summary

What and Why:
Updated the flag text for `fly deploy --strategy` to be correct now that we're in a world without nomad.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
