### PR TITLE
`launch`: always high-availability

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -84,11 +84,6 @@ var CommonFlags = flag.Set{
 		Hidden:      true,
 	},
 	flag.Bool{
-		Name:        "ha",
-		Description: "Create spare machines that increases app availability",
-		Default:     true,
-	},
-	flag.Bool{
 		Name:        "smoke-checks",
 		Description: "Perform smoke checks during deployment",
 		Default:     true,
@@ -192,6 +187,11 @@ func New() *Command {
 		flag.App(),
 		flag.AppConfig(),
 		// Not in CommonFlags because it's not relevant to a first deploy
+		flag.Bool{
+			Name:        "ha",
+			Description: "Create spare machines that increases app availability",
+			Default:     true,
+		},
 		flag.Bool{
 			Name:        "update-only",
 			Description: "Do not create Machines for new process groups",

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -35,15 +35,6 @@ func (state *launchState) Launch(ctx context.Context) error {
 		return err
 	}
 
-	org, err := state.Org(ctx)
-	if err != nil {
-		return err
-	}
-	if !planValidateHighAvailability(ctx, state.Plan, org, !state.warnedNoCcHa) {
-		state.Plan.HighAvailability = false
-		state.warnedNoCcHa = true
-	}
-
 	app, err := state.createApp(ctx)
 	if err != nil {
 		return err

--- a/internal/command/launch/plan/plan.go
+++ b/internal/command/launch/plan/plan.go
@@ -10,8 +10,9 @@ type LaunchPlan struct {
 	AppName string `json:"name"`
 	OrgSlug string `json:"org"`
 
-	RegionCode       string `json:"region"`
-	HighAvailability bool   `json:"ha"`
+	RegionCode string `json:"region"`
+	// Deprecated: The UI exposes this for now so we'll honor it, but we're moving towards always HA for Fly Launch apps
+	HighAvailability bool `json:"ha"`
 
 	// Deprecated: The UI currently returns this instead of Compute, but new development should use Compute.
 	CPUKind string `json:"vm_cpukind,omitempty"`

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -60,9 +60,8 @@ const recoverableSpecifyInUi = "must be specified in UI"
 // Doing this can lead to double-calculation, especially of scanners which could
 // have a lot of processing to do. Hence, a cache :)
 type planBuildCache struct {
-	appConfig    *appconfig.Config
-	sourceInfo   *scanner.SourceInfo
-	warnedNoCcHa bool // true => We have already warned that deploying ha is impossible for an org with no payment method
+	appConfig  *appconfig.Config
+	sourceInfo *scanner.SourceInfo
 }
 
 func appNameTakenErr(appName string) error {
@@ -207,13 +206,8 @@ func buildManifest(ctx context.Context, recoverableErrors *recoverableErrorBuild
 	}
 
 	buildCache := &planBuildCache{
-		appConfig:    appConfig,
-		sourceInfo:   srcInfo,
-		warnedNoCcHa: false,
-	}
-
-	if planValidateHighAvailability(ctx, lp, org, true) {
-		buildCache.warnedNoCcHa = true
+		appConfig:  appConfig,
+		sourceInfo: srcInfo,
 	}
 
 	if srcInfo != nil {
@@ -264,11 +258,9 @@ func stateFromManifest(ctx context.Context, m LaunchManifest, optionalCache *pla
 	var (
 		appConfig    *appconfig.Config
 		copiedConfig bool
-		warnedNoCcHa bool
 	)
 	if optionalCache != nil {
 		appConfig = optionalCache.appConfig
-		warnedNoCcHa = optionalCache.warnedNoCcHa
 	} else {
 		appConfig, copiedConfig, err = determineBaseAppConfig(ctx)
 		if err != nil {
@@ -348,9 +340,8 @@ func stateFromManifest(ctx context.Context, m LaunchManifest, optionalCache *pla
 		},
 		env: envVars,
 		planBuildCache: planBuildCache{
-			appConfig:    appConfig,
-			sourceInfo:   srcInfo,
-			warnedNoCcHa: warnedNoCcHa,
+			appConfig:  appConfig,
+			sourceInfo: srcInfo,
 		},
 		cache: map[string]interface{}{},
 	}, nil
@@ -651,14 +642,4 @@ func determineCompute(ctx context.Context, config *appconfig.Config, srcInfo *sc
 		reason = "specified on the command line"
 	}
 	return []*appconfig.Compute{guestToCompute(guest)}, reason, nil
-}
-
-func planValidateHighAvailability(ctx context.Context, p *plan.LaunchPlan, org *fly.Organization, print bool) bool {
-	if !org.Billable && p.HighAvailability {
-		if print {
-			fmt.Fprintln(iostreams.FromContext(ctx).ErrOut, "Warning: This organization has no payment method, turning off high availability")
-		}
-		return false
-	}
-	return true
 }

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -183,7 +183,7 @@ func buildManifest(ctx context.Context, recoverableErrors *recoverableErrorBuild
 		AppName:          appName,
 		OrgSlug:          org.Slug,
 		RegionCode:       region.Code,
-		HighAvailability: flag.GetBool(ctx, "ha"),
+		HighAvailability: true,
 		Compute:          compute,
 		CPUKind:          guest.CPUKind,
 		CPUs:             guest.CPUs,


### PR DESCRIPTION
### Change Summary

What and Why: turning off high availability is a footgun - launch presents as slightly higher level than raw machines. At its level of abstraction, one wouldn't assume a single host outage should take down an app.

To fix this mismatch of expectations, `fly launch` will *always* launch a high availability version of an app.

If you *need* to run single machines, you naturally still have the primitives to do this via machines, but Fly Launch apps should always be high availability.

How: removing the high availability option from `fly launch`. (partially, for now, until the UI catches up)

---

### Documentation

- [ ] Fresh Produce (SOON)
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
