### PR TITLE
Outputting errors in a muted color and then letting them scroll by

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -271,12 +271,6 @@ func run(ctx context.Context) (err error) {
 		return err
 	}
 
-	if errors := recoverableErrors.build(); errors != "" {
-
-		fmt.Fprintf(io.ErrOut, "\n%s\n%s\n", aurora.Yellow("The following problems must be fixed in the Launch UI:"), errors)
-		incompleteLaunchManifest = true
-	}
-
 	summary, err := state.PlanSummary(ctx)
 	if err != nil {
 		return err
@@ -293,6 +287,12 @@ func run(ctx context.Context) (err error) {
 		familyToAppType(family),
 		summary,
 	)
+
+	if errors := recoverableErrors.build(); errors != "" {
+
+		fmt.Fprintf(io.ErrOut, "\n%s\n%s\n", aurora.Reverse(aurora.Red("The following problems must be fixed in the Launch UI:")), errors)
+		incompleteLaunchManifest = true
+	}
 
 	editInUi := false
 	if !flag.GetBool(ctx, "yes") {


### PR DESCRIPTION
Outputting the errors then the plan is less likely to be noticed than showing the plan then the error in a more "in your face" manner.

Current Rails failures over the past 7 days:

| Count | Error |
| --- | --- |
| 40 | launch can not continue with errors present |
| 40 | We need your payment information to continue! Add a credit card or buy credit: `https://fly.io/dashboard/` |
| 24 | interrupt |
| 14 | Your account has been marked as high risk. Please go to `https://fly.io/high-risk-unlock` to verify your account. |
| 7 | Not Found |

Current user experience:

<img width="581" alt="image" src="https://github.com/superfly/flyctl/assets/4815/d9bcd3b3-cc06-4efa-9069-00ca035d7a70">

---

Proposed new user experience:

<img width="577" alt="image" src="https://github.com/superfly/flyctl/assets/4815/72ba0536-0de3-465d-8168-844cdf928a54">
