### PR TITLE
bugfix: build upon default sentry-go transport config

### DIFF
--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -23,15 +23,20 @@ var initError error // set during init
 type Context = sentry.Context
 
 func init() {
+	// Set the timeout on the default HTTPSyncTransport to 3 seconds
+	// This is used over initializing the struct directly as we can't
+	// set non-exported fields such as transport.limits to a non-nil
+	// value, which can result in panics in sentry-go.
+	transport := sentry.NewHTTPSyncTransport()
+	transport.Timeout = 3 * time.Second
+
 	opts := sentry.ClientOptions{
 		Dsn: "https://89fa584dc19b47a6952dd94bf72dbab4@sentry.io/4492967",
 		// TODO: maybe set Debug to buildinfo.IsDev?
 		// Debug:       true,
 		Environment: buildinfo.Environment(),
 		Release:     "v" + buildinfo.Version().String(),
-		Transport: &sentry.HTTPSyncTransport{
-			Timeout: 3 * time.Second,
-		},
+		Transport:   transport,
 		BeforeSend: func(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			if buildinfo.IsDev() {
 				return nil


### PR DESCRIPTION
Directly initializing the HTTPSyncTransport struct results in the non-exported limits map being nil, which can cause a panic in sentry-go under certain conditions

### Change Summary

Fixes: #3642

What and Why: By setting the timeout on the default `HTTPSyncTransport` returned by `NewHTTPSyncTransport`, we avoid a panic within the sentry-go SDK

How: 

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
