### PR TITLE
Help docs: updates to volumes and apps command help

### DIFF
--- a/internal/command/apps/apps.go
+++ b/internal/command/apps/apps.go
@@ -17,11 +17,8 @@ import (
 // New initializes and returns a new apps Command.
 func New() *cobra.Command {
 	const (
-		long = `The APPS commands focus on managing your Fly applications.
-Start with the CREATE command to register your application.
-The LIST command will list all currently registered applications.
-`
-		short = "Manage apps"
+		long = "Manage your Fly applications."		
+		short = "Manage apps."
 	)
 
 	// TODO: list should also accept the --org param

--- a/internal/command/apps/apps.go
+++ b/internal/command/apps/apps.go
@@ -17,7 +17,7 @@ import (
 // New initializes and returns a new apps Command.
 func New() *cobra.Command {
 	const (
-		long = "Manage your Fly applications."		
+		long = "Manage your Fly applications."
 		short = "Manage apps."
 	)
 

--- a/internal/command/apps/apps.go
+++ b/internal/command/apps/apps.go
@@ -17,7 +17,7 @@ import (
 // New initializes and returns a new apps Command.
 func New() *cobra.Command {
 	const (
-		long = "Manage your Fly applications."
+		long  = "Manage your Fly applications."
 		short = "Manage apps."
 	)
 

--- a/internal/command/apps/create.go
+++ b/internal/command/apps/create.go
@@ -21,7 +21,7 @@ import (
 func newCreate() (cmd *cobra.Command) {
 	const (
 		long = `Create a new application on the Fly platform.
-This command won't generate a fly.toml configuration file, but you can 
+This command won't generate a fly.toml configuration file, but you can
 fetch one with 'fly config save -a <app_name>'.`
 
 		short = "Create a new application."

--- a/internal/command/apps/create.go
+++ b/internal/command/apps/create.go
@@ -20,12 +20,12 @@ import (
 
 func newCreate() (cmd *cobra.Command) {
 	const (
-		long = `The APPS CREATE command will register a new application
-with the Fly platform. It will not generate a configuration file, but one
-may be fetched with 'fly config save -a <app_name>'`
+		long = `Create a new application on the Fly platform.
+This command won't generate a fly.toml configuration file, but you can 
+fetch one with 'fly config save -a <app_name>'.`
 
-		short = "Create a new application"
-		usage = "create [APPNAME]"
+		short = "Create a new application."
+		usage = "create <app name>"
 	)
 
 	cmd = command.New(usage, short, long, RunCreate,

--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -17,11 +17,10 @@ import (
 
 func newDestroy() *cobra.Command {
 	const (
-		long = `The APPS DESTROY command will remove an application
-from the Fly platform.
-`
-		short = "Permanently destroys an app"
-		usage = "destroy <APPNAME>"
+		long = "Delete an application from the Fly platform."
+
+		short = "Permanently destroy an app."
+		usage = "destroy <app name>"
 	)
 
 	destroy := command.New(usage, short, long, RunDestroy,

--- a/internal/command/apps/list.go
+++ b/internal/command/apps/list.go
@@ -19,12 +19,12 @@ import (
 
 func newList() *cobra.Command {
 	const (
-		long = `The APPS LIST command will show the applications currently
-registered and available to this user. The list will include applications
-from all the organizations the user is a member of. Each application will
-be shown with its name, owner and when it was last deployed.
+		long = `Show the applications currently
+available to this user. The list includes applications
+from all the organizations the user is a member of. The list shows
+the name, owner (org), status, and date/time of latest deploy for each app.
 `
-		short = "List applications"
+		short = "List applications."
 	)
 
 	cmd := command.New("list", short, long, runList,

--- a/internal/command/apps/list.go
+++ b/internal/command/apps/list.go
@@ -19,7 +19,7 @@ import (
 
 func newList() *cobra.Command {
 	const (
-		long = `Show the applications currently
+		long = `List the applications currently
 available to this user. The list includes applications
 from all the organizations the user is a member of. The list shows
 the name, owner (org), status, and date/time of latest deploy for each app.

--- a/internal/command/apps/move.go
+++ b/internal/command/apps/move.go
@@ -18,11 +18,11 @@ import (
 
 func newMove() *cobra.Command {
 	const (
-		long = `The APPS MOVE command will move an application to another
+		long = `Move an application to another
 organization the current user belongs to.
 `
-		short = "Move an app to another organization"
-		usage = "move <APPNAME>"
+		short = "Move an app to another organization."
+		usage = "move <app name>"
 	)
 
 	move := command.New(usage, short, long, RunMove,

--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -18,9 +18,9 @@ import (
 
 func newRestart() *cobra.Command {
 	const (
-		long  = `The APPS RESTART command will perform a rolling restart against all running VMs`
-		short = "Restart an application"
-		usage = "restart [APPNAME]"
+		long  = `Restart an application. Perform a rolling restart against all running Machines.`
+		short = "Restart an application."
+		usage = "restart <app name>"
 	)
 
 	cmd := command.New(usage, short, long, runRestart,

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -23,8 +23,7 @@ import (
 func newClone() *cobra.Command {
 	const (
 		short = "Clone a Fly Machine"
-		long  = "Clone a Fly Machine. The new Machine will be a copy of the specified Machine.
-If the original Machine has a volume, then a new empty volume will be created and attached to the new Machine."
+		long  = "Clone a Fly Machine. The new Machine will be a copy of the specified Machine. If the original Machine has a volume, then a new empty volume will be created and attached to the new Machine."
 
 		usage = "clone [machine_id]"
 	)

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -23,8 +23,8 @@ import (
 func newClone() *cobra.Command {
 	const (
 		short = "Clone a Fly Machine"
-		long  = short + ` The new Machine will be a copy of the specified Machine.
-If the original Machine has a volume, then a new empty volume will be created and attached to the new Machine.`
+		long  = "Clone a Fly Machine. The new Machine will be a copy of the specified Machine.
+If the original Machine has a volume, then a new empty volume will be created and attached to the new Machine."
 
 		usage = "clone [machine_id]"
 	)

--- a/internal/command/volumes/create.go
+++ b/internal/command/volumes/create.go
@@ -22,8 +22,8 @@ import (
 func newCreate() *cobra.Command {
 	const (
 		short = "Create a new volume for an app."
-		long  = "Volumes are persistent storage for Fly Machines. Learn how to add a volume to your app: https://fly.io/docs/apps/volume-storage/"
-		usage = "create <volumename>"
+		long  = "Create a new volume for an app. Volumes are persistent storage for Fly Machines. Learn how to add a volume to your app: https://fly.io/docs/apps/volume-storage/."
+		usage = "create <volume name>"
 	)
 
 	cmd := command.New(usage, short, long, runCreate,
@@ -45,7 +45,7 @@ func newCreate() *cobra.Command {
 		flag.Int{
 			Name:        "snapshot-retention",
 			Default:     5,
-			Description: "Snapshot retention in days (min 5)",
+			Description: "Snapshot retention in days",
 		},
 		flag.Bool{
 			Name:        "no-encryption",
@@ -54,7 +54,7 @@ func newCreate() *cobra.Command {
 		},
 		flag.Bool{
 			Name:        "require-unique-zone",
-			Description: "Place the volume in a separate hardware zone from existing volumes. This is the default.",
+			Description: "Place the volume in a separate hardware zone from existing volumes to help ensure availability",
 			Default:     true,
 		},
 		flag.String{

--- a/internal/command/volumes/destroy.go
+++ b/internal/command/volumes/destroy.go
@@ -22,7 +22,7 @@ func newDestroy() *cobra.Command {
 		long = short + " When you destroy a volume, you permanently delete all its data."
 	)
 
-	cmd := command.New("destroy [flags] ID ID ...", short, long, runDestroy,
+	cmd := command.New("destroy <volume id> ... [flags]", short, long, runDestroy,
 		command.RequireSession,
 		command.LoadAppNameIfPresent,
 	)

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -24,7 +24,7 @@ func newExtend() *cobra.Command {
 
 		long = short + ` Most Machines don't require a restart. Some older Machines get a message to manually restart the Machine to increase the size of the file system.`
 
-		usage = "extend [id]"
+		usage = "extend <volume id>"
 	)
 
 	cmd := command.New(usage, short, long, runExtend,

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -22,7 +22,7 @@ func newExtend() *cobra.Command {
 	const (
 		short = "Extend a volume to the specified size."
 
-		long = short + ` Most Machines don't require a restart. Some older Machines get a message to manually restart the Machine to increase the size of the file system.`
+		long = short + ` Most Machines don't require a restart after extending a volume. Some older Machines get a message to manually restart the Machine to increase the size of the file system.`
 
 		usage = "extend <volume id>"
 	)

--- a/internal/command/volumes/fork.go
+++ b/internal/command/volumes/fork.go
@@ -22,7 +22,7 @@ func newFork() *cobra.Command {
 
 		long = short + ` Volume forking creates an independent copy of a storage volume for backup, testing, and experimentation without altering the original data.`
 
-		usage = "fork [id]"
+		usage = "fork <volume id>"
 	)
 
 	cmd := command.New(usage, short, long, runFork,

--- a/internal/command/volumes/show.go
+++ b/internal/command/volumes/show.go
@@ -23,7 +23,7 @@ func newShow() (cmd *cobra.Command) {
 		long = short
 	)
 
-	cmd = command.New("show [id]", short, long, runShow,
+	cmd = command.New("show <volume id>", short, long, runShow,
 		command.RequireSession,
 		command.LoadAppNameIfPresent,
 	)

--- a/internal/command/volumes/snapshots/create.go
+++ b/internal/command/volumes/snapshots/create.go
@@ -15,9 +15,9 @@ import (
 
 func newCreate() *cobra.Command {
 	const (
-		short = "Snapshot a volume"
+		short = "Create a volume snapshot."
 		long  = "Snapshot a volume\n"
-		usage = "create <volume-id>"
+		usage = "create <volume id>"
 	)
 
 	cmd := command.New(usage, short, long, create, command.RequireSession)

--- a/internal/command/volumes/snapshots/list.go
+++ b/internal/command/volumes/snapshots/list.go
@@ -22,10 +22,10 @@ import (
 
 func newList() *cobra.Command {
 	const (
-		long  = "List snapshots associated with the specified volume"
-		short = "List snapshots"
+		long  = "List snapshots associated with the specified volume."
+		short = "List snapshots."
 
-		usage = "list <volume-id>"
+		usage = "list <volume id>"
 	)
 
 	cmd := command.New(usage, short, long, runList,

--- a/internal/command/volumes/snapshots/snapshots.go
+++ b/internal/command/volumes/snapshots/snapshots.go
@@ -9,7 +9,7 @@ import (
 func New() *cobra.Command {
 	const (
 		long = "Manage volume snapshots. A snapshot is a point-in-time copy of a volume. Snapshots can be used to create new volumes or restore a volume to a previous state."
-`
+
 		short = "Manage volume snapshots."
 		usage = "snapshots"
 	)

--- a/internal/command/volumes/snapshots/snapshots.go
+++ b/internal/command/volumes/snapshots/snapshots.go
@@ -8,7 +8,6 @@ import (
 
 func New() *cobra.Command {
 	const (
-
 		short = "Manage volume snapshots."
 
 		long = short + " A snapshot is a point-in-time copy of a volume. Snapshots can be used to create new volumes or restore a volume to a previous state."

--- a/internal/command/volumes/snapshots/snapshots.go
+++ b/internal/command/volumes/snapshots/snapshots.go
@@ -8,9 +8,11 @@ import (
 
 func New() *cobra.Command {
 	const (
-		long = short + " A snapshot is a point-in-time copy of a volume. Snapshots can be used to create new volumes or restore a volume to a previous state."
 
 		short = "Manage volume snapshots."
+
+		long = short + " A snapshot is a point-in-time copy of a volume. Snapshots can be used to create new volumes or restore a volume to a previous state."
+
 		usage = "snapshots"
 	)
 

--- a/internal/command/volumes/snapshots/snapshots.go
+++ b/internal/command/volumes/snapshots/snapshots.go
@@ -8,7 +8,7 @@ import (
 
 func New() *cobra.Command {
 	const (
-		long = "Manage volume snapshots. A snapshot is a point-in-time copy of a volume. Snapshots can be used to create new volumes or restore a volume to a previous state."
+		long = short + " A snapshot is a point-in-time copy of a volume. Snapshots can be used to create new volumes or restore a volume to a previous state."
 
 		short = "Manage volume snapshots."
 		usage = "snapshots"

--- a/internal/command/volumes/snapshots/snapshots.go
+++ b/internal/command/volumes/snapshots/snapshots.go
@@ -8,9 +8,9 @@ import (
 
 func New() *cobra.Command {
 	const (
-		long = `"Commands for managing volume snapshots"
+		long = "Manage volume snapshots. A snapshot is a point-in-time copy of a volume. Snapshots can be used to create new volumes or restore a volume to a previous state."
 `
-		short = "Manage volume snapshots"
+		short = "Manage volume snapshots."
 		usage = "snapshots"
 	)
 
@@ -27,3 +27,4 @@ func New() *cobra.Command {
 
 	return snapshots
 }
+ 

--- a/internal/command/volumes/snapshots/snapshots.go
+++ b/internal/command/volumes/snapshots/snapshots.go
@@ -27,4 +27,3 @@ func New() *cobra.Command {
 
 	return snapshots
 }
- 

--- a/internal/command/volumes/update.go
+++ b/internal/command/volumes/update.go
@@ -21,10 +21,9 @@ func newUpdate() *cobra.Command {
 		short = "Update a volume for an app."
 
 		long = short + ` Volumes are persistent storage for
-		Fly Machines. Learn how to add a volume to
-		your app: https://fly.io/docs/apps/volume-storage/`
+		Fly Machines.`
 
-		usage = "update <volumename>"
+		usage = "update <volume id>"
 	)
 
 	cmd := command.New(usage, short, long, runUpdate,
@@ -39,11 +38,11 @@ func newUpdate() *cobra.Command {
 		flag.AppConfig(),
 		flag.Int{
 			Name:        "snapshot-retention",
-			Description: "Snapshot retention in days (min 5)",
+			Description: "Snapshot retention in days",
 		},
 		flag.Bool{
 			Name:        "scheduled-snapshots",
-			Description: "Disable/Enable scheduled snapshots",
+			Description: "Activate/deactivate scheduled automatic snapshots",
 		},
 	)
 

--- a/internal/command/volumes/volumes.go
+++ b/internal/command/volumes/volumes.go
@@ -27,7 +27,7 @@ func New() *cobra.Command {
 	const (
 		short = "Manage Fly Volumes."
 
-		long = short
+		long = short + " Volumes are persistent storage for Fly Machines. Learn how how volumes work: https://fly.io/docs/reference/volumes/."
 
 		usage = "volumes"
 	)

--- a/internal/command/volumes/volumes.go
+++ b/internal/command/volumes/volumes.go
@@ -29,7 +29,7 @@ func New() *cobra.Command {
 
 		long = short
 
-		usage = "volumes <command>"
+		usage = "volumes"
 	)
 
 	cmd := command.New(usage, short, long, nil)


### PR DESCRIPTION
### Change Summary

What and Why:

- volumes and apps help needed a few updates/fixes

How:

- remove "min 5" from snapshot retention help
- clean up apps command help
- make volumes help consistent

Related to:

---

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a
