### PR TITLE
fix: do not run dns checks if the deployment failed

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -83,7 +83,8 @@ func (md *machineDeployment) DeployMachinesApp(ctx context.Context) error {
 		}
 	}
 
-	if !md.skipDNSChecks {
+	// no need to run dns checks if the deployment failed
+	if !md.skipDNSChecks && err == nil {
 		if err := md.checkDNS(ctx); err != nil {
 			terminal.Warnf("DNS checks failed: %v\n", err)
 		}


### PR DESCRIPTION
### Change Summary
We currently run DNS checks if a deployment failed, which leads to things like 👇 
![Screenshot 2024-06-19 at 00 31 40](https://github.com/superfly/flyctl/assets/24861123/603da0bb-f369-4035-b053-c7848c017196)
https://atc.fly.dev/deployment/1204