### PR TITLE
Some Remote Builder Heartbeat Improvements

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -251,6 +251,7 @@ func newRemoteDockerClient(ctx context.Context, apiClient flyutil.Client, appNam
 		req.SetBasicAuth(appName, config.Tokens(ctx).Docker())
 
 		fmt.Fprintln(streams.Out, streams.ColorScheme().Yellow("👀 checking remote builder compatibility with wireguardless deploys ..."))
+		span.AddEvent("checking remote builder compatibility with wireguardless deploys")
 
 		res, err := client.Do(req)
 		if err != nil {
@@ -261,6 +262,7 @@ func newRemoteDockerClient(ctx context.Context, apiClient flyutil.Client, appNam
 		if res.StatusCode == http.StatusNotFound {
 			logClearLinesAbove(streams, 1)
 			fmt.Fprintln(streams.Out, streams.ColorScheme().Yellow("🔧 automatically deleting and recreating builder"))
+			span.AddEvent("automatically deleting and recreating builder")
 
 			err := apiClient.DeleteApp(ctx, app.Name)
 			if err != nil {

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -590,7 +590,7 @@ func heartbeat(ctx context.Context, client *dockerclient.Client, req *http.Reque
 	ctx, span := tracing.GetTracer().Start(ctx, "heartbeat")
 	defer span.End()
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	resp, err := client.HTTPClient().Do(req.Clone(ctx))

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -660,7 +660,6 @@ func (r *Resolver) StartHeartbeat(ctx context.Context) (*StopSignal, error) {
 	if err != nil {
 		var h *httpError
 		if errors.As(err, &h) {
-			span.SetAttributes(attribute.String("status_code", fmt.Sprintf("%d", h.StatusCode)))
 			if h.StatusCode == http.StatusNotFound {
 				terminal.Debugf("This builder doesn't have the heartbeat endpoint %s\n", heartbeatUrl)
 				return nil, nil

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -707,6 +707,8 @@ func (r *Resolver) StartHeartbeat(ctx context.Context) (*StopSignal, error) {
 					}
 
 					terminal.Debugf("Remote builder heartbeat pulse failed: %v%s\n", err, wglessSuggestion)
+				} else {
+					consecutiveTunnelErrors = 0
 				}
 			}
 		}

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -629,6 +629,8 @@ func (r *Resolver) StartHeartbeat(ctx context.Context) (*StopSignal, error) {
 		return nil, nil
 	}
 
+	span.SetAttributes(attribute.String("builder_app_name", r.dockerFactory.appName))
+
 	errMsg := "Failed to start remote builder heartbeat: %v\n"
 	dockerClient, err := r.dockerFactory.buildFn(ctx, nil)
 	if err != nil {

--- a/internal/build/imgsrc/resolver_test.go
+++ b/internal/build/imgsrc/resolver_test.go
@@ -2,11 +2,14 @@ package imgsrc
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 
 	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/superfly/fly-go/tokens"
+	"github.com/superfly/flyctl/internal/config"
 )
 
 func TestHeartbeat(t *testing.T) {
@@ -18,5 +21,127 @@ func TestHeartbeat(t *testing.T) {
 	assert.NoError(t, err)
 
 	err = heartbeat(ctx, dc, req)
+	assert.Error(t, err)
+}
+
+func TestStartHeartbeat(t *testing.T) {
+	ctx := context.Background()
+	ctx = config.NewContext(ctx, &config.Config{
+		Tokens: &tokens.Tokens{},
+	})
+
+	dc, err := client.NewClientWithOpts()
+	assert.NoError(t, err)
+
+	resolver := Resolver{
+		dockerFactory: &dockerClientFactory{
+			remote: true,
+			buildFn: func(ctx context.Context, build *build) (*client.Client, error) {
+				return dc, nil
+			},
+			apiClient: nil,
+			appName:   "myapp",
+		},
+		apiClient: nil,
+		heartbeatFn: func(ctx context.Context, client *client.Client, req *http.Request) error {
+			return nil
+		},
+	}
+
+	_, err = resolver.StartHeartbeat(ctx)
+	assert.NoError(t, err)
+}
+
+func TestStartHeartbeatFirstRetry(t *testing.T) {
+	ctx := context.Background()
+	ctx = config.NewContext(ctx, &config.Config{
+		Tokens: &tokens.Tokens{},
+	})
+
+	dc, err := client.NewClientWithOpts()
+	assert.NoError(t, err)
+
+	numCalls := 0
+
+	resolver := Resolver{
+		dockerFactory: &dockerClientFactory{
+			remote: true,
+			buildFn: func(ctx context.Context, build *build) (*client.Client, error) {
+				return dc, nil
+			},
+			apiClient: nil,
+			appName:   "myapp",
+		},
+		apiClient: nil,
+		heartbeatFn: func(ctx context.Context, client *client.Client, req *http.Request) error {
+			if numCalls == 0 {
+				numCalls += 1
+				return errors.New("first error")
+			}
+			return nil
+		},
+	}
+
+	_, err = resolver.StartHeartbeat(ctx)
+	assert.NoError(t, err)
+}
+
+func TestStartHeartbeatNoEndpoint(t *testing.T) {
+	ctx := context.Background()
+	ctx = config.NewContext(ctx, &config.Config{
+		Tokens: &tokens.Tokens{},
+	})
+
+	dc, err := client.NewClientWithOpts()
+	assert.NoError(t, err)
+
+	resolver := Resolver{
+		dockerFactory: &dockerClientFactory{
+			remote: true,
+			buildFn: func(ctx context.Context, build *build) (*client.Client, error) {
+				return dc, nil
+			},
+			apiClient: nil,
+			appName:   "myapp",
+		},
+		apiClient: nil,
+		heartbeatFn: func(ctx context.Context, client *client.Client, req *http.Request) error {
+			return &httpError{
+				StatusCode: http.StatusNotFound,
+			}
+		},
+	}
+
+	_, err = resolver.StartHeartbeat(ctx)
+	assert.NoError(t, err)
+}
+
+func TestStartHeartbeatWError(t *testing.T) {
+	ctx := context.Background()
+	ctx = config.NewContext(ctx, &config.Config{
+		Tokens: &tokens.Tokens{},
+	})
+
+	dc, err := client.NewClientWithOpts()
+	assert.NoError(t, err)
+
+	resolver := Resolver{
+		dockerFactory: &dockerClientFactory{
+			remote: true,
+			buildFn: func(ctx context.Context, build *build) (*client.Client, error) {
+				return dc, nil
+			},
+			apiClient: nil,
+			appName:   "myapp",
+		},
+		apiClient: nil,
+		heartbeatFn: func(ctx context.Context, client *client.Client, req *http.Request) error {
+			return &httpError{
+				StatusCode: http.StatusBadRequest,
+			}
+		},
+	}
+
+	_, err = resolver.StartHeartbeat(ctx)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
### Change Summary

What and Why:
This PR extends some timeouts, removes some unnecessary operations, and retries ones that can fail an entire deploy.

How:
We extended some timeouts to make sure that a blip in internet doesn't kill a deployment. Also, for whatever reason we were doing two heartbeat operations that could possibly fail, instead of just one. Just removing the second 'could fail' heartbeat operation should help deployment success rates. Finally, we're now retrying the first heartbeat up to 3 times, to try and make sure that we can actually communicate with the remote builder.

In the future, I'd like to either
a. understand why remote builders just randomly fail to respond to heartbeats or
b. automatically destroy remote builders if they aren't functioniong.

Related to:

---

### Documentation

- [x] Fresh Produce (soon, I want to make sure these changes reduce failure rates first)
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
