### PR TITLE
Force the DNS check to timeout after 70 seconds

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -1072,6 +1072,8 @@ func (md *machineDeployment) doSmokeChecks(ctx context.Context, lm machine.Leasa
 func (md *machineDeployment) checkDNS(ctx context.Context) error {
 	ctx, span := tracing.GetTracer().Start(ctx, "check_dns")
 	defer span.End()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*70)
+	defer cancel()
 
 	client := flyutil.ClientFromContext(ctx)
 	ipAddrs, err := client.GetIPAddresses(ctx, md.appConfig.AppName)


### PR DESCRIPTION
### Change Summary

What and Why:
This should fix an issue that Matthew has noticed where DNS checks could hang indefinetely

How:
Adding a timeout to the context in checkDNS

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
