### PR TITLE
Fetch tags in auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          ref: master
+          fetch-tags: true
       - name: bump version
         run: |
           ./scripts/force_bump_version.sh


### PR DESCRIPTION
### Change Summary

What and Why:
We need to fetch tags to make sure that the bump script works

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
