### PR TITLE
Export env vars logging Erlang crash dumps

### DIFF
--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -134,6 +134,11 @@ export ECTO_IPV6="true"
 export DNS_CLUSTER_QUERY="${FLY_APP_NAME}.internal"
 export RELEASE_DISTRIBUTION="name"
 export RELEASE_NODE="${FLY_APP_NAME}-${FLY_IMAGE_REF##*-}@${FLY_PRIVATE_IP}"
+
+# Uncomment to send crash dumps to stderr
+# This can be useful for debugging, but may log sensitive information
+# export ERL_CRASH_DUMP=/dev/stderr
+# export ERL_CRASH_DUMP_BYTES=4096
 `
 	_, err := os.Stat(envEExPath)
 	if os.IsNotExist(err) {


### PR DESCRIPTION

### Change Summary

What and Why:

This will output Erlang crash dumps to stderr, rather than to an erl_crash.dump file.

Many folks run into issues trying to debug an Elixir application that is crashing and the logs output this:

    Crash dump is being written to: erl_crash.dump...done

Because our machines are ephemeral, this is cleared immediately and there's no way get the file without doing shenanigans with your Dockerfile. Now you have minimal shenanigans to get the info via `fly logs`.


How:

Environment variable exports

Related to:

https://community.fly.io/t/how-to-read-erl-crash-dump/20404?u=morzaram

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
