### PR TITLE
Refactor API & FLAPS clients to interfaces for unit testing

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -18,12 +18,12 @@ import (
 	"github.com/azazeal/pause"
 	"golang.org/x/sync/errgroup"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent/internal/proto"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/sentry"
 	"github.com/superfly/flyctl/internal/version"
@@ -34,7 +34,7 @@ import (
 )
 
 // Establish starts the daemon, if necessary, and returns a client to it.
-func Establish(ctx context.Context, apiClient *fly.Client) (*Client, error) {
+func Establish(ctx context.Context, apiClient flyutil.Client) (*Client, error) {
 	if err := wireguard.PruneInvalidPeers(ctx, apiClient); err != nil {
 		return nil, err
 	}
@@ -540,7 +540,7 @@ func arrayEqual(a, b []string) bool {
 }
 
 func gqlGetInstances(ctx context.Context, orgSlug, appName string) instancesResult {
-	gqlClient := fly.ClientFromContext(ctx).GenqClient
+	gqlClient := flyutil.ClientFromContext(ctx).GenqClient()
 	_ = `# @genqlient
 	query AgentGetInstances($appName: String!) {
 		app(name: $appName) {

--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -224,7 +224,7 @@ func (s *server) checkForConfigChange() (err error) {
 	return
 }
 
-func (s *server) buildTunnel(ctx context.Context, org *fly.Organization, recycle bool, network string, client *fly.Client) (tunnel *wg.Tunnel, err error) {
+func (s *server) buildTunnel(ctx context.Context, org *fly.Organization, recycle bool, network string, client flyutil.Client) (tunnel *wg.Tunnel, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -392,7 +392,7 @@ func (s *server) clean(ctx context.Context) {
 
 // GetClient returns an API client that uses the server's tokens. Sessions may
 // have their own tokens, so should use session.getClient instead.
-func (s *server) GetClient(ctx context.Context) *fly.Client {
+func (s *server) GetClient(ctx context.Context) flyutil.Client {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/agent/server/session.go
+++ b/agent/server/session.go
@@ -579,7 +579,7 @@ func (s *session) setToken(ctx context.Context, args ...string) {
 
 // getClient returns an API client that uses any API tokens sent by the client.
 // If none have been sent, it falls back to using the server's tokens.
-func (s *session) getClient(ctx context.Context) *fly.Client {
+func (s *session) getClient(ctx context.Context) flyutil.Client {
 	if s.tokens == nil {
 		return s.srv.GetClient(ctx)
 	}

--- a/flypg/cmd.go
+++ b/flypg/cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/command/ssh"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -31,7 +32,7 @@ type Command struct {
 }
 
 func NewCommand(ctx context.Context, app *fly.AppCompact) (*Command, error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	agentclient, err := agent.Establish(ctx, client)
 	if err != nil {

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/watch"
 
@@ -35,7 +36,7 @@ const (
 )
 
 type Launcher struct {
-	client *fly.Client
+	client flyutil.Client
 }
 
 type CreateClusterInput struct {
@@ -55,7 +56,7 @@ type CreateClusterInput struct {
 	ForkFrom           string
 }
 
-func NewLauncher(client *fly.Client) *Launcher {
+func NewLauncher(client flyutil.Client) *Launcher {
 	return &Launcher{
 		client: client,
 	}
@@ -66,7 +67,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 	var (
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
-		client   = fly.ClientFromContext(ctx)
+		client   = flyutil.ClientFromContext(ctx)
 	)
 
 	// Ensure machines can be started when scaling to zero is enabled
@@ -102,7 +103,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 	if err != nil {
 		return err
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	nodes := make([]*fly.Machine, 0)
 

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.1.11
+	github.com/superfly/fly-go v0.1.12
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.13

--- a/go.sum
+++ b/go.sum
@@ -614,8 +614,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.11 h1:gYoTIHqsaLvmfQWmKwX4uGWdzvu+hUnklYtwX+sUtJE=
-github.com/superfly/fly-go v0.1.11/go.mod h1:0wgmVsqPPDgPSTsZA0L0zI5uajxx86KfuBoPQT87B1E=
+github.com/superfly/fly-go v0.1.12 h1:Ql+wbDFuiWEGK+qskuSTtMft/zfh1rIBp/1Dcu7JbgQ=
+github.com/superfly/fly-go v0.1.12/go.mod h1:0wgmVsqPPDgPSTsZA0L0zI5uajxx86KfuBoPQT87B1E=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/appconfig/remote.go
+++ b/internal/appconfig/remote.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/gql"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/iostreams"
 )
 
 func FromRemoteApp(ctx context.Context, appName string) (*Config, error) {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	cfg, err := getAppV2ConfigFromReleases(ctx, apiClient, appName)
 	if cfg == nil {
@@ -29,7 +30,7 @@ func FromRemoteApp(ctx context.Context, appName string) (*Config, error) {
 }
 
 func getAppV2ConfigFromMachines(ctx context.Context, appName string) (*Config, error) {
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 
 	activeMachines, err := machine.ListActive(ctx)
@@ -47,7 +48,7 @@ func getAppV2ConfigFromMachines(ctx context.Context, appName string) (*Config, e
 	return appConfig, nil
 }
 
-func getAppV2ConfigFromReleases(ctx context.Context, apiClient *fly.Client, appName string) (*Config, error) {
+func getAppV2ConfigFromReleases(ctx context.Context, apiClient flyutil.Client, appName string) (*Config, error) {
 	_ = `# @genqlient
 	query FlyctlConfigCurrentRelease($appName: String!) {
 		app(name:$appName) {
@@ -57,7 +58,7 @@ func getAppV2ConfigFromReleases(ctx context.Context, apiClient *fly.Client, appN
 		}
 	}
 	`
-	resp, err := gql.FlyctlConfigCurrentRelease(ctx, apiClient.GenqClient, appName)
+	resp, err := gql.FlyctlConfigCurrentRelease(ctx, apiClient.GenqClient(), appName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/build/imgsrc/remote_image_resolver.go
+++ b/internal/build/imgsrc/remote_image_resolver.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"strconv"
 
-	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/tracing"
 	"github.com/superfly/flyctl/iostreams"
 	"go.opentelemetry.io/otel/trace"
 )
 
 type remoteImageResolver struct {
-	flyApi *fly.Client
+	flyApi flyutil.Client
 }
 
 func (*remoteImageResolver) Name() string {

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -22,11 +22,11 @@ import (
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/sentry"
 	"github.com/superfly/flyctl/internal/tracing"
 	"github.com/superfly/flyctl/iostreams"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/terminal"
 )
 
@@ -144,7 +144,7 @@ func (di DeploymentImage) ToSpanAttributes() []attribute.KeyValue {
 
 type Resolver struct {
 	dockerFactory *dockerClientFactory
-	apiClient     *fly.Client
+	apiClient     flyutil.Client
 }
 
 type StopSignal struct {
@@ -310,7 +310,7 @@ func (r *Resolver) createBuildGql(ctx context.Context, strategiesAvailable []str
 	ctx, span := tracing.GetTracer().Start(ctx, "web.create_build")
 	defer span.End()
 
-	gqlClient := fly.ClientFromContext(ctx).GenqClient
+	gqlClient := flyutil.ClientFromContext(ctx).GenqClient()
 	_ = `# @genqlient
 	mutation ResolverCreateBuild($input:CreateBuildInput!) {
 		createBuild(input:$input) {
@@ -513,7 +513,7 @@ func (r *Resolver) finishBuild(ctx context.Context, build *build, failed bool, l
 		terminal.Debug("Skipping FinishBuild() gql call, because CreateBuild() failed.\n")
 		return nil, nil
 	}
-	gqlClient := fly.ClientFromContext(ctx).GenqClient
+	gqlClient := flyutil.ClientFromContext(ctx).GenqClient()
 	_ = `# @genqlient
 	mutation ResolverFinishBuild($input:FinishBuildInput!) {
 		finishBuild(input:$input) {
@@ -750,7 +750,7 @@ func (s *StopSignal) Stop() {
 	})
 }
 
-func NewResolver(daemonType DockerDaemonType, apiClient *fly.Client, appName string, iostreams *iostreams.IOStreams, connectOverWireguard bool) *Resolver {
+func NewResolver(daemonType DockerDaemonType, apiClient flyutil.Client, appName string, iostreams *iostreams.IOStreams, connectOverWireguard bool) *Resolver {
 	return &Resolver{
 		dockerFactory: newDockerClientFactory(daemonType, apiClient, appName, iostreams, connectOverWireguard),
 		apiClient:     apiClient,

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -50,10 +50,13 @@ func InitClient(ctx context.Context) (context.Context, error) {
 	fly.SetInstrumenter(instrument.ApiAdapter)
 	fly.SetTransport(otelhttp.NewTransport(http.DefaultTransport))
 
-	c := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{Tokens: cfg.Tokens})
-	logger.Debug("client initialized.")
+	if flyutil.ClientFromContext(ctx) == nil {
+		client := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{Tokens: cfg.Tokens})
+		logger.Debug("client initialized.")
+		ctx = flyutil.NewContextWithClient(ctx, client)
+	}
 
-	return fly.NewContextWithClient(ctx, c), nil
+	return ctx, nil
 }
 
 func DetermineConfigDir(ctx context.Context) (context.Context, error) {

--- a/internal/command/agent/agent.go
+++ b/internal/command/agent/agent.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/env"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/state"
 )
 
@@ -48,7 +48,7 @@ func New() (cmd *cobra.Command) {
 }
 
 func establish(ctx context.Context) (ac *agent.Client, err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	if ac, err = agent.Establish(ctx, client); err != nil {
 		err = fmt.Errorf("failed establishing connection to agent: %w", err)

--- a/internal/command/agent/instances.go
+++ b/internal/command/agent/instances.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -38,7 +39,7 @@ func runInstances(ctx context.Context) (err error) {
 	}
 
 	slug := flag.FirstArg(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	var org *fly.Organization
 	if org, err = apiClient.GetOrganizationBySlug(ctx, slug); err != nil {

--- a/internal/command/apps/apps.go
+++ b/internal/command/apps/apps.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 // New initializes and returns a new apps Command.
@@ -48,7 +49,7 @@ The LIST command will list all currently registered applications.
 
 // BuildContext is a helper that builds out commonly required context requirements
 func BuildContext(ctx context.Context, app *fly.AppCompact) (context.Context, error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	agentclient, err := agent.Establish(ctx, client)
 	if err != nil {
@@ -69,7 +70,7 @@ func BuildContext(ctx context.Context, app *fly.AppCompact) (context.Context, er
 		return nil, err
 	}
 
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	return ctx, nil
 }

--- a/internal/command/apps/create.go
+++ b/internal/command/apps/create.go
@@ -14,6 +14,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
 )
@@ -68,7 +69,7 @@ func RunCreate(ctx context.Context) (err error) {
 		aName         = flag.FirstArg(ctx)
 		fName         = flag.GetString(ctx, "name")
 		fGenerateName = flag.GetBool(ctx, "generate-name")
-		apiClient     = fly.ClientFromContext(ctx)
+		apiClient     = flyutil.ClientFromContext(ctx)
 	)
 
 	var name string

--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/flag/completion"
+	"github.com/superfly/flyctl/internal/flyutil"
 
 	"github.com/superfly/flyctl/iostreams"
 
@@ -44,7 +44,7 @@ func RunDestroy(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
 	appName := flag.FirstArg(ctx)
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	if !flag.GetYes(ctx) {
 		const msg = "Destroying an app is not reversible."

--- a/internal/command/apps/list.go
+++ b/internal/command/apps/list.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/format"
 	"github.com/superfly/flyctl/internal/render"
 )
@@ -39,7 +40,7 @@ be shown with its name, owner and when it was last deployed.
 }
 
 func runList(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	cfg := config.FromContext(ctx)
 	org, err := getOrg(ctx)
 	if err != nil {
@@ -91,7 +92,7 @@ func runList(ctx context.Context) (err error) {
 }
 
 func getOrg(ctx context.Context) (*fly.Organization, error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	orgName := flag.GetOrg(ctx)
 

--- a/internal/command/apps/move.go
+++ b/internal/command/apps/move.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/flag/completion"
+	"github.com/superfly/flyctl/internal/flyutil"
 
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
@@ -50,7 +51,7 @@ organization the current user belongs to.
 func RunMove(ctx context.Context) error {
 	var (
 		appName  = flag.FirstArg(ctx)
-		client   = fly.ClientFromContext(ctx)
+		client   = flyutil.ClientFromContext(ctx)
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
 		logger   = logger.FromContext(ctx)
@@ -95,7 +96,7 @@ Please confirm whether you wish to restart this app now.`
 
 func runMoveAppOnMachines(ctx context.Context, app *fly.AppCompact, targetOrg *fly.Organization) error {
 	var (
-		client           = fly.ClientFromContext(ctx)
+		client           = flyutil.ClientFromContext(ctx)
 		io               = iostreams.FromContext(ctx)
 		skipHealthChecks = flag.GetBool(ctx, "skip-health-checks")
 	)

--- a/internal/command/apps/open.go
+++ b/internal/command/apps/open.go
@@ -52,7 +52,7 @@ func runOpen(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not create flaps client: %w", err)
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	appConfig := appconfig.ConfigFromContext(ctx)
 	if appConfig == nil {

--- a/internal/command/apps/releases.go
+++ b/internal/command/apps/releases.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/format"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -49,7 +50,7 @@ including type, when, success/fail and which user triggered the release.
 func runReleases(ctx context.Context) error {
 	var (
 		appName = appconfig.NameFromContext(ctx)
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 		out     = iostreams.FromContext(ctx).Out
 	)
 

--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flag/completion"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/machine"
 )
 
@@ -51,7 +52,7 @@ func newRestart() *cobra.Command {
 func runRestart(ctx context.Context) error {
 	var (
 		appName = flag.FirstArg(ctx)
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 	)
 
 	if appName == "" {

--- a/internal/command/auth/logout.go
+++ b/internal/command/auth/logout.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/env"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/state"
 	"github.com/superfly/flyctl/iostreams"
@@ -31,8 +31,8 @@ To continue interacting with Fly, the user will need to log in again.
 func runLogout(ctx context.Context) (err error) {
 	log := logger.FromContext(ctx)
 
-	if c := fly.ClientFromContext(ctx); c.Authenticated() {
-		resp, err := gql.LogOut(ctx, c.GenqClient)
+	if c := flyutil.ClientFromContext(ctx); c.Authenticated() {
+		resp, err := gql.LogOut(ctx, c.GenqClient())
 		if err != nil || !resp.LogOut.Ok {
 			log.Warnf("Unable to revoke token")
 		}

--- a/internal/command/auth/whoami.go
+++ b/internal/command/auth/whoami.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -30,7 +30,7 @@ authenticated and in use.
 }
 
 func runWhoAmI(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	user, err := client.GetCurrentUser(ctx)
 	if err != nil {

--- a/internal/command/certificates/root.go
+++ b/internal/command/certificates/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -137,7 +138,7 @@ Displays results in the same format as the SHOW command.`
 
 func runCertificatesList(ctx context.Context) error {
 	appName := appconfig.NameFromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	certs, err := apiClient.GetAppCertificates(ctx, appName)
 	if err != nil {
@@ -148,7 +149,7 @@ func runCertificatesList(ctx context.Context) error {
 }
 
 func runCertificatesShow(ctx context.Context) error {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	hostname := flag.FirstArg(ctx)
 
@@ -167,7 +168,7 @@ func runCertificatesShow(ctx context.Context) error {
 }
 
 func runCertificatesCheck(ctx context.Context) error {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	hostname := flag.FirstArg(ctx)
 
@@ -186,7 +187,7 @@ func runCertificatesCheck(ctx context.Context) error {
 }
 
 func runCertificatesAdd(ctx context.Context) error {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	hostname := flag.FirstArg(ctx)
 
@@ -201,7 +202,7 @@ func runCertificatesAdd(ctx context.Context) error {
 func runCertificatesRemove(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	hostname := flag.FirstArg(ctx)
 
@@ -239,7 +240,7 @@ func reportNextStepCert(ctx context.Context, hostname string, cert *fly.AppCerti
 
 	colorize := io.ColorScheme()
 	appName := appconfig.NameFromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	alternateHostname := getAlternateHostname(hostname)
 
 	// These are the IPs we have for the app

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command/auth/webauth"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 
@@ -507,7 +508,7 @@ func ExcludeFromMetrics(ctx context.Context) (context.Context, error) {
 
 // RequireSession is a Preparer which makes sure a session exists.
 func RequireSession(ctx context.Context) (context.Context, error) {
-	if !fly.ClientFromContext(ctx).Authenticated() {
+	if !flyutil.ClientFromContext(ctx).Authenticated() {
 		io := iostreams.FromContext(ctx)
 		// Ensure we have a session, and that the user hasn't set any flags that would lead them to expect consistent output or a lack of prompts
 		if io.IsInteractive() &&

--- a/internal/command/command_run.go
+++ b/internal/command/command_run.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/iostreams"
 	"golang.org/x/exp/slices"
 
@@ -25,12 +24,14 @@ import (
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/state"
 )
 
 func DetermineImage(ctx context.Context, appName string, imageOrPath string) (img *imgsrc.DeploymentImage, err error) {
 	var (
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 		io     = iostreams.FromContext(ctx)
 		cfg    = appconfig.ConfigFromContext(ctx)
 	)
@@ -369,8 +370,8 @@ func DetermineMounts(ctx context.Context, mounts []fly.MachineMount, region stri
 }
 
 func getUnattachedVolumes(ctx context.Context, regionCode string) (map[string][]fly.Volume, error) {
-	apiclient := fly.ClientFromContext(ctx)
-	flapsClient := flaps.FromContext(ctx)
+	apiclient := flyutil.ClientFromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	if regionCode == "" {
 		region, err := apiclient.GetNearestRegion(ctx)

--- a/internal/command/config/env.go
+++ b/internal/command/config/env.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -31,7 +32,7 @@ secrets and another for config file defined environment variables.`
 }
 
 func runEnv(ctx context.Context) error {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 
@@ -53,7 +54,7 @@ func runEnv(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	cfg, err := appconfig.FromRemoteApp(ctx, appName)
 	if err != nil {

--- a/internal/command/config/save.go
+++ b/internal/command/config/save.go
@@ -49,7 +49,7 @@ func runSave(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	cfg, err := appconfig.FromRemoteApp(ctx, appName)
 	if err != nil {

--- a/internal/command/config/show.go
+++ b/internal/command/config/show.go
@@ -49,7 +49,7 @@ func runShow(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		ctx = flaps.NewContext(ctx, flapsClient)
+		ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 		cfg, err = appconfig.FromRemoteApp(ctx, appName)
 		if err != nil {

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -20,6 +20,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
@@ -159,7 +160,7 @@ func runConsole(ctx context.Context) error {
 	var (
 		io        = iostreams.FromContext(ctx)
 		appName   = appconfig.NameFromContext(ctx)
-		apiClient = fly.ClientFromContext(ctx)
+		apiClient = flyutil.ClientFromContext(ctx)
 	)
 
 	app, err := apiClient.GetAppCompact(ctx, appName)
@@ -179,7 +180,7 @@ func runConsole(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create flaps client: %w", err)
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	appConfig := appconfig.ConfigFromContext(ctx)
 	if appConfig == nil {
@@ -249,7 +250,7 @@ func promptForMachine(ctx context.Context, app *fly.AppCompact, appConfig *appco
 		return nil, nil, errors.New("--machine can't be used with -s/--select")
 	}
 
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 	machines, err := flapsClient.ListActive(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -292,7 +293,7 @@ func getMachineByID(ctx context.Context) (*fly.Machine, func(), error) {
 		return nil, nil, errors.New("--region can't be used with --machine")
 	}
 
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 	machineID := flag.GetString(ctx, "machine")
 	machine, err := flapsClient.Get(ctx, machineID)
 	if err != nil {
@@ -309,7 +310,7 @@ func getMachineByID(ctx context.Context) (*fly.Machine, func(), error) {
 }
 
 func makeEphemeralConsoleMachine(ctx context.Context, app *fly.AppCompact, appConfig *appconfig.Config, guest *fly.MachineGuest) (*fly.Machine, func(), error) {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	currentRelease, err := apiClient.GetAppCurrentReleaseMachines(ctx, app.Name)
 	if err != nil {
 		return nil, nil, err

--- a/internal/command/consul/attach.go
+++ b/internal/command/consul/attach.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/secrets"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 const (
@@ -40,7 +40,7 @@ func newAttach() *cobra.Command {
 
 func runAttach(ctx context.Context) error {
 	var (
-		apiClient  = fly.ClientFromContext(ctx)
+		apiClient  = flyutil.ClientFromContext(ctx)
 		appName    = appconfig.NameFromContext(ctx)
 		secretName = flag.GetString(ctx, "variable-name")
 	)

--- a/internal/command/consul/detach.go
+++ b/internal/command/consul/detach.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/secrets"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func newDetach() *cobra.Command {
@@ -36,7 +36,7 @@ func newDetach() *cobra.Command {
 
 func runDetach(ctx context.Context) error {
 	var (
-		apiClient  = fly.ClientFromContext(ctx)
+		apiClient  = flyutil.ClientFromContext(ctx)
 		appName    = appconfig.NameFromContext(ctx)
 		secretName = flag.GetString(ctx, "variable-name")
 	)

--- a/internal/command/curl/curl.go
+++ b/internal/command/curl/curl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -76,7 +77,7 @@ func run(ctx context.Context) error {
 }
 
 func fetchRegionCodes(ctx context.Context) (codes []string, err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	var regions []fly.Region
 	if regions, _, err = client.PlatformRegions(ctx); err != nil {

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -7,12 +7,12 @@ import (
 	"path/filepath"
 
 	"github.com/dustin/go-humanize"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/internal/state"
@@ -57,7 +57,7 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config, useWG bool
 	tb := render.NewTextBlock(ctx, "Building image")
 	daemonType := imgsrc.NewDockerDaemonType(!flag.GetRemoteOnly(ctx), !flag.GetLocalOnly(ctx), env.IsCI(), flag.GetBool(ctx, "nixpacks"))
 
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 
 	span.SetAttributes(attribute.String("daemon_type", daemonType.String()))

--- a/internal/command/deploy/deploy_test.go
+++ b/internal/command/deploy/deploy_test.go
@@ -1,0 +1,105 @@
+package deploy_test
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	genq "github.com/Khan/genqlient/graphql"
+	"github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/command/deploy"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/logger"
+	"github.com/superfly/flyctl/internal/mock"
+	"github.com/superfly/flyctl/internal/task"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+//go:embed testdata
+var testdata embed.FS
+
+func TestCommand_Execute(t *testing.T) {
+	t.Skip("in progress")
+
+	dir := t.TempDir()
+	fsys, _ := fs.Sub(testdata, "testdata/basic")
+	if err := copyFS(fsys, dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil { // TODO: Revert working directory
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	cmd := deploy.New()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--image", "registry.fly.io/my-image:deployment-00000000000000000000000000"})
+
+	ctx := context.Background()
+	ctx = iostreams.NewContext(ctx, &iostreams.IOStreams{Out: &buf, ErrOut: &buf})
+	ctx = task.NewWithContext(ctx)
+	ctx = logger.NewContext(ctx, logger.New(&buf, logger.Info, true))
+
+	var genqlient mock.GraphQLClient
+	var client mock.Client
+	client.GenqClientFunc = func() genq.Client { return &genqlient }
+	ctx = flyutil.NewContextWithClient(ctx, &client)
+
+	var flapsClient mock.FlapsClient
+	ctx = flapsutil.NewContextWithClient(ctx, &flapsClient)
+
+	client.AuthenticatedFunc = func() bool { return true }
+	client.GetCurrentUserFunc = func(ctx context.Context) (*fly.User, error) {
+		return &fly.User{ID: "USER1"}, nil
+	}
+	client.GetAppCompactFunc = func(ctx context.Context, appName string) (*fly.AppCompact, error) {
+		if got, want := appName, "test-basic"; got != want {
+			t.Fatalf("appName=%s, want %s", got, want)
+		}
+		return &fly.AppCompact{}, nil // TODO
+	}
+
+	genqlient.MakeRequestFunc = func(ctx context.Context, req *genq.Request, resp *genq.Response) error {
+		vars, _ := json.Marshal(req.Variables)
+
+		switch req.OpName {
+		case "ResolverCreateBuild":
+			if got, want := string(vars), `-`; got != want {
+				t.Fatalf("unexpected vars: %s", vars)
+			}
+			// resp.Data =
+		}
+		return nil
+	}
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// copyFS writes the contents of a file system to a destination path on disk.
+func copyFS(fsys fs.FS, dst string) error {
+	return fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		target := filepath.Join(dst, filepath.FromSlash(path))
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+
+		b, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, b, 0o666)
+	})
+}

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -21,6 +21,7 @@ import (
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/tracing"
 	"github.com/superfly/flyctl/iostreams"
@@ -76,7 +77,7 @@ type MachineDeploymentArgs struct {
 }
 
 type machineDeployment struct {
-	apiClient             *fly.Client
+	apiClient             flyutil.Client
 	gqlClient             graphql.Client
 	flapsClient           *flaps.Client
 	io                    *iostreams.IOStreams
@@ -192,7 +193,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 	}
 
 	io := iostreams.FromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	maxUnavailable := DefaultMaxUnavailable
 	if appConfig.Deploy != nil && appConfig.Deploy.MaxUnavailable != nil {
@@ -206,7 +207,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (Mach
 
 	md := &machineDeployment{
 		apiClient:             apiClient,
-		gqlClient:             apiClient.GenqClient,
+		gqlClient:             apiClient.GenqClient(),
 		flapsClient:           flapsClient,
 		io:                    io,
 		colorize:              io.ColorScheme(),

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -17,10 +17,11 @@ import (
 	"github.com/samber/lo"
 	"github.com/sourcegraph/conc/pool"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/helpers"
 	machcmd "github.com/superfly/flyctl/internal/command/machine"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyerr"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/statuslogger"
 	"github.com/superfly/flyctl/internal/tracing"
@@ -44,7 +45,7 @@ func (md *machineDeployment) DeployMachinesApp(ctx context.Context) error {
 	ctx, span := tracing.GetTracer().Start(ctx, "deploy_machines")
 	defer span.End()
 
-	ctx = flaps.NewContext(ctx, md.flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, md.flapsClient)
 
 	onInterruptContext := context.WithoutCancel(ctx)
 
@@ -1071,7 +1072,7 @@ func (md *machineDeployment) checkDNS(ctx context.Context) error {
 	ctx, span := tracing.GetTracer().Start(ctx, "check_dns")
 	defer span.End()
 
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	ipAddrs, err := client.GetIPAddresses(ctx, md.appConfig.AppName)
 	if err != nil {
 		tracing.RecordError(span, err, "failed to get ip addresses")

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -21,6 +21,7 @@ import (
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/ctrlc"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/tracing"
 	"github.com/superfly/flyctl/iostreams"
@@ -57,7 +58,7 @@ type blueGreen struct {
 	greenMachines       machineUpdateEntries
 	blueMachines        machineUpdateEntries
 	flaps               *flaps.Client
-	apiClient           *fly.Client
+	apiClient           flyutil.Client
 	io                  *iostreams.IOStreams
 	colorize            *iostreams.ColorScheme
 	clearLinesAbove     func(count int)
@@ -902,6 +903,7 @@ func (bg *blueGreen) CanDestroyGreenMachines(err error) bool {
 
 	return false
 }
+
 func (bg *blueGreen) Rollback(ctx context.Context, err error) error {
 	ctx, span := tracing.GetTracer().Start(ctx, "rollback")
 	defer span.End()

--- a/internal/command/deploy/testdata/basic/Dockerfile
+++ b/internal/command/deploy/testdata/basic/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine
+CMD run.sh

--- a/internal/command/deploy/testdata/basic/fly.toml
+++ b/internal/command/deploy/testdata/basic/fly.toml
@@ -1,0 +1,2 @@
+app = "test-basic"
+primary_region = "ord"

--- a/internal/command/dig/dig.go
+++ b/internal/command/dig/dig.go
@@ -14,13 +14,13 @@ import (
 	"github.com/miekg/dns"
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 var nameErrorRx = regexp.MustCompile(`\[.*?\]:53`)
@@ -63,7 +63,7 @@ attached to the current app (you can pass an app in with -a <appname>).`
 
 func run(ctx context.Context) error {
 	var (
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 		io     = iostreams.FromContext(ctx)
 
 		err error

--- a/internal/command/dnsrecords/root.go
+++ b/internal/command/dnsrecords/root.go
@@ -8,10 +8,10 @@ import (
 	"strconv"
 
 	"github.com/olekukonko/tablewriter"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 
@@ -78,7 +78,7 @@ func newDNSRecordsImport() *cobra.Command {
 
 func runDNSRecordsList(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	name := flag.FirstArg(ctx)
 
@@ -117,7 +117,7 @@ func runDNSRecordsList(ctx context.Context) error {
 
 func runDNSRecordsExport(ctx context.Context) error {
 	name := flag.FirstArg(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	domain, err := apiClient.GetDomain(ctx, name)
 	if err != nil {
@@ -153,7 +153,7 @@ func runDNSRecordsExport(ctx context.Context) error {
 
 func runDNSRecordsImport(ctx context.Context) error {
 	name := flag.FirstArg(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	var filename string
 

--- a/internal/command/doctor/app_checks.go
+++ b/internal/command/doctor/app_checks.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
 	"github.com/superfly/flyctl/internal/command/apps"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/state"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -28,7 +29,7 @@ type AppChecker struct {
 	app        *fly.AppCompact
 	workDir    string
 	appConfig  *appconfig.Config
-	apiClient  *fly.Client
+	apiClient  flyutil.Client
 }
 
 func NewAppChecker(ctx context.Context, jsonOutput bool, color *iostreams.ColorScheme) (*AppChecker, error) {
@@ -40,7 +41,7 @@ func NewAppChecker(ctx context.Context, jsonOutput bool, color *iostreams.ColorS
 		return nil, nil
 	}
 
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	appCompact, err := apiClient.GetAppCompact(ctx, appName)
 	if err != nil {
 		return nil, err

--- a/internal/command/doctor/diag/diag.go
+++ b/internal/command/doctor/diag/diag.go
@@ -16,12 +16,12 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/state"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -107,7 +107,7 @@ add the --force flag to send us best-effort diagnostics.`)
 
 	zip.Close()
 
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	url, err := client.CreateDoctorUrl(context.Background())
 	if err != nil {

--- a/internal/command/doctor/doctor.go
+++ b/internal/command/doctor/doctor.go
@@ -7,8 +7,8 @@ import (
 
 	dockerclient "github.com/docker/docker/client"
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/flag/completion"
+	"github.com/superfly/flyctl/internal/flyutil"
 
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/iostreams"
@@ -218,7 +218,7 @@ This is likely a platform issue, please contact support.
 }
 
 func runAuth(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	if _, err = client.GetCurrentUser(ctx); err != nil {
 		err = fmt.Errorf("can't verify access token: %w", err)

--- a/internal/command/doctor/wireguard.go
+++ b/internal/command/doctor/wireguard.go
@@ -8,14 +8,14 @@ import (
 	"net/http"
 	"time"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/command/dig"
 	"github.com/superfly/flyctl/internal/command/ping"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func runPersonalOrgPing(ctx context.Context, orgSlug string) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	ac, err := agent.DefaultClient(ctx)
 	if err != nil {
@@ -59,7 +59,7 @@ func runPersonalOrgPing(ctx context.Context, orgSlug string) (err error) {
 }
 
 func runPersonalOrgCheckDns(ctx context.Context, orgSlug string) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	ac, err := agent.DefaultClient(ctx)
 	if err != nil {
@@ -82,7 +82,7 @@ func runPersonalOrgCheckDns(ctx context.Context, orgSlug string) error {
 }
 
 func runPersonalOrgCheckFlaps(ctx context.Context, orgSlug string) error {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	// Set up the agent connection
 	ac, err := agent.DefaultClient(ctx)

--- a/internal/command/domains/root.go
+++ b/internal/command/domains/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/format"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
@@ -101,7 +102,7 @@ func newDomainsRegister() *cobra.Command {
 
 func runDomainsList(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	args := flag.Args(ctx)
 	var orgSlug string
@@ -138,7 +139,7 @@ func runDomainsList(ctx context.Context) error {
 
 func runDomainsShow(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	name := flag.FirstArg(ctx)
 
 	domain, err := apiClient.GetDomain(ctx, name)
@@ -180,7 +181,7 @@ func runDomainsShow(ctx context.Context) error {
 
 func runDomainsCreate(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	var org *fly.Organization
 	var name string

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -17,6 +17,7 @@ import (
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -47,7 +48,7 @@ var SharedFlags = flag.Set{
 }
 
 func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension Extension, err error) {
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
 
@@ -96,7 +97,6 @@ func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension 
 
 	// Prompt to name the provisioned resource, or use the target app name like in Sentry's case
 	if provider.SelectName {
-
 		if override := params.OverrideName; override != nil {
 			name = *override
 		} else {
@@ -237,7 +237,7 @@ func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension 
 }
 
 func AgreeToProviderTos(ctx context.Context, provider gql.ExtensionProviderData) error {
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 	out := iostreams.FromContext(ctx).Out
 
 	// Internal providers like kubernetes don't need ToS agreement
@@ -282,7 +282,7 @@ func AgreeToProviderTos(ctx context.Context, provider gql.ExtensionProviderData)
 
 func WaitForProvision(ctx context.Context, name string) error {
 	io := iostreams.FromContext(ctx)
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 
 	s := spinner.New(spinner.CharSets[9], 200*time.Millisecond)
 	s.Writer = io.ErrOut
@@ -333,7 +333,7 @@ func GetExcludedRegions(ctx context.Context, provider gql.ExtensionProviderData)
 }
 
 func OpenOrgDashboard(ctx context.Context, orgSlug string, providerName string) (err error) {
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 
 	resp, err := gql.GetAddOnProvider(ctx, client, providerName)
 	if err != nil {
@@ -370,7 +370,7 @@ func openUrl(ctx context.Context, url string) (err error) {
 }
 
 func OpenDashboard(ctx context.Context, extensionName string) (err error) {
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 
 	result, err := gql.GetAddOn(ctx, client, extensionName)
 	if err != nil {
@@ -390,7 +390,7 @@ func OpenDashboard(ctx context.Context, extensionName string) (err error) {
 }
 
 func Discover(ctx context.Context, provider gql.AddOnType) (addOn *gql.AddOnData, app *gql.AppData, err error) {
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 	appName := appconfig.NameFromContext(ctx)
 
 	if len(flag.Args(ctx)) == 1 {
@@ -424,7 +424,7 @@ func Discover(ctx context.Context, provider gql.AddOnType) (addOn *gql.AddOnData
 func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *Extension) (err error) {
 	var (
 		io              = iostreams.FromContext(ctx)
-		client          = fly.ClientFromContext(ctx).GenqClient
+		client          = flyutil.ClientFromContext(ctx).GenqClient()
 		setSecrets bool = true
 	)
 
@@ -491,7 +491,7 @@ func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *E
 }
 
 func AgreedToProviderTos(ctx context.Context, providerName string) (bool, error) {
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 
 	tosResp, err := gql.AgreedToProviderTos(ctx, client, providerName)
 	if err != nil {

--- a/internal/command/extensions/enveloop/destroy.go
+++ b/internal/command/extensions/enveloop/destroy.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -60,7 +60,7 @@ func runDestroy(ctx context.Context) (err error) {
 		}
 	}
 
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 	if _, err := gql.DeleteAddOn(ctx, client, extension.Name); err != nil {
 		return err
 	}

--- a/internal/command/extensions/enveloop/list.go
+++ b/internal/command/extensions/enveloop/list.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -31,7 +31,7 @@ func list() (cmd *cobra.Command) {
 }
 
 func runList(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 	response, err := gql.ListAddOns(ctx, client, "enveloop")
 	if err != nil {
 		return err

--- a/internal/command/extensions/kafka/destroy.go
+++ b/internal/command/extensions/kafka/destroy.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -60,7 +60,7 @@ func runDestroy(ctx context.Context) (err error) {
 		}
 	}
 
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 	if _, err := gql.DeleteAddOn(ctx, client, extension.Name); err != nil {
 		return err
 	}

--- a/internal/command/extensions/kafka/list.go
+++ b/internal/command/extensions/kafka/list.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -31,7 +31,7 @@ func list() (cmd *cobra.Command) {
 }
 
 func runList(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 	response, err := gql.ListAddOns(ctx, client, "upstash_kafka")
 	if err != nil {
 		return err

--- a/internal/command/extensions/kafka/update.go
+++ b/internal/command/extensions/kafka/update.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func update() (cmd *cobra.Command) {
@@ -29,7 +29,7 @@ func update() (cmd *cobra.Command) {
 }
 
 func runUpdate(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 
 	id := flag.FirstArg(ctx)
 	response, err := gql.GetAddOn(ctx, client, id)

--- a/internal/command/extensions/kubernetes/auth.go
+++ b/internal/command/extensions/kubernetes/auth.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/orgs"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 const (
@@ -59,7 +59,7 @@ func kubectlToken() (cmd *cobra.Command) {
 }
 
 func runAuth(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	execInfo := os.Getenv(execInfoEnv)
 	if execInfo == "" {
@@ -146,11 +146,11 @@ func runAuth(ctx context.Context) error {
 	return nil
 }
 
-func makeOrgToken(ctx context.Context, apiClient *fly.Client, orgID string) (string, int64, error) {
+func makeOrgToken(ctx context.Context, apiClient flyutil.Client, orgID string) (string, int64, error) {
 	options := gql.LimitedAccessTokenOptions{}
 	resp, err := gql.CreateLimitedAccessToken(
 		ctx,
-		apiClient.GenqClient,
+		apiClient.GenqClient(),
 		"FKS org deploy token",
 		orgID,
 		"deploy_organization",

--- a/internal/command/extensions/kubernetes/create.go
+++ b/internal/command/extensions/kubernetes/create.go
@@ -6,13 +6,13 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/command/orgs"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -21,7 +21,6 @@ const (
 )
 
 func create() (cmd *cobra.Command) {
-
 	const (
 		short = "Provision a Kubernetes cluster for an organization"
 		long  = short + "\n"
@@ -50,7 +49,7 @@ func runK8sCreate(ctx context.Context) (err error) {
 	colorize := io.ColorScheme()
 	fmt.Fprintln(io.Out, colorize.Yellow(betaMsg))
 
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 	appName := appconfig.NameFromContext(ctx)
 	targetOrg, err := orgs.OrgFromFlagOrSelect(ctx)
 	if err != nil {

--- a/internal/command/extensions/kubernetes/destroy.go
+++ b/internal/command/extensions/kubernetes/destroy.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 )
 
@@ -41,7 +41,6 @@ func runDestroy(ctx context.Context) (err error) {
 	colorize := io.ColorScheme()
 
 	extension, _, err := extensions_core.Discover(ctx, gql.AddOnTypeKubernetes)
-
 	if err != nil {
 		return err
 	}
@@ -64,7 +63,7 @@ func runDestroy(ctx context.Context) (err error) {
 
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = fly.ClientFromContext(ctx).GenqClient
+		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
 	_, err = gql.DeleteAddOn(ctx, client, extension.Name)

--- a/internal/command/extensions/kubernetes/kubeconfig.go
+++ b/internal/command/extensions/kubernetes/kubeconfig.go
@@ -6,10 +6,10 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func saveKubeconfig() (cmd *cobra.Command) {
@@ -33,7 +33,7 @@ func saveKubeconfig() (cmd *cobra.Command) {
 }
 
 func runSaveKubeconfig(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 	clusterName := flag.FirstArg(ctx)
 
 	resp, err := gql.GetAddOn(ctx, client, clusterName)

--- a/internal/command/extensions/kubernetes/list.go
+++ b/internal/command/extensions/kubernetes/list.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -29,7 +29,7 @@ func list() (cmd *cobra.Command) {
 func runList(ctx context.Context) (err error) {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = fly.ClientFromContext(ctx).GenqClient
+		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
 	response, err := gql.ListAddOns(ctx, client, "kubernetes")

--- a/internal/command/extensions/supabase/destroy.go
+++ b/internal/command/extensions/supabase/destroy.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 )
 
@@ -64,7 +64,7 @@ func runDestroy(ctx context.Context) (err error) {
 
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = fly.ClientFromContext(ctx).GenqClient
+		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
 	_, err = gql.DeleteAddOn(ctx, client, extension.Name)

--- a/internal/command/extensions/supabase/list.go
+++ b/internal/command/extensions/supabase/list.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -37,7 +37,7 @@ func list() (cmd *cobra.Command) {
 func runList(ctx context.Context) (err error) {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = fly.ClientFromContext(ctx).GenqClient
+		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
 	response, err := gql.ListAddOns(ctx, client, "supabase")

--- a/internal/command/extensions/tigris/destroy.go
+++ b/internal/command/extensions/tigris/destroy.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 )
 
@@ -64,7 +64,7 @@ func runDestroy(ctx context.Context) (err error) {
 
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = fly.ClientFromContext(ctx).GenqClient
+		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
 	_, err = gql.DeleteAddOn(ctx, client, extension.Name)

--- a/internal/command/extensions/tigris/list.go
+++ b/internal/command/extensions/tigris/list.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -37,7 +37,7 @@ func list() (cmd *cobra.Command) {
 func runList(ctx context.Context) (err error) {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = fly.ClientFromContext(ctx).GenqClient
+		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
 	response, err := gql.ListAddOns(ctx, client, "tigris")

--- a/internal/command/extensions/tigris/update.go
+++ b/internal/command/extensions/tigris/update.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -56,7 +56,7 @@ func update() (cmd *cobra.Command) {
 func runUpdate(ctx context.Context) (err error) {
 	io := iostreams.FromContext(ctx)
 
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 
 	id := flag.FirstArg(ctx)
 	response, err := gql.GetAddOn(ctx, client, id)

--- a/internal/command/extensions/vector/destroy.go
+++ b/internal/command/extensions/vector/destroy.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -60,7 +60,7 @@ func runDestroy(ctx context.Context) (err error) {
 		}
 	}
 
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 	if _, err := gql.DeleteAddOn(ctx, client, extension.Name); err != nil {
 		return err
 	}

--- a/internal/command/extensions/vector/list.go
+++ b/internal/command/extensions/vector/list.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -31,7 +31,7 @@ func list() (cmd *cobra.Command) {
 }
 
 func runList(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 	response, err := gql.ListAddOns(ctx, client, "upstash_vector")
 	if err != nil {
 		return err

--- a/internal/command/image/show.go
+++ b/internal/command/image/show.go
@@ -14,6 +14,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -44,7 +45,7 @@ func newShow() *cobra.Command {
 
 func runShow(ctx context.Context) error {
 	var (
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 
@@ -60,7 +61,7 @@ func showMachineImage(ctx context.Context, app *fly.AppCompact) error {
 	var (
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
-		client   = fly.ClientFromContext(ctx)
+		client   = flyutil.ClientFromContext(ctx)
 		cfg      = config.FromContext(ctx)
 	)
 

--- a/internal/command/image/update.go
+++ b/internal/command/image/update.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func newUpdate() *cobra.Command {
@@ -49,7 +49,7 @@ The update will perform a rolling restart against each Machine, which may result
 func runUpdate(ctx context.Context) error {
 	var (
 		appName = appconfig.NameFromContext(ctx)
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 	)
 
 	app, err := client.GetAppCompact(ctx, appName)

--- a/internal/command/image/update_machines.go
+++ b/internal/command/image/update_machines.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -256,7 +257,7 @@ func machineRole(machine *fly.Machine) (role string) {
 
 func resolveImage(ctx context.Context, machine fly.Machine) (string, error) {
 	var (
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 		image  = flag.GetString(ctx, "image")
 	)
 

--- a/internal/command/ips/allocate.go
+++ b/internal/command/ips/allocate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/orgs"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 )
 
@@ -110,7 +111,7 @@ func runAllocateIPAddressV6(ctx context.Context) (err error) {
 }
 
 func runAllocateIPAddress(ctx context.Context, addrType string, org *fly.Organization, network string) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	appName := appconfig.NameFromContext(ctx)
 

--- a/internal/command/ips/list.go
+++ b/internal/command/ips/list.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -37,7 +37,7 @@ func newList() *cobra.Command {
 
 func runIPAddressesList(ctx context.Context) error {
 	cfg := config.FromContext(ctx)
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
 
 	appName := appconfig.NameFromContext(ctx)

--- a/internal/command/ips/release.go
+++ b/internal/command/ips/release.go
@@ -6,10 +6,10 @@ import (
 	"net"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func newRelease() *cobra.Command {
@@ -33,7 +33,7 @@ func newRelease() *cobra.Command {
 }
 
 func runReleaseIPAddress(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	appName := appconfig.NameFromContext(ctx)
 

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/tracing"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -144,7 +145,7 @@ func (state *launchState) updateConfig(ctx context.Context) {
 
 // createApp creates the fly.io app for the plan
 func (state *launchState) createApp(ctx context.Context) (*fly.App, error) {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	org, err := state.Org(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/command/launch/launch_databases.go
+++ b/internal/command/launch/launch_databases.go
@@ -12,12 +12,12 @@ import (
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/command/postgres"
 	"github.com/superfly/flyctl/internal/command/redis"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
 // createDatabases creates databases requested by the plan
 func (state *launchState) createDatabases(ctx context.Context) error {
-
 	if state.Plan.Postgres.FlyPostgres != nil {
 		err := state.createFlyPostgres(ctx)
 		if err != nil {
@@ -67,7 +67,7 @@ func (state *launchState) createDatabases(ctx context.Context) error {
 func (state *launchState) createFlyPostgres(ctx context.Context) error {
 	var (
 		pgPlan    = state.Plan.Postgres.FlyPostgres
-		apiClient = fly.ClientFromContext(ctx)
+		apiClient = flyutil.ClientFromContext(ctx)
 		io        = iostreams.FromContext(ctx)
 	)
 
@@ -195,7 +195,7 @@ func (state *launchState) createUpstashRedis(ctx context.Context) error {
 
 	var readReplicaRegions []fly.Region
 	{
-		client := fly.ClientFromContext(ctx)
+		client := flyutil.ClientFromContext(ctx)
 		regions, _, err := client.PlatformRegions(ctx)
 		if err != nil {
 			return err
@@ -217,7 +217,6 @@ func (state *launchState) createUpstashRedis(ctx context.Context) error {
 }
 
 func (state *launchState) createTigrisObjectStorage(ctx context.Context) error {
-
 	tigrisPlan := state.Plan.ObjectStorage.TigrisObjectStorage
 
 	org, err := state.Org(ctx)

--- a/internal/command/launch/launch_frameworks.go
+++ b/internal/command/launch/launch_frameworks.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/scanner"
@@ -113,7 +113,7 @@ func (state *launchState) scannerCreateSecrets(ctx context.Context) error {
 	}
 
 	if len(secrets) > 0 {
-		apiClient := fly.ClientFromContext(ctx)
+		apiClient := flyutil.ClientFromContext(ctx)
 		_, err := apiClient.SetSecrets(ctx, state.Plan.AppName, secrets)
 		if err != nil {
 			return err

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -19,6 +19,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/launch/plan"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flyerr"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/haikunator"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
@@ -246,7 +247,7 @@ func buildManifest(ctx context.Context, recoverableErrors *recoverableErrorBuild
 func stateFromManifest(ctx context.Context, m LaunchManifest, optionalCache *planBuildCache, recoverableErrors *recoverableErrorBuilder) (*launchState, error) {
 	var (
 		io     = iostreams.FromContext(ctx)
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 	)
 
 	org, err := client.GetOrganizationBySlug(ctx, m.Plan.OrgSlug)
@@ -492,7 +493,7 @@ func determineAppName(ctx context.Context, appConfig *appconfig.Config, configPa
 }
 
 func appNameTaken(ctx context.Context, name string) (bool, error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	available, err := client.AppNameAvailable(ctx, name)
 	if err != nil {
@@ -503,7 +504,7 @@ func appNameTaken(ctx context.Context, name string) (bool, error) {
 
 // determineOrg returns the org specified on the command line, or the personal org if left unspecified
 func determineOrg(ctx context.Context) (*fly.Organization, string, error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	orgs, err := client.GetOrganizations(ctx)
 	if err != nil {
@@ -543,7 +544,7 @@ func determineOrg(ctx context.Context) (*fly.Organization, string, error) {
 //  2. the region specified on the command line, if specified
 //  3. the nearest region to the user
 func determineRegion(ctx context.Context, config *appconfig.Config, paidPlan bool) (*fly.Region, string, error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	regionCode := flag.GetRegion(ctx)
 	explanation := "specified on the command line"
 
@@ -571,7 +572,7 @@ func determineRegion(ctx context.Context, config *appconfig.Config, paidPlan boo
 
 // getRegionByCode returns the region with the IATA code, or an error if it doesn't exist
 func getRegionByCode(ctx context.Context, regionCode string) (*fly.Region, error) {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	allRegions, _, err := apiClient.PlatformRegions(ctx)
 	if err != nil {

--- a/internal/command/lfsc/clusters_create.go
+++ b/internal/command/lfsc/clusters_create.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -40,7 +40,7 @@ func newClustersCreate() *cobra.Command {
 }
 
 func runClustersCreate(ctx context.Context) error {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	orgID, err := getOrgID(ctx)
 	if err != nil {
@@ -66,7 +66,7 @@ func runClustersCreate(ctx context.Context) error {
 		return err
 	}
 
-	resp, err := gql.CreateLimitedAccessToken(ctx, apiClient.GenqClient, clusterName, orgID, "litefs_cloud",
+	resp, err := gql.CreateLimitedAccessToken(ctx, apiClient.GenqClient(), clusterName, orgID, "litefs_cloud",
 		&gql.LimitedAccessTokenOptions{
 			"cluster": clusterName,
 		},

--- a/internal/command/lfsc/lfsc.go
+++ b/internal/command/lfsc/lfsc.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/lfsc-go"
 )
 
@@ -82,7 +82,7 @@ func regionFlag() flag.String {
 
 // newLFSCClient returns an lfsc.Client with a temporary auth token.
 func newLFSCClient(ctx context.Context, clusterName string) (*lfsc.Client, error) {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	// Determine the org via flag or environment variable first.
 	// If neither is available, use the local app's org, if available.
@@ -92,7 +92,7 @@ func newLFSCClient(ctx context.Context, clusterName string) (*lfsc.Client, error
 	}
 
 	// Acquire a temporary auth token to access LiteFS Cloud.
-	resp, err := gql.CreateLimitedAccessToken(ctx, apiClient.GenqClient, "flyctl-lfsc", orgID, "litefs_cloud",
+	resp, err := gql.CreateLimitedAccessToken(ctx, apiClient.GenqClient(), "flyctl-lfsc", orgID, "litefs_cloud",
 		&gql.LimitedAccessTokenOptions{
 			"cluster": clusterName,
 		},
@@ -110,7 +110,7 @@ func newLFSCClient(ctx context.Context, clusterName string) (*lfsc.Client, error
 }
 
 func getOrgID(ctx context.Context) (string, error) {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	if slug := flag.GetOrg(ctx); slug != "" {
 		org, err := apiClient.GetOrganizationBySlug(ctx, slug)

--- a/internal/command/lfsc/regions.go
+++ b/internal/command/lfsc/regions.go
@@ -6,10 +6,10 @@ import (
 	"sort"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/lfsc-go"
@@ -33,7 +33,7 @@ func newRegions() (cmd *cobra.Command) {
 }
 
 func runRegions(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	flyRegions, _, err := client.PlatformRegions(ctx)
 	if err != nil {

--- a/internal/command/logs/logs.go
+++ b/internal/command/logs/logs.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/logs"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/render"
 )
@@ -64,7 +64,7 @@ Use --no-tail to only fetch the logs in the buffer.
 }
 
 func run(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	opts := &logs.LogOptions{
 		AppName:    appconfig.NameFromContext(ctx),
@@ -96,7 +96,7 @@ func run(ctx context.Context) error {
 	return eg.Wait()
 }
 
-func poll(ctx context.Context, eg *errgroup.Group, client *fly.Client, opts *logs.LogOptions) <-chan logs.LogEntry {
+func poll(ctx context.Context, eg *errgroup.Group, client flyutil.Client, opts *logs.LogOptions) <-chan logs.LogEntry {
 	c := make(chan logs.LogEntry)
 
 	eg.Go(func() (err error) {
@@ -114,7 +114,7 @@ func poll(ctx context.Context, eg *errgroup.Group, client *fly.Client, opts *log
 	return c
 }
 
-func nats(ctx context.Context, eg *errgroup.Group, client *fly.Client, opts *logs.LogOptions, cancelPolling context.CancelFunc) <-chan logs.LogEntry {
+func nats(ctx context.Context, eg *errgroup.Group, client flyutil.Client, opts *logs.LogOptions, cancelPolling context.CancelFunc) <-chan logs.LogEntry {
 	c := make(chan logs.LogEntry)
 
 	eg.Go(func() error {

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -10,11 +10,11 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/watch"
 	"github.com/superfly/flyctl/iostreams"
@@ -97,7 +97,7 @@ func runMachineClone(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	var vol *fly.Volume
 	if volumeInfo := flag.GetString(ctx, "attach-volume"); volumeInfo != "" {

--- a/internal/command/machine/cordon.go
+++ b/internal/command/machine/cordon.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -52,7 +52,7 @@ func runMachineCordon(ctx context.Context) (err error) {
 	}
 	defer release()
 
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	for _, machine := range machines {
 		fmt.Fprintf(io.Out, "Activating cordon on machine %s...\n", machine.ID)

--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
@@ -60,7 +61,7 @@ func runMachineDestroy(ctx context.Context) (err error) {
 	ids := []string{}
 
 	if image != "" {
-		machines, err := flaps.FromContext(ctx).ListActive(ctx)
+		machines, err := flapsutil.ClientFromContext(ctx).ListActive(ctx)
 		if err != nil {
 			return err
 		}
@@ -147,7 +148,7 @@ func singleDestroyRun(ctx context.Context, machine *fly.Machine) error {
 	appName := appconfig.NameFromContext(ctx)
 
 	// This is used for the deletion hook below.
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("could not get app '%s': %w", appName, err)
@@ -166,7 +167,7 @@ func singleDestroyRun(ctx context.Context, machine *fly.Machine) error {
 func Destroy(ctx context.Context, app *fly.AppCompact, machine *fly.Machine, force bool) error {
 	var (
 		out         = iostreams.FromContext(ctx).Out
-		flapsClient = flaps.FromContext(ctx)
+		flapsClient = flapsutil.ClientFromContext(ctx)
 
 		input = fly.RemoveMachineInput{
 			ID:   machine.ID,

--- a/internal/command/machine/exec.go
+++ b/internal/command/machine/exec.go
@@ -6,16 +6,15 @@ import (
 
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
 
 func newMachineExec() *cobra.Command {
-
 	const (
 		short = "Execute a command on a machine"
 		long  = short + "\n"
@@ -67,9 +66,9 @@ func runMachineExec(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
-	var timeout = flag.GetInt(ctx, "timeout")
+	timeout := flag.GetInt(ctx, "timeout")
 
 	in := &fly.MachineExecRequest{
 		Cmd:     command,

--- a/internal/command/machine/kill.go
+++ b/internal/command/machine/kill.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -45,7 +45,7 @@ func runMachineKill(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	if current.State == "destroyed" {
 		return fmt.Errorf("machine %s has already been destroyed", current.ID)

--- a/internal/command/machine/leases.go
+++ b/internal/command/machine/leases.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -97,9 +97,9 @@ func runLeaseView(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
-	var leases = make(map[string]*fly.MachineLease)
+	leases := make(map[string]*fly.MachineLease)
 
 	for _, machine := range machines {
 		lease, err := flapsClient.FindLease(ctx, machine.ID)
@@ -154,7 +154,7 @@ func runLeaseClear(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	for _, machineID := range machineIDs {
 		lease, err := flapsClient.FindLease(ctx, machineID)

--- a/internal/command/machine/proxy.go
+++ b/internal/command/machine/proxy.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/proxy"
 )
@@ -35,7 +35,7 @@ func newProxy() *cobra.Command {
 }
 
 func runMachineProxy(ctx context.Context) error {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	orgSlug := flag.GetOrg(ctx)
 
 	if orgSlug == "" {

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/ssh"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/watch"
@@ -286,7 +287,7 @@ func runMachineCreate(ctx context.Context) error {
 func runMachineRun(ctx context.Context) error {
 	var (
 		appName  = appconfig.NameFromContext(ctx)
-		client   = fly.ClientFromContext(ctx)
+		client   = flyutil.ClientFromContext(ctx)
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
 		err      error
@@ -371,7 +372,7 @@ func runMachineRun(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not make API client: %w", err)
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	imageOrPath := flag.FirstArg(ctx)
 	if imageOrPath == "" && shell {
@@ -494,7 +495,7 @@ func runMachineRun(ctx context.Context) error {
 	return nil
 }
 
-func getOrCreateEphemeralShellApp(ctx context.Context, client *fly.Client) (*fly.AppCompact, error) {
+func getOrCreateEphemeralShellApp(ctx context.Context, client flyutil.Client) (*fly.AppCompact, error) {
 	// no prompt if --org, buried in the context code
 	org, err := prompt.Org(ctx)
 	if err != nil {
@@ -543,7 +544,7 @@ func getOrCreateEphemeralShellApp(ctx context.Context, client *fly.Client) (*fly
 	return app, nil
 }
 
-func createApp(ctx context.Context, message, name string, client *fly.Client) (*fly.AppCompact, error) {
+func createApp(ctx context.Context, message, name string, client flyutil.Client) (*fly.AppCompact, error) {
 	confirm, err := prompt.Confirm(ctx, message)
 	if err != nil {
 		return nil, err

--- a/internal/command/machine/select.go
+++ b/internal/command/machine/select.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -46,7 +47,7 @@ func selectOneMachine(ctx context.Context, appName string, machineID string, hav
 			return nil, nil, err
 		}
 	} else {
-		machine, err = flaps.FromContext(ctx).Get(ctx, machineID)
+		machine, err = flapsutil.ClientFromContext(ctx).Get(ctx, machineID)
 		if err != nil {
 			if err := rewriteMachineNotFoundErrors(ctx, err, machineID); err != nil {
 				return nil, nil, err
@@ -75,7 +76,7 @@ func selectManyMachines(ctx context.Context, machineIDs []string) ([]*fly.Machin
 			return nil, nil, err
 		}
 	} else {
-		flapsClient := flaps.FromContext(ctx)
+		flapsClient := flapsutil.ClientFromContext(ctx)
 		for _, machineID := range machineIDs {
 			machine, err := flapsClient.Get(ctx, machineID)
 			if err != nil {
@@ -121,7 +122,7 @@ func buildContextFromAppName(ctx context.Context, appName string) (context.Conte
 	if err != nil {
 		return nil, fmt.Errorf("could not create flaps client: %w", err)
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 	return ctx, nil
 }
 
@@ -137,7 +138,7 @@ func buildContextFromAppNameOrMachineID(ctx context.Context, machineIDs ...strin
 		// NOTE: assuming that we validated the command line arguments
 		// correctly, we must have at least one machine ID when no app
 		// is set.
-		client := fly.ClientFromContext(ctx)
+		client := flyutil.ClientFromContext(ctx)
 		var gqlMachine *fly.GqlMachine
 		gqlMachine, err = client.GetMachine(ctx, machineIDs[0])
 		if err != nil {
@@ -157,12 +158,12 @@ func buildContextFromAppNameOrMachineID(ctx context.Context, machineIDs ...strin
 		return nil, fmt.Errorf("could not create flaps client: %w", err)
 	}
 
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 	return ctx, nil
 }
 
 func promptForOneMachine(ctx context.Context) (*fly.Machine, error) {
-	machines, err := flaps.FromContext(ctx).List(ctx, "")
+	machines, err := flapsutil.ClientFromContext(ctx).List(ctx, "")
 	if err != nil {
 		return nil, fmt.Errorf("could not get a list of machines: %w", err)
 	} else if len(machines) == 0 {
@@ -178,7 +179,7 @@ func promptForOneMachine(ctx context.Context) (*fly.Machine, error) {
 }
 
 func promptForManyMachines(ctx context.Context) ([]*fly.Machine, error) {
-	machines, err := flaps.FromContext(ctx).List(ctx, "")
+	machines, err := flapsutil.ClientFromContext(ctx).List(ctx, "")
 	if err != nil {
 		return nil, fmt.Errorf("could not get a list of machines: %w", err)
 	} else if len(machines) == 0 {

--- a/internal/command/machine/start.go
+++ b/internal/command/machine/start.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -67,9 +67,9 @@ func runMachineStart(ctx context.Context) (err error) {
 }
 
 func Start(ctx context.Context, machine *fly.Machine) (err error) {
-	res, err := flaps.FromContext(ctx).Start(ctx, machine.ID, machine.LeaseNonce)
+	res, err := flapsutil.ClientFromContext(ctx).Start(ctx, machine.ID, machine.LeaseNonce)
 	if err != nil {
-		//TODO(dov): just do the clone
+		// TODO(dov): just do the clone
 		switch {
 		case strings.Contains(err.Error(), " for machine"):
 			return fmt.Errorf("could not start machine due to lack of capacity. Try 'flyctl machine clone %s -a %s'", machine.ID, appconfig.NameFromContext(ctx))

--- a/internal/command/machine/stop.go
+++ b/internal/command/machine/stop.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -97,7 +97,7 @@ func Stop(ctx context.Context, machine *fly.Machine, signal string, timeout int)
 
 	waitTimeout := flag.GetDuration(ctx, "wait-timeout")
 
-	client := flaps.FromContext(ctx)
+	client := flapsutil.ClientFromContext(ctx)
 	err = client.Stop(ctx, machineStopInput, machine.LeaseNonce)
 	if err != nil {
 		if err := rewriteMachineNotFoundErrors(ctx, err, machine.ID); err != nil {

--- a/internal/command/machine/uncordon.go
+++ b/internal/command/machine/uncordon.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -52,7 +52,7 @@ func runMachineUncordon(ctx context.Context) (err error) {
 	}
 	defer release()
 
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	for _, machine := range machines {
 		fmt.Fprintf(io.Out, "Deactivating cordon on machine %s...\n", machine.ID)

--- a/internal/command/orgs/create.go
+++ b/internal/command/orgs/create.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
 )
@@ -43,7 +43,7 @@ organization later.
 }
 
 func runCreate(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
 	user, err := client.GetCurrentUser(ctx)

--- a/internal/command/orgs/delete.go
+++ b/internal/command/orgs/delete.go
@@ -9,6 +9,7 @@ import (
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -58,7 +59,7 @@ func runDelete(ctx context.Context) error {
 		}
 	}
 
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	if _, err := client.DeleteOrganization(ctx, org.ID); err != nil {
 		return fmt.Errorf("failed deleting organization %s", err)
 	}

--- a/internal/command/orgs/invite.go
+++ b/internal/command/orgs/invite.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -35,7 +36,7 @@ sent, and the user will be pending until they respond.
 }
 
 func runInvite(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	org, err := OrgFromEnvVarOrFirstArgOrSelect(ctx, fly.AdminOnly)
 	if err != nil {

--- a/internal/command/orgs/list.go
+++ b/internal/command/orgs/list.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -32,7 +32,7 @@ func newList() *cobra.Command {
 }
 
 func runList(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	orgs, err := client.GetOrganizations(ctx)
 	if err != nil {

--- a/internal/command/orgs/orgs.go
+++ b/internal/command/orgs/orgs.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/sort"
 )
@@ -76,7 +77,7 @@ func slugFromArgOrSelect(ctx context.Context, orgSlug string, filters ...fly.Org
 		return
 	}
 
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	var orgs []fly.Organization
 	if orgs, err = client.GetOrganizations(ctx, filters...); err != nil {
@@ -117,7 +118,7 @@ func OrgFromFlagOrSelect(ctx context.Context, filters ...fly.OrganizationFilter)
 }
 
 func OrgFromSlug(ctx context.Context, slug string) (*fly.Organization, error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	org, err := client.GetOrganizationBySlug(ctx, slug)
 	if err != nil {

--- a/internal/command/orgs/remove.go
+++ b/internal/command/orgs/remove.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func newRemove() *cobra.Command {
@@ -31,7 +32,7 @@ invitation to join (if not, see orgs revoke).
 }
 
 func runRemove(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	selectedOrg, err := OrgFromEnvVarOrFirstArgOrSelect(ctx, fly.AdminOnly)
 	if err != nil {
 		return nil

--- a/internal/command/orgs/show.go
+++ b/internal/command/orgs/show.go
@@ -8,10 +8,10 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -37,7 +37,7 @@ associated member. Details full list of members and roles.
 }
 
 func runShow(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	selectedOrg, err := OrgFromEnvVarOrFirstArgOrSelect(ctx)
 	if err != nil {
 		return err

--- a/internal/command/ping/ping.go
+++ b/internal/command/ping/ping.go
@@ -14,12 +14,12 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/dig"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv6"
 )
@@ -75,7 +75,7 @@ The target argument can be either a ".internal" DNS name in our network
 }
 
 func run(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	var (
 		err  error

--- a/internal/command/platform/regions.go
+++ b/internal/command/platform/regions.go
@@ -8,12 +8,12 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -38,7 +38,7 @@ func newRegions() (cmd *cobra.Command) {
 }
 
 func runRegions(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	regions, _, err := client.PlatformRegions(ctx)
 	if err != nil {

--- a/internal/command/postgres/add_flycast.go
+++ b/internal/command/postgres/add_flycast.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
 )
@@ -40,7 +41,7 @@ func newAddFlycast() *cobra.Command {
 
 func runAddFlycast(ctx context.Context) error {
 	var (
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 
@@ -92,37 +93,36 @@ func doAddFlycast(ctx context.Context) error {
 		}
 
 		conf := machine.Config
-		conf.Services =
-			[]fly.MachineService{
-				{
-					Protocol:     "tcp",
-					InternalPort: bouncerPort,
-					Ports: []fly.MachinePort{
-						{
-							Port: &bouncerPort,
-							Handlers: []string{
-								"pg_tls",
-							},
-							ForceHTTPS: false,
+		conf.Services = []fly.MachineService{
+			{
+				Protocol:     "tcp",
+				InternalPort: bouncerPort,
+				Ports: []fly.MachinePort{
+					{
+						Port: &bouncerPort,
+						Handlers: []string{
+							"pg_tls",
 						},
+						ForceHTTPS: false,
 					},
-					Concurrency: nil,
 				},
-				{
-					Protocol:     "tcp",
-					InternalPort: pgPort,
-					Ports: []fly.MachinePort{
-						{
-							Port: &pgPort,
-							Handlers: []string{
-								"pg_tls",
-							},
-							ForceHTTPS: false,
+				Concurrency: nil,
+			},
+			{
+				Protocol:     "tcp",
+				InternalPort: pgPort,
+				Ports: []fly.MachinePort{
+					{
+						Port: &pgPort,
+						Handlers: []string{
+							"pg_tls",
 						},
+						ForceHTTPS: false,
 					},
-					Concurrency: nil,
 				},
-			}
+				Concurrency: nil,
+			},
+		}
 
 		err = mach.Update(ctx, machine, &fly.LaunchMachineInput{
 			Config: conf,

--- a/internal/command/postgres/attach.go
+++ b/internal/command/postgres/attach.go
@@ -14,6 +14,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
@@ -73,7 +74,7 @@ func runAttach(ctx context.Context) error {
 	var (
 		pgAppName = flag.FirstArg(ctx)
 		appName   = appconfig.NameFromContext(ctx)
-		client    = fly.ClientFromContext(ctx)
+		client    = flyutil.ClientFromContext(ctx)
 	)
 
 	pgApp, err := client.GetAppCompact(ctx, pgAppName)
@@ -125,7 +126,7 @@ func runAttach(ctx context.Context) error {
 // AttachCluster is mean't to be called from an external package.
 func AttachCluster(ctx context.Context, params AttachParams) error {
 	var (
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 
 		pgAppName = params.PgAppName
 		appName   = params.AppName
@@ -197,7 +198,7 @@ func machineAttachCluster(ctx context.Context, params AttachParams, flycast *str
 
 func runAttachCluster(ctx context.Context, leaderIP string, params AttachParams, flycast *string) error {
 	var (
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 		dialer = agent.DialerFromContext(ctx)
 		io     = iostreams.FromContext(ctx)
 

--- a/internal/command/postgres/barman.go
+++ b/internal/command/postgres/barman.go
@@ -19,6 +19,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/ssh"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/sentry"
@@ -92,7 +93,7 @@ func newCreateBarman() *cobra.Command {
 func runBarmanCreate(ctx context.Context) error {
 	var (
 		io      = iostreams.FromContext(ctx)
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 
@@ -102,7 +103,7 @@ func runBarmanCreate(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	// pre-fetch platform regions for later use
 	prompt.PlatformRegions(ctx)
@@ -448,7 +449,7 @@ func runBarmanRecover(ctx context.Context) error {
 }
 
 func runConsole(ctx context.Context, cmd string) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 
 	app, err := client.GetAppCompact(ctx, appName)

--- a/internal/command/postgres/config_show.go
+++ b/internal/command/postgres/config_show.go
@@ -14,6 +14,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -43,7 +44,7 @@ func newConfigShow() (cmd *cobra.Command) {
 
 func runConfigShow(ctx context.Context) error {
 	var (
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 

--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -15,6 +15,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
@@ -89,7 +90,7 @@ func newConfigUpdate() (cmd *cobra.Command) {
 
 func runConfigUpdate(ctx context.Context) error {
 	var (
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 

--- a/internal/command/postgres/connect.go
+++ b/internal/command/postgres/connect.go
@@ -9,13 +9,14 @@ import (
 	"github.com/mattn/go-colorable"
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/command/ssh"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func newConnect() *cobra.Command {
@@ -58,7 +59,7 @@ func newConnect() *cobra.Command {
 
 func runConnect(ctx context.Context) error {
 	var (
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 
@@ -90,7 +91,7 @@ func runMachineConnect(ctx context.Context, app *fly.AppCompact) error {
 		password = flag.GetString(ctx, "password")
 	)
 
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	machines, err := flapsClient.ListActive(ctx)
 	if err != nil {

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
@@ -97,7 +98,7 @@ func newCreate() *cobra.Command {
 func run(ctx context.Context) (err error) {
 	var (
 		appName  = flag.GetString(ctx, "name")
-		client   = fly.ClientFromContext(ctx)
+		client   = flyutil.ClientFromContext(ctx)
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
 	)
@@ -191,7 +192,7 @@ func run(ctx context.Context) (err error) {
 			params.ForkFrom = volID
 		}
 
-		flapsClient := flaps.FromContext(ctx)
+		flapsClient := flapsutil.ClientFromContext(ctx)
 
 		// Resolve the volume
 		vol, err := flapsClient.GetVolume(ctx, params.ForkFrom)
@@ -265,7 +266,7 @@ func run(ctx context.Context) (err error) {
 // CreateCluster creates a Postgres cluster with an optional name. The name will be prompted for if not supplied.
 func CreateCluster(ctx context.Context, org *fly.Organization, region *fly.Region, params *ClusterParams) (err error) {
 	var (
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 		io     = iostreams.FromContext(ctx)
 	)
 

--- a/internal/command/postgres/db.go
+++ b/internal/command/postgres/db.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -60,7 +61,7 @@ func newListDbs() *cobra.Command {
 
 func runListDbs(ctx context.Context) error {
 	var (
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 

--- a/internal/command/postgres/detach.go
+++ b/internal/command/postgres/detach.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
@@ -41,7 +42,7 @@ func newDetach() *cobra.Command {
 
 func runDetach(ctx context.Context) error {
 	var (
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 
 		pgAppName = flag.FirstArg(ctx)
 		appName   = appconfig.NameFromContext(ctx)
@@ -95,7 +96,7 @@ func runMachineDetach(ctx context.Context, app *fly.AppCompact, pgApp *fly.AppCo
 // TODO - This process needs to be re-written to suppport non-interactive terminals.
 func detachAppFromPostgres(ctx context.Context, leaderIP string, app *fly.AppCompact, pgApp *fly.AppCompact) error {
 	var (
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 		dialer = agent.DialerFromContext(ctx)
 		io     = iostreams.FromContext(ctx)
 	)

--- a/internal/command/postgres/events.go
+++ b/internal/command/postgres/events.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 )
 
@@ -83,12 +83,11 @@ func newListEvents() *cobra.Command {
 	)
 
 	return cmd
-
 }
 
 func runListEvents(ctx context.Context) error {
 	var (
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 
@@ -120,8 +119,10 @@ func runListEvents(ctx context.Context) error {
 		return fmt.Errorf("this feature is not compatible with this postgres service ")
 	}
 
-	ignoreFlags := []string{flagnames.AccessToken, flagnames.App, flagnames.AppConfigFilePath,
-		flagnames.Verbose, "help"}
+	ignoreFlags := []string{
+		flagnames.AccessToken, flagnames.App, flagnames.AppConfigFilePath,
+		flagnames.Verbose, "help",
+	}
 
 	flagsName := flag.GetFlagsName(ctx, ignoreFlags)
 

--- a/internal/command/postgres/failover.go
+++ b/internal/command/postgres/failover.go
@@ -11,7 +11,6 @@ import (
 	"github.com/mattn/go-colorable"
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -19,6 +18,8 @@ import (
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/command/ssh"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/watch"
 	"github.com/superfly/flyctl/iostreams"
@@ -62,7 +63,7 @@ func runFailover(ctx context.Context) (err error) {
 		MinPostgresStandaloneVersion = "0.0.7"
 
 		io      = iostreams.FromContext(ctx)
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 
@@ -114,7 +115,7 @@ func runFailover(ctx context.Context) (err error) {
 		}
 	}
 
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	dialer := agent.DialerFromContext(ctx)
 
@@ -132,7 +133,6 @@ func runFailover(ctx context.Context) (err error) {
 			if err != nil {
 				return err
 			} else if machineRole(leader) == "leader" {
-
 				return fmt.Errorf("%s hasn't lost its leader role", leader.ID)
 			}
 			return nil
@@ -214,7 +214,7 @@ func flexFailover(ctx context.Context, machines []*fly.Machine, app *fly.AppComp
 		Signal: "SIGINT",
 	}
 
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 	err = flapsClient.Stop(ctx, machineStopInput, oldLeader.LeaseNonce)
 	if err != nil {
 		return fmt.Errorf("could not stop pg leader %s: %w", oldLeader.ID, err)
@@ -293,7 +293,7 @@ func flexFailover(ctx context.Context, machines []*fly.Machine, app *fly.AppComp
 
 func handleFlexFailoverFail(ctx context.Context, machines []*fly.Machine) (err error) {
 	io := iostreams.FromContext(ctx)
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	leader, err := pickLeader(ctx, machines)
 	if err != nil {

--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -17,6 +17,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/ssh"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
 )
@@ -76,7 +77,7 @@ func newImport() *cobra.Command {
 
 func runImport(ctx context.Context) error {
 	var (
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 
 		sourceURI = flag.FirstArg(ctx)

--- a/internal/command/postgres/list.go
+++ b/internal/command/postgres/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/format"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -31,7 +32,7 @@ func newList() *cobra.Command {
 
 func runList(ctx context.Context) (err error) {
 	var (
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 		io     = iostreams.FromContext(ctx)
 		cfg    = config.FromContext(ctx)
 	)

--- a/internal/command/postgres/restart.go
+++ b/internal/command/postgres/restart.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -49,7 +50,7 @@ func newRestart() *cobra.Command {
 func runRestart(ctx context.Context) error {
 	var (
 		appName = appconfig.NameFromContext(ctx)
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 	)
 
 	app, err := client.GetAppCompact(ctx, appName)

--- a/internal/command/postgres/users.go
+++ b/internal/command/postgres/users.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/apps"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -62,7 +63,7 @@ func newListUsers() *cobra.Command {
 
 func runListUsers(ctx context.Context) error {
 	var (
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 

--- a/internal/command/proxy/proxy.go
+++ b/internal/command/proxy/proxy.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/proxy"
 )
@@ -56,7 +56,7 @@ connects to the first Machine address returned by an internal DNS query on the a
 }
 
 func run(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 
 	orgSlug := flag.GetOrg(ctx)

--- a/internal/command/redis/attach.go
+++ b/internal/command/redis/attach.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
 func AttachDatabase(ctx context.Context, db *gql.AddOn, appName string) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 	s := map[string]string{}
 	s["REDIS_URL"] = db.PublicUrl

--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/spinner"
 )
@@ -70,7 +71,7 @@ func runCreate(ctx context.Context) (err error) {
 		return err
 	}
 
-	var name = flag.GetString(ctx, "name")
+	name := flag.GetString(ctx, "name")
 
 	if name == "" {
 		err = prompt.String(ctx, &name, "Choose a Redis database name (leave blank to generate one):", "", false)
@@ -81,7 +82,6 @@ func runCreate(ctx context.Context) (err error) {
 	}
 
 	excludedRegions, err := GetExcludedRegions(ctx)
-
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,6 @@ func runCreate(ctx context.Context) (err error) {
 		Message:             "Choose a primary region (can't be changed later)",
 		ExcludedRegionCodes: excludedRegions,
 	})
-
 	if err != nil {
 		return err
 	}
@@ -118,7 +117,6 @@ func Create(ctx context.Context, org *fly.Organization, name string, region *fly
 	)
 
 	excludedRegions, err := GetExcludedRegions(ctx)
-
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +184,7 @@ type RedisConfiguration struct {
 }
 
 func ProvisionDatabase(ctx context.Context, org *fly.Organization, config RedisConfiguration) (addOn *gql.AddOn, err error) {
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 
 	var readRegionCodes []string
 
@@ -219,13 +217,12 @@ func ProvisionDatabase(ctx context.Context, org *fly.Organization, config RedisC
 }
 
 func DeterminePlan(ctx context.Context, org *fly.Organization) (*gql.ListAddOnPlansAddOnPlansAddOnPlanConnectionNodesAddOnPlan, error) {
-
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	planId := redisPlanPayAsYouGo
 
 	// Now that we have the Plan ID, look up the actual plan
-	allAddons, err := gql.ListAddOnPlans(ctx, client.GenqClient, gql.AddOnTypeUpstashRedis)
+	allAddons, err := gql.ListAddOnPlans(ctx, client.GenqClient(), gql.AddOnTypeUpstashRedis)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/redis/dashboard.go
+++ b/internal/command/redis/dashboard.go
@@ -7,10 +7,10 @@ import (
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -32,13 +32,12 @@ func newDashboard() (cmd *cobra.Command) {
 func runDashboard(ctx context.Context) (err error) {
 	var (
 		io     = iostreams.FromContext(ctx)
-		client = fly.ClientFromContext(ctx).GenqClient
+		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
 	orgSlug := flag.FirstArg(ctx)
 
 	result, err := gql.GetOrganization(ctx, client, orgSlug)
-
 	if err != nil {
 		return err
 	}

--- a/internal/command/redis/destroy.go
+++ b/internal/command/redis/destroy.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 )
 
@@ -58,7 +58,7 @@ func runDestroy(ctx context.Context) (err error) {
 
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = fly.ClientFromContext(ctx).GenqClient
+		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
 	name := flag.FirstArg(ctx)

--- a/internal/command/redis/list.go
+++ b/internal/command/redis/list.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -36,7 +36,7 @@ func newList() (cmd *cobra.Command) {
 func runList(ctx context.Context) (err error) {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = fly.ClientFromContext(ctx).GenqClient
+		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
 	response, err := gql.ListAddOns(ctx, client, "upstash_redis")
@@ -45,7 +45,7 @@ func runList(ctx context.Context) (err error) {
 
 	for _, addon := range response.AddOns.Nodes {
 		options, _ := addon.Options.(map[string]interface{})
-		var eviction = "Disabled"
+		eviction := "Disabled"
 
 		if options["eviction"] != nil && options["eviction"].(bool) {
 			eviction = "Enabled"

--- a/internal/command/redis/plans.go
+++ b/internal/command/redis/plans.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -32,7 +32,7 @@ func newPlans() (cmd *cobra.Command) {
 func runPlans(ctx context.Context) (err error) {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = fly.ClientFromContext(ctx).GenqClient
+		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
 	result, err := gql.ListAddOnPlans(ctx, client, gql.AddOnTypeUpstashRedis)

--- a/internal/command/redis/proxy.go
+++ b/internal/command/redis/proxy.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/proxy"
 	"github.com/superfly/flyctl/terminal"
@@ -46,12 +46,12 @@ func runProxy(ctx context.Context) (err error) {
 }
 
 func getRedisProxyParams(ctx context.Context, localProxyPort string) (*proxy.ConnectParams, string, error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	var index int
 	var options []string
 
-	result, err := gql.ListAddOns(ctx, client.GenqClient, "upstash_redis")
+	result, err := gql.ListAddOns(ctx, client.GenqClient(), "upstash_redis")
 	if err != nil {
 		return nil, "", err
 	}
@@ -67,7 +67,7 @@ func getRedisProxyParams(ctx context.Context, localProxyPort string) (*proxy.Con
 		return nil, "", err
 	}
 
-	response, err := gql.GetAddOn(ctx, client.GenqClient, databases[index].Name)
+	response, err := gql.GetAddOn(ctx, client.GenqClient(), databases[index].Name)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/command/redis/redis.go
+++ b/internal/command/redis/redis.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 // TODO: make internal once the open command has been deprecated
@@ -36,10 +36,9 @@ func New() (cmd *cobra.Command) {
 }
 
 func GetExcludedRegions(ctx context.Context) (excludedRegions []string, err error) {
-	client := fly.ClientFromContext(ctx).GenqClient
+	client := flyutil.ClientFromContext(ctx).GenqClient()
 
 	response, err := gql.GetAddOnProvider(ctx, client, "upstash_redis")
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/command/redis/reset_password.go
+++ b/internal/command/redis/reset_password.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func newReset() (cmd *cobra.Command) {
@@ -33,7 +33,7 @@ func newReset() (cmd *cobra.Command) {
 func runReset(ctx context.Context) (err error) {
 	var (
 		io       = iostreams.FromContext(ctx)
-		client   = fly.ClientFromContext(ctx).GenqClient
+		client   = flyutil.ClientFromContext(ctx).GenqClient()
 		colorize = io.ColorScheme()
 		out      = io.Out
 	)
@@ -51,7 +51,6 @@ func runReset(ctx context.Context) (err error) {
 	`
 
 	response, err := gql.ResetAddOnPassword(ctx, client, name)
-
 	if err != nil {
 		return
 	}

--- a/internal/command/redis/status.go
+++ b/internal/command/redis/status.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -36,7 +36,7 @@ func runStatus(ctx context.Context) (err error) {
 	var (
 		io     = iostreams.FromContext(ctx)
 		name   = flag.FirstArg(ctx)
-		client = fly.ClientFromContext(ctx).GenqClient
+		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
 	response, err := gql.GetAddOn(ctx, client, name)

--- a/internal/command/redis/update.go
+++ b/internal/command/redis/update.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 )
 
@@ -37,7 +37,7 @@ func newUpdate() (cmd *cobra.Command) {
 func runUpdate(ctx context.Context) (err error) {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = fly.ClientFromContext(ctx).GenqClient
+		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
 	id := flag.FirstArg(ctx)

--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -8,7 +8,6 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/agent"
@@ -64,6 +63,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/volumes"
 	"github.com/superfly/flyctl/internal/command/wireguard"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 // New initializes and returns a reference to a new root command.
@@ -95,7 +95,7 @@ func New() *cobra.Command {
 		group(platform.New(), "more_help"),
 		group(docs.New(), "more_help"),
 		group(releases.New(), "upkeep"),
-		group(deploy.New(), "deploy"),
+		group(deploy.New().Command, "deploy"),
 		group(history.New(), "upkeep"),
 		group(status.New(), "deploy"),
 		group(logs.New(), "upkeep"),
@@ -188,7 +188,7 @@ func run(ctx context.Context) error {
 	cmd.Printf("  %s\n", "flyctl [command]")
 	cmd.Println()
 
-	if !fly.ClientFromContext(ctx).Authenticated() {
+	if !flyutil.ClientFromContext(ctx).Authenticated() {
 		msg := `It doesn't look like you're logged in. Try "fly auth signup" to create an account, or "fly auth login" to log in to an existing account.`
 		cmd.Println(text.Wrap(msg, 80))
 		cmd.Println()

--- a/internal/command/scale/count.go
+++ b/internal/command/scale/count.go
@@ -53,7 +53,7 @@ func runScaleCount(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	appConfig, err := appconfig.FromRemoteApp(ctx, appName)
 	if err != nil {

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -9,10 +9,11 @@ import (
 	"github.com/samber/lo"
 	"github.com/sourcegraph/conc/pool"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
@@ -22,9 +23,9 @@ const maxConcurrentActions = 5
 
 func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appconfig.Config, expectedGroupCounts map[string]int, maxPerRegion int) error {
 	io := iostreams.FromContext(ctx)
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 	ctx = appconfig.WithConfig(ctx, appConfig)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	machines, _, err := flapsClient.ListFlyAppsMachines(ctx)
 	if err != nil {
@@ -161,7 +162,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 }
 
 func launchMachine(ctx context.Context, action *planItem, idx int) (*fly.Machine, error) {
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
 
@@ -199,7 +200,7 @@ func launchMachine(ctx context.Context, action *planItem, idx int) (*fly.Machine
 }
 
 func destroyMachine(ctx context.Context, machine *fly.Machine) error {
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 	input := fly.RemoveMachineInput{
 		ID:   machine.ID,
 		Kill: true,

--- a/internal/command/scale/machines.go
+++ b/internal/command/scale/machines.go
@@ -19,7 +19,7 @@ func v2ScaleVM(ctx context.Context, appName, group, sizeName string, memoryMB in
 	if err != nil {
 		return nil, err
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	// Quickly validate sizeName before any network call
 	if err := (&fly.MachineGuest{}).SetSize(sizeName); err != nil && sizeName != "" {

--- a/internal/command/scale/show_machines.go
+++ b/internal/command/scale/show_machines.go
@@ -27,7 +27,7 @@ func runMachinesScaleShow(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	machines, _, err := flapsClient.ListFlyAppsMachines(ctx)
 	if err != nil {

--- a/internal/command/secrets/deploy.go
+++ b/internal/command/secrets/deploy.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyerr"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func newDeploy() (cmd *cobra.Command) {
@@ -33,7 +33,7 @@ func newDeploy() (cmd *cobra.Command) {
 }
 
 func runDeploy(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {

--- a/internal/command/secrets/import.go
+++ b/internal/command/secrets/import.go
@@ -7,10 +7,10 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func newImport() (cmd *cobra.Command) {
@@ -30,7 +30,7 @@ func newImport() (cmd *cobra.Command) {
 }
 
 func runImport(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {

--- a/internal/command/secrets/list.go
+++ b/internal/command/secrets/list.go
@@ -4,11 +4,11 @@ import (
 	"context"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/format"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -37,7 +37,7 @@ actual value of the secret is only available to the application.`
 }
 
 func runList(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
 	secrets, err := client.GetAppSecrets(ctx, appName)

--- a/internal/command/secrets/secrets.go
+++ b/internal/command/secrets/secrets.go
@@ -64,7 +64,7 @@ func DeploySecrets(ctx context.Context, app *fly.AppCompact, stage bool, detach 
 	if err != nil {
 		return fmt.Errorf("could not create flaps client: %w", err)
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	// Due to https://github.com/superfly/web/issues/1397 we have to be extra careful
 	machines, _, err := flapsClient.ListFlyAppsMachines(ctx)

--- a/internal/command/secrets/set.go
+++ b/internal/command/secrets/set.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func newSet() (cmd *cobra.Command) {
@@ -33,7 +34,7 @@ func newSet() (cmd *cobra.Command) {
 }
 
 func runSet(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
@@ -66,7 +67,7 @@ func runSet(ctx context.Context) (err error) {
 }
 
 func SetSecretsAndDeploy(ctx context.Context, app *fly.AppCompact, secrets map[string]string, stage bool, detach bool) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	if _, err := client.SetSecrets(ctx, app.Name, secrets); err != nil {
 		return err
 	}

--- a/internal/command/secrets/unset.go
+++ b/internal/command/secrets/unset.go
@@ -8,6 +8,7 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func newUnset() (cmd *cobra.Command) {
@@ -29,7 +30,7 @@ func newUnset() (cmd *cobra.Command) {
 }
 
 func runUnset(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
@@ -40,7 +41,7 @@ func runUnset(ctx context.Context) (err error) {
 }
 
 func UnsetSecretsAndDeploy(ctx context.Context, app *fly.AppCompact, secrets []string, stage bool, detach bool) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	if _, err := client.UnsetSecrets(ctx, app.Name, secrets); err != nil {
 		return err
 	}

--- a/internal/command/services/list.go
+++ b/internal/command/services/list.go
@@ -49,7 +49,7 @@ func runList(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	machines, err := machine.ListActive(ctx)
 	if err != nil {

--- a/internal/command/ssh/connect.go
+++ b/internal/command/ssh/connect.go
@@ -13,6 +13,7 @@ import (
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/helpers"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/ssh"
 	"github.com/superfly/flyctl/terminal"
@@ -20,7 +21,7 @@ import (
 
 const DefaultSshUsername = "root"
 
-func BringUpAgent(ctx context.Context, client *fly.Client, app *fly.AppCompact, network string, quiet bool) (*agent.Client, agent.Dialer, error) {
+func BringUpAgent(ctx context.Context, client flyutil.Client, app *fly.AppCompact, network string, quiet bool) (*agent.Client, agent.Dialer, error) {
 	io := iostreams.FromContext(ctx)
 
 	agentclient, err := agent.Establish(ctx, client)
@@ -101,7 +102,7 @@ func Connect(p *ConnectParams, addr string) (*ssh.Client, error) {
 }
 
 func singleUseSSHCertificate(ctx context.Context, org fly.OrganizationImpl, appNames []string, user string) (*fly.IssuedCertificate, ed25519.PrivateKey, error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	hours := 1
 
 	pub, priv, err := ed25519.GenerateKey(nil)

--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -19,6 +19,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/sentry"
 	"github.com/superfly/flyctl/iostreams"
@@ -132,7 +133,7 @@ func captureError(ctx context.Context, err error, app *fly.AppCompact) {
 }
 
 func runConsole(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 
 	if !quiet(ctx) {

--- a/internal/command/ssh/issue.go
+++ b/internal/command/ssh/issue.go
@@ -22,6 +22,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/orgs"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -76,7 +77,7 @@ validity.`
 }
 
 func runSSHIssue(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
 
 	org, err := orgs.OrgFromEnvVarOrFirstArgOrSelect(ctx)

--- a/internal/command/ssh/log.go
+++ b/internal/command/ssh/log.go
@@ -7,11 +7,11 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/orgs"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -34,7 +34,7 @@ func newLog() *cobra.Command {
 }
 
 func runLog(ctx context.Context) (err error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	jsonOutput := config.FromContext(ctx).JSONOutput
 	out := iostreams.FromContext(ctx).Out
 

--- a/internal/command/ssh/sftp.go
+++ b/internal/command/ssh/sftp.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/pkg/sftp"
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 
 	"github.com/chzyer/readline"
 	"github.com/google/shlex"
@@ -87,7 +87,7 @@ func newGet() *cobra.Command {
 }
 
 func newSFTPConnection(ctx context.Context) (*sftp.Client, error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 
 	app, err := client.GetAppCompact(ctx, appName)
@@ -184,7 +184,7 @@ func runGet(ctx context.Context) error {
 	}
 	defer rf.Close()
 
-	f, err := os.OpenFile(local, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0644)
+	f, err := os.OpenFile(local, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o644)
 	if err != nil {
 		return fmt.Errorf("get: local file %s: %w", local, err)
 	}
@@ -311,7 +311,7 @@ func (sc *sftpContext) getDir(rpath string, args []string) {
 		return
 	}
 
-	f, err := os.OpenFile(lpath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	f, err := os.OpenFile(lpath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
 		sc.out("get %s -> %s: %s", rpath, lpath, err)
 		return
@@ -502,7 +502,7 @@ func (sc *sftpContext) get(args ...string) error {
 		}
 		defer rf.Close()
 
-		f, err := os.OpenFile(localFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+		f, err := os.OpenFile(localFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 		if err != nil {
 			sc.out("get %s -> %s: %s", rpath, localFile, err)
 			return

--- a/internal/command/status/machines.go
+++ b/internal/command/status/machines.go
@@ -14,6 +14,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/postgres"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -76,7 +77,7 @@ func RenderMachineStatus(ctx context.Context, app *fly.AppCompact, out io.Writer
 	var (
 		io         = iostreams.FromContext(ctx)
 		colorize   = io.ColorScheme()
-		client     = fly.ClientFromContext(ctx)
+		client     = flyutil.ClientFromContext(ctx)
 		jsonOutput = config.FromContext(ctx).JSONOutput
 	)
 
@@ -221,7 +222,7 @@ func RenderMachineStatus(ctx context.Context, app *fly.AppCompact, out io.Writer
 func renderMachineJSONStatus(ctx context.Context, app *fly.AppCompact, machines []*fly.Machine) error {
 	var (
 		out    = iostreams.FromContext(ctx).Out
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 	)
 
 	versionQuery := `
@@ -274,7 +275,7 @@ func renderPGStatus(ctx context.Context, app *fly.AppCompact, machines []*fly.Ma
 	var (
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
-		client   = fly.ClientFromContext(ctx)
+		client   = flyutil.ClientFromContext(ctx)
 	)
 
 	if len(machines) > 0 {

--- a/internal/command/status/status.go
+++ b/internal/command/status/status.go
@@ -14,13 +14,13 @@ import (
 	"github.com/inancgumus/screen"
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func New() (cmd *cobra.Command) {
@@ -85,7 +85,7 @@ func runOnce(ctx context.Context) error {
 func once(ctx context.Context, out io.Writer) (err error) {
 	var (
 		appName = appconfig.NameFromContext(ctx)
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 	)
 
 	app, err := client.GetAppCompact(ctx, appName)

--- a/internal/command/tokens/create.go
+++ b/internal/command/tokens/create.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"time"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command/orgs"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/macaroon"
@@ -254,10 +254,10 @@ func newMachineExec() *cobra.Command {
 	return cmd
 }
 
-func makeToken(ctx context.Context, apiClient *fly.Client, orgID string, expiry string, profile string, options *gql.LimitedAccessTokenOptions) (*gql.CreateLimitedAccessTokenResponse, error) {
+func makeToken(ctx context.Context, apiClient flyutil.Client, orgID string, expiry string, profile string, options *gql.LimitedAccessTokenOptions) (*gql.CreateLimitedAccessTokenResponse, error) {
 	resp, err := gql.CreateLimitedAccessToken(
 		ctx,
-		apiClient.GenqClient,
+		apiClient.GenqClient(),
 		flag.GetString(ctx, "name"),
 		orgID,
 		profile,
@@ -272,7 +272,7 @@ func makeToken(ctx context.Context, apiClient *fly.Client, orgID string, expiry 
 
 func runOrg(ctx context.Context) error {
 	var token string
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	expiry := ""
 	if expiryDuration := flag.GetDuration(ctx, "expiry"); expiryDuration != 0 {
@@ -303,7 +303,7 @@ func runOrg(ctx context.Context) error {
 
 func runSSH(ctx context.Context) error {
 	var token string
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	expiry := ""
 	if expiryDuration := flag.GetDuration(ctx, "expiry"); expiryDuration != 0 {
@@ -377,7 +377,7 @@ func runSSH(ctx context.Context) error {
 func runOrgRead(ctx context.Context) error {
 	var (
 		token          string
-		apiClient      = fly.ClientFromContext(ctx)
+		apiClient      = flyutil.ClientFromContext(ctx)
 		expiry         = ""
 		expiryDuration = flag.GetDuration(ctx, "expiry")
 		perm           []byte
@@ -472,7 +472,7 @@ func runOrgRead(ctx context.Context) error {
 
 func runDeploy(ctx context.Context) (err error) {
 	var token string
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	expiry := ""
 	if expiryDuration := flag.GetDuration(ctx, "expiry"); expiryDuration != 0 {
@@ -507,7 +507,7 @@ func runDeploy(ctx context.Context) (err error) {
 
 func runMachineExec(ctx context.Context) error {
 	var token string
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	expiry := ""
 	if expiryDuration := flag.GetDuration(ctx, "expiry"); expiryDuration != 0 {
@@ -628,7 +628,7 @@ func getCommandCaveat(ctx context.Context) (macaroon.Caveat, error) {
 
 func runLiteFSCloud(ctx context.Context) (err error) {
 	var token string
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	expiry := ""
 	if expiryDuration := flag.GetDuration(ctx, "expiry"); expiryDuration != 0 {

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/orgs"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -41,7 +41,7 @@ func newList() *cobra.Command {
 }
 
 func runList(ctx context.Context) (err error) {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
 	var rows [][]string
 

--- a/internal/command/tokens/revoke.go
+++ b/internal/command/tokens/revoke.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func newRevoke() *cobra.Command {
@@ -25,7 +25,7 @@ func newRevoke() *cobra.Command {
 }
 
 func runRevoke(ctx context.Context) (err error) {
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	args := flag.Args(ctx)
 	for _, id := range args {

--- a/internal/command/volumes/create.go
+++ b/internal/command/volumes/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/future"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
@@ -78,7 +79,7 @@ func newCreate() *cobra.Command {
 func runCreate(ctx context.Context) error {
 	var (
 		cfg    = config.FromContext(ctx)
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 
 		volumeName = flag.FirstArg(ctx)
 		appName    = appconfig.NameFromContext(ctx)
@@ -91,7 +92,7 @@ func runCreate(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	// pre-fetch platform regions from API in background
 	prompt.PlatformRegions(ctx)

--- a/internal/command/volumes/destroy.go
+++ b/internal/command/volumes/destroy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -41,7 +42,7 @@ func newDestroy() *cobra.Command {
 func runDestroy(ctx context.Context) error {
 	var (
 		io     = iostreams.FromContext(ctx)
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 		volIDs = flag.Args(ctx)
 	)
 
@@ -64,7 +65,7 @@ func runDestroy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	if len(volIDs) == 0 {
 		app, err := client.GetAppBasic(ctx, appName)
@@ -98,7 +99,7 @@ func runDestroy(ctx context.Context) error {
 
 func confirmVolumeDelete(ctx context.Context, volID string) (bool, error) {
 	var (
-		flapsClient = flaps.FromContext(ctx)
+		flapsClient = flapsutil.ClientFromContext(ctx)
 		io          = iostreams.FromContext(ctx)
 		colorize    = io.ColorScheme()
 

--- a/internal/command/volumes/extend.go
+++ b/internal/command/volumes/extend.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -14,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -55,7 +55,7 @@ func runExtend(ctx context.Context) error {
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
 		appName  = appconfig.NameFromContext(ctx)
-		client   = fly.ClientFromContext(ctx)
+		client   = flyutil.ClientFromContext(ctx)
 		volID    = flag.FirstArg(ctx)
 	)
 
@@ -65,7 +65,7 @@ func runExtend(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx = flaps.NewContext(ctx, flapsClient)
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 
 	app, err := client.GetAppBasic(ctx, appName)
 	if err != nil {

--- a/internal/command/volumes/fork.go
+++ b/internal/command/volumes/fork.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -67,7 +68,7 @@ func runFork(ctx context.Context) error {
 		cfg     = config.FromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 		volID   = flag.FirstArg(ctx)
-		client  = fly.ClientFromContext(ctx)
+		client  = flyutil.ClientFromContext(ctx)
 	)
 
 	flapsClient, err := flapsutil.NewClientWithOptions(ctx, flaps.NewClientOpts{

--- a/internal/command/volumes/list.go
+++ b/internal/command/volumes/list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -45,7 +46,7 @@ func newList() *cobra.Command {
 
 func runList(ctx context.Context) error {
 	cfg := config.FromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	appName := appconfig.NameFromContext(ctx)
 

--- a/internal/command/volumes/lsvd/setup.go
+++ b/internal/command/volumes/lsvd/setup.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flyerr"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -31,7 +31,7 @@ func newSetup() *cobra.Command {
 
 func runSetup(ctx context.Context) error {
 	appName := appconfig.NameFromContext(ctx)
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 
 	secrets, err := client.GetAppSecrets(ctx, appName)

--- a/internal/command/volumes/show.go
+++ b/internal/command/volumes/show.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -40,7 +41,7 @@ func newShow() (cmd *cobra.Command) {
 
 func runShow(ctx context.Context) error {
 	cfg := config.FromContext(ctx)
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	volumeID := flag.FirstArg(ctx)
 

--- a/internal/command/volumes/snapshots/create.go
+++ b/internal/command/volumes/snapshots/create.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func newCreate() *cobra.Command {
@@ -28,7 +28,7 @@ func newCreate() *cobra.Command {
 }
 
 func create(ctx context.Context) error {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	volumeId := flag.FirstArg(ctx)
 

--- a/internal/command/volumes/snapshots/list.go
+++ b/internal/command/volumes/snapshots/list.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -51,7 +52,7 @@ func runList(ctx context.Context) error {
 	var (
 		io     = iostreams.FromContext(ctx)
 		cfg    = config.FromContext(ctx)
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 	)
 
 	volID := flag.FirstArg(ctx)

--- a/internal/command/volumes/update.go
+++ b/internal/command/volumes/update.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -54,7 +55,7 @@ func newUpdate() *cobra.Command {
 func runUpdate(ctx context.Context) error {
 	var (
 		cfg      = config.FromContext(ctx)
-		client   = fly.ClientFromContext(ctx)
+		client   = flyutil.ClientFromContext(ctx)
 		volumeID = flag.FirstArg(ctx)
 	)
 

--- a/internal/command/volumes/volumes.go
+++ b/internal/command/volumes/volumes.go
@@ -19,6 +19,7 @@ import (
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/volumes/lsvd"
 	"github.com/superfly/flyctl/internal/command/volumes/snapshots"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
 )
@@ -75,7 +76,7 @@ func countVolumesMatchingName(ctx context.Context, volumeName string) (int32, er
 		volumes []fly.Volume
 		err     error
 
-		flapsClient = flaps.FromContext(ctx)
+		flapsClient = flapsutil.ClientFromContext(ctx)
 	)
 
 	if volumes, err = flapsClient.GetVolumes(ctx); err != nil {

--- a/internal/command/wireguard/others.go
+++ b/internal/command/wireguard/others.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -42,7 +43,7 @@ func orgByArg(ctx context.Context) (*fly.Organization, error) {
 		return org, nil
 	}
 
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	return apiClient.GetOrganizationBySlug(ctx, args[0])
 }
 
@@ -117,7 +118,7 @@ PersistentKeepalive = 15
 	tmpl.Execute(w, &data)
 }
 
-func selectWireGuardPeer(ctx context.Context, client *fly.Client, slug string) (string, error) {
+func selectWireGuardPeer(ctx context.Context, client flyutil.Client, slug string) (string, error) {
 	peers, err := client.GetWireGuardPeers(ctx, slug)
 	if err != nil {
 		return "", err

--- a/internal/command/wireguard/tokens.go
+++ b/internal/command/wireguard/tokens.go
@@ -12,6 +12,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/internal/wireguard"
 	"github.com/superfly/flyctl/iostreams"
@@ -19,7 +20,7 @@ import (
 
 func runWireguardTokenList(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	org, err := orgByArg(ctx)
 	if err != nil {
@@ -48,7 +49,7 @@ func runWireguardTokenList(ctx context.Context) error {
 
 func runWireguardTokenCreate(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	org, err := orgByArg(ctx)
 	if err != nil {
@@ -101,7 +102,7 @@ and 'pubkey' (the public key of the gateway), which you can inject into a
 
 func runWireguardTokenDelete(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	org, err := orgByArg(ctx)
 	if err != nil {

--- a/internal/command/wireguard/wireguard.go
+++ b/internal/command/wireguard/wireguard.go
@@ -8,11 +8,11 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/internal/state"
 	"github.com/superfly/flyctl/internal/wireguard"
@@ -22,7 +22,7 @@ import (
 
 func runWireguardList(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	org, err := orgByArg(ctx)
 	if err != nil {
@@ -105,7 +105,7 @@ func runWireguardReset(ctx context.Context) error {
 		return err
 	}
 
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 	agentclient, err := agent.Establish(ctx, apiClient)
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func runWireguardReset(ctx context.Context) error {
 
 func runWireguardCreate(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	org, err := orgByArg(ctx)
 	if err != nil {
@@ -141,7 +141,7 @@ func runWireguardCreate(ctx context.Context) error {
 		name = args[2]
 	}
 
-	//TODO: allow custom network
+	// TODO: allow custom network
 	network := ""
 
 	state, err := wireguard.Create(apiClient, org, region, name, network)
@@ -177,7 +177,7 @@ func runWireguardCreate(ctx context.Context) error {
 
 func runWireguardRemove(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
-	apiClient := fly.ClientFromContext(ctx)
+	apiClient := flyutil.ClientFromContext(ctx)
 
 	org, err := orgByArg(ctx)
 	if err != nil {

--- a/internal/config/tokens.go
+++ b/internal/config/tokens.go
@@ -45,7 +45,6 @@ func MonitorTokens(monitorCtx context.Context, t *tokens.Tokens, uucb UserURLCal
 	updated2, err := refreshDischargeTokens(monitorCtx, t, uucb)
 	if err != nil {
 		log.Debugf("failed to update discharge tokens: %s", err)
-
 	}
 
 	if file != "" && updated1 || updated2 {
@@ -322,9 +321,9 @@ func doFetchOrgTokens(ctx context.Context, t *tokens.Tokens, fetchOrgs orgFetche
 }
 
 // orgFetcher allows us to stub out gql calls in tests
-type orgFetcher func(context.Context, *fly.Client) (map[uint64]string, error)
+type orgFetcher func(context.Context, flyutil.Client) (map[uint64]string, error)
 
-func defaultOrgFetcher(ctx context.Context, c *fly.Client) (map[uint64]string, error) {
+func defaultOrgFetcher(ctx context.Context, c flyutil.Client) (map[uint64]string, error) {
 	orgs, err := c.GetOrganizations(ctx)
 	if err != nil {
 		return nil, err
@@ -341,10 +340,10 @@ func defaultOrgFetcher(ctx context.Context, c *fly.Client) (map[uint64]string, e
 }
 
 // tokenMinter allows us to stub out gql calls in tests
-type tokenMinter func(context.Context, *fly.Client, string) (string, error)
+type tokenMinter func(context.Context, flyutil.Client, string) (string, error)
 
-func defaultTokenMinter(ctx context.Context, c *fly.Client, id string) (string, error) {
-	resp, err := gql.CreateLimitedAccessToken(ctx, c.GenqClient, "flyctl", id, "deploy_organization", &gql.LimitedAccessTokenOptions{}, "10m")
+func defaultTokenMinter(ctx context.Context, c flyutil.Client, id string) (string, error) {
+	resp, err := gql.CreateLimitedAccessToken(ctx, c.GenqClient(), "flyctl", id, "deploy_organization", &gql.LimitedAccessTokenOptions{}, "10m")
 	if err != nil {
 		return "", err
 	}

--- a/internal/config/tokens_test.go
+++ b/internal/config/tokens_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/tokens"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/macaroon"
 	"github.com/superfly/macaroon/flyio"
@@ -74,19 +74,19 @@ func TestFetchOrgTokens(t *testing.T) {
 }
 
 func fakeOrgFetcher(orgs map[uint64]string, err error) orgFetcher {
-	return func(context.Context, *fly.Client) (map[uint64]string, error) { return orgs, err }
+	return func(context.Context, flyutil.Client) (map[uint64]string, error) { return orgs, err }
 }
 
 func fakeOrgTokenMinter(tb testing.TB, expectedGraphID string, oid uint64) tokenMinter {
 	tb.Helper()
-	return func(_ context.Context, _ *fly.Client, graphID string) (string, error) {
+	return func(_ context.Context, _ flyutil.Client, graphID string) (string, error) {
 		require.Equal(tb, expectedGraphID, graphID)
 		return fakeTokenHeader(tb, "", oid), nil
 	}
 }
 
 func fakeTokenMinter(hdrsOrErrors ...any) tokenMinter {
-	return func(context.Context, *fly.Client, string) (string, error) {
+	return func(context.Context, flyutil.Client, string) (string, error) {
 		if len(hdrsOrErrors) == 0 {
 			panic("unexpected call to fakeTokenMinter")
 		}

--- a/internal/flag/completion/completions.go
+++ b/internal/flag/completion/completions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 func CompleteApps(
@@ -19,7 +20,7 @@ func CompleteApps(
 	partial string,
 ) ([]string, error) {
 	var (
-		client = fly.ClientFromContext(ctx)
+		client = flyutil.ClientFromContext(ctx)
 
 		apps []fly.App
 		err  error
@@ -65,7 +66,7 @@ func CompleteOrgs(
 	args []string,
 	partial string,
 ) ([]string, error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	format := func(org fly.Organization) string {
 		return fmt.Sprintf("%s\t%s", org.Slug, org.Name)
@@ -92,7 +93,7 @@ func CompleteRegions(
 	args []string,
 	partial string,
 ) ([]string, error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	format := func(org fly.Region) string {
 		return fmt.Sprintf("%s\t%s", org.Code, org.Name)

--- a/internal/flapsutil/flaps_client.go
+++ b/internal/flapsutil/flaps_client.go
@@ -1,0 +1,66 @@
+package flapsutil
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
+)
+
+var _ FlapsClient = (*flaps.Client)(nil)
+
+type FlapsClient interface {
+	AcquireLease(ctx context.Context, machineID string, ttl *int) (*fly.MachineLease, error)
+	Cordon(ctx context.Context, machineID string, nonce string) (err error)
+	CreateApp(ctx context.Context, name string, org string) (err error)
+	CreateVolume(ctx context.Context, req fly.CreateVolumeRequest) (*fly.Volume, error)
+	CreateVolumeSnapshot(ctx context.Context, volumeId string) error
+	DeleteMetadata(ctx context.Context, machineID, key string) error
+	DeleteVolume(ctx context.Context, volumeId string) (*fly.Volume, error)
+	Destroy(ctx context.Context, input fly.RemoveMachineInput, nonce string) (err error)
+	Exec(ctx context.Context, machineID string, in *fly.MachineExecRequest) (*fly.MachineExecResponse, error)
+	ExtendVolume(ctx context.Context, volumeId string, size_gb int) (*fly.Volume, bool, error)
+	FindLease(ctx context.Context, machineID string) (*fly.MachineLease, error)
+	Get(ctx context.Context, machineID string) (*fly.Machine, error)
+	GetAllVolumes(ctx context.Context) ([]fly.Volume, error)
+	GetMany(ctx context.Context, machineIDs []string) ([]*fly.Machine, error)
+	GetMetadata(ctx context.Context, machineID string) (map[string]string, error)
+	GetProcesses(ctx context.Context, machineID string) (fly.MachinePsResponse, error)
+	GetVolume(ctx context.Context, volumeId string) (*fly.Volume, error)
+	GetVolumeSnapshots(ctx context.Context, volumeId string) ([]fly.VolumeSnapshot, error)
+	GetVolumes(ctx context.Context) ([]fly.Volume, error)
+	Kill(ctx context.Context, machineID string) (err error)
+	Launch(ctx context.Context, builder fly.LaunchMachineInput) (out *fly.Machine, err error)
+	List(ctx context.Context, state string) ([]*fly.Machine, error)
+	ListActive(ctx context.Context) ([]*fly.Machine, error)
+	ListFlyAppsMachines(ctx context.Context) ([]*fly.Machine, *fly.Machine, error)
+	NewRequest(ctx context.Context, method, path string, in interface{}, headers map[string][]string) (*http.Request, error)
+	RefreshLease(ctx context.Context, machineID string, ttl *int, nonce string) (*fly.MachineLease, error)
+	ReleaseLease(ctx context.Context, machineID, nonce string) error
+	Restart(ctx context.Context, in fly.RestartMachineInput, nonce string) (err error)
+	SetMetadata(ctx context.Context, machineID, key, value string) error
+	Start(ctx context.Context, machineID string, nonce string) (out *fly.MachineStartResponse, err error)
+	Stop(ctx context.Context, in fly.StopMachineInput, nonce string) (err error)
+	Uncordon(ctx context.Context, machineID string, nonce string) (err error)
+	Update(ctx context.Context, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error)
+	UpdateVolume(ctx context.Context, volumeId string, req fly.UpdateVolumeRequest) (*fly.Volume, error)
+	Wait(ctx context.Context, machine *fly.Machine, state string, timeout time.Duration) (err error)
+	WaitForApp(ctx context.Context, name string) error
+}
+
+type contextKey struct{}
+
+var clientContextKey = &contextKey{}
+
+// NewContext derives a context that carries c from ctx.
+func NewContextWithClient(ctx context.Context, c FlapsClient) context.Context {
+	return context.WithValue(ctx, clientContextKey, c)
+}
+
+// ClientFromContext returns the client ctx carries.
+func ClientFromContext(ctx context.Context) FlapsClient {
+	c, _ := ctx.Value(clientContextKey).(FlapsClient)
+	return c
+}

--- a/internal/flyutil/client.go
+++ b/internal/flyutil/client.go
@@ -1,0 +1,107 @@
+package flyutil
+
+import (
+	"context"
+	"crypto/ed25519"
+	"net"
+
+	genq "github.com/Khan/genqlient/graphql"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/graphql"
+)
+
+var _ Client = (*fly.Client)(nil)
+
+type Client interface {
+	AddCertificate(ctx context.Context, appName, hostname string) (*fly.AppCertificate, *fly.HostnameCheck, error)
+	AllocateIPAddress(ctx context.Context, appName string, addrType string, region string, org *fly.Organization, network string) (*fly.IPAddress, error)
+	AllocateSharedIPAddress(ctx context.Context, appName string) (net.IP, error)
+	AppNameAvailable(ctx context.Context, appName string) (bool, error)
+	AttachPostgresCluster(ctx context.Context, input fly.AttachPostgresClusterInput) (*fly.AttachPostgresClusterPayload, error)
+	Authenticated() bool
+	CanPerformBluegreenDeployment(ctx context.Context, appName string) (bool, error)
+	CheckAppCertificate(ctx context.Context, appName, hostname string) (*fly.AppCertificate, *fly.HostnameCheck, error)
+	CheckDomain(ctx context.Context, name string) (*fly.CheckDomainResult, error)
+	ClosestWireguardGatewayRegion(ctx context.Context) (*fly.Region, error)
+	CreateAndRegisterDomain(organizationID string, name string) (*fly.Domain, error)
+	CreateApp(ctx context.Context, input fly.CreateAppInput) (*fly.App, error)
+	CreateDelegatedWireGuardToken(ctx context.Context, org *fly.Organization, name string) (*fly.DelegatedWireGuardToken, error)
+	CreateDoctorUrl(ctx context.Context) (putUrl string, err error)
+	CreateDomain(organizationID string, name string) (*fly.Domain, error)
+	CreateOrganization(ctx context.Context, organizationname string) (*fly.Organization, error)
+	CreateOrganizationInvite(ctx context.Context, id, email string) (*fly.Invitation, error)
+	CreateWireGuardPeer(ctx context.Context, org *fly.Organization, region, name, pubkey, network string) (*fly.CreatedWireGuardPeer, error)
+	DeleteApp(ctx context.Context, appName string) error
+	DeleteCertificate(ctx context.Context, appName, hostname string) (*fly.DeleteCertificatePayload, error)
+	DeleteDelegatedWireGuardToken(ctx context.Context, org *fly.Organization, name, token *string) error
+	DeleteOrganization(ctx context.Context, id string) (deletedid string, err error)
+	DeleteOrganizationMembership(ctx context.Context, orgId, userId string) (string, string, error)
+	DetachPostgresCluster(ctx context.Context, input fly.DetachPostgresClusterInput) error
+	EnablePostgresConsul(ctx context.Context, appName string) (*fly.PostgresEnableConsulPayload, error)
+	EnsureRemoteBuilder(ctx context.Context, orgID, appName, region string) (*fly.GqlMachine, *fly.App, error)
+	ExportDNSRecords(ctx context.Context, domainId string) (string, error)
+	GetApp(ctx context.Context, appName string) (*fly.App, error)
+	GetAppBasic(ctx context.Context, appName string) (*fly.AppBasic, error)
+	GetAppCertificates(ctx context.Context, appName string) ([]fly.AppCertificateCompact, error)
+	GetAppCompact(ctx context.Context, appName string) (*fly.AppCompact, error)
+	GetAppCurrentReleaseMachines(ctx context.Context, appName string) (*fly.Release, error)
+	GetAppLimitedAccessTokens(ctx context.Context, appName string) ([]fly.LimitedAccessToken, error)
+	GetAppLogs(ctx context.Context, appName, token, region, instanceID string) (entries []fly.LogEntry, nextToken string, err error)
+	GetAppNameFromVolume(ctx context.Context, volID string) (*string, error)
+	GetAppNameStateFromVolume(ctx context.Context, volID string) (*string, *string, error)
+	GetAppNetwork(ctx context.Context, appName string) (*string, error)
+	GetAppReleasesMachines(ctx context.Context, appName, status string, limit int) ([]fly.Release, error)
+	GetAppSecrets(ctx context.Context, appName string) ([]fly.Secret, error)
+	GetApps(ctx context.Context, role *string) ([]fly.App, error)
+	GetAppsForOrganization(ctx context.Context, orgID string) ([]fly.App, error)
+	GetCurrentUser(ctx context.Context) (*fly.User, error)
+	GetDNSRecords(ctx context.Context, domainName string) ([]*fly.DNSRecord, error)
+	GetDelegatedWireGuardTokens(ctx context.Context, slug string) ([]*fly.DelegatedWireGuardTokenHandle, error)
+	GetDetailedOrganizationBySlug(ctx context.Context, slug string) (*fly.OrganizationDetails, error)
+	GetDomain(ctx context.Context, name string) (*fly.Domain, error)
+	GetDomains(ctx context.Context, organizationSlug string) ([]*fly.Domain, error)
+	GetIPAddresses(ctx context.Context, appName string) ([]fly.IPAddress, error)
+	GetLatestImageDetails(ctx context.Context, image string) (*fly.ImageVersion, error)
+	GetLatestImageTag(ctx context.Context, repository string, snapshotId *string) (string, error)
+	GetLoggedCertificates(ctx context.Context, slug string) ([]fly.LoggedCertificate, error)
+	GetMachine(ctx context.Context, machineId string) (*fly.GqlMachine, error)
+	GetNearestRegion(ctx context.Context) (*fly.Region, error)
+	GetOrganizationBySlug(ctx context.Context, slug string) (*fly.Organization, error)
+	GetOrganizations(ctx context.Context, filters ...fly.OrganizationFilter) ([]fly.Organization, error)
+	GetSnapshotsFromVolume(ctx context.Context, volID string) ([]fly.VolumeSnapshot, error)
+	GetWireGuardPeer(ctx context.Context, slug, name string) (*fly.WireGuardPeer, error)
+	GetWireGuardPeers(ctx context.Context, slug string) ([]*fly.WireGuardPeer, error)
+	GenqClient() genq.Client
+	ImportDNSRecords(ctx context.Context, domainId string, zonefile string) ([]fly.ImportDnsWarning, []fly.ImportDnsChange, error)
+	IssueSSHCertificate(ctx context.Context, org fly.OrganizationImpl, principals []string, appNames []string, valid_hours *int, publicKey ed25519.PublicKey) (*fly.IssuedCertificate, error)
+	ListPostgresClusterAttachments(ctx context.Context, appName, postgresAppName string) ([]*fly.PostgresClusterAttachment, error)
+	Logger() fly.Logger
+	MoveApp(ctx context.Context, appName string, orgID string) (*fly.App, error)
+	NewRequest(q string) *graphql.Request
+	PlatformRegions(ctx context.Context) ([]fly.Region, *fly.Region, error)
+	ReleaseIPAddress(ctx context.Context, appName string, ip string) error
+	RemoveWireGuardPeer(ctx context.Context, org *fly.Organization, name string) error
+	ResolveImageForApp(ctx context.Context, appName, imageRef string) (*fly.Image, error)
+	RevokeLimitedAccessToken(ctx context.Context, id string) error
+	Run(req *graphql.Request) (fly.Query, error)
+	RunWithContext(ctx context.Context, req *graphql.Request) (fly.Query, error)
+	SetGenqClient(client genq.Client)
+	SetSecrets(ctx context.Context, appName string, secrets map[string]string) (*fly.Release, error)
+	UnsetSecrets(ctx context.Context, appName string, keys []string) (*fly.Release, error)
+	ValidateWireGuardPeers(ctx context.Context, peerIPs []string) (invalid []string, err error)
+}
+
+type contextKey string
+
+const contextKeyClient = contextKey("client")
+
+// NewContextWithClient derives a Context that carries c from ctx.
+func NewContextWithClient(ctx context.Context, c Client) context.Context {
+	return context.WithValue(ctx, contextKeyClient, c)
+}
+
+// ClientFromContext returns the Client ctx carries.
+func ClientFromContext(ctx context.Context) Client {
+	c, _ := ctx.Value(contextKeyClient).(Client)
+	return c
+}

--- a/internal/machine/ephemeral.go
+++ b/internal/machine/ephemeral.go
@@ -27,7 +27,7 @@ func LaunchEphemeral(ctx context.Context, input *EphemeralInput) (*fly.Machine, 
 	var (
 		io          = iostreams.FromContext(ctx)
 		colorize    = io.ColorScheme()
-		flapsClient = flaps.FromContext(ctx)
+		flapsClient = flapsutil.ClientFromContext(ctx)
 	)
 
 	if !input.LaunchInput.Config.AutoDestroy {
@@ -88,7 +88,7 @@ func LaunchEphemeral(ctx context.Context, input *EphemeralInput) (*fly.Machine, 
 }
 
 func checkMachineDestruction(ctx context.Context, machine *fly.Machine, firstErr error) (bool, error) {
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 	machine, err := flapsClient.Get(ctx, machine.ID)
 	if err != nil {
 		return false, fmt.Errorf("failed to check status of machine: %w", err)
@@ -122,7 +122,7 @@ func makeCleanupFunc(ctx context.Context, machine *fly.Machine) func() {
 	var (
 		io          = iostreams.FromContext(ctx)
 		colorize    = io.ColorScheme()
-		flapsClient = flaps.FromContext(ctx)
+		flapsClient = flapsutil.ClientFromContext(ctx)
 	)
 
 	return func() {

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -11,6 +11,7 @@ import (
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/ctrlc"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/statuslogger"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/terminal"
@@ -41,7 +42,7 @@ type LeasableMachine interface {
 }
 
 type leasableMachine struct {
-	flapsClient            *flaps.Client
+	flapsClient            flapsutil.FlapsClient
 	io                     *iostreams.IOStreams
 	colorize               *iostreams.ColorScheme
 	machine                *fly.Machine
@@ -50,7 +51,7 @@ type leasableMachine struct {
 	destroyed              bool
 }
 
-func NewLeasableMachine(flapsClient *flaps.Client, io *iostreams.IOStreams, machine *fly.Machine) LeasableMachine {
+func NewLeasableMachine(flapsClient flapsutil.FlapsClient, io *iostreams.IOStreams, machine *fly.Machine) LeasableMachine {
 	return &leasableMachine{
 		flapsClient: flapsClient,
 		io:          io,

--- a/internal/machine/lease.go
+++ b/internal/machine/lease.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sourcegraph/conc/pool"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -58,7 +58,7 @@ func releaseLease(ctx context.Context, machine *fly.Machine) {
 	}
 
 	io := iostreams.FromContext(ctx)
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	if err := flapsClient.ReleaseLease(ctx, machine.ID, machine.LeaseNonce); err != nil {
 		if !strings.Contains(err.Error(), "lease not found") {
@@ -70,7 +70,7 @@ func releaseLease(ctx context.Context, machine *fly.Machine) {
 // AcquireLease works to acquire/attach a lease for the specified machine.
 // WARNING: Make sure you defer the lease release process.
 func AcquireLease(ctx context.Context, machine *fly.Machine) (*fly.Machine, releaseLeaseFunc, error) {
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	lease, err := flapsClient.AcquireLease(ctx, machine.ID, fly.IntPointer(120))
 	if err != nil {

--- a/internal/machine/machine_set.go
+++ b/internal/machine/machine_set.go
@@ -11,6 +11,7 @@ import (
 
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/tracing"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/terminal"
@@ -30,7 +31,7 @@ type machineSet struct {
 	machines []LeasableMachine
 }
 
-func NewMachineSet(flapsClient *flaps.Client, io *iostreams.IOStreams, machines []*fly.Machine) *machineSet {
+func NewMachineSet(flapsClient flapsutil.FlapsClient, io *iostreams.IOStreams, machines []*fly.Machine) *machineSet {
 	leaseMachines := make([]LeasableMachine, 0)
 	for _, m := range machines {
 		leaseMachines = append(leaseMachines, NewLeasableMachine(flapsClient, io, m))

--- a/internal/machine/query.go
+++ b/internal/machine/query.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/samber/lo"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flapsutil"
 )
 
 func ListActive(ctx context.Context) ([]*fly.Machine, error) {
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	machines, err := flapsClient.List(ctx, "")
 	if err != nil {

--- a/internal/machine/restart.go
+++ b/internal/machine/restart.go
@@ -6,14 +6,14 @@ import (
 	"time"
 
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/watch"
 	"github.com/superfly/flyctl/iostreams"
 )
 
 func Restart(ctx context.Context, m *fly.Machine, input *fly.RestartMachineInput, nonce string) error {
 	var (
-		flapsClient = flaps.FromContext(ctx)
+		flapsClient = flapsutil.ClientFromContext(ctx)
 		io          = iostreams.FromContext(ctx)
 		colorize    = io.ColorScheme()
 	)

--- a/internal/machine/update.go
+++ b/internal/machine/update.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/watch"
 	"github.com/superfly/flyctl/iostreams"
 	"golang.org/x/exp/maps"
@@ -20,7 +20,7 @@ var cpusPerKind = map[string][]int{
 
 func Update(ctx context.Context, m *fly.Machine, input *fly.LaunchMachineInput) error {
 	var (
-		flapsClient    = flaps.FromContext(ctx)
+		flapsClient    = flapsutil.ClientFromContext(ctx)
 		io             = iostreams.FromContext(ctx)
 		colorize       = io.ColorScheme()
 		updatedMachine *fly.Machine

--- a/internal/machine/wait.go
+++ b/internal/machine/wait.go
@@ -11,11 +11,12 @@ import (
 	"github.com/jpillora/backoff"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyerr"
 )
 
 func WaitForStartOrStop(ctx context.Context, machine *fly.Machine, action string, timeout time.Duration) error {
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/metrics/token.go
+++ b/internal/metrics/token.go
@@ -32,7 +32,7 @@ func queryMetricsToken(ctx context.Context) (string, error) {
 
 	resp, err := gql.CreateLimitedAccessToken(
 		ctx,
-		apiClient.GenqClient,
+		apiClient.GenqClient(),
 		"flyctl-metrics",
 		personal.ID,
 		"identity",

--- a/internal/mock/client.go
+++ b/internal/mock/client.go
@@ -1,0 +1,397 @@
+package mock
+
+import (
+	"context"
+	"crypto/ed25519"
+	"net"
+
+	genq "github.com/Khan/genqlient/graphql"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/graphql"
+)
+
+var _ flyutil.Client = (*Client)(nil)
+
+type Client struct {
+	AddCertificateFunc                 func(ctx context.Context, appName, hostname string) (*fly.AppCertificate, *fly.HostnameCheck, error)
+	AllocateIPAddressFunc              func(ctx context.Context, appName string, addrType string, region string, org *fly.Organization, network string) (*fly.IPAddress, error)
+	AllocateSharedIPAddressFunc        func(ctx context.Context, appName string) (net.IP, error)
+	AppNameAvailableFunc               func(ctx context.Context, appName string) (bool, error)
+	AttachPostgresClusterFunc          func(ctx context.Context, input fly.AttachPostgresClusterInput) (*fly.AttachPostgresClusterPayload, error)
+	AuthenticatedFunc                  func() bool
+	CanPerformBluegreenDeploymentFunc  func(ctx context.Context, appName string) (bool, error)
+	CheckAppCertificateFunc            func(ctx context.Context, appName, hostname string) (*fly.AppCertificate, *fly.HostnameCheck, error)
+	CheckDomainFunc                    func(ctx context.Context, name string) (*fly.CheckDomainResult, error)
+	ClosestWireguardGatewayRegionFunc  func(ctx context.Context) (*fly.Region, error)
+	CreateAndRegisterDomainFunc        func(organizationID string, name string) (*fly.Domain, error)
+	CreateAppFunc                      func(ctx context.Context, input fly.CreateAppInput) (*fly.App, error)
+	CreateDelegatedWireGuardTokenFunc  func(ctx context.Context, org *fly.Organization, name string) (*fly.DelegatedWireGuardToken, error)
+	CreateDoctorUrlFunc                func(ctx context.Context) (putUrl string, err error)
+	CreateDomainFunc                   func(organizationID string, name string) (*fly.Domain, error)
+	CreateOrganizationFunc             func(ctx context.Context, organizationname string) (*fly.Organization, error)
+	CreateOrganizationInviteFunc       func(ctx context.Context, id, email string) (*fly.Invitation, error)
+	CreateWireGuardPeerFunc            func(ctx context.Context, org *fly.Organization, region, name, pubkey, network string) (*fly.CreatedWireGuardPeer, error)
+	DeleteAppFunc                      func(ctx context.Context, appName string) error
+	DeleteCertificateFunc              func(ctx context.Context, appName, hostname string) (*fly.DeleteCertificatePayload, error)
+	DeleteDelegatedWireGuardTokenFunc  func(ctx context.Context, org *fly.Organization, name, token *string) error
+	DeleteOrganizationFunc             func(ctx context.Context, id string) (deletedid string, err error)
+	DeleteOrganizationMembershipFunc   func(ctx context.Context, orgId, userId string) (string, string, error)
+	DetachPostgresClusterFunc          func(ctx context.Context, input fly.DetachPostgresClusterInput) error
+	EnablePostgresConsulFunc           func(ctx context.Context, appName string) (*fly.PostgresEnableConsulPayload, error)
+	EnsureRemoteBuilderFunc            func(ctx context.Context, orgID, appName, region string) (*fly.GqlMachine, *fly.App, error)
+	ExportDNSRecordsFunc               func(ctx context.Context, domainId string) (string, error)
+	GetAppFunc                         func(ctx context.Context, appName string) (*fly.App, error)
+	GetAppBasicFunc                    func(ctx context.Context, appName string) (*fly.AppBasic, error)
+	GetAppCertificatesFunc             func(ctx context.Context, appName string) ([]fly.AppCertificateCompact, error)
+	GetAppCompactFunc                  func(ctx context.Context, appName string) (*fly.AppCompact, error)
+	GetAppCurrentReleaseMachinesFunc   func(ctx context.Context, appName string) (*fly.Release, error)
+	GetAppLimitedAccessTokensFunc      func(ctx context.Context, appName string) ([]fly.LimitedAccessToken, error)
+	GetAppLogsFunc                     func(ctx context.Context, appName, token, region, instanceID string) (entries []fly.LogEntry, nextToken string, err error)
+	GetAppNameFromVolumeFunc           func(ctx context.Context, volID string) (*string, error)
+	GetAppNameStateFromVolumeFunc      func(ctx context.Context, volID string) (*string, *string, error)
+	GetAppNetworkFunc                  func(ctx context.Context, appName string) (*string, error)
+	GetAppReleasesMachinesFunc         func(ctx context.Context, appName, status string, limit int) ([]fly.Release, error)
+	GetAppSecretsFunc                  func(ctx context.Context, appName string) ([]fly.Secret, error)
+	GetAppsFunc                        func(ctx context.Context, role *string) ([]fly.App, error)
+	GetAppsForOrganizationFunc         func(ctx context.Context, orgID string) ([]fly.App, error)
+	GetCurrentUserFunc                 func(ctx context.Context) (*fly.User, error)
+	GetDNSRecordsFunc                  func(ctx context.Context, domainName string) ([]*fly.DNSRecord, error)
+	GetDelegatedWireGuardTokensFunc    func(ctx context.Context, slug string) ([]*fly.DelegatedWireGuardTokenHandle, error)
+	GetDetailedOrganizationBySlugFunc  func(ctx context.Context, slug string) (*fly.OrganizationDetails, error)
+	GetDomainFunc                      func(ctx context.Context, name string) (*fly.Domain, error)
+	GetDomainsFunc                     func(ctx context.Context, organizationSlug string) ([]*fly.Domain, error)
+	GetIPAddressesFunc                 func(ctx context.Context, appName string) ([]fly.IPAddress, error)
+	GetLatestImageDetailsFunc          func(ctx context.Context, image string) (*fly.ImageVersion, error)
+	GetLatestImageTagFunc              func(ctx context.Context, repository string, snapshotId *string) (string, error)
+	GetLoggedCertificatesFunc          func(ctx context.Context, slug string) ([]fly.LoggedCertificate, error)
+	GetMachineFunc                     func(ctx context.Context, machineId string) (*fly.GqlMachine, error)
+	GetNearestRegionFunc               func(ctx context.Context) (*fly.Region, error)
+	GetOrganizationBySlugFunc          func(ctx context.Context, slug string) (*fly.Organization, error)
+	GetOrganizationsFunc               func(ctx context.Context, filters ...fly.OrganizationFilter) ([]fly.Organization, error)
+	GetSnapshotsFromVolumeFunc         func(ctx context.Context, volID string) ([]fly.VolumeSnapshot, error)
+	GetWireGuardPeerFunc               func(ctx context.Context, slug, name string) (*fly.WireGuardPeer, error)
+	GetWireGuardPeersFunc              func(ctx context.Context, slug string) ([]*fly.WireGuardPeer, error)
+	GenqClientFunc                     func() genq.Client
+	ImportDNSRecordsFunc               func(ctx context.Context, domainId string, zonefile string) ([]fly.ImportDnsWarning, []fly.ImportDnsChange, error)
+	IssueSSHCertificateFunc            func(ctx context.Context, org fly.OrganizationImpl, principals []string, appNames []string, valid_hours *int, publicKey ed25519.PublicKey) (*fly.IssuedCertificate, error)
+	ListPostgresClusterAttachmentsFunc func(ctx context.Context, appName, postgresAppName string) ([]*fly.PostgresClusterAttachment, error)
+	LoggerFunc                         func() fly.Logger
+	MoveAppFunc                        func(ctx context.Context, appName string, orgID string) (*fly.App, error)
+	NewRequestFunc                     func(q string) *graphql.Request
+	PlatformRegionsFunc                func(ctx context.Context) ([]fly.Region, *fly.Region, error)
+	ReleaseIPAddressFunc               func(ctx context.Context, appName string, ip string) error
+	RemoveWireGuardPeerFunc            func(ctx context.Context, org *fly.Organization, name string) error
+	ResolveImageForAppFunc             func(ctx context.Context, appName, imageRef string) (*fly.Image, error)
+	RevokeLimitedAccessTokenFunc       func(ctx context.Context, id string) error
+	RunFunc                            func(req *graphql.Request) (fly.Query, error)
+	RunWithContextFunc                 func(ctx context.Context, req *graphql.Request) (fly.Query, error)
+	SetGenqClientFunc                  func(client genq.Client)
+	SetSecretsFunc                     func(ctx context.Context, appName string, secrets map[string]string) (*fly.Release, error)
+	UnsetSecretsFunc                   func(ctx context.Context, appName string, keys []string) (*fly.Release, error)
+	ValidateWireGuardPeersFunc         func(ctx context.Context, peerIPs []string) (invalid []string, err error)
+}
+
+func (m *Client) AddCertificate(ctx context.Context, appName, hostname string) (*fly.AppCertificate, *fly.HostnameCheck, error) {
+	return m.AddCertificateFunc(ctx, appName, hostname)
+}
+
+func (m *Client) AllocateIPAddress(ctx context.Context, appName string, addrType string, region string, org *fly.Organization, network string) (*fly.IPAddress, error) {
+	return m.AllocateIPAddressFunc(ctx, appName, addrType, region, org, network)
+}
+
+func (m *Client) AllocateSharedIPAddress(ctx context.Context, appName string) (net.IP, error) {
+	return m.AllocateSharedIPAddressFunc(ctx, appName)
+}
+
+func (m *Client) AppNameAvailable(ctx context.Context, appName string) (bool, error) {
+	return m.AppNameAvailableFunc(ctx, appName)
+}
+
+func (m *Client) AttachPostgresCluster(ctx context.Context, input fly.AttachPostgresClusterInput) (*fly.AttachPostgresClusterPayload, error) {
+	return m.AttachPostgresClusterFunc(ctx, input)
+}
+
+func (m *Client) Authenticated() bool {
+	return m.AuthenticatedFunc()
+}
+
+func (m *Client) CanPerformBluegreenDeployment(ctx context.Context, appName string) (bool, error) {
+	return m.CanPerformBluegreenDeploymentFunc(ctx, appName)
+}
+
+func (m *Client) CheckAppCertificate(ctx context.Context, appName, hostname string) (*fly.AppCertificate, *fly.HostnameCheck, error) {
+	return m.CheckAppCertificateFunc(ctx, appName, hostname)
+}
+
+func (m *Client) CheckDomain(ctx context.Context, name string) (*fly.CheckDomainResult, error) {
+	return m.CheckDomainFunc(ctx, name)
+}
+
+func (m *Client) ClosestWireguardGatewayRegion(ctx context.Context) (*fly.Region, error) {
+	return m.ClosestWireguardGatewayRegionFunc(ctx)
+}
+
+func (m *Client) CreateAndRegisterDomain(organizationID string, name string) (*fly.Domain, error) {
+	return m.CreateAndRegisterDomainFunc(organizationID, name)
+}
+
+func (m *Client) CreateApp(ctx context.Context, input fly.CreateAppInput) (*fly.App, error) {
+	return m.CreateAppFunc(ctx, input)
+}
+
+func (m *Client) CreateDelegatedWireGuardToken(ctx context.Context, org *fly.Organization, name string) (*fly.DelegatedWireGuardToken, error) {
+	return m.CreateDelegatedWireGuardTokenFunc(ctx, org, name)
+}
+
+func (m *Client) CreateDoctorUrl(ctx context.Context) (putUrl string, err error) {
+	return m.CreateDoctorUrlFunc(ctx)
+}
+
+func (m *Client) CreateDomain(organizationID string, name string) (*fly.Domain, error) {
+	return m.CreateDomainFunc(organizationID, name)
+}
+
+func (m *Client) CreateOrganization(ctx context.Context, organizationname string) (*fly.Organization, error) {
+	return m.CreateOrganizationFunc(ctx, organizationname)
+}
+
+func (m *Client) CreateOrganizationInvite(ctx context.Context, id, email string) (*fly.Invitation, error) {
+	return m.CreateOrganizationInviteFunc(ctx, id, email)
+}
+
+func (m *Client) CreateWireGuardPeer(ctx context.Context, org *fly.Organization, region, name, pubkey, network string) (*fly.CreatedWireGuardPeer, error) {
+	return m.CreateWireGuardPeerFunc(ctx, org, region, name, pubkey, network)
+}
+
+func (m *Client) DeleteApp(ctx context.Context, appName string) error {
+	return m.DeleteAppFunc(ctx, appName)
+}
+
+func (m *Client) DeleteCertificate(ctx context.Context, appName, hostname string) (*fly.DeleteCertificatePayload, error) {
+	return m.DeleteCertificateFunc(ctx, appName, hostname)
+}
+
+func (m *Client) DeleteDelegatedWireGuardToken(ctx context.Context, org *fly.Organization, name, token *string) error {
+	return m.DeleteDelegatedWireGuardTokenFunc(ctx, org, name, token)
+}
+
+func (m *Client) DeleteOrganization(ctx context.Context, id string) (deletedid string, err error) {
+	return m.DeleteOrganizationFunc(ctx, id)
+}
+
+func (m *Client) DeleteOrganizationMembership(ctx context.Context, orgId, userId string) (string, string, error) {
+	return m.DeleteOrganizationMembershipFunc(ctx, orgId, userId)
+}
+
+func (m *Client) DetachPostgresCluster(ctx context.Context, input fly.DetachPostgresClusterInput) error {
+	return m.DetachPostgresClusterFunc(ctx, input)
+}
+
+func (m *Client) EnablePostgresConsul(ctx context.Context, appName string) (*fly.PostgresEnableConsulPayload, error) {
+	return m.EnablePostgresConsulFunc(ctx, appName)
+}
+
+func (m *Client) EnsureRemoteBuilder(ctx context.Context, orgID, appName, region string) (*fly.GqlMachine, *fly.App, error) {
+	return m.EnsureRemoteBuilderFunc(ctx, orgID, appName, region)
+}
+
+func (m *Client) ExportDNSRecords(ctx context.Context, domainId string) (string, error) {
+	return m.ExportDNSRecordsFunc(ctx, domainId)
+}
+
+func (m *Client) GetApp(ctx context.Context, appName string) (*fly.App, error) {
+	return m.GetAppFunc(ctx, appName)
+}
+
+func (m *Client) GetAppBasic(ctx context.Context, appName string) (*fly.AppBasic, error) {
+	return m.GetAppBasicFunc(ctx, appName)
+}
+
+func (m *Client) GetAppCertificates(ctx context.Context, appName string) ([]fly.AppCertificateCompact, error) {
+	return m.GetAppCertificatesFunc(ctx, appName)
+}
+
+func (m *Client) GetAppCompact(ctx context.Context, appName string) (*fly.AppCompact, error) {
+	return m.GetAppCompactFunc(ctx, appName)
+}
+
+func (m *Client) GetAppCurrentReleaseMachines(ctx context.Context, appName string) (*fly.Release, error) {
+	return m.GetAppCurrentReleaseMachinesFunc(ctx, appName)
+}
+
+func (m *Client) GetAppLimitedAccessTokens(ctx context.Context, appName string) ([]fly.LimitedAccessToken, error) {
+	return m.GetAppLimitedAccessTokensFunc(ctx, appName)
+}
+
+func (m *Client) GetAppLogs(ctx context.Context, appName, token, region, instanceID string) (entries []fly.LogEntry, nextToken string, err error) {
+	return m.GetAppLogsFunc(ctx, appName, token, region, instanceID)
+}
+
+func (m *Client) GetAppNameFromVolume(ctx context.Context, volID string) (*string, error) {
+	return m.GetAppNameFromVolumeFunc(ctx, volID)
+}
+
+func (m *Client) GetAppNameStateFromVolume(ctx context.Context, volID string) (*string, *string, error) {
+	return m.GetAppNameStateFromVolumeFunc(ctx, volID)
+}
+
+func (m *Client) GetAppNetwork(ctx context.Context, appName string) (*string, error) {
+	return m.GetAppNetworkFunc(ctx, appName)
+}
+
+func (m *Client) GetAppReleasesMachines(ctx context.Context, appName, status string, limit int) ([]fly.Release, error) {
+	return m.GetAppReleasesMachinesFunc(ctx, appName, status, limit)
+}
+
+func (m *Client) GetAppSecrets(ctx context.Context, appName string) ([]fly.Secret, error) {
+	return m.GetAppSecretsFunc(ctx, appName)
+}
+
+func (m *Client) GetApps(ctx context.Context, role *string) ([]fly.App, error) {
+	return m.GetAppsFunc(ctx, role)
+}
+
+func (m *Client) GetAppsForOrganization(ctx context.Context, orgID string) ([]fly.App, error) {
+	return m.GetAppsForOrganizationFunc(ctx, orgID)
+}
+
+func (m *Client) GetCurrentUser(ctx context.Context) (*fly.User, error) {
+	return m.GetCurrentUserFunc(ctx)
+}
+
+func (m *Client) GetDNSRecords(ctx context.Context, domainName string) ([]*fly.DNSRecord, error) {
+	return m.GetDNSRecordsFunc(ctx, domainName)
+}
+
+func (m *Client) GetDelegatedWireGuardTokens(ctx context.Context, slug string) ([]*fly.DelegatedWireGuardTokenHandle, error) {
+	return m.GetDelegatedWireGuardTokensFunc(ctx, slug)
+}
+
+func (m *Client) GetDetailedOrganizationBySlug(ctx context.Context, slug string) (*fly.OrganizationDetails, error) {
+	return m.GetDetailedOrganizationBySlugFunc(ctx, slug)
+}
+
+func (m *Client) GetDomain(ctx context.Context, name string) (*fly.Domain, error) {
+	return m.GetDomainFunc(ctx, name)
+}
+
+func (m *Client) GetDomains(ctx context.Context, organizationSlug string) ([]*fly.Domain, error) {
+	return m.GetDomainsFunc(ctx, organizationSlug)
+}
+
+func (m *Client) GetIPAddresses(ctx context.Context, appName string) ([]fly.IPAddress, error) {
+	return m.GetIPAddressesFunc(ctx, appName)
+}
+
+func (m *Client) GetLatestImageDetails(ctx context.Context, image string) (*fly.ImageVersion, error) {
+	return m.GetLatestImageDetailsFunc(ctx, image)
+}
+
+func (m *Client) GetLatestImageTag(ctx context.Context, repository string, snapshotId *string) (string, error) {
+	return m.GetLatestImageTagFunc(ctx, repository, snapshotId)
+}
+
+func (m *Client) GetLoggedCertificates(ctx context.Context, slug string) ([]fly.LoggedCertificate, error) {
+	return m.GetLoggedCertificatesFunc(ctx, slug)
+}
+
+func (m *Client) GetMachine(ctx context.Context, machineId string) (*fly.GqlMachine, error) {
+	return m.GetMachineFunc(ctx, machineId)
+}
+
+func (m *Client) GetNearestRegion(ctx context.Context) (*fly.Region, error) {
+	return m.GetNearestRegionFunc(ctx)
+}
+
+func (m *Client) GetOrganizationBySlug(ctx context.Context, slug string) (*fly.Organization, error) {
+	return m.GetOrganizationBySlugFunc(ctx, slug)
+}
+
+func (m *Client) GetOrganizations(ctx context.Context, filters ...fly.OrganizationFilter) ([]fly.Organization, error) {
+	return m.GetOrganizationsFunc(ctx, filters...)
+}
+
+func (m *Client) GetSnapshotsFromVolume(ctx context.Context, volID string) ([]fly.VolumeSnapshot, error) {
+	return m.GetSnapshotsFromVolumeFunc(ctx, volID)
+}
+
+func (m *Client) GetWireGuardPeer(ctx context.Context, slug, name string) (*fly.WireGuardPeer, error) {
+	return m.GetWireGuardPeerFunc(ctx, slug, name)
+}
+
+func (m *Client) GetWireGuardPeers(ctx context.Context, slug string) ([]*fly.WireGuardPeer, error) {
+	return m.GetWireGuardPeersFunc(ctx, slug)
+}
+
+func (m *Client) GenqClient() genq.Client {
+	return m.GenqClientFunc()
+}
+
+func (m *Client) ImportDNSRecords(ctx context.Context, domainId string, zonefile string) ([]fly.ImportDnsWarning, []fly.ImportDnsChange, error) {
+	return m.ImportDNSRecordsFunc(ctx, domainId, zonefile)
+}
+
+func (m *Client) IssueSSHCertificate(ctx context.Context, org fly.OrganizationImpl, principals []string, appNames []string, valid_hours *int, publicKey ed25519.PublicKey) (*fly.IssuedCertificate, error) {
+	return m.IssueSSHCertificateFunc(ctx, org, principals, appNames, valid_hours, publicKey)
+}
+
+func (m *Client) ListPostgresClusterAttachments(ctx context.Context, appName, postgresAppName string) ([]*fly.PostgresClusterAttachment, error) {
+	return m.ListPostgresClusterAttachmentsFunc(ctx, appName, postgresAppName)
+}
+
+func (m *Client) Logger() fly.Logger {
+	return m.LoggerFunc()
+}
+
+func (m *Client) MoveApp(ctx context.Context, appName string, orgID string) (*fly.App, error) {
+	return m.MoveAppFunc(ctx, appName, orgID)
+}
+
+func (m *Client) NewRequest(q string) *graphql.Request {
+	return m.NewRequestFunc(q)
+}
+
+func (m *Client) PlatformRegions(ctx context.Context) ([]fly.Region, *fly.Region, error) {
+	return m.PlatformRegionsFunc(ctx)
+}
+
+func (m *Client) ReleaseIPAddress(ctx context.Context, appName string, ip string) error {
+	return m.ReleaseIPAddressFunc(ctx, appName, ip)
+}
+
+func (m *Client) RemoveWireGuardPeer(ctx context.Context, org *fly.Organization, name string) error {
+	return m.RemoveWireGuardPeerFunc(ctx, org, name)
+}
+
+func (m *Client) ResolveImageForApp(ctx context.Context, appName, imageRef string) (*fly.Image, error) {
+	return m.ResolveImageForAppFunc(ctx, appName, imageRef)
+}
+
+func (m *Client) RevokeLimitedAccessToken(ctx context.Context, id string) error {
+	return m.RevokeLimitedAccessTokenFunc(ctx, id)
+}
+
+func (m *Client) Run(req *graphql.Request) (fly.Query, error) {
+	return m.RunFunc(req)
+}
+
+func (m *Client) RunWithContext(ctx context.Context, req *graphql.Request) (fly.Query, error) {
+	return m.RunWithContextFunc(ctx, req)
+}
+
+func (m *Client) SetGenqClient(client genq.Client) {
+	m.SetGenqClientFunc(client)
+}
+
+func (m *Client) SetSecrets(ctx context.Context, appName string, secrets map[string]string) (*fly.Release, error) {
+	return m.SetSecretsFunc(ctx, appName, secrets)
+}
+
+func (m *Client) UnsetSecrets(ctx context.Context, appName string, keys []string) (*fly.Release, error) {
+	return m.UnsetSecretsFunc(ctx, appName, keys)
+}
+
+func (m *Client) ValidateWireGuardPeers(ctx context.Context, peerIPs []string) (invalid []string, err error) {
+	return m.ValidateWireGuardPeersFunc(ctx, peerIPs)
+}

--- a/internal/mock/flaps_client.go
+++ b/internal/mock/flaps_client.go
@@ -1,0 +1,195 @@
+package mock
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/flapsutil"
+)
+
+var _ flapsutil.FlapsClient = (*FlapsClient)(nil)
+
+type FlapsClient struct {
+	AcquireLeaseFunc         func(ctx context.Context, machineID string, ttl *int) (*fly.MachineLease, error)
+	CordonFunc               func(ctx context.Context, machineID string, nonce string) (err error)
+	CreateAppFunc            func(ctx context.Context, name string, org string) (err error)
+	CreateVolumeFunc         func(ctx context.Context, req fly.CreateVolumeRequest) (*fly.Volume, error)
+	CreateVolumeSnapshotFunc func(ctx context.Context, volumeId string) error
+	DeleteMetadataFunc       func(ctx context.Context, machineID, key string) error
+	DeleteVolumeFunc         func(ctx context.Context, volumeId string) (*fly.Volume, error)
+	DestroyFunc              func(ctx context.Context, input fly.RemoveMachineInput, nonce string) (err error)
+	ExecFunc                 func(ctx context.Context, machineID string, in *fly.MachineExecRequest) (*fly.MachineExecResponse, error)
+	ExtendVolumeFunc         func(ctx context.Context, volumeId string, size_gb int) (*fly.Volume, bool, error)
+	FindLeaseFunc            func(ctx context.Context, machineID string) (*fly.MachineLease, error)
+	GetFunc                  func(ctx context.Context, machineID string) (*fly.Machine, error)
+	GetAllVolumesFunc        func(ctx context.Context) ([]fly.Volume, error)
+	GetManyFunc              func(ctx context.Context, machineIDs []string) ([]*fly.Machine, error)
+	GetMetadataFunc          func(ctx context.Context, machineID string) (map[string]string, error)
+	GetProcessesFunc         func(ctx context.Context, machineID string) (fly.MachinePsResponse, error)
+	GetVolumeFunc            func(ctx context.Context, volumeId string) (*fly.Volume, error)
+	GetVolumeSnapshotsFunc   func(ctx context.Context, volumeId string) ([]fly.VolumeSnapshot, error)
+	GetVolumesFunc           func(ctx context.Context) ([]fly.Volume, error)
+	KillFunc                 func(ctx context.Context, machineID string) (err error)
+	LaunchFunc               func(ctx context.Context, builder fly.LaunchMachineInput) (out *fly.Machine, err error)
+	ListFunc                 func(ctx context.Context, state string) ([]*fly.Machine, error)
+	ListActiveFunc           func(ctx context.Context) ([]*fly.Machine, error)
+	ListFlyAppsMachinesFunc  func(ctx context.Context) ([]*fly.Machine, *fly.Machine, error)
+	NewRequestFunc           func(ctx context.Context, method, path string, in interface{}, headers map[string][]string) (*http.Request, error)
+	RefreshLeaseFunc         func(ctx context.Context, machineID string, ttl *int, nonce string) (*fly.MachineLease, error)
+	ReleaseLeaseFunc         func(ctx context.Context, machineID, nonce string) error
+	RestartFunc              func(ctx context.Context, in fly.RestartMachineInput, nonce string) (err error)
+	SetMetadataFunc          func(ctx context.Context, machineID, key, value string) error
+	StartFunc                func(ctx context.Context, machineID string, nonce string) (out *fly.MachineStartResponse, err error)
+	StopFunc                 func(ctx context.Context, in fly.StopMachineInput, nonce string) (err error)
+	UncordonFunc             func(ctx context.Context, machineID string, nonce string) (err error)
+	UpdateFunc               func(ctx context.Context, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error)
+	UpdateVolumeFunc         func(ctx context.Context, volumeId string, req fly.UpdateVolumeRequest) (*fly.Volume, error)
+	WaitFunc                 func(ctx context.Context, machine *fly.Machine, state string, timeout time.Duration) (err error)
+	WaitForAppFunc           func(ctx context.Context, name string) error
+}
+
+func (m *FlapsClient) AcquireLease(ctx context.Context, machineID string, ttl *int) (*fly.MachineLease, error) {
+	return m.AcquireLeaseFunc(ctx, machineID, ttl)
+}
+
+func (m *FlapsClient) Cordon(ctx context.Context, machineID string, nonce string) (err error) {
+	return m.CordonFunc(ctx, machineID, nonce)
+}
+
+func (m *FlapsClient) CreateApp(ctx context.Context, name string, org string) (err error) {
+	return m.CreateAppFunc(ctx, name, org)
+}
+
+func (m *FlapsClient) CreateVolume(ctx context.Context, req fly.CreateVolumeRequest) (*fly.Volume, error) {
+	return m.CreateVolumeFunc(ctx, req)
+}
+
+func (m *FlapsClient) CreateVolumeSnapshot(ctx context.Context, volumeId string) error {
+	return m.CreateVolumeSnapshotFunc(ctx, volumeId)
+}
+
+func (m *FlapsClient) DeleteMetadata(ctx context.Context, machineID, key string) error {
+	return m.DeleteMetadataFunc(ctx, machineID, key)
+}
+
+func (m *FlapsClient) DeleteVolume(ctx context.Context, volumeId string) (*fly.Volume, error) {
+	return m.DeleteVolumeFunc(ctx, volumeId)
+}
+
+func (m *FlapsClient) Destroy(ctx context.Context, input fly.RemoveMachineInput, nonce string) (err error) {
+	return m.DestroyFunc(ctx, input, nonce)
+}
+
+func (m *FlapsClient) Exec(ctx context.Context, machineID string, in *fly.MachineExecRequest) (*fly.MachineExecResponse, error) {
+	return m.ExecFunc(ctx, machineID, in)
+}
+
+func (m *FlapsClient) ExtendVolume(ctx context.Context, volumeId string, size_gb int) (*fly.Volume, bool, error) {
+	return m.ExtendVolumeFunc(ctx, volumeId, size_gb)
+}
+
+func (m *FlapsClient) FindLease(ctx context.Context, machineID string) (*fly.MachineLease, error) {
+	return m.FindLeaseFunc(ctx, machineID)
+}
+
+func (m *FlapsClient) Get(ctx context.Context, machineID string) (*fly.Machine, error) {
+	return m.GetFunc(ctx, machineID)
+}
+
+func (m *FlapsClient) GetAllVolumes(ctx context.Context) ([]fly.Volume, error) {
+	return m.GetAllVolumesFunc(ctx)
+}
+
+func (m *FlapsClient) GetMany(ctx context.Context, machineIDs []string) ([]*fly.Machine, error) {
+	return m.GetManyFunc(ctx, machineIDs)
+}
+
+func (m *FlapsClient) GetMetadata(ctx context.Context, machineID string) (map[string]string, error) {
+	return m.GetMetadataFunc(ctx, machineID)
+}
+
+func (m *FlapsClient) GetProcesses(ctx context.Context, machineID string) (fly.MachinePsResponse, error) {
+	return m.GetProcessesFunc(ctx, machineID)
+}
+
+func (m *FlapsClient) GetVolume(ctx context.Context, volumeId string) (*fly.Volume, error) {
+	return m.GetVolumeFunc(ctx, volumeId)
+}
+
+func (m *FlapsClient) GetVolumeSnapshots(ctx context.Context, volumeId string) ([]fly.VolumeSnapshot, error) {
+	return m.GetVolumeSnapshotsFunc(ctx, volumeId)
+}
+
+func (m *FlapsClient) GetVolumes(ctx context.Context) ([]fly.Volume, error) {
+	return m.GetVolumesFunc(ctx)
+}
+
+func (m *FlapsClient) Kill(ctx context.Context, machineID string) (err error) {
+	return m.KillFunc(ctx, machineID)
+}
+
+func (m *FlapsClient) Launch(ctx context.Context, builder fly.LaunchMachineInput) (out *fly.Machine, err error) {
+	return m.LaunchFunc(ctx, builder)
+}
+
+func (m *FlapsClient) List(ctx context.Context, state string) ([]*fly.Machine, error) {
+	return m.ListFunc(ctx, state)
+}
+
+func (m *FlapsClient) ListActive(ctx context.Context) ([]*fly.Machine, error) {
+	return m.ListActiveFunc(ctx)
+}
+
+func (m *FlapsClient) ListFlyAppsMachines(ctx context.Context) ([]*fly.Machine, *fly.Machine, error) {
+	return m.ListFlyAppsMachinesFunc(ctx)
+}
+
+func (m *FlapsClient) NewRequest(ctx context.Context, method, path string, in interface{}, headers map[string][]string) (*http.Request, error) {
+	return m.NewRequestFunc(ctx, method, path, in, headers)
+}
+
+func (m *FlapsClient) RefreshLease(ctx context.Context, machineID string, ttl *int, nonce string) (*fly.MachineLease, error) {
+	return m.RefreshLeaseFunc(ctx, machineID, ttl, nonce)
+}
+
+func (m *FlapsClient) ReleaseLease(ctx context.Context, machineID, nonce string) error {
+	return m.ReleaseLeaseFunc(ctx, machineID, nonce)
+}
+
+func (m *FlapsClient) Restart(ctx context.Context, in fly.RestartMachineInput, nonce string) (err error) {
+	return m.RestartFunc(ctx, in, nonce)
+}
+
+func (m *FlapsClient) SetMetadata(ctx context.Context, machineID, key, value string) error {
+	return m.SetMetadataFunc(ctx, machineID, key, value)
+}
+
+func (m *FlapsClient) Start(ctx context.Context, machineID string, nonce string) (out *fly.MachineStartResponse, err error) {
+	return m.StartFunc(ctx, machineID, nonce)
+}
+
+func (m *FlapsClient) Stop(ctx context.Context, in fly.StopMachineInput, nonce string) (err error) {
+	return m.StopFunc(ctx, in, nonce)
+}
+
+func (m *FlapsClient) Uncordon(ctx context.Context, machineID string, nonce string) (err error) {
+	return m.UncordonFunc(ctx, machineID, nonce)
+}
+
+func (m *FlapsClient) Update(ctx context.Context, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error) {
+	return m.UpdateFunc(ctx, builder, nonce)
+}
+
+func (m *FlapsClient) UpdateVolume(ctx context.Context, volumeId string, req fly.UpdateVolumeRequest) (*fly.Volume, error) {
+	return m.UpdateVolumeFunc(ctx, volumeId, req)
+}
+
+func (m *FlapsClient) Wait(ctx context.Context, machine *fly.Machine, state string, timeout time.Duration) (err error) {
+	return m.WaitFunc(ctx, machine, state, timeout)
+}
+
+func (m *FlapsClient) WaitForApp(ctx context.Context, name string) error {
+	return m.WaitForAppFunc(ctx, name)
+}

--- a/internal/mock/graphql_client.go
+++ b/internal/mock/graphql_client.go
@@ -1,0 +1,15 @@
+package mock
+
+import (
+	"context"
+
+	genq "github.com/Khan/genqlient/graphql"
+)
+
+type GraphQLClient struct {
+	MakeRequestFunc func(ctx context.Context, req *genq.Request, resp *genq.Response) error
+}
+
+func (m *GraphQLClient) MakeRequest(ctx context.Context, req *genq.Request, resp *genq.Response) error {
+	return m.MakeRequestFunc(ctx, req, resp)
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -18,6 +18,7 @@ import (
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/future"
 	"github.com/superfly/flyctl/internal/sort"
 	"github.com/superfly/flyctl/iostreams"
@@ -223,7 +224,7 @@ var errOrgSlugRequired = NonInteractiveError("org slug must be specified when no
 // Org returns the Organization the user has passed in via flag or prompts the
 // user for one.
 func Org(ctx context.Context) (*fly.Organization, error) {
-	client := fly.ClientFromContext(ctx)
+	client := flyutil.ClientFromContext(ctx)
 
 	orgs, err := client.GetOrganizations(ctx)
 	if err != nil {
@@ -299,7 +300,7 @@ var (
 func PlatformRegions(ctx context.Context) *future.Future[RegionInfo] {
 	regionsOnce.Do(func() {
 		regionsFuture = future.Spawn(func() (RegionInfo, error) {
-			client := fly.ClientFromContext(ctx)
+			client := flyutil.ClientFromContext(ctx)
 			regions, defaultRegion, err := client.PlatformRegions(ctx)
 			regionInfo := RegionInfo{
 				Regions:       regions,

--- a/internal/watch/watch.go
+++ b/internal/watch/watch.go
@@ -9,7 +9,7 @@ import (
 	"github.com/morikuni/aec"
 	"github.com/samber/lo"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -68,7 +68,7 @@ func MachinesChecks(ctx context.Context, machines []*fly.Machine) error {
 
 // retryGetMachines calls flaps with exponential backoff 10s max interval and up to 6 times
 func retryGetMachines(ctx context.Context, machineIDs ...string) (result []*fly.Machine, err error) {
-	flapsClient := flaps.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 	err = retry.Do(
 		func() (err2 error) {
 			result, err2 = flapsClient.GetMany(ctx, machineIDs)

--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -15,6 +15,7 @@ import (
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/state"
 	"github.com/superfly/flyctl/terminal"
 	"github.com/superfly/flyctl/wg"
@@ -23,7 +24,7 @@ import (
 
 var cleanDNSPattern = regexp.MustCompile(`[^a-zA-Z0-9\\-]`)
 
-func generatePeerName(ctx context.Context, apiClient *fly.Client) (string, error) {
+func generatePeerName(ctx context.Context, apiClient flyutil.Client) (string, error) {
 	user, err := apiClient.GetCurrentUser(ctx)
 	if err != nil {
 		return "", err
@@ -40,7 +41,7 @@ func generatePeerName(ctx context.Context, apiClient *fly.Client) (string, error
 	return name, nil
 }
 
-func StateForOrg(ctx context.Context, apiClient *fly.Client, org *fly.Organization, regionCode string, name string, recycle bool, network string) (*wg.WireGuardState, error) {
+func StateForOrg(ctx context.Context, apiClient flyutil.Client, org *fly.Organization, regionCode string, name string, recycle bool, network string) (*wg.WireGuardState, error) {
 	state, err := getWireGuardStateForOrg(org.Slug, network)
 	if err != nil {
 		return nil, err
@@ -63,7 +64,7 @@ func StateForOrg(ctx context.Context, apiClient *fly.Client, org *fly.Organizati
 	return stateb, nil
 }
 
-func Create(apiClient *fly.Client, org *fly.Organization, regionCode, name, network string) (*wg.WireGuardState, error) {
+func Create(apiClient flyutil.Client, org *fly.Organization, regionCode, name, network string) (*wg.WireGuardState, error) {
 	ctx := context.TODO()
 	var (
 		err error
@@ -180,7 +181,7 @@ func setWireGuardStateForOrg(ctx context.Context, orgSlug, network string, s *wg
 	return setWireGuardState(ctx, states)
 }
 
-func PruneInvalidPeers(ctx context.Context, apiClient *fly.Client) error {
+func PruneInvalidPeers(ctx context.Context, apiClient flyutil.Client) error {
 	state, err := GetWireGuardState()
 	if err != nil {
 		return nil

--- a/logs/nats.go
+++ b/logs/nats.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/nats-io/nats.go"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 type natsLogStream struct {
@@ -18,7 +18,7 @@ type natsLogStream struct {
 	err error
 }
 
-func NewNatsStream(ctx context.Context, apiClient *fly.Client, opts *LogOptions) (LogStream, error) {
+func NewNatsStream(ctx context.Context, apiClient flyutil.Client, opts *LogOptions) (LogStream, error) {
 	app, err := apiClient.GetAppBasic(ctx, opts.AppName)
 	if err != nil {
 		return nil, fmt.Errorf("failed fetching target app: %w", err)

--- a/logs/polling.go
+++ b/logs/polling.go
@@ -8,14 +8,15 @@ import (
 	"github.com/pkg/errors"
 
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/flyutil"
 )
 
 type pollingStream struct {
 	err       error
-	apiClient *fly.Client
+	apiClient flyutil.Client
 }
 
-func NewPollingStream(client *fly.Client, opts *LogOptions) (LogStream, error) {
+func NewPollingStream(client flyutil.Client, opts *LogOptions) (LogStream, error) {
 	return &pollingStream{apiClient: client}, nil
 }
 
@@ -35,7 +36,7 @@ func (s *pollingStream) Err() error {
 	return s.err
 }
 
-func Poll(ctx context.Context, out chan<- LogEntry, client *fly.Client, opts *LogOptions) error {
+func Poll(ctx context.Context, out chan<- LogEntry, client flyutil.Client, opts *LogOptions) error {
 	const (
 		minWait = time.Millisecond << 6
 		maxWait = minWait << 6

--- a/proxy/connect.go
+++ b/proxy/connect.go
@@ -6,8 +6,8 @@ import (
 	"net"
 	"strconv"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/ip"
@@ -55,7 +55,7 @@ func Start(ctx context.Context, p *ConnectParams) error {
 func NewServer(ctx context.Context, p *ConnectParams) (*Server, error) {
 	var (
 		io            = iostreams.FromContext(ctx)
-		client        = fly.ClientFromContext(ctx)
+		client        = flyutil.ClientFromContext(ctx)
 		orgSlug       = p.OrganizationSlug
 		localBindAddr = p.BindAddr
 		localPort     = p.Ports[0]

--- a/scripts/clean-up-preflight-apps/main.go
+++ b/scripts/clean-up-preflight-apps/main.go
@@ -45,7 +45,7 @@ func run() error {
 			}
 		}
 	}`
-	resp, err := gql.AllApps(ctx, apiClient.GenqClient, os.Getenv("FLY_PREFLIGHT_TEST_FLY_ORG"))
+	resp, err := gql.AllApps(ctx, apiClient.GenqClient(), os.Getenv("FLY_PREFLIGHT_TEST_FLY_ORG"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Change Summary

This pull request creates interfaces & mock implementations for `fly.Client` & `flaps.Client`. This is to enable unit testing of failure scenarios with launch & deploy that we can't easily test with integration testing. A partial, in-progress unit test is also checked in but it's disabled. 

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
