### PR TITLE
fix: if no personal org found, select first org in list

### DIFF
--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -521,7 +521,12 @@ func determineOrg(ctx context.Context) (*fly.Organization, string, error) {
 	orgSlug := flag.GetOrg(ctx)
 	if orgSlug == "" {
 		if !foundPersonal {
-			return nil, "", errors.New("no personal organization found")
+			if len(orgs) == 0 {
+				return nil, "", errors.New("no organizations found. Please create one from your fly dashboard first.")
+			} else {
+				o := orgs[0]
+				return &o, fmt.Sprintf("defaulting to '%s'", o.Slug), nil
+			}
 		}
 
 		return &personal, "fly launch defaults to the personal org", nil


### PR DESCRIPTION
### Change Summary

What and Why:

fixes an issue where a user has deleted their personal organization and running `fly launch` no longer works as expected. rather than error on not having a personal org, use the first org found instead.

How:

rather than error on not having a personal org, use the first org found instead.

```
fly launch

Scanning source code
Detected a Dockerfile app
Creating app in /Users/nathan/github/nbw/conway8

We're about to launch your app on Fly.io. Here's what you're getting:

Organization: nathan-second-org      (defaulting to 'nathan-second-org')
Name:         <unspecified>          (must be specified in UI)
Region:       Tokyo, Japan           (this is the fastest region for you)
App Machines: shared-cpu-1x, 1GB RAM (most apps need about 1GB of RAM)
Postgres:     <none>                 (not requested)
Redis:        <none>                 (not requested)
Sentry:       false                  (not requested)
```

the relevant line here is `(defaulting to 'nathan-second-org')`



