### PR TITLE
Make fly config validate detect unknown fields

### DIFF
--- a/internal/appconfig/patches.go
+++ b/internal/appconfig/patches.go
@@ -4,11 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/superfly/flyctl/terminal"
 )
 
 type patchFuncType func(map[string]any) (map[string]any, error)
@@ -49,7 +48,7 @@ func mapToConfig(cfgMap map[string]any) (*Config, error) {
 		message := fmt.Sprintf("%v", err)
 		if strings.HasPrefix(message, "json: ") && strings.Contains(message, "unknown field") {
 			// just warn about the unknown fields, omitting the "json: " prefix
-			terminal.Warn(message[6:])
+			fmt.Fprintln(os.Stderr, "Error: "+message[6:])
 			err = nil
 		}
 	}

--- a/internal/command/config/validate.go
+++ b/internal/command/config/validate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -23,6 +24,7 @@ ensure it is correct and meaningful to the platform.`
 	)
 	cmd.Args = cobra.NoArgs
 	flag.Add(cmd, flag.App(), flag.AppConfig())
+	viper.Set("ConfigStrictDecoding", true)
 	return
 }
 

--- a/internal/command/config/validate.go
+++ b/internal/command/config/validate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -24,7 +23,6 @@ ensure it is correct and meaningful to the platform.`
 	)
 	cmd.Args = cobra.NoArgs
 	flag.Add(cmd, flag.App(), flag.AppConfig())
-	viper.Set("ConfigStrictDecoding", true)
 	return
 }
 


### PR DESCRIPTION
While we have a number of validators that will check to make sure that field _values_ are correct, we surprisingly do not check to make sure theat field _names_ are correct.  Instead we silently ignore fields that have unknown names, often leading to difficult to debug situations.

This change makes use of `decoder.DisallowUnknownFields` to enable reporting on these errors by fly config validate.