### PR TITLE
Build flyctl before GPU integration tests

### DIFF
--- a/.github/workflows/preflight_gpu.yml
+++ b/.github/workflows/preflight_gpu.yml
@@ -13,7 +13,34 @@ on:
   workflow_call:
 
 jobs:
+  build:
+    runs-on: ubuntu-latest-m
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          check-latest: true
+      - name: "Place wintun.dll"
+        run: cp deps/wintun/bin/amd64/wintun.dll ./
+      - name: build
+        uses: goreleaser/goreleaser-action@v5
+        env:
+          BUILD_ENV: "development"
+        with:
+          version: latest
+          args: build --clean --snapshot --verbose
+      - name: Upload flyctl for preflight
+        uses: actions/upload-artifact@v4
+        with:
+          name: flyctl
+          path: dist/default_linux_amd64_v1/flyctl
+          overwrite: true
+
   preflight-gpu-tests:
+    needs: build
     if: ${{ github.repository == 'superfly/flyctl' }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
This duplicates effort a bit and might be worth investigating, but without it, flyctl isn't available to download when the preflight_gpu workflow runs on schedule.

Reusing the workflow directly would trigger an additional preflight (non-GPU) run. This may be OK--it's just a question of what scope we want for this change and whether or not extra preflight runs are worth less duplication.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
