### PR TITLE
Configure Postgres for Phoenix apps on `fly launch`

### DIFF
--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -108,11 +108,16 @@ a Postgres database.
 `
 	}
 
-	// Add migration task if we find one of the dependencies that would run migrations.
-	// They are listed here: https://github.com/elixir-ecto/ecto?tab=readme-ov-file#usage
-	if checksPass(sourceDir, dirContains("mix.exs", "postgrex", "myxql", "tds")) {
+	if checksPass(sourceDir, dirContains("mix.exs", "postgrex")) {
+		s.DatabaseDesired = DatabaseKindPostgres
+		s.ReleaseCmd = "/app/bin/migrate"
+	} else if checksPass(sourceDir, dirContains("mix.exs", "myxql")) {
+		s.DatabaseDesired = DatabaseKindMySQL
+		s.ReleaseCmd = "/app/bin/migrate"
+	} else if checksPass(sourceDir, dirContains("mix.exs", "tds")) {
 		s.ReleaseCmd = "/app/bin/migrate"
 	} else if checksPass(sourceDir, dirContains("mix.exs", "ecto_sqlite3")) {
+		s.DatabaseDesired = DatabaseKindSqlite
 		s.Env["DATABASE_PATH"] = "/mnt/name/name.db"
 
 		s.Volumes = []Volume{

--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -111,15 +111,9 @@ a Postgres database.
 	if checksPass(sourceDir, dirContains("mix.exs", "postgrex")) {
 		s.DatabaseDesired = DatabaseKindPostgres
 		s.ReleaseCmd = "/app/bin/migrate"
-	} else if checksPass(sourceDir, dirContains("mix.exs", "myxql")) {
-		s.DatabaseDesired = DatabaseKindMySQL
-		s.ReleaseCmd = "/app/bin/migrate"
-	} else if checksPass(sourceDir, dirContains("mix.exs", "tds")) {
-		s.ReleaseCmd = "/app/bin/migrate"
 	} else if checksPass(sourceDir, dirContains("mix.exs", "ecto_sqlite3")) {
 		s.DatabaseDesired = DatabaseKindSqlite
 		s.Env["DATABASE_PATH"] = "/mnt/name/name.db"
-
 		s.Volumes = []Volume{
 			{
 				Source:      "name",


### PR DESCRIPTION
### Change Summary

I created a new Phoenix app with `mix phx.new app --database postgres` and `fly launch` failed since we are not putting Postgres on the launch plan.

This PR sets the `s.DatabaseKind` property, which puts Postgres on the launch plan and makes the launch succeed.

---

### Documentation

- [X] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
