### PR TITLE
Postgres: update help to be clear about unmanaged

### DIFF
--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -275,7 +275,7 @@ func (l *Launcher) LaunchMachinesPostgres(ctx context.Context, config *CreateClu
 	fmt.Fprintf(io.Out, "Any app within the %s organization can connect to this Postgres using the above connection string\n", config.Organization.Name)
 
 	fmt.Fprintln(io.Out)
-	fmt.Fprintln(io.Out, "Now that you've set up Postgres, here's what you need to understand: https://fly.io/docs/postgres/getting-started/what-you-should-know/")
+	fmt.Fprintln(io.Out, "Fly Postgres is not a managed database service. Read more: https://fly.io/docs/postgres/getting-started/what-you-should-know/")
 
 	// TODO: wait for the cluster to be ready
 

--- a/internal/command/postgres/add_flycast.go
+++ b/internal/command/postgres/add_flycast.go
@@ -17,7 +17,7 @@ import (
 
 func newAddFlycast() *cobra.Command {
 	const (
-		short = "Switch from DNS to flycast based pg connections"
+		short = "Switch from DNS to Flycast-based Fly Postgres connections."
 		long  = short + "\n"
 
 		usage = "add_flycast"

--- a/internal/command/postgres/attach.go
+++ b/internal/command/postgres/attach.go
@@ -32,8 +32,8 @@ type AttachParams struct {
 
 func newAttach() *cobra.Command {
 	const (
-		short = "Attach a postgres cluster to an app"
-		long  = short + "\n"
+		short = "Attach a Fly Postgres cluster to a Fly App."
+		long  = short + " Learn more: https://fly.io/docs/postgres/managing/attach-detach/"
 		usage = "attach <POSTGRES APP>"
 	)
 

--- a/internal/command/postgres/barman.go
+++ b/internal/command/postgres/barman.go
@@ -39,7 +39,7 @@ var (
 
 func newBarman() *cobra.Command {
 	const (
-		short = "Manage databases in a cluster"
+		short = "Manage databases in a cluster."
 		long  = short + "\n"
 	)
 

--- a/internal/command/postgres/config.go
+++ b/internal/command/postgres/config.go
@@ -23,7 +23,7 @@ var pgSettings = map[string]string{
 
 func newConfig() (cmd *cobra.Command) {
 	const (
-		short = "Show and manage Postgres configuration."
+		short = "Show and manage Fly Postgres configuration."
 		long  = short + "\n"
 	)
 

--- a/internal/command/postgres/config_show.go
+++ b/internal/command/postgres/config_show.go
@@ -22,8 +22,8 @@ import (
 
 func newConfigShow() (cmd *cobra.Command) {
 	const (
-		long  = `Show Postgres configuration`
-		short = "Show Postgres configuration"
+		long  = `Show Fly Postgres configuration.`
+		short = "Show Fly Postgres configuration."
 		usage = "show"
 	)
 

--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -24,8 +24,8 @@ import (
 
 func newConfigUpdate() (cmd *cobra.Command) {
 	const (
-		long  = `Update Postgres configuration.`
-		short = "Update Postgres configuration."
+		long  = `Update Fly Postgres configuration.`
+		short = "Update Fly Postgres configuration."
 		usage = "update"
 	)
 

--- a/internal/command/postgres/connect.go
+++ b/internal/command/postgres/connect.go
@@ -21,7 +21,7 @@ import (
 
 func newConnect() *cobra.Command {
 	const (
-		short = "Connect to the Postgres console"
+		short = "Connect to the Postgres console."
 		long  = short + "\n"
 
 		usage = "connect"

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -21,8 +21,8 @@ import (
 
 func newCreate() *cobra.Command {
 	const (
-		short = "Create a new Postgres cluster"
-		long  = short + "\n"
+		short = `Create a new Fly Postgres cluster.`
+		long  = short +  `Fly Postgres not a managed database service. Read more: https://fly.io/docs/postgres/getting-started/what-you-should-know/`
 	)
 
 	cmd := command.New("create", short, long, run,

--- a/internal/command/postgres/db.go
+++ b/internal/command/postgres/db.go
@@ -21,7 +21,7 @@ import (
 
 func newDb() *cobra.Command {
 	const (
-		short = "Manage databases in a cluster"
+		short = "Manage databases in a cluster."
 		long  = short + "\n"
 	)
 

--- a/internal/command/postgres/detach.go
+++ b/internal/command/postgres/detach.go
@@ -20,8 +20,8 @@ import (
 
 func newDetach() *cobra.Command {
 	const (
-		short = "Detach a postgres cluster from an app"
-		long  = short + "\n"
+		short = "Detach a Fly Postgres cluster from a Fly App."
+		long  = short + " Learn more: https://fly.io/docs/postgres/managing/attach-detach/"
 		usage = "detach <POSTGRES APP>"
 	)
 

--- a/internal/command/postgres/events.go
+++ b/internal/command/postgres/events.go
@@ -17,7 +17,7 @@ import (
 
 func newEvents() *cobra.Command {
 	const (
-		short = "Track major cluster events"
+		short = "Track major cluster events."
 		long  = short + "\n"
 
 		usage = "events"

--- a/internal/command/postgres/failover.go
+++ b/internal/command/postgres/failover.go
@@ -27,7 +27,7 @@ import (
 
 func newFailover() *cobra.Command {
 	const (
-		short = "Failover to a new primary"
+		short = "Failover to a new primary."
 		long  = short + "\n"
 		usage = "failover"
 	)

--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -24,7 +24,7 @@ import (
 
 func newImport() *cobra.Command {
 	const (
-		short = "Imports database from a specified Postgres URI"
+		short = "Imports database from a specified Postgres URI."
 		long  = short + "\n"
 		usage = "import <source-uri>"
 	)

--- a/internal/command/postgres/list.go
+++ b/internal/command/postgres/list.go
@@ -17,7 +17,7 @@ import (
 
 func newList() *cobra.Command {
 	const (
-		short = "List postgres clusters"
+		short = "List Fly Postgres clusters."
 		long  = short + "\n"
 
 		usage = "list"

--- a/internal/command/postgres/postgres.go
+++ b/internal/command/postgres/postgres.go
@@ -15,7 +15,7 @@ import (
 
 func New() *cobra.Command {
 	const (
-		short = `Manage Postgres clusters.`
+		short = `Manage Fly Postgres clusters. Fly Postgres not a managed database service. Read more: https://fly.io/docs/postgres/getting-started/what-you-should-know/`
 
 		long = short + "\n"
 	)

--- a/internal/command/postgres/renew_certs.go
+++ b/internal/command/postgres/renew_certs.go
@@ -19,8 +19,8 @@ import (
 
 func newRenewSSHCerts() *cobra.Command {
 	const (
-		short = "Renews the SSH certificates for the Postgres cluster."
-		long  = "Renews the SSH certificates for the Postgres cluster. This is useful when the certificates have expired or need to be rotated."
+		short = "Renews the SSH certificates for the Fly Postgres cluster."
+		long  = "Renews the SSH certificates for the Fly Postgres cluster. This is useful when the certificates have expired or need to be rotated."
 		usage = "renew-certs"
 	)
 

--- a/internal/command/postgres/restart.go
+++ b/internal/command/postgres/restart.go
@@ -19,7 +19,7 @@ import (
 
 func newRestart() *cobra.Command {
 	const (
-		short = "Restarts each member of the Postgres cluster one by one."
+		short = "Restarts each member of the Fly Postgres cluster one by one."
 		long  = short + " Downtime should be minimal." + "\n"
 		usage = "restart"
 	)

--- a/internal/command/postgres/users.go
+++ b/internal/command/postgres/users.go
@@ -21,7 +21,7 @@ import (
 
 func newUsers() *cobra.Command {
 	const (
-		short = "Manage users in a postgres cluster"
+		short = "Manage users in a Fly Postgres cluster."
 		long  = short + "\n"
 
 		usage = "users"


### PR DESCRIPTION
### Change Summary

What and Why:
update the Fly Postgres help text and the final prompt when you run `fly pg create` to emphasize that it's not a managed solution.

How:
change text

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
