### PR TITLE
require-unique-zone by default in volume fork and machine clone

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -73,8 +73,8 @@ If the original Machine has a volume, then a new empty volume will be created an
 		},
 		flag.Bool{
 			Name:        "volume-requires-unique-zone",
-			Description: "Require volume to be placed in separate hardware zone from existing volumes. Default false.",
-			Default:     false,
+			Description: "Require volume to be placed in separate hardware zone from existing volumes. Default true.",
+			Default:     true,
 		},
 		flag.Detach(),
 		flag.VMSizeFlags,

--- a/internal/command/volumes/fork.go
+++ b/internal/command/volumes/fork.go
@@ -48,6 +48,7 @@ func newFork() *cobra.Command {
 		flag.Bool{
 			Name:        "require-unique-zone",
 			Description: "Place the volume in a separate hardware zone from existing volumes. This is the default.",
+			Default:     true,
 		},
 		flag.String{
 			Name:        "region",


### PR DESCRIPTION
Change `fly volume fork` and `fly machine clone` commands to have `require-unique-zone` and `volume-requires-unique-zone` respectively, set to true by default.

### Change Summary

What and Why:

1. The current description for the `--require-unique-zone` flag reads: "Place the volume in a separate hardware zone from existing volumes. This is the default.", but the flag doesn't seem to default to true. (I may be misunderstanding how cobra boolean flag defaults work, but I think it's clearer to have it explicitly default to true anyways)
2. `fly m clone` has a `--volume-requires-unique-zone` that defaults to false. Our docs for [horizontal scaling PG clusters](https://fly.io/docs/postgres/managing/horizontal-scaling/) recommend clone without the extra arg. Given the current "image-layer-centric" placement logic, machines are likely to end up getting cloned to the same hosts.

This change would go towards making it as easy as possible for people to get off deployments with single-host dependencies.

These may have been set to default to false to avoid placement errors in cases of regions with only two hosts, but currently, any non-internal region with a worker presence has > 2 hosts now. I'm not aware of any other reasons the defaults have been set the way they are right now. 

discussion on slack:
- https://flyio.slack.com/archives/C04SFST8P0D/p1715874169282649
- https://flyio.slack.com/archives/C0736NYB57D/p1715875267422229

How:

Adding `Default: True` to Cobra flag definitions, updating flag description for machine clone. Is that the right way to do this?

---

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a

Do I need to do anything to update the reference docs for flyctl? I also haven't checked yet if this change would create inconsistencies in any existing docs