### PR TITLE
Set the default PG certificate lifespan to 100 years

### DIFF
--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -423,8 +423,11 @@ func (l *Launcher) setSecrets(ctx context.Context, config *CreateClusterInput) (
 			return nil, err
 		}
 
+		// 100 years in hours
+		validHours := 876600
+
 		app := fly.App{Name: config.AppName}
-		cert, err := l.client.IssueSSHCertificate(ctx, config.Organization, []string{"root", "fly", "postgres"}, []string{app.Name}, nil, pub)
+		cert, err := l.client.IssueSSHCertificate(ctx, config.Organization, []string{"root", "fly", "postgres"}, []string{app.Name}, &validHours, pub)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Change Summary

**What and Why:**
The current default PG certificate lifespan is only a couple of days.  This causes issues when users attempt to issue a manual failover, or use internal repmgr commands that require cross-member ssh access.  This PR extends the default certificate lifespan to 100 years.

