### PR TITLE
Provide a more meaningful error when probing wg fails

### DIFF
--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -326,7 +326,10 @@ func (s *server) probeTunnel(ctx context.Context, slug, network string) (err err
 	var results []net.IP
 	switch results, err = tunnel.LookupAAAA(ctx, "_api.internal"); {
 	case err != nil:
-		err = fmt.Errorf("failed probing %q: %w", slug, err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			err = fmt.Errorf("Timed out (%w)", err)
+		}
+		err = fmt.Errorf("Error contacting Fly.io API when probing %q: %w", slug, err)
 	case len(results) == 0:
 		s.printf("%q probed.", slug)
 	default:


### PR DESCRIPTION
### Change Summary

What and Why:
Updating the error message that gets shown to the user when probing the connection after establishing a wg peer. The original error message did not convey much information and was confusing.

How:
Rewrite the error to include more info and to translate the meaning of "context timeout" to something understandable.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
