### PR TITLE
Added tracing for errors to deployments and launch

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -207,7 +207,7 @@ func New() *Command {
 	return cmd
 }
 
-func (cmd *Command) run(ctx context.Context) error {
+func (cmd *Command) run(ctx context.Context) (err error) {
 	io := iostreams.FromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 
@@ -225,6 +225,13 @@ func (cmd *Command) run(ctx context.Context) error {
 
 	defer tp.Shutdown(ctx)
 
+	ctx, span := tracing.CMDSpan(ctx, "cmd.deploy")
+	defer span.End()
+
+	defer func() {
+		tracing.RecordError(span, err, "error deploying")
+	}()
+
 	// Instantiate FLAPS client if we haven't initialized one via a unit test.
 	if flapsutil.ClientFromContext(ctx) == nil {
 		flapsClient, err := flapsutil.NewClientWithOptions(ctx, flaps.NewClientOpts{
@@ -237,9 +244,6 @@ func (cmd *Command) run(ctx context.Context) error {
 	}
 
 	client := flyutil.ClientFromContext(ctx)
-
-	ctx, span := tracing.CMDSpan(ctx, "cmd.deploy")
-	defer span.End()
 
 	user, err := client.GetCurrentUser(ctx)
 	if err != nil {
@@ -267,7 +271,8 @@ func (cmd *Command) run(ctx context.Context) error {
 	span.SetAttributes(attribute.StringSlice("gpu.kinds", gpuKinds))
 	span.SetAttributes(attribute.StringSlice("cpu.kinds", cpuKinds))
 
-	return DeployWithConfig(ctx, appConfig, flag.GetYes(ctx))
+	err = DeployWithConfig(ctx, appConfig, flag.GetYes(ctx))
+	return err
 }
 
 func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, forceYes bool) (err error) {

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -189,6 +189,7 @@ func run(ctx context.Context) (err error) {
 
 	defer func() {
 		if err != nil {
+			tracing.RecordError(span, err, "launch failed")
 			status.Error = err.Error()
 
 			if state != nil && state.sourceInfo != nil && state.sourceInfo.FailureCallback != nil {


### PR DESCRIPTION
### Change Summary

What and Why:
Added  tracing for errors to the cmd.deploy and cmd.launch spans, so we can more easily link specific errors to deployments themselves, do more complex queries, etc

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
