### PR TITLE
Fix Postgres plan display on `fly launch`

### DIFF
--- a/internal/command/launch/describe_plan.go
+++ b/internal/command/launch/describe_plan.go
@@ -32,13 +32,7 @@ func describeFlyPostgresPlan(p *plan.FlyPostgresPlan) (string, error) {
 	nodePlural := lo.Ternary(p.Nodes == 1, "", "s")
 	nodesStr := fmt.Sprintf("(Fly Postgres) %d Node%s", p.Nodes, nodePlural)
 
-	guestStr := p.VmSize
-	if p.VmRam > 0 {
-		guest := fly.MachinePresets[p.VmSize]
-		if guest.MemoryMB != p.VmRam {
-			guestStr = fmt.Sprintf("%s (%dGB RAM)", guest, p.VmRam/1024)
-		}
-	}
+	guestStr := fly.MachinePresets[p.VmSize].String()
 
 	diskSizeStr := fmt.Sprintf("%dGB disk", p.DiskSizeGB)
 

--- a/internal/command/launch/plan/postgres.go
+++ b/internal/command/launch/plan/postgres.go
@@ -32,7 +32,7 @@ func DefaultPostgres(plan *LaunchPlan) PostgresPlan {
 			//        so it constructs the name on-the-spot each time it needs it)
 			AppName:    plan.AppName + "-db",
 			VmSize:     "shared-cpu-1x",
-			VmRam:      1024,
+			VmRam:      256,
 			Nodes:      1,
 			DiskSizeGB: 1,
 		},


### PR DESCRIPTION
### Change Summary

What and Why:

On `fly launch`, we were suggesting Postgres instances with 1GB of RAM, which is not an option on the Launch UI or on `fly postgres create`. This was causing confusing on the text being displayed as seen on the image below, and was causing the Launch UI to open with the wrong Postgres configs, as the UI is not aware of a possible Postgres config with 1GB of RAM.

Before:
![Screenshot 2024-05-08 at 20 30 37](https://github.com/superfly/flyctl/assets/20505117/30689478-ba6a-49cb-9f86-8c69d9fabc05)

\* Notice that we were displaying "256MB (1GB RAM)", as the guest machine has 256MB, but Postgres was configured as 1GB. Just a confusing experience overall. The postgres RAM for `fly launch` is now matching the guest machine's RAM.

After:
<img width="797" alt="Screenshot 2024-05-10 at 22 41 13" src="https://github.com/superfly/flyctl/assets/20505117/638a672d-092b-403c-969e-092606418927">

---

### Documentation

- [X] Fresh Produce (soon, with a couple other related changes)
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
