### PR TITLE
POC: elixir base URL

### DIFF
--- a/flyctl/config.go
+++ b/flyctl/config.go
@@ -5,15 +5,16 @@ import (
 )
 
 const (
-	ConfigAPIToken        = "access_token"
-	ConfigAPIBaseURL      = "api_base_url"
-	ConfigFlapsBaseUrl    = "flaps_base_url"
-	ConfigAppName         = "app"
-	ConfigVerboseOutput   = "verbose"
-	ConfigBuiltinsfile    = "builtins_file"
-	ConfigGQLErrorLogging = "gqlerrorlogging"
-	ConfigInstaller       = "installer"
-	BuildKitNodeID        = "buildkit_node_id"
+	ConfigAPIToken         = "access_token"
+	ConfigAPIBaseURL       = "api_base_url"
+	ConfigElixirAPIBaseURL = "elixir_api_base_url"
+	ConfigFlapsBaseUrl     = "flaps_base_url"
+	ConfigAppName          = "app"
+	ConfigVerboseOutput    = "verbose"
+	ConfigBuiltinsfile     = "builtins_file"
+	ConfigGQLErrorLogging  = "gqlerrorlogging"
+	ConfigInstaller        = "installer"
+	BuildKitNodeID         = "buildkit_node_id"
 
 	ConfigWireGuardState      = "wire_guard_state"
 	ConfigWireGuardWebsockets = "wire_guard_websockets"

--- a/flyctl/flyctl.go
+++ b/flyctl/flyctl.go
@@ -69,6 +69,7 @@ func initViper() {
 	}
 
 	viper.SetDefault(ConfigAPIBaseURL, "https://api.fly.io")
+	viper.SetDefault(ConfigElixirAPIBaseURL, "https://api.fly.io")
 	viper.SetDefault(ConfigFlapsBaseUrl, "https://api.machines.dev")
 	viper.SetDefault(ConfigRegistryHost, "registry.fly.io")
 	viper.SetDefault(ConfigWireGuardWebsockets, true)
@@ -85,6 +86,7 @@ func initViper() {
 	}
 
 	fly.SetBaseURL(viper.GetString(ConfigAPIBaseURL))
+	fly.SetElixirBaseURL(viper.GetString(ConfigElixirAPIBaseURL))
 	fly.SetErrorLog(viper.GetBool(ConfigGQLErrorLogging))
 	fly.SetInstrumenter(instrument.ApiAdapter)
 }

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.1.13
+	github.com/superfly/fly-go v0.1.15-0.20240607184320-8300e50c16b8
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.13

--- a/go.sum
+++ b/go.sum
@@ -607,8 +607,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.13 h1:cb69Yg29fdaye8Q0MmXrnKSX115V+Uv2dQrHUlSj1Sg=
-github.com/superfly/fly-go v0.1.13/go.mod h1:fopkB+iOiuZHNcukZjzZx31e4JL7hn6yE+FRasD3m2I=
+github.com/superfly/fly-go v0.1.15-0.20240607184320-8300e50c16b8 h1:phqNvEvTnt3hnvkvsr3GbbgGCNVCNT4sWMmHuB0AKWM=
+github.com/superfly/fly-go v0.1.15-0.20240607184320-8300e50c16b8/go.mod h1:JQke/BwoZqrWurqYkypSlcSo7bIUgCI3eVnqMC6AUj0=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ const (
 	FileName = "config.yml"
 
 	apiBaseURLEnvKey           = "FLY_API_BASE_URL"
+	elixirApiBaseURLEnvKey     = "FLY_ELIXIR_API_BASE_URL"
 	flapsBaseURLEnvKey         = "FLY_FLAPS_BASE_URL"
 	metricsBaseURLEnvKey       = "FLY_METRICS_BASE_URL"
 	AccessTokenEnvKey          = "FLY_ACCESS_TOKEN"
@@ -54,6 +55,9 @@ type Config struct {
 
 	// APIBaseURL denotes the base URL of the API.
 	APIBaseURL string
+
+	// ElixirAPIBaseURL denotes the base URL of the Elixir API.
+	ElixirAPIBaseURL string
 
 	// FlapsBaseURL denotes base URL for FLAPS (also known as the Machines API).
 	FlapsBaseURL string
@@ -141,6 +145,7 @@ func (cfg *Config) applyEnv() {
 	cfg.Region = env.FirstOrDefault(cfg.Region, regionEnvKey)
 	cfg.RegistryHost = env.FirstOrDefault(cfg.RegistryHost, registryHostEnvKey)
 	cfg.APIBaseURL = env.FirstOrDefault(cfg.APIBaseURL, apiBaseURLEnvKey)
+	cfg.ElixirAPIBaseURL = env.FirstOrDefault(cfg.ElixirAPIBaseURL, elixirApiBaseURLEnvKey)
 	cfg.FlapsBaseURL = env.FirstOrDefault(cfg.FlapsBaseURL, flapsBaseURLEnvKey)
 	cfg.MetricsBaseURL = env.FirstOrDefault(cfg.MetricsBaseURL, metricsBaseURLEnvKey)
 	cfg.SendMetrics = env.IsTruthy(SendMetricsEnvKey) || cfg.SendMetrics


### PR DESCRIPTION
### Change Summary

What and Why: support `FLY_ELIXIR_API_BASE_URL` so devs can set this up locally for tests

How: added an opt-in env to use this as `FLY_ELIXIR_API_BASE_URL=http://localhost:4000`

Related to: https://github.com/superfly/fly-go/pull/68

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
