### PR TITLE
Display previous machines versions events

### DIFF
--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -6356,6 +6356,8 @@ A machine state change event
 interface MachineEvent {
   id: ID!
   kind: String!
+  machineVersion: MachineVersion!
+  source: String
   timestamp: ISO8601DateTime!
 }
 
@@ -6382,6 +6384,8 @@ type MachineEventConnection {
 type MachineEventDestroy implements MachineEvent {
   id: ID!
   kind: String!
+  machineVersion: MachineVersion!
+  source: String
   timestamp: ISO8601DateTime!
 }
 
@@ -6404,21 +6408,27 @@ type MachineEventExit implements MachineEvent {
   exitCode: Int!
   id: ID!
   kind: String!
+  machineVersion: MachineVersion!
   metadata: JSON!
   oomKilled: Boolean!
   requestedStop: Boolean!
+  source: String
   timestamp: ISO8601DateTime!
 }
 
 type MachineEventGeneric implements MachineEvent {
   id: ID!
   kind: String!
+  machineVersion: MachineVersion!
+  source: String
   timestamp: ISO8601DateTime!
 }
 
 type MachineEventStart implements MachineEvent {
   id: ID!
   kind: String!
+  machineVersion: MachineVersion!
+  source: String
   timestamp: ISO8601DateTime!
 }
 
@@ -6468,6 +6478,10 @@ type MachineIPEdge {
   The item at the end of the edge.
   """
   node: MachineIP
+}
+
+type MachineVersion implements Node {
+  id: ID!
 }
 
 """

--- a/internal/flyutil/client.go
+++ b/internal/flyutil/client.go
@@ -70,6 +70,7 @@ type Client interface {
 	GetLatestImageTag(ctx context.Context, repository string, snapshotId *string) (string, error)
 	GetLoggedCertificates(ctx context.Context, slug string) ([]fly.LoggedCertificate, error)
 	GetMachine(ctx context.Context, machineId string) (*fly.GqlMachine, error)
+	GetMachineWithEvents(ctx context.Context, machineId string) (*fly.GqlMachine, error)
 	GetNearestRegion(ctx context.Context) (*fly.Region, error)
 	GetOrganizationBySlug(ctx context.Context, slug string) (*fly.Organization, error)
 	GetOrganizationByApp(ctx context.Context, appName string) (*fly.Organization, error)


### PR DESCRIPTION
### Change Summary

What and Why:
We want to provide a breadcrumb view of a machine current state.

For that we are now listing the previous machines versions events. In this way we users can track what happened to a given machine from initial creation to current state.

How:

By pulling all events for a given machine over GraphQL.

Related to:
- https://github.com/superfly/web/pull/3220
- https://github.com/superfly/fly-go/pull/72
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
