### PR TITLE
Make Statuspage incident-notify errors debug-level logs, not warn

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -540,9 +540,9 @@ func notifyStatuspageIncidents(ctx context.Context) (context.Context, error) {
 				break
 			}
 		case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
-			logger.Warnf("failed querying for Statuspage incidents. Context cancelled or deadline exceeded: %v", err)
+			logger.Debugf("failed querying for Statuspage incidents. Context cancelled or deadline exceeded: %v", err)
 		default:
-			logger.Warnf("failed querying for Statuspage incidents: %v", err)
+			logger.Debugf("failed querying for Statuspage incidents: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Followup to #3589. These requests are often canceled at the end of quick flyctl commands (like `fly version`) and should be logged with `debug` level, if at all, not `warn`.