### PR TITLE
Implement unit test with in-memory server implementation.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.1.15
+	github.com/superfly/fly-go v0.1.16
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.13

--- a/go.sum
+++ b/go.sum
@@ -607,8 +607,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.15 h1:F/OXCHSecghrdoNc9JOZjUcfGPGra2ULjVNEiM4Aan8=
-github.com/superfly/fly-go v0.1.15/go.mod h1:JQke/BwoZqrWurqYkypSlcSo7bIUgCI3eVnqMC6AUj0=
+github.com/superfly/fly-go v0.1.16 h1:fXM2ybR86SoZHeybmwwpTAqtm7SJmtTQO1Haguf2mj0=
+github.com/superfly/fly-go v0.1.16/go.mod h1:JQke/BwoZqrWurqYkypSlcSo7bIUgCI3eVnqMC6AUj0=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/command/deploy/deploy_test.go
+++ b/internal/command/deploy/deploy_test.go
@@ -8,14 +8,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command/deploy"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/inmem"
 	"github.com/superfly/flyctl/internal/logger"
-	"github.com/superfly/flyctl/internal/mock"
 	"github.com/superfly/flyctl/internal/task"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -35,90 +34,28 @@ func TestCommand_Execute(t *testing.T) {
 	cmd := deploy.New()
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
-	cmd.SetArgs([]string{"--image", "registry.fly.io/my-image:deployment-00000000000000000000000000"})
+	cmd.SetArgs([]string{"--image", "test-registry.fly.io/my-image:deployment-00000000000000000000000000"})
 
 	ctx := context.Background()
 	ctx = iostreams.NewContext(ctx, &iostreams.IOStreams{Out: &buf, ErrOut: &buf})
 	ctx = task.NewWithContext(ctx)
 	ctx = logger.NewContext(ctx, logger.New(&buf, logger.Info, true))
 
-	var client mock.Client
-	ctx = flyutil.NewContextWithClient(ctx, &client)
-
-	var flapsClient mock.FlapsClient
-	ctx = flapsutil.NewContextWithClient(ctx, &flapsClient)
-
-	client.AuthenticatedFunc = func() bool { return true }
-	client.GetCurrentUserFunc = func(ctx context.Context) (*fly.User, error) {
-		return &fly.User{ID: "USER1"}, nil
-	}
-	client.GetAppCompactFunc = func(ctx context.Context, appName string) (*fly.AppCompact, error) {
-		if got, want := appName, "test-basic"; got != want {
-			t.Fatalf("appName=%s, want %s", got, want)
-		}
-		return &fly.AppCompact{
-			Organization: &fly.OrganizationBasic{Slug: "my-org"},
-		}, nil
-	}
-	client.CreateBuildFunc = func(ctx context.Context, input fly.CreateBuildInput) (*fly.CreateBuildResponse, error) {
-		return &fly.CreateBuildResponse{
-			CreateBuild: fly.CreateBuildCreateBuildCreateBuildPayload{
-				Id: "BUILD1",
-			},
-		}, nil
-	}
-	client.ResolveImageForAppFunc = func(ctx context.Context, appName, imageRef string) (*fly.Image, error) {
-		return &fly.Image{
-			ID:             "IMAGE1",
-			Ref:            "test-registry.fly.io/test-basic/deployment-123",
-			CompressedSize: "1000",
-		}, nil
-	}
-	client.FinishBuildFunc = func(ctx context.Context, input fly.FinishBuildInput) (*fly.FinishBuildResponse, error) {
-		return &fly.FinishBuildResponse{
-			FinishBuild: fly.FinishBuildFinishBuildFinishBuildPayload{
-				Id:              "BUILD1",
-				Status:          "",
-				WallclockTimeMs: 2000,
-			},
-		}, nil
-	}
-	client.CreateReleaseFunc = func(ctx context.Context, input fly.CreateReleaseInput) (*fly.CreateReleaseResponse, error) {
-		return &fly.CreateReleaseResponse{}, nil
-	}
-	client.UpdateReleaseFunc = func(ctx context.Context, input fly.UpdateReleaseInput) (*fly.UpdateReleaseResponse, error) {
-		return &fly.UpdateReleaseResponse{}, nil
-	}
-	client.GetIPAddressesFunc = func(ctx context.Context, appName string) ([]fly.IPAddress, error) {
-		return nil, nil
+	server := inmem.NewServer()
+	server.CreateApp(&fly.App{
+		Name:         "test-basic",
+		Organization: fly.Organization{Slug: "my-org"},
+	})
+	if err := server.CreateImage(context.Background(), "test-basic", "test-registry.fly.io/my-image:deployment-00000000000000000000000000", &fly.Image{
+		ID:             "IMAGE1",
+		Ref:            "test-registry.fly.io/my-image:deployment-00000000000000000000000000",
+		CompressedSize: "1000",
+	}); err != nil {
+		t.Fatal(err)
 	}
 
-	flapsClient.ListFlyAppsMachinesFunc = func(ctx context.Context) ([]*fly.Machine, *fly.Machine, error) {
-		return nil, nil, nil // no machines
-	}
-	flapsClient.ListActiveFunc = func(ctx context.Context) ([]*fly.Machine, error) {
-		return nil, nil // no active machines
-	}
-	flapsClient.LaunchFunc = func(ctx context.Context, builder fly.LaunchMachineInput) (out *fly.Machine, err error) {
-		return &fly.Machine{
-			ID:     "m0",
-			Region: "ord",
-			Config: &fly.MachineConfig{},
-		}, nil
-	}
-	flapsClient.GetFunc = func(ctx context.Context, machineID string) (*fly.Machine, error) {
-		return &fly.Machine{
-			ID:     "m0",
-			Region: "ord",
-			Config: &fly.MachineConfig{},
-		}, nil
-	}
-	flapsClient.WaitFunc = func(ctx context.Context, machine *fly.Machine, state string, timeout time.Duration) (err error) {
-		return nil
-	}
-	flapsClient.GetProcessesFunc = func(ctx context.Context, machineID string) (fly.MachinePsResponse, error) {
-		return nil, nil
-	}
+	ctx = flyutil.NewContextWithClient(ctx, server.Client())
+	ctx = flapsutil.NewContextWithClient(ctx, server.FlapsClient("test-basic"))
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		t.Fatal(err)

--- a/internal/inmem/client.go
+++ b/internal/inmem/client.go
@@ -1,0 +1,422 @@
+package inmem
+
+import (
+	"context"
+	"crypto/ed25519"
+	"fmt"
+	"net"
+
+	genq "github.com/Khan/genqlient/graphql"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/graphql"
+)
+
+var DefaultUser = fly.User{
+	ID:              "USER1",
+	Name:            "TestUser",
+	Email:           "test@fly.dev",
+	EnablePaidHobby: false,
+}
+
+var _ flyutil.Client = (*Client)(nil)
+
+type Client struct {
+	server *Server
+
+	CurrentUser *fly.User
+}
+
+func NewClient(s *Server) *Client {
+	u := DefaultUser
+
+	return &Client{
+		server:      s,
+		CurrentUser: &u,
+	}
+}
+
+func (m *Client) AddCertificate(ctx context.Context, appName, hostname string) (*fly.AppCertificate, *fly.HostnameCheck, error) {
+	panic("TODO")
+}
+
+func (m *Client) AllocateIPAddress(ctx context.Context, appName string, addrType string, region string, org *fly.Organization, network string) (*fly.IPAddress, error) {
+	panic("TODO")
+}
+
+func (m *Client) AllocateSharedIPAddress(ctx context.Context, appName string) (net.IP, error) {
+	panic("TODO")
+}
+
+func (m *Client) AppNameAvailable(ctx context.Context, appName string) (bool, error) {
+	panic("TODO")
+}
+
+func (m *Client) AttachPostgresCluster(ctx context.Context, input fly.AttachPostgresClusterInput) (*fly.AttachPostgresClusterPayload, error) {
+	panic("TODO")
+}
+
+func (m *Client) Authenticated() bool {
+	return m.CurrentUser != nil
+}
+
+func (m *Client) CanPerformBluegreenDeployment(ctx context.Context, appName string) (bool, error) {
+	panic("TODO")
+}
+
+func (m *Client) CheckAppCertificate(ctx context.Context, appName, hostname string) (*fly.AppCertificate, *fly.HostnameCheck, error) {
+	panic("TODO")
+}
+
+func (m *Client) CheckDomain(ctx context.Context, name string) (*fly.CheckDomainResult, error) {
+	panic("TODO")
+}
+
+func (m *Client) ClosestWireguardGatewayRegion(ctx context.Context) (*fly.Region, error) {
+	panic("TODO")
+}
+
+func (m *Client) CreateAndRegisterDomain(organizationID string, name string) (*fly.Domain, error) {
+	panic("TODO")
+}
+
+func (m *Client) CreateApp(ctx context.Context, input fly.CreateAppInput) (*fly.App, error) {
+	panic("TODO")
+}
+
+func (m *Client) CreateBuild(ctx context.Context, input fly.CreateBuildInput) (*fly.CreateBuildResponse, error) {
+	build, err := m.server.CreateBuild(ctx, input.AppName)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp fly.CreateBuildResponse
+	resp.CreateBuild.Id = build.ID
+	resp.CreateBuild.Status = build.Status
+	return &resp, nil
+}
+
+func (m *Client) CreateDelegatedWireGuardToken(ctx context.Context, org *fly.Organization, name string) (*fly.DelegatedWireGuardToken, error) {
+	panic("TODO")
+}
+
+func (m *Client) CreateDoctorUrl(ctx context.Context) (putUrl string, err error) {
+	panic("TODO")
+}
+
+func (m *Client) CreateDomain(organizationID string, name string) (*fly.Domain, error) {
+	panic("TODO")
+}
+
+func (m *Client) CreateOrganization(ctx context.Context, organizationname string) (*fly.Organization, error) {
+	panic("TODO")
+}
+
+func (m *Client) CreateOrganizationInvite(ctx context.Context, id, email string) (*fly.Invitation, error) {
+	panic("TODO")
+}
+
+func (m *Client) CreateRelease(ctx context.Context, input fly.CreateReleaseInput) (*fly.CreateReleaseResponse, error) {
+	release, err := m.server.CreateRelease(ctx, input.AppId, input.ClientMutationId, input.Image, input.PlatformVersion, string(input.Strategy))
+	if err != nil {
+		return nil, err
+	}
+
+	var resp fly.CreateReleaseResponse
+	resp.CreateRelease.Release.Id = release.ID
+	resp.CreateRelease.Release.Version = release.Version
+	return &resp, nil
+}
+
+func (m *Client) CreateWireGuardPeer(ctx context.Context, org *fly.Organization, region, name, pubkey, network string) (*fly.CreatedWireGuardPeer, error) {
+	panic("TODO")
+}
+
+func (m *Client) DeleteApp(ctx context.Context, appName string) error {
+	panic("TODO")
+}
+
+func (m *Client) DeleteCertificate(ctx context.Context, appName, hostname string) (*fly.DeleteCertificatePayload, error) {
+	panic("TODO")
+}
+
+func (m *Client) DeleteDelegatedWireGuardToken(ctx context.Context, org *fly.Organization, name, token *string) error {
+	panic("TODO")
+}
+
+func (m *Client) DeleteOrganization(ctx context.Context, id string) (deletedid string, err error) {
+	panic("TODO")
+}
+
+func (m *Client) DeleteOrganizationMembership(ctx context.Context, orgId, userId string) (string, string, error) {
+	panic("TODO")
+}
+
+func (m *Client) DetachPostgresCluster(ctx context.Context, input fly.DetachPostgresClusterInput) error {
+	panic("TODO")
+}
+
+func (m *Client) EnablePostgresConsul(ctx context.Context, appName string) (*fly.PostgresEnableConsulPayload, error) {
+	panic("TODO")
+}
+
+func (m *Client) EnsureRemoteBuilder(ctx context.Context, orgID, appName, region string) (*fly.GqlMachine, *fly.App, error) {
+	panic("TODO")
+}
+
+func (m *Client) ExportDNSRecords(ctx context.Context, domainId string) (string, error) {
+	panic("TODO")
+}
+
+func (m *Client) FinishBuild(ctx context.Context, input fly.FinishBuildInput) (*fly.FinishBuildResponse, error) {
+	build, err := m.server.FinishBuild(ctx, input.BuildId, input.Status)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp fly.FinishBuildResponse
+	resp.FinishBuild.Id = build.ID
+	resp.FinishBuild.Status = build.Status
+	return &resp, nil
+}
+
+func (m *Client) GetApp(ctx context.Context, appName string) (*fly.App, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetAppBasic(ctx context.Context, appName string) (*fly.AppBasic, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetAppCertificates(ctx context.Context, appName string) ([]fly.AppCertificateCompact, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetAppCompact(ctx context.Context, appName string) (*fly.AppCompact, error) {
+	m.server.mu.Lock()
+	defer m.server.mu.Unlock()
+
+	app := m.server.apps[appName]
+	if app == nil {
+		return nil, fmt.Errorf("app not found: %q", appName) // TODO: Match actual error
+	}
+
+	return app.Compact(), nil
+}
+
+func (m *Client) GetAppCurrentReleaseMachines(ctx context.Context, appName string) (*fly.Release, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetAppHostIssues(ctx context.Context, appName string) ([]fly.HostIssue, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetAppLimitedAccessTokens(ctx context.Context, appName string) ([]fly.LimitedAccessToken, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetAppRemoteBuilder(ctx context.Context, appName string) (*fly.App, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetAppLogs(ctx context.Context, appName, token, region, instanceID string) (entries []fly.LogEntry, nextToken string, err error) {
+	panic("TODO")
+}
+
+func (m *Client) GetAppNameFromVolume(ctx context.Context, volID string) (*string, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetAppNameStateFromVolume(ctx context.Context, volID string) (*string, *string, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetAppNetwork(ctx context.Context, appName string) (*string, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetAppReleasesMachines(ctx context.Context, appName, status string, limit int) ([]fly.Release, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetAppSecrets(ctx context.Context, appName string) ([]fly.Secret, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetApps(ctx context.Context, role *string) ([]fly.App, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetAppsForOrganization(ctx context.Context, orgID string) ([]fly.App, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetCurrentUser(ctx context.Context) (*fly.User, error) {
+	return m.CurrentUser, nil
+}
+
+func (m *Client) GetDNSRecords(ctx context.Context, domainName string) ([]*fly.DNSRecord, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetDelegatedWireGuardTokens(ctx context.Context, slug string) ([]*fly.DelegatedWireGuardTokenHandle, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetDetailedOrganizationBySlug(ctx context.Context, slug string) (*fly.OrganizationDetails, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetDomain(ctx context.Context, name string) (*fly.Domain, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetDomains(ctx context.Context, organizationSlug string) ([]*fly.Domain, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetIPAddresses(ctx context.Context, appName string) ([]fly.IPAddress, error) {
+	return nil, nil // TODO
+}
+
+func (m *Client) GetLatestImageDetails(ctx context.Context, image string) (*fly.ImageVersion, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetLatestImageTag(ctx context.Context, repository string, snapshotId *string) (string, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetLoggedCertificates(ctx context.Context, slug string) ([]fly.LoggedCertificate, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetMachine(ctx context.Context, machineId string) (*fly.GqlMachine, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetNearestRegion(ctx context.Context) (*fly.Region, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetOrganizationByApp(ctx context.Context, appName string) (*fly.Organization, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetOrganizationBySlug(ctx context.Context, slug string) (*fly.Organization, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetOrganizationRemoteBuilderBySlug(ctx context.Context, slug string) (*fly.Organization, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetOrganizations(ctx context.Context, filters ...fly.OrganizationFilter) ([]fly.Organization, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetSnapshotsFromVolume(ctx context.Context, volID string) ([]fly.VolumeSnapshot, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetWireGuardPeer(ctx context.Context, slug, name string) (*fly.WireGuardPeer, error) {
+	panic("TODO")
+}
+
+func (m *Client) GetWireGuardPeers(ctx context.Context, slug string) ([]*fly.WireGuardPeer, error) {
+	panic("TODO")
+}
+
+func (m *Client) GenqClient() genq.Client {
+	panic("TODO")
+}
+
+func (m *Client) LatestImage(ctx context.Context, appName string) (string, error) {
+	panic("TODO")
+}
+
+func (m *Client) ImportDNSRecords(ctx context.Context, domainId string, zonefile string) ([]fly.ImportDnsWarning, []fly.ImportDnsChange, error) {
+	panic("TODO")
+}
+
+func (m *Client) IssueSSHCertificate(ctx context.Context, org fly.OrganizationImpl, principals []string, appNames []string, valid_hours *int, publicKey ed25519.PublicKey) (*fly.IssuedCertificate, error) {
+	panic("TODO")
+}
+
+func (m *Client) ListPostgresClusterAttachments(ctx context.Context, appName, postgresAppName string) ([]*fly.PostgresClusterAttachment, error) {
+	panic("TODO")
+}
+
+func (m *Client) Logger() fly.Logger {
+	panic("TODO")
+}
+
+func (m *Client) MoveApp(ctx context.Context, appName string, orgID string) (*fly.App, error) {
+	panic("TODO")
+}
+
+func (m *Client) NewRequest(q string) *graphql.Request {
+	panic("TODO")
+}
+
+func (m *Client) PlatformRegions(ctx context.Context) ([]fly.Region, *fly.Region, error) {
+	panic("TODO")
+}
+
+func (m *Client) ReleaseIPAddress(ctx context.Context, appName string, ip string) error {
+	panic("TODO")
+}
+
+func (m *Client) RemoveWireGuardPeer(ctx context.Context, org *fly.Organization, name string) error {
+	panic("TODO")
+}
+
+func (m *Client) ResolveImageForApp(ctx context.Context, appName, imageRef string) (*fly.Image, error) {
+	m.server.mu.Lock()
+	defer m.server.mu.Unlock()
+
+	image := m.server.images[imageKey{appName, imageRef}]
+	if image == nil {
+		return nil, fmt.Errorf("image not found for app %q: %s", appName, imageRef)
+	}
+	return image, nil
+}
+
+func (m *Client) RevokeLimitedAccessToken(ctx context.Context, id string) error {
+	panic("TODO")
+}
+
+func (m *Client) Run(req *graphql.Request) (fly.Query, error) {
+	panic("TODO")
+}
+
+func (m *Client) RunWithContext(ctx context.Context, req *graphql.Request) (fly.Query, error) {
+	panic("TODO")
+}
+
+func (m *Client) SetGenqClient(client genq.Client) {
+	panic("TODO")
+}
+
+func (m *Client) SetSecrets(ctx context.Context, appName string, secrets map[string]string) (*fly.Release, error) {
+	panic("TODO")
+}
+
+func (m *Client) UpdateRelease(ctx context.Context, input fly.UpdateReleaseInput) (*fly.UpdateReleaseResponse, error) {
+	if err := m.server.UpdateRelease(ctx, input.ReleaseId, input.ClientMutationId, input.Status); err != nil {
+		return nil, err
+	}
+
+	var resp fly.UpdateReleaseResponse
+	resp.UpdateRelease.Release.Id = input.ReleaseId
+	return &resp, nil
+}
+
+func (m *Client) UnsetSecrets(ctx context.Context, appName string, keys []string) (*fly.Release, error) {
+	panic("TODO")
+}
+
+func (m *Client) ValidateWireGuardPeers(ctx context.Context, peerIPs []string) (invalid []string, err error) {
+	panic("TODO")
+}

--- a/internal/inmem/flaps_client.go
+++ b/internal/inmem/flaps_client.go
@@ -1,0 +1,199 @@
+package inmem
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/flapsutil"
+)
+
+var _ flapsutil.FlapsClient = (*FlapsClient)(nil)
+
+type FlapsClient struct {
+	server  *Server
+	appName string
+}
+
+func NewFlapsClient(server *Server, appName string) *FlapsClient {
+	return &FlapsClient{
+		server:  server,
+		appName: appName,
+	}
+}
+
+func (m *FlapsClient) AcquireLease(ctx context.Context, machineID string, ttl *int) (*fly.MachineLease, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) Cordon(ctx context.Context, machineID string, nonce string) (err error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) CreateApp(ctx context.Context, name string, org string) (err error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) CreateVolume(ctx context.Context, req fly.CreateVolumeRequest) (*fly.Volume, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) CreateVolumeSnapshot(ctx context.Context, volumeId string) error {
+	panic("TODO")
+}
+
+func (m *FlapsClient) DeleteMetadata(ctx context.Context, machineID, key string) error {
+	panic("TODO")
+}
+
+func (m *FlapsClient) DeleteVolume(ctx context.Context, volumeId string) (*fly.Volume, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) Destroy(ctx context.Context, input fly.RemoveMachineInput, nonce string) (err error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) Exec(ctx context.Context, machineID string, in *fly.MachineExecRequest) (*fly.MachineExecResponse, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) ExtendVolume(ctx context.Context, volumeId string, size_gb int) (*fly.Volume, bool, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) FindLease(ctx context.Context, machineID string) (*fly.MachineLease, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) Get(ctx context.Context, machineID string) (*fly.Machine, error) {
+	return m.server.GetMachine(ctx, m.appName, machineID)
+}
+
+func (m *FlapsClient) GetAllVolumes(ctx context.Context) ([]fly.Volume, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) GetMany(ctx context.Context, machineIDs []string) ([]*fly.Machine, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) GetMetadata(ctx context.Context, machineID string) (map[string]string, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) GetProcesses(ctx context.Context, machineID string) (fly.MachinePsResponse, error) {
+	return nil, nil // TODO
+}
+
+func (m *FlapsClient) GetVolume(ctx context.Context, volumeId string) (*fly.Volume, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) GetVolumeSnapshots(ctx context.Context, volumeId string) ([]fly.VolumeSnapshot, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) GetVolumes(ctx context.Context) ([]fly.Volume, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) Kill(ctx context.Context, machineID string) (err error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) Launch(ctx context.Context, builder fly.LaunchMachineInput) (out *fly.Machine, err error) {
+	return m.server.Launch(ctx, m.appName, builder.Name, builder.Region, builder.Config)
+}
+
+func (m *FlapsClient) List(ctx context.Context, state string) ([]*fly.Machine, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) ListActive(ctx context.Context) ([]*fly.Machine, error) {
+	m.server.mu.Lock()
+	defer m.server.mu.Unlock()
+
+	var a []*fly.Machine
+	for _, machine := range m.server.machines[m.appName] {
+		if !machine.IsReleaseCommandMachine() && !machine.IsFlyAppsConsole() && machine.IsActive() {
+			a = append(a, machine)
+		}
+	}
+	return a, nil
+}
+
+func (m *FlapsClient) ListFlyAppsMachines(ctx context.Context) (machines []*fly.Machine, releaseCmdMachine *fly.Machine, err error) {
+	m.server.mu.Lock()
+	defer m.server.mu.Unlock()
+
+	machines = make([]*fly.Machine, 0)
+	for _, machine := range m.server.machines[m.appName] {
+		if machine.IsFlyAppsPlatform() && machine.IsActive() && !machine.IsFlyAppsReleaseCommand() && !machine.IsFlyAppsConsole() {
+			machines = append(machines, machine)
+		} else if machine.IsFlyAppsReleaseCommand() {
+			releaseCmdMachine = machine
+		}
+	}
+	return machines, releaseCmdMachine, nil
+}
+
+func (m *FlapsClient) NewRequest(ctx context.Context, method, path string, in interface{}, headers map[string][]string) (*http.Request, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) RefreshLease(ctx context.Context, machineID string, ttl *int, nonce string) (*fly.MachineLease, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) ReleaseLease(ctx context.Context, machineID, nonce string) error {
+	panic("TODO")
+}
+
+func (m *FlapsClient) Restart(ctx context.Context, in fly.RestartMachineInput, nonce string) (err error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) SetMetadata(ctx context.Context, machineID, key, value string) error {
+	panic("TODO")
+}
+
+func (m *FlapsClient) Start(ctx context.Context, machineID string, nonce string) (out *fly.MachineStartResponse, err error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) Stop(ctx context.Context, in fly.StopMachineInput, nonce string) (err error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) Uncordon(ctx context.Context, machineID string, nonce string) (err error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) Update(ctx context.Context, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) UpdateVolume(ctx context.Context, volumeId string, req fly.UpdateVolumeRequest) (*fly.Volume, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) Wait(ctx context.Context, machine *fly.Machine, state string, timeout time.Duration) (err error) {
+	if state == "" {
+		state = "started"
+	}
+	mach, err := m.server.GetMachine(ctx, m.appName, machine.ID)
+	if err != nil {
+		return err
+	}
+	if mach.State != state {
+		return fmt.Errorf("machine did not reach state %q, current state is %q", state, mach.State)
+	}
+	return nil
+}
+
+func (m *FlapsClient) WaitForApp(ctx context.Context, name string) error {
+	panic("TODO")
+}

--- a/internal/inmem/server.go
+++ b/internal/inmem/server.go
@@ -1,0 +1,199 @@
+package inmem
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/helpers"
+)
+
+type Server struct {
+	mu sync.Mutex
+
+	apps   map[string]*fly.App     // apps by app name
+	images map[imageKey]*fly.Image // images by app name & image ref
+
+	machineSeq int                       // machine id generation
+	machines   map[string][]*fly.Machine // machines by app name
+
+	buildSeq int               // build id generation
+	builds   map[string]*Build // builds by id
+
+	releaseSeq int                 // release id generation
+	releases   map[string]*Release // releases by id
+}
+
+func NewServer() *Server {
+	return &Server{
+		apps:     make(map[string]*fly.App),
+		machines: make(map[string][]*fly.Machine),
+		images:   make(map[imageKey]*fly.Image),
+		builds:   make(map[string]*Build),
+		releases: make(map[string]*Release),
+	}
+}
+
+func (s *Server) Client() *Client {
+	return NewClient(s)
+}
+
+func (s *Server) FlapsClient(appName string) *FlapsClient {
+	return NewFlapsClient(s, appName)
+}
+
+func (s *Server) CreateApp(app *fly.App) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.apps[app.Name]; ok {
+		panic(fmt.Sprintf("app name already exists: %q", app.Name))
+	}
+	s.apps[app.Name] = app
+}
+
+func (s *Server) CreateBuild(ctx context.Context, appName string) (*Build, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.apps[appName]; ok {
+		return nil, fmt.Errorf("app not found: %q", appName)
+	}
+
+	s.buildSeq++
+
+	build := &Build{
+		ID:        fmt.Sprintf("BUILD%d", s.buildSeq),
+		AppName:   appName,
+		Status:    "started",
+		CreatedAt: time.Now(),
+	}
+	s.builds[build.ID] = build
+
+	return build, nil
+}
+
+func (s *Server) FinishBuild(ctx context.Context, id, status string) (*Build, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	build, ok := s.builds[id]
+	if ok {
+		return nil, fmt.Errorf("build not found: %q", id)
+	}
+	build.Status = status
+	build.WallClockTimeMs = time.Since(build.CreatedAt).Milliseconds()
+
+	return build, nil
+}
+
+func (s *Server) CreateRelease(ctx context.Context, appID, clientMutationID, image, platformVersion, strategy string) (*Release, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var n int
+	for _, r := range s.releases {
+		if r.AppID == appID {
+			n++
+		}
+	}
+
+	s.releaseSeq++
+
+	release := &Release{
+		ID:               fmt.Sprintf("RELEASE%d", s.releaseSeq),
+		AppID:            appID,
+		ClientMutationID: clientMutationID,
+		Image:            image,
+		PlatformVersion:  platformVersion,
+		Status:           "pending",
+		Strategy:         strategy,
+		Version:          n + 1,
+	}
+	s.releases[release.ID] = release
+
+	return release, nil
+}
+
+func (s *Server) UpdateRelease(ctx context.Context, id, clientMutationID, status string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	release := s.releases[id]
+	if release == nil {
+		return fmt.Errorf("release not found: %q", id)
+	}
+
+	release.Status = status
+
+	return nil
+}
+
+func (s *Server) CreateImage(ctx context.Context, appName, imageRef string, image *fly.Image) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.apps[appName]; !ok {
+		return fmt.Errorf("app not found: %q", appName)
+	}
+
+	other := *image
+	s.images[imageKey{appName, imageRef}] = &other
+	return nil
+}
+
+func (s *Server) Launch(ctx context.Context, appName, name, region string, config *fly.MachineConfig) (*fly.Machine, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.machineSeq++
+	id := s.machineSeq
+
+	machine := &fly.Machine{
+		ID:     fmt.Sprintf("%014x", id),
+		Name:   name,
+		Region: region,
+		State:  "started",
+		Config: helpers.Clone(config),
+	}
+	s.machines[appName] = append(s.machines[appName], machine)
+
+	return machine, nil
+}
+
+func (s *Server) GetMachine(ctx context.Context, appName, machineID string) (*fly.Machine, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, machine := range s.machines[appName] {
+		if machine.ID == machineID {
+			return helpers.Clone(machine), nil
+		}
+	}
+	return nil, fmt.Errorf("machine not found: %q", machineID)
+}
+
+type Build struct {
+	ID              string
+	AppName         string
+	Status          string
+	CreatedAt       time.Time
+	WallClockTimeMs int64
+}
+
+type Release struct {
+	ID               string
+	AppID            string
+	ClientMutationID string
+	Definition       any
+	Image            string
+	PlatformVersion  string
+	Status           string
+	Strategy         string
+	Version          int
+}
+
+type imageKey struct {
+	appName, imageRef string
+}


### PR DESCRIPTION
### Change Summary

This pull request changes the mock implementation of the deploy test to use a simple, in-memory server implementation. This should help us to build tests faster and more consistently by not having to mock every since call.

Related to: https://github.com/superfly/fly-go/pull/69

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
