### PR TITLE
wg: reuse peer from any region if not specific region is requested

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -279,10 +279,10 @@ type EstablishResponse struct {
 	TunnelConfig   *wg.Config
 }
 
-func (c *Client) doEstablish(ctx context.Context, slug string, recycle bool, network string) (res *EstablishResponse, err error) {
+func (c *Client) doEstablish(ctx context.Context, slug string, reestablish bool, network string) (res *EstablishResponse, err error) {
 	err = c.do(ctx, func(conn net.Conn) (err error) {
 		verb := "establish"
-		if recycle {
+		if reestablish {
 			verb = "reestablish"
 		}
 

--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -224,20 +224,20 @@ func (s *server) checkForConfigChange() (err error) {
 	return
 }
 
-func (s *server) buildTunnel(ctx context.Context, org *fly.Organization, recycle bool, network string, client flyutil.Client) (tunnel *wg.Tunnel, err error) {
+func (s *server) buildTunnel(ctx context.Context, org *fly.Organization, reestablish bool, network string, client flyutil.Client) (tunnel *wg.Tunnel, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	tk := tunnelKey{orgSlug: org.Slug, networkName: network}
 
 	// not checking the region is intentional, it's static during the lifetime of the agent
-	if tunnel = s.tunnels[tk]; tunnel != nil && !recycle {
+	if tunnel = s.tunnels[tk]; tunnel != nil && !reestablish {
 		// tunnel already exists
 		return
 	}
 
 	var state *wg.WireGuardState
-	if state, err = wireguard.StateForOrg(ctx, client, org, os.Getenv("FLY_AGENT_WG_REGION"), "", recycle, network); err != nil {
+	if state, err = wireguard.StateForOrg(ctx, client, org, os.Getenv("FLY_AGENT_WG_REGION"), "", reestablish, network); err != nil {
 		return
 	}
 

--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -41,12 +41,12 @@ func generatePeerName(ctx context.Context, apiClient flyutil.Client) (string, er
 	return name, nil
 }
 
-func StateForOrg(ctx context.Context, apiClient flyutil.Client, org *fly.Organization, regionCode string, name string, recycle bool, network string) (*wg.WireGuardState, error) {
+func StateForOrg(ctx context.Context, apiClient flyutil.Client, org *fly.Organization, regionCode string, name string, reestablish bool, network string) (*wg.WireGuardState, error) {
 	state, err := getWireGuardStateForOrg(org.Slug, network)
 	if err != nil {
 		return nil, err
 	}
-	if state != nil && !recycle && (regionCode == "" || state.Region == regionCode) {
+	if state != nil && !reestablish && (regionCode == "" || state.Region == regionCode) {
 		return state, nil
 	}
 

--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -46,7 +46,7 @@ func StateForOrg(ctx context.Context, apiClient flyutil.Client, org *fly.Organiz
 	if err != nil {
 		return nil, err
 	}
-	if state != nil && !recycle && state.Region == regionCode {
+	if state != nil && !recycle && (regionCode == "" || state.Region == regionCode) {
 		return state, nil
 	}
 


### PR DESCRIPTION
Every time the agent was restarted we'd create a new wg peer (unless `FLY_AGENT_WG_REGION` was explicitly set). This isn't necessary.