### PR TITLE
fix(bluegreen): fix bug preventing rollbacks on failed green machine creations

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -472,12 +472,13 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 func (md *machineDeployment) updateUsingBlueGreenStrategy(ctx context.Context, updateEntries []*machineUpdateEntry) error {
 	bg := BlueGreenStrategy(md, updateEntries)
 	if err := bg.Deploy(ctx); err != nil {
-		fmt.Fprintf(md.io.ErrOut, "Deployment failed after error: %s\n", err)
-
 		if rollbackErr := bg.Rollback(ctx, err); rollbackErr != nil {
 			fmt.Fprintf(md.io.ErrOut, "Error in rollback: %s\n", rollbackErr)
+			fmt.Fprintf(md.io.ErrOut, "Deployment failed after error: %s\n", err)
 			return rollbackErr
 		}
+
+		fmt.Fprintf(md.io.ErrOut, "Deployment failed after error: %s\n", err)
 		return suggestChangeWaitTimeout(err, "wait-timeout")
 	}
 	return nil


### PR DESCRIPTION
### Change Summary
This PR properly handles aborts during green machine creations and fixes the rollback bug.

The bug was being caused by the fact that greenMachines array was only being updated if an error didn't happen across all creations. 
And so in cases where an error happened, the greenMachines array was empty and rollback logic couldn't see any machines to delete.

I narrowed this down by looking at the trace for the failed deployment, which showed that the rollback fn was actually called. All the tracing we have helped me narrow down my search area

.
<img width="694" alt="Screenshot 2024-06-05 at 22 41 05" src="https://github.com/superfly/flyctl/assets/24861123/db2689d6-399c-4a99-93db-a38b8b23c717">
