### PR TITLE
Clean up user messages & cmd descriptions for Enveloop extension

### DIFF
--- a/internal/command/extensions/enveloop/create.go
+++ b/internal/command/extensions/enveloop/create.go
@@ -15,7 +15,7 @@ import (
 
 func create() (cmd *cobra.Command) {
 	const (
-		short = "Provision a Upstash Enveloop project"
+		short = "Provision an Enveloop project"
 		long  = short + "\n"
 	)
 

--- a/internal/command/extensions/enveloop/dashboard.go
+++ b/internal/command/extensions/enveloop/dashboard.go
@@ -12,7 +12,7 @@ import (
 
 func dashboard() (cmd *cobra.Command) {
 	const (
-		long = `Visit the Enveloop dashboard on the Upstash web console`
+		long = `Open the Enveloop dashboard via your web browser`
 
 		short = long
 		usage = "dashboard"

--- a/internal/command/extensions/enveloop/destroy.go
+++ b/internal/command/extensions/enveloop/destroy.go
@@ -16,7 +16,7 @@ import (
 
 func destroy() (cmd *cobra.Command) {
 	const (
-		long = `Permanently destroy an Upstash Enveloop project`
+		long = `Permanently destroy an Enveloop project`
 
 		short = long
 		usage = "destroy [name]"
@@ -45,10 +45,10 @@ func runDestroy(ctx context.Context) (err error) {
 	}
 
 	if !flag.GetYes(ctx) {
-		const msg = "Destroying an Upstash Enveloop project is not reversible."
+		const msg = "Destroying an Enveloop project is not reversible. All Enveloop templates, message settings, and message logs will be lost."
 		fmt.Fprintln(io.ErrOut, colorize.Red(msg))
 
-		switch confirmed, err := prompt.Confirmf(ctx, "Do you want to destroy the index named %s?", extension.Name); {
+		switch confirmed, err := prompt.Confirmf(ctx, "Do you want to destroy the Enveloop project named %s?", extension.Name); {
 		case err == nil:
 			if !confirmed {
 				return nil
@@ -66,7 +66,7 @@ func runDestroy(ctx context.Context) (err error) {
 	}
 
 	out := iostreams.FromContext(ctx).Out
-	fmt.Fprintf(out, "Your Upstash Enveloop project %s was destroyed\n", extension.Name)
+	fmt.Fprintf(out, "Your Enveloop project %s was destroyed\n", extension.Name)
 
 	return nil
 }

--- a/internal/command/extensions/enveloop/list.go
+++ b/internal/command/extensions/enveloop/list.go
@@ -15,7 +15,7 @@ import (
 
 func list() (cmd *cobra.Command) {
 	const (
-		long  = `List your Upstash Enveloop project`
+		long  = `List your Enveloop projects`
 		short = long
 		usage = "list"
 	)

--- a/internal/command/extensions/enveloop/status.go
+++ b/internal/command/extensions/enveloop/status.go
@@ -14,7 +14,7 @@ import (
 
 func status() *cobra.Command {
 	const (
-		short = "Show details about an Upstash Enveloop project"
+		short = "Show details about an Enveloop project"
 		long  = short + "\n"
 
 		usage = "status [name]"


### PR DESCRIPTION
### Change Summary

What and Why:
Some minor artifacts were left over from copy/paste of commands from a previous extension implementation. Cleaning those up.

How:
Updated text strings for command descriptions and user messages displayed to user via command line.

Related to:
Creation of the extension for Enveloop on Fly.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
