### PR TITLE
Automatically release a new version of flyctl daily

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -2,7 +2,7 @@ name: Automatically release a new version of flyctl
 
 on:
   schedule:
-    - cron: '0 20 * * MON-THU'  # Runs at 3 PM Eastern Time Monday Through Thursday (8 PM UTC)
+    - cron: '0 20 * * MON-THU'  # Runs at 3 PM Eastern Standard Time Monday Through Thursday (8 PM UTC)
 
 jobs:
   run_script:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -2,7 +2,7 @@ name: Automatically release a new version of flyctl
 
 on:
   schedule:
-    - cron: '0 20 * * *'  # Runs at 3 PM Eastern Time every day (8 PM UTC)
+    - cron: '0 20 * * MON-THU'  # Runs at 3 PM Eastern Time Monday Through Thursday (8 PM UTC)
 
 jobs:
   run_script:
@@ -14,4 +14,4 @@ jobs:
           ref: master
       - name: bump version
         run: |
-          sh scripts/force_bump_version.sh
+          ./scripts/force_bump_version.sh

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,17 @@
+name: Automatically release a new version of flyctl
+
+on:
+  schedule:
+    - cron: '0 20 * * *'  # Runs at 3 PM Eastern Time every day (8 PM UTC)
+
+jobs:
+  run_script:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v3
+        with:
+          ref: master
+      - name: bump version
+        run: |
+          sh scripts/force_bump_version.sh

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ app: banana
 
 `flyctl` will operate against the `banana` app unless overridden by the -a flag or other app name setting in the command line.
 
+## Releases
+`flyctl` is automatically released at 3 PM Eastern Standard Time Monday - Thursday. If needed, you can bump a release by running `./scripts/bump_version.sh`.
+
 ## Building on Windows
 
 There is a simple Powershell script, `winbuild.ps1`, which will run the code generation for the help files, format them, and run a full build, leaving a new binary in the bin directory.

--- a/scripts/force_bump_version.sh
+++ b/scripts/force_bump_version.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ORIGIN=${ORIGIN:-origin}
+
+bump=${1:-patch}
+
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+previous_version="$("$dir"/../scripts/version.sh -s)"
+
+prerelversion=$("$dir"/../scripts/semver get prerel "$previous_version")
+if [[ $prerelversion == "" ]]; then
+  new_version=$("$dir"/../scripts/semver bump "$bump" "$previous_version")
+else
+  new_version=${previous_version//-$prerelversion/}
+fi
+
+new_version="v$new_version"
+
+echo "Bumping version from v${previous_version} to ${new_version}"
+
+git tag -m "release ${new_version}" -a "$new_version" && git push "${ORIGIN}" tag "$new_version"


### PR DESCRIPTION
### Change Summary

What and Why:
By automatically releasing flyctl, as long as a PR gets approved and merged, it'll show up in a new flyctl release relatively soon. We can also release a new version if necessary.

How:
Added a new Github Action that runs every day at 3 PM eastern

Related to:
https://flyio.slack.com/archives/C06G424TJRF/p1718101085197859?thread_ts=1718047902.923779&cid=C06G424TJRF

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
