### PR TITLE
intelligently add blank lines to json and yaml config files

### DIFF
--- a/internal/command/config/show.go
+++ b/internal/command/config/show.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -70,20 +69,19 @@ func runShow(ctx context.Context) error {
 		}
 	}
 
-	var b []byte
-	var err error
+	format := "json"
 
 	if flag.GetBool(ctx, "yaml") {
-		b, err = cfg.MarshalAsYAML()
+		format = "yaml"
 	} else if flag.GetBool(ctx, "toml") {
-		b, err = cfg.MarshalAsTOML()
-	} else {
-		b, err = json.MarshalIndent(cfg, "", "  ")
+		format = "toml"
 	}
+
+	_, err := cfg.WriteTo(io.Out, format)
 
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(io.Out, string(b))
+
 	return nil
 }


### PR DESCRIPTION
match the look of toml serialization

example output:

```
% ~/git/flyctl/bin/flyctl config show --local
{
  "app": "demo-rubys-11060",
  "primary_region": "iad",
  "console_command": "/rails/bin/rails console",

  "mounts": [
    {
      "source": "data",
      "destination": "/data"
    }
  ],

  "http_service": {
    "internal_port": 3000,
    "force_https": true,
    "auto_stop_machines": true,
    "auto_start_machines": true,
    "min_machines_running": 0,

    "processes": [
      "app"
    ]
  },

  "checks": {
    "status": {
      "port": 3000,
      "type": "http",
      "interval": "10s",
      "timeout": "2s",
      "grace_period": "5s",
      "method": "GET",
      "path": "/up",
      "protocol": "http",
      "tls_skip_verify": false,

      "headers": {
        "X-Forwarded-Proto": "https"
      }
    }
  },

  "vm": [
    {
      "memory": "1gb",
      "cpu_kind": "shared",
      "cpus": 1
    }
  ],

  "statics": [
    {
      "guest_path": "/rails/public",
      "url_prefix": "/",
      "tigris_bucket": ""
    }
  ]
}
```