### PR TITLE
make "make test" pass again on MacOS

### DIFF
--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -150,7 +150,12 @@ func (c *Config) ToTestMachineConfig(svc *ServiceMachineCheck, origMachine *fly.
 	if c.PrimaryRegion != "" {
 		mConfig.Env["PRIMARY_REGION"] = c.PrimaryRegion
 	}
-	mConfig.Env["FLY_TEST_MACHINE_IP"] = lo.Ternary(origMachine == nil, "", origMachine.PrivateIP)
+
+	if origMachine == nil {
+		mConfig.Env["FLY_TEST_MACHINE_IP"] = ""
+	} else {
+		mConfig.Env["FLY_TEST_MACHINE_IP"] = origMachine.PrivateIP
+	}
 
 	// Use the stop config from the app config by default
 	c.tomachineSetStopConfig(mConfig)


### PR DESCRIPTION
lo.Ternary doesn't "short circuit" evaluation - all operands are evaluated, then one is selected.

As an alternative, [lo.TernaryF](https://github.com/samber/lo?tab=readme-ov-file#ternaryf) can be used, but I opted to make this explicit instead.