### PR TITLE
Display secrets in the provision output

### DIFF
--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -64,7 +64,6 @@ func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension 
 
 	// Ensure users have agreed to the provider terms of service
 	err = AgreeToProviderTos(ctx, provider)
-
 	if err != nil {
 		return extension, err
 	}
@@ -109,7 +108,6 @@ func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension 
 					name = targetApp.Name + "-" + provider.NameSuffix
 				}
 				err = prompt.String(ctx, &name, "Choose a name, use the default, or leave blank to generate one:", name, false)
-
 				if err != nil {
 					return
 				}
@@ -182,7 +180,6 @@ func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension 
 		}
 
 		detectedPlatform, err = scanner.Scan(absDir, &scanner.ScannerConfig{Colorize: io.ColorScheme()})
-
 		if err != nil {
 			return extension, err
 		}
@@ -343,7 +340,6 @@ func OpenOrgDashboard(ctx context.Context, orgSlug string, providerName string) 
 	provider := resp.AddOnProvider.ExtensionProviderData
 
 	err = AgreeToProviderTos(ctx, provider)
-
 	if err != nil {
 		return err
 	}
@@ -378,7 +374,6 @@ func OpenDashboard(ctx context.Context, extensionName string) (err error) {
 	}
 
 	err = AgreeToProviderTos(ctx, result.AddOn.AddOnProvider.ExtensionProviderData)
-
 	if err != nil {
 		return err
 	}
@@ -469,13 +464,12 @@ func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *E
 		}
 		for _, key := range keys {
 			input.Secrets = append(input.Secrets, gql.SecretInput{Key: key, Value: secrets[key].(string)})
-			fmt.Fprintln(io.Out, key)
+			fmt.Fprintf(io.Out, "%s: %s\n", key, secrets[key].(string))
 		}
 
 		fmt.Fprintln(io.Out)
 
 		_, err = gql.SetSecrets(ctx, client, input)
-
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Display secrets in the provision output.

### Change Summary

This change displays all the secrets set as part of the provisioning output.

Many users ask for this because creating the storage bucket sets the secrets on the app, and getting the secret afterward is not easy. Especially if the app is not yet deployed.

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
