### PR TITLE
Hide sentry from launch plan unless selected

### DIFF
--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -136,7 +136,10 @@ func (state *launchState) PlanSummary(ctx context.Context) (string, error) {
 		{"Postgres", postgresStr, state.PlanSource.postgresSource},
 		{"Redis", redisStr, state.PlanSource.redisSource},
 		{"Tigris", tigrisStr, state.PlanSource.tigrisSource},
-		{"Sentry", strconv.FormatBool(state.Plan.Sentry), state.PlanSource.sentrySource},
+	}
+
+	if state.PlanSource.sentrySource != "not requested" {
+		rows = append(rows, []string{"Sentry", strconv.FormatBool(state.Plan.Sentry), state.PlanSource.sentrySource})
 	}
 
 	for _, row := range rows {


### PR DESCRIPTION
1) No scanners currently select sentry
2) Sentry is typically added post-launch