### PR TITLE
Set HTTPS Failover to true by defualt

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -37,7 +37,7 @@ var CommonFlags = flag.Set{
 	flag.LocalOnly(),
 	flag.Push(),
 	flag.Wireguard(),
-	flag.HttpFailover(),
+	flag.HttpsFailover(),
 	flag.Detach(),
 	flag.Strategy(),
 	flag.Dockerfile(),
@@ -280,7 +280,7 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes
 		}
 	}
 
-	httpFailover := flag.GetHTTPFailover(ctx)
+	httpFailover := flag.GetHTTPSFailover(ctx)
 	usingWireguard := flag.GetWireguard(ctx)
 
 	// Fetch an image ref or build from source to get the final image reference to deploy

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -416,19 +416,19 @@ func GetWireguard(ctx context.Context) bool {
 	return GetBool(ctx, wireguard)
 }
 
-const httpFailover = "http-failover"
+const httpsFailover = "https-failover"
 
-func HttpFailover() Bool {
+func HttpsFailover() Bool {
 	return Bool{
-		Name:        httpFailover,
+		Name:        httpsFailover,
 		Description: "Determines whether to failover to plain internet(https) communication with remote builders if wireguard fails",
-		// TODO(billy): Determine this based on feature flag
-		Default: false,
+		Aliases:     []string{"http-failover"},
+		Default:     true,
 	}
 }
 
-func GetHTTPFailover(ctx context.Context) bool {
-	return GetBool(ctx, httpFailover)
+func GetHTTPSFailover(ctx context.Context) bool {
+	return GetBool(ctx, httpsFailover)
 }
 
 const localOnlyName = "local-only"


### PR DESCRIPTION
### Change Summary

What and Why:
This commit does two things:
1. We're now using HTTP failover by default, and seeing if it helps with remote builder connections. The original plan was to use flyctl feature flags, but plans change ¯\_(ツ)_/¯
2. We're renaming HTTP failover to HTTPS failover, and keeping http-failover as an alias. It's a bit more accurate to what's happening

How:

Related to:

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
