### PR TITLE
Change fly m clone default to unique zone

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -73,8 +73,8 @@ If the original Machine has a volume, then a new empty volume will be created an
 		},
 		flag.Bool{
 			Name:        "volume-requires-unique-zone",
-			Description: "Require volume to be placed in separate hardware zone from existing volumes. Default false.",
-			Default:     false,
+			Description: "Require volume to be placed in separate hardware zone from existing volumes. Default true.",
+			Default:     true,
 		},
 		flag.Detach(),
 		flag.VMSizeFlags,


### PR DESCRIPTION
Previously, `fly machines clone` would default to allowing the clone Machine to be placed on the same host as another Machine in the app. This keeps the flag but changes the default to forbidding this.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
