### PR TITLE
Display proxy ephemeral port when the user specifies 0

### DIFF
--- a/proxy/connect.go
+++ b/proxy/connect.go
@@ -108,6 +108,10 @@ func NewServer(ctx context.Context, p *ConnectParams) (*Server, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		if localPort == "0" {
+			localPort = strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+		}
 	} else {
 		// probably a unix path
 		addr, err := net.ResolveUnixAddr("unix", localPort)


### PR DESCRIPTION
The current behaviour is to print 0, which is not meaningful:

```
$ fly proxy 0:5558 ...
Proxying local port 0 to remote [...]:5558
```

With this change we special case port 0 and print the actual ephemeral port assigned to the listener.