### PR TITLE
name wg peers "static-" when created manually.

### DIFF
--- a/internal/command/wireguard/wireguard.go
+++ b/internal/command/wireguard/wireguard.go
@@ -144,7 +144,7 @@ func runWireguardCreate(ctx context.Context) error {
 	// TODO: allow custom network
 	network := ""
 
-	state, err := wireguard.Create(apiClient, org, region, name, network)
+	state, err := wireguard.Create(apiClient, org, region, name, network, "static")
 	if err != nil {
 		return err
 	}

--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -52,7 +52,7 @@ func StateForOrg(ctx context.Context, apiClient flyutil.Client, org *fly.Organiz
 
 	terminal.Debugf("Can't find matching WireGuard configuration; creating new one\n")
 
-	stateb, err := Create(apiClient, org, regionCode, name, network)
+	stateb, err := Create(apiClient, org, regionCode, name, network, "interactive")
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func StateForOrg(ctx context.Context, apiClient flyutil.Client, org *fly.Organiz
 	return stateb, nil
 }
 
-func Create(apiClient flyutil.Client, org *fly.Organization, regionCode, name, network string) (*wg.WireGuardState, error) {
+func Create(apiClient flyutil.Client, org *fly.Organization, regionCode, name, network string, namePrefix string) (*wg.WireGuardState, error) {
 	ctx := context.TODO()
 	var (
 		err error
@@ -77,7 +77,7 @@ func Create(apiClient flyutil.Client, org *fly.Organization, regionCode, name, n
 			return nil, err
 		}
 
-		name = fmt.Sprintf("interactive-%s", n)
+		name = fmt.Sprintf("%s-%s", namePrefix, n)
 	}
 
 	if regionCode == "" {


### PR DESCRIPTION
- when a wg peer name is not specified, name it "interactive-*" or "static-*" based on how it was created.

### Change Summary

What and Why: When a wg peer name is not specified, name it "interactive-*" or "static-*" based on how it was created. We were previously giving default names of "interactive-" even for peers explicitly created by customers on the command line. We want to reserve the "interactive-" prefix for peers that are auto-generated and can be deleted at will without causing disruption.

How: Internally select the prefix for default names to be "interactive-" for automatically generated peers or "static-" for explicitly generated peers.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
