### PR TITLE
Config file flag

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -56,6 +56,11 @@ func New() (cmd *cobra.Command) {
 			Name:        "name",
 			Description: `Name of the new app`,
 		},
+		flag.String{
+			Name:        "config-file",
+			Description: "Path to which the generated configuration file should be saved",
+			Default:     "fly.toml",
+		},
 		flag.Bool{
 			Name:        "copy-config",
 			Description: "Use the configuration file if present without prompting",

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -43,6 +43,7 @@ func New() (cmd *cobra.Command) {
 		flag.Region(),
 		flag.Org(),
 		flag.NoDeploy(),
+		flag.AppConfig(),
 		flag.Bool{
 			Name:        "generate-name",
 			Description: "Always generate a name for the app, without prompting",
@@ -55,11 +56,6 @@ func New() (cmd *cobra.Command) {
 		flag.String{
 			Name:        "name",
 			Description: `Name of the new app`,
-		},
-		flag.String{
-			Name:        "config-file",
-			Description: "Path to which the generated configuration file should be saved",
-			Default:     "fly.toml",
 		},
 		flag.Bool{
 			Name:        "copy-config",

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -82,7 +82,8 @@ func (state *launchState) Launch(ctx context.Context) error {
 	}
 
 	// Finally write application configuration to fly.toml
-	configPath := state.configPath
+	configDir := filepath.Dir(state.configPath)
+	configPath := filepath.Join(configDir, flag.GetString(ctx, "config-file"))
 	if flag.GetBool(ctx, "json") {
 		configPath = strings.TrimSuffix(configPath, filepath.Ext(configPath)) + ".json"
 	} else if flag.GetBool(ctx, "yaml") {

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -84,9 +84,9 @@ func (state *launchState) Launch(ctx context.Context) error {
 	// Finally write application configuration to fly.toml
 	configDir := filepath.Dir(state.configPath)
 	configPath := filepath.Join(configDir, flag.GetString(ctx, "config-file"))
-	if flag.GetBool(ctx, "json") {
+	if flag.GetBool(ctx, "json") || strings.HasSuffix(configPath, ".json") {
 		configPath = strings.TrimSuffix(configPath, filepath.Ext(configPath)) + ".json"
-	} else if flag.GetBool(ctx, "yaml") {
+	} else if flag.GetBool(ctx, "yaml") || strings.HasSuffix(configPath, ".yaml") {
 		configPath = strings.TrimSuffix(configPath, filepath.Ext(configPath)) + ".yaml"
 	}
 	state.appConfig.SetConfigFilePath(configPath)

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -83,7 +83,10 @@ func (state *launchState) Launch(ctx context.Context) error {
 
 	// Finally write application configuration to fly.toml
 	configDir := filepath.Dir(state.configPath)
-	configPath := filepath.Join(configDir, flag.GetString(ctx, "config-file"))
+	configPath := filepath.Join(configDir, flag.GetString(ctx, "config"))
+	if configPath == "" {
+		configPath = filepath.Join(configDir, "fly.toml")
+	}
 	if flag.GetBool(ctx, "json") || strings.HasSuffix(configPath, ".json") {
 		configPath = strings.TrimSuffix(configPath, filepath.Ext(configPath)) + ".json"
 	} else if flag.GetBool(ctx, "yaml") || strings.HasSuffix(configPath, ".yaml") {

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -3,6 +3,7 @@ package launch
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/tracing"
@@ -83,10 +85,11 @@ func (state *launchState) Launch(ctx context.Context) error {
 
 	// Finally write application configuration to fly.toml
 	configDir := filepath.Dir(state.configPath)
-	configPath := filepath.Join(configDir, flag.GetString(ctx, "config"))
-	if configPath == "" {
-		configPath = filepath.Join(configDir, "fly.toml")
+	configPath := filepath.Join(configDir, flag.GetString(ctx, flagnames.AppConfigFilePath))
+	if fileInfo, err := os.Stat(configPath); err == nil && fileInfo.IsDir() {
+		configPath = filepath.Join(configPath, "fly.toml")
 	}
+
 	if flag.GetBool(ctx, "json") || strings.HasSuffix(configPath, ".json") {
 		configPath = strings.TrimSuffix(configPath, filepath.Ext(configPath)) + ".json"
 	} else if flag.GetBool(ctx, "yaml") || strings.HasSuffix(configPath, ".yaml") {


### PR DESCRIPTION
### Change Summary

What and Why:
Adds a `--config` flag to launch to enable managing multiple environments easier.

```sh
fly launch --config fly.dev.toml
```

this also works for `yaml` and `json` files

```sh
fly launch --config fly.dev.json
```

and with the shorthand

```sh
fly launch -c fly.dev.json
```

How:

Related to: #3584

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
