### PR TITLE
Add machine status info about import/migration event

### DIFF
--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -163,7 +163,7 @@ func runMachineStatus(ctx context.Context) (err error) {
 		// This is terrible but will inform the users good enough while I build something
 		// elegant like the ExitEvent above
 		if event.Type == "launch" && event.Status == "created" && event.Source == "flyd" {
-			fields = append(fields, "import=true")
+			fields = append(fields, "migrated=true")
 		}
 
 		eventLogs = append(eventLogs, fields)

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -160,6 +160,12 @@ func runMachineStatus(ctx context.Context) (err error) {
 				exitEvent.ExitCode, exitEvent.OOMKilled, exitEvent.RequestedStop))
 		}
 
+		// This is terrible but will inform the users good enough while I build something
+		// elegant like the ExitEvent above
+		if event.Type == "launch" && event.Status == "created" && event.Source == "flyd" {
+			fields = append(fields, "import=true")
+		}
+
 		eventLogs = append(eventLogs, fields)
 	}
 	_ = render.Table(io.Out, "Event Logs", eventLogs, "State", "Event", "Source", "Timestamp", "Info")


### PR DESCRIPTION
### Change Summary

What and Why:
This change notifies the user when a machine was created by flyd because of a migration action.
It's a first iteration while a better solution is implemented in nomad-firecracker.

