### PR TITLE
Add Rails + Tigris support to fly launch

### DIFF
--- a/internal/command/launch/describe_plan.go
+++ b/internal/command/launch/describe_plan.go
@@ -68,3 +68,11 @@ func describeUpstashRedisPlan(ctx context.Context, p *plan.UpstashRedisPlan, org
 	evictionStatus := lo.Ternary(p.Eviction, "enabled", "disabled")
 	return fmt.Sprintf("%s Plan: %s Max Data Size, eviction %s", plan.DisplayName, plan.MaxDataSize, evictionStatus), nil
 }
+
+func describeObjectStoragePlan(p plan.ObjectStoragePlan) (string, error) {
+	if p.TigrisObjectStorage == nil {
+		return descriptionNone, nil
+	}
+
+	return "private bucket", nil
+}

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -203,6 +203,7 @@ func buildManifest(ctx context.Context, recoverableErrors *recoverableErrorBuild
 		computeSource:  computeExplanation,
 		postgresSource: "not requested",
 		redisSource:    "not requested",
+		tigrisSource:   "not requested",
 		sentrySource:   "not requested",
 	}
 
@@ -234,6 +235,7 @@ func buildManifest(ctx context.Context, recoverableErrors *recoverableErrorBuild
 		}
 		if srcInfo.ObjectStorageDesired {
 			lp.ObjectStorage = plan.DefaultObjectStorage(lp)
+			planSource.tigrisSource = scannerSource
 		}
 		if srcInfo.Port != 0 {
 			lp.HttpServicePort = srcInfo.Port

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -232,6 +232,9 @@ func buildManifest(ctx context.Context, recoverableErrors *recoverableErrorBuild
 			lp.Redis = plan.DefaultRedis(lp)
 			planSource.redisSource = scannerSource
 		}
+		if srcInfo.ObjectStorageDesired {
+			lp.ObjectStorage = plan.DefaultObjectStorage(lp)
+		}
 		if srcInfo.Port != 0 {
 			lp.HttpServicePort = srcInfo.Port
 			lp.HttpServicePortSetByScanner = true

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -26,6 +26,7 @@ type launchPlanSource struct {
 	computeSource  string
 	postgresSource string
 	redisSource    string
+	tigrisSource   string
 	sentrySource   string
 }
 
@@ -122,6 +123,11 @@ func (state *launchState) PlanSummary(ctx context.Context) (string, error) {
 		return "", err
 	}
 
+	tigrisStr, err := describeObjectStoragePlan(state.Plan.ObjectStorage)
+	if err != nil {
+		return "", err
+	}
+
 	rows := [][]string{
 		{"Organization", org.Name, state.PlanSource.orgSource},
 		{"Name", state.Plan.AppName, state.PlanSource.appNameSource},
@@ -129,6 +135,7 @@ func (state *launchState) PlanSummary(ctx context.Context) (string, error) {
 		{"App Machines", guestStr, state.PlanSource.computeSource},
 		{"Postgres", postgresStr, state.PlanSource.postgresSource},
 		{"Redis", redisStr, state.PlanSource.redisSource},
+		{"Tigris", tigrisStr, state.PlanSource.tigrisSource},
 		{"Sentry", strconv.FormatBool(state.Plan.Sentry), state.PlanSource.sentrySource},
 	}
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -73,6 +73,7 @@ type SourceInfo struct {
 	PostgresInitCommandCondition bool
 	DatabaseDesired              DatabaseKind
 	RedisDesired                 bool
+	ObjectStorageDesired         bool
 	Concurrency                  map[string]int
 	Callback                     func(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan, flags []string) error
 	HttpCheckPath                string


### PR DESCRIPTION
Set `lp.ObjectStorage = plan.DefaultObjectStorage(lp)` if any of the following are true:

  *  aws-sdk-s3 in Gemfile or Gemfile.lock
  *  any migration containing active_storage_attachments
  *  an uncommented line in config/storage.yml containing service: S3

If after (optionally) invoking the fly launch UI, objectstorage is (still) selected, add a '--tigris' option to the call to the rails dockerfile generator.

See related pull request: https://github.com/fly-apps/dockerfile-rails/pull/104
