### PR TITLE
Show warning for active incidents

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -533,7 +533,7 @@ func notifyStatuspageIncidents(ctx context.Context) (context.Context, error) {
 
 			logger.Debugf("querying for statuspage incidents resulted to %v", incidents)
 			incidentCount := len(incidents.Incidents)
-			if (incidentCount > 0) {
+			if incidentCount > 0 {
 				fmt.Fprintln(io.ErrOut, colorize.WarningIcon(),
 					colorize.Yellow("WARNING: There are active incidents. Please check `fly incidents list` or visit https://status.flyio.net\n\n"),
 				)

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -28,6 +28,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/incidents"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/internal/state"
@@ -64,6 +65,7 @@ var commonPreparers = []preparers.Preparer{
 	startQueryingForNewRelease,
 	promptAndAutoUpdate,
 	startMetrics,
+	notifyStatuspageIncidents,
 }
 
 var authPreparers = []preparers.Preparer{
@@ -498,6 +500,53 @@ func startMetrics(ctx context.Context) (context.Context, error) {
 	task.FromContext(ctx).RunFinalizer(func(ctx context.Context) {
 		metrics.FlushPending()
 	})
+
+	return ctx, nil
+}
+
+func notifyStatuspageIncidents(ctx context.Context) (context.Context, error) {
+	if shouldIgnore(ctx, [][]string{
+		{"incidents", "list"},
+	}) {
+		return ctx, nil
+	}
+
+	if !incidents.Check() {
+		return ctx, nil
+	}
+
+	logger := logger.FromContext(ctx)
+	io := iostreams.FromContext(ctx)
+	colorize := io.ColorScheme()
+
+	queryStatuspageIncidents := func(parent context.Context) {
+		logger.Debug("started querying for statuspage incidents")
+
+		ctx, cancel := context.WithTimeout(parent, time.Second)
+		defer cancel()
+
+		switch incidents, err := incidents.StatuspageIncidentsRequest(ctx); {
+		case err == nil:
+			if incidents == nil {
+				break
+			}
+
+			logger.Debugf("querying for statuspage incidents resulted to %v", incidents)
+			incidentCount := len(incidents.Incidents)
+			if (incidentCount > 0) {
+				fmt.Fprintln(io.ErrOut, colorize.WarningIcon(),
+					colorize.Yellow("WARNING: There are active incidents. Please check `fly incidents list` or visit https://status.flyio.net\n\n"),
+				)
+				break
+			}
+		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			break
+		default:
+			logger.Warnf("failed querying for Statuspage incidents: %v", err)
+		}
+	}
+
+	task.FromContext(ctx).Run(queryStatuspageIncidents)
 
 	return ctx, nil
 }

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -540,7 +540,7 @@ func notifyStatuspageIncidents(ctx context.Context) (context.Context, error) {
 				break
 			}
 		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-			break
+			logger.Warnf("failed querying for Statuspage incidents. Context cancelled or deadline exceeded: %v", err)
 		default:
 			logger.Warnf("failed querying for Statuspage incidents: %v", err)
 		}

--- a/internal/command/incidents/incidents.go
+++ b/internal/command/incidents/incidents.go
@@ -1,0 +1,79 @@
+package incidents
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/helpers"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/incidents"
+	"github.com/superfly/flyctl/internal/render"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func New() *cobra.Command {
+	const (
+		short = "Show incidents"
+		long  = `Show incidents that may be affecting your organization.`
+	)
+	cmd := command.New("incidents", short, long, nil)
+	cmd.AddCommand(
+		newIncidentsList(),
+	)
+	return cmd
+}
+
+func newIncidentsList() *cobra.Command {
+	const (
+		short = "List active incidents."
+		long  = `List the active incidents that may be affecting your apps or deployments.`
+	)
+	cmd := command.New("list", short, long, runIncidentsList,
+		command.RequireSession,
+		command.LoadAppNameIfPresent,
+	)
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+		flag.JSONOutput(),
+		flag.Org(),
+	)
+	cmd.Args = cobra.NoArgs
+	return cmd
+}
+
+func runIncidentsList(ctx context.Context) error {
+	out := iostreams.FromContext(ctx).Out
+
+	statuspageIncidents, err := incidents.StatuspageIncidentsRequest(ctx)
+	if err != nil {
+		return err
+	}
+
+	if config.FromContext(ctx).JSONOutput {
+		return render.JSON(out, statuspageIncidents)
+	}
+
+	incidentCount := len(statuspageIncidents.Incidents)
+	if incidentCount > 0 {
+		fmt.Fprintf(out, "Incidents count: %d\n\n", incidentCount)
+		table := helpers.MakeSimpleTable(out, []string{"Id", "Name", "Status", "Components", "Started At", "Last Updated"})
+		table.SetRowLine(true)
+		for _, incident := range statuspageIncidents.Incidents {
+			var components []string
+			for _, component := range incident.Components {
+				components = append(components, component.Name)
+			}
+			table.Append([]string{incident.ID, incident.Name, incident.Status, strings.Join(components, ", "), incident.StartedAt, incident.UpdatedAt})
+		}
+		table.Render()
+	} else {
+		fmt.Fprintf(out, "There are no active incidents\n")
+	}
+
+	return nil
+}

--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -31,6 +31,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/extensions"
 	"github.com/superfly/flyctl/internal/command/history"
 	"github.com/superfly/flyctl/internal/command/image"
+	"github.com/superfly/flyctl/internal/command/incidents"
 	"github.com/superfly/flyctl/internal/command/info"
 	"github.com/superfly/flyctl/internal/command/ips"
 	"github.com/superfly/flyctl/internal/command/jobs"
@@ -105,6 +106,7 @@ func New() *cobra.Command {
 		group(lfsc.New(), "dbs_and_extensions"),
 		agent.New(),
 		group(image.New(), "configuring"),
+		group(incidents.New(), "upkeep"),
 		group(ping.New(), "upkeep"),
 		group(proxy.New(), "upkeep"),
 		group(postgres.New(), "dbs_and_extensions"),

--- a/internal/incidents/incidents.go
+++ b/internal/incidents/incidents.go
@@ -1,0 +1,21 @@
+package incidents
+
+import (
+	"os"
+	"github.com/superfly/flyctl/internal/cmdutil"
+	"github.com/superfly/flyctl/internal/env"
+)
+
+// Check for incidents
+func Check() bool {
+	switch {
+	case env.IsTruthy("FLY_INCIDENTS_CHECK"):
+		return true
+	case env.IsTruthy("FLY_NO_INCIDENTS_CHECK"):
+		return false
+	case !cmdutil.IsTerminal(os.Stdout), !cmdutil.IsTerminal(os.Stderr):
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/incidents/incidents.go
+++ b/internal/incidents/incidents.go
@@ -1,9 +1,9 @@
 package incidents
 
 import (
-	"os"
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/env"
+	"os"
 )
 
 // Check for incidents

--- a/internal/incidents/statuspage.go
+++ b/internal/incidents/statuspage.go
@@ -7,27 +7,26 @@ import (
 	"net/http"
 	"os"
 	"time"
-
 )
 
 type StatusPageApiResponse struct {
-    Incidents []Incident `json:"incidents"`
+	Incidents []Incident `json:"incidents"`
 }
 
 type Incident struct {
-    Components       []Component      `json:"components"`
-    CreatedAt        string           `json:"created_at"`
-    ID               string           `json:"id"`
-    Name             string           `json:"name"`
-    ResolvedAt       string           `json:"resolved_at"`
-    StartedAt        string           `json:"started_at"`
-    Status           string           `json:"status"`
-    UpdatedAt        string           `json:"updated_at"`
+	Components []Component `json:"components"`
+	CreatedAt  string      `json:"created_at"`
+	ID         string      `json:"id"`
+	Name       string      `json:"name"`
+	ResolvedAt string      `json:"resolved_at"`
+	StartedAt  string      `json:"started_at"`
+	Status     string      `json:"status"`
+	UpdatedAt  string      `json:"updated_at"`
 }
 
 type Component struct {
-    ID                  string      `json:"id"`
-    Name                string      `json:"name"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 func getStatuspageUnresolvedIncidentsUrl() string {

--- a/internal/incidents/statuspage.go
+++ b/internal/incidents/statuspage.go
@@ -1,0 +1,69 @@
+package incidents
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+)
+
+type StatusPageApiResponse struct {
+    Incidents []Incident `json:"incidents"`
+}
+
+type Incident struct {
+    Components       []Component      `json:"components"`
+    CreatedAt        string           `json:"created_at"`
+    ID               string           `json:"id"`
+    Name             string           `json:"name"`
+    ResolvedAt       string           `json:"resolved_at"`
+    StartedAt        string           `json:"started_at"`
+    Status           string           `json:"status"`
+    UpdatedAt        string           `json:"updated_at"`
+}
+
+type Component struct {
+    ID                  string      `json:"id"`
+    Name                string      `json:"name"`
+}
+
+func getStatuspageUnresolvedIncidentsUrl() string {
+	url := os.Getenv("FLY_STATUSPAGE_UNRESOLVED_INCIDENTS_URL")
+	if url != "" {
+		return url
+	}
+
+	return "https://status.flyio.net/api/v2/incidents/unresolved.json"
+}
+
+func StatuspageIncidentsRequest(ctx context.Context) (*StatusPageApiResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", getStatuspageUnresolvedIncidentsUrl(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{}
+	response, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, nil
+	}
+
+	var apiResponse StatusPageApiResponse
+	decoder := json.NewDecoder(response.Body)
+	if err := decoder.Decode(&apiResponse); err != nil {
+		return nil, fmt.Errorf("error: %s", err)
+	}
+
+	return &apiResponse, nil
+}

--- a/internal/incidents/statuspage.go
+++ b/internal/incidents/statuspage.go
@@ -42,7 +42,7 @@ func StatuspageIncidentsRequest(ctx context.Context) (*StatusPageApiResponse, er
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", getStatuspageUnresolvedIncidentsUrl(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", getStatuspageUnresolvedIncidentsUrl(), http.NoBody)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,7 @@ func StatuspageIncidentsRequest(ctx context.Context) (*StatusPageApiResponse, er
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer response.Body.Close() // skipcq: GO-S2307
 
 	if response.StatusCode != http.StatusOK {
 		return nil, nil


### PR DESCRIPTION
### Change Summary
This change adds a background task that queries status.flyio.net for unresolved incidents for every command.

If any incident is returned, it will show a warning to the user. 
The warning includes instructions to either check statuspage or execute the specific command for listing the incidents which provides extended information.

How:
- Adding a background task that is enqueued from a common preparer so it's executed for every command. It can be disabled by setting `FLY_NO_INCIDENTS_CHECK` env var to a truthy value. The check is ignored for the more specific `incidents list` command. 
- Adding a `incidents list` command which will provided detailed information about the unresolved incidents.


### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
