### PR TITLE
Ensure that we only run tracing.RecordError when error is nil

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -229,7 +229,9 @@ func (cmd *Command) run(ctx context.Context) (err error) {
 	defer span.End()
 
 	defer func() {
-		tracing.RecordError(span, err, "error deploying")
+		if err != nil {
+			tracing.RecordError(span, err, "error deploying")
+		}
 	}()
 
 	// Instantiate FLAPS client if we haven't initialized one via a unit test.


### PR DESCRIPTION
### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
