### PR TITLE
[draft] Rust scanner

### DIFF
--- a/scanner/rust.go
+++ b/scanner/rust.go
@@ -1,0 +1,63 @@
+package scanner
+
+import  (
+	"fmt"
+	"os"
+	"github.com/pelletier/go-toml/v2"
+)
+
+func readCargoFile() (map[string]interface{}, error) {
+	doc, err := os.ReadFile("Cargo.toml")
+	if err != nil {
+		return nil, fmt.Errorf("Error reading Cargo file:", err)
+	}
+	cargoData := make(map[string]interface{})
+	readErr := toml.Unmarshal(doc, &cargoData)
+	if readErr != nil {
+		return nil, fmt.Errorf("Error parsing Cargo file:", readErr)
+	}
+	return cargoData, nil
+}
+
+func configureRust(sourceDir string, _ *ScannerConfig) (*SourceInfo, error) {
+	if !checksPass(sourceDir, fileExists("Cargo.toml", "Cargo.lock")) {
+		return nil, nil
+	}
+
+	cargoData, err := readCargoFile()
+	if err != nil {
+		return nil, err
+	}
+
+	deps := cargoData["dependencies"].(map[string]interface{})
+	family := "Rust"
+	env := map[string]string{
+		"PORT": "8080",
+	}
+	
+	if _, ok := deps["rocket"]; ok {
+		family = "Rocket"
+		env["ROCKET_PORT"] = "8080"
+		env["ROCKET_ADDRESS"] = "0.0.0.0"
+	} else if _, ok := deps["actix-web"]; ok {
+		family = "Actix Web"
+	} else if _, ok := deps["warp"]; ok {
+		family = "Warp"
+	} else if _, ok := deps["axum"]; ok {
+		family = "Axum"
+	} else if _, ok := deps["poem"]; ok {
+		family = "Poem"
+	}
+
+	vars := make(map[string]interface{})
+	vars["appName"] = cargoData["package"].(map[string]interface{})["name"].(string)
+
+	s := &SourceInfo{
+		Files:      	templatesExecute("templates/rust", vars),
+		Family:     	family,
+		Port:       	8080,
+		Env:			env,
+		SkipDatabase: 	true,
+	}
+	return s, nil
+}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -122,6 +122,7 @@ func Scan(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
 		configureNode,
 		configureStatic,
 		configureDotnet,
+		configureRust,
 	}
 
 	for _, scanner := range scanners {

--- a/scanner/templates/rust/.dockerignore
+++ b/scanner/templates/rust/.dockerignore
@@ -1,0 +1,2 @@
+fly.toml
+.git/

--- a/scanner/templates/rust/Dockerfile
+++ b/scanner/templates/rust/Dockerfile
@@ -1,0 +1,20 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder 
+COPY --from=planner /app/recipe.json recipe.json
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook --release --recipe-path recipe.json
+# Build application
+COPY . .
+RUN cargo build --release --bin {{ .appName }}
+
+# We do not need the Rust toolchain to run the binary!
+FROM debian:bookworm-slim AS runtime
+WORKDIR /app
+COPY --from=builder /app/target/release/{{ .appName }} /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/{{ .appName }}"]


### PR DESCRIPTION
### Change Summary

Add a generic rust webapp scanner to flyctl. It would work for most web frameworks, the exceptions are frameworks that have additional bundling needs (e.g. including wasm files or other frontend stuffs)

The [rust-templates repo](https://github.com/superfly/rust-templates) includes speedruns for 5 frameworks. Depending on review, docs will be crafted accordingly. 

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
