### PR TITLE
Restart remote builder machine if it's stopped

### DIFF
--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -110,6 +110,8 @@ func (e ValidateBuilderError) Error() string {
 		return "no builder volume"
 	case InvalidMachineCount:
 		return "invalid machine count"
+	case BuilderMachineNotStarted:
+		return "builder machine not started"
 	default:
 		return "unknown error validating builder"
 	}

--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -61,6 +61,20 @@ func EnsureBuilder(ctx context.Context, org *fly.Organization, region string) (*
 		return nil, nil, err
 	}
 
+	if validateBuilderErr == BuilderMachineNotStarted {
+		span.AddEvent("builder machine not started, restarting")
+		flapsClient := flapsutil.ClientFromContext(ctx)
+
+		if err := flapsClient.Restart(ctx, fly.RestartMachineInput{
+			ID: builderMachine.ID,
+		}, ""); err != nil {
+			tracing.RecordError(span, err, "error restarting builder machine")
+			return nil, nil, err
+		}
+
+		return builderMachine, builderApp, nil
+	}
+
 	if validateBuilderErr != NoBuilderApp {
 		span.AddEvent(fmt.Sprintf("deleting existing invalid builder due to %s", validateBuilderErr))
 		client := flyutil.ClientFromContext(ctx)
@@ -105,6 +119,7 @@ const (
 	NoBuilderApp ValidateBuilderError = iota
 	NoBuilderVolume
 	InvalidMachineCount
+	BuilderMachineNotStarted
 )
 
 func validateBuilder(ctx context.Context, app *fly.App) (*fly.Machine, error) {
@@ -127,6 +142,12 @@ func validateBuilder(ctx context.Context, app *fly.App) (*fly.Machine, error) {
 		tracing.RecordError(span, err, "error validating builder machines")
 		return nil, err
 	}
+
+	if machine.State != "started" {
+		tracing.RecordError(span, BuilderMachineNotStarted, "builder machine not started")
+		return machine, BuilderMachineNotStarted
+	}
+
 	return machine, nil
 
 }

--- a/internal/build/imgsrc/ensure_builder_test.go
+++ b/internal/build/imgsrc/ensure_builder_test.go
@@ -32,7 +32,8 @@ func TestValidateBuilder(t *testing.T) {
 		ListFunc: func(ctx context.Context, state string) ([]*fly.Machine, error) {
 			if hasMachines {
 				return []*fly.Machine{{
-					ID: "bigmachine",
+					ID:    "bigmachine",
+					State: "started",
 				}}, nil
 			} else {
 				return []*fly.Machine{}, nil
@@ -99,7 +100,8 @@ func TestValidateBuilderAPIErrors(t *testing.T) {
 				}
 			}
 			return []*fly.Machine{{
-				ID: "bigmachine",
+				ID:    "bigmachine",
+				State: "started",
 			}}, nil
 		},
 	}
@@ -209,7 +211,8 @@ func TestCreateBuilder(t *testing.T) {
 				return nil, errors.New("launch machine failed")
 			}
 			return &fly.Machine{
-				ID: "bigmachine",
+				ID:    "bigmachine",
+				State: "started",
 			}, nil
 		},
 	}


### PR DESCRIPTION
### Change Summary

What and Why:
We autostop remote builders (which I didn't know!). We need to be sure to start the remote builder machine before trying to connect.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
