### PR TITLE
Change launch confirm default when manifest is incomplete

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/command/deploy"
@@ -296,12 +295,12 @@ func run(ctx context.Context) (err error) {
 
 	editInUi := false
 	if !flag.GetBool(ctx, "yes") {
-		message := lo.Ternary(
-			incompleteLaunchManifest,
-			"Would you like to continue in the web UI?",
-			"Do you want to tweak these settings before proceeding?",
-		)
-		editInUi, err = prompt.Confirm(ctx, message)
+		if incompleteLaunchManifest {
+			editInUi, err = prompt.ConfirmYes(ctx, "Would you like to continue in the web UI?")
+		} else {
+			editInUi, err = prompt.Confirm(ctx, "Do you want to tweak these settings before proceeding?")
+		}
+
 		if err != nil && !errors.Is(err, prompt.ErrNonInteractive) {
 			return err
 		}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -165,6 +165,22 @@ func Confirm(ctx context.Context, message string) (confirm bool, err error) {
 	return
 }
 
+func ConfirmYes(ctx context.Context, message string) (confirm bool, err error) {
+	var opt survey.AskOpt
+	if opt, err = newSurveyIO(ctx); err != nil {
+		return
+	}
+
+	prompt := &survey.Confirm{
+		Message: message,
+		Default: true,
+	}
+
+	err = survey.AskOne(prompt, &confirm, opt)
+
+	return
+}
+
 func ConfirmOverwrite(ctx context.Context, filename string) (confirm bool, err error) {
 	prompt := &survey.Confirm{
 		Message: fmt.Sprintf(`Overwrite "%s"?`, filename),


### PR DESCRIPTION
Currently, the top reason why a Rails launch fails is that there is a clear problem (example: name already in use) but our prompt for whether or not the user wants to continue in the web UI defaults to No.