### PR TITLE
Fix spelling of "fulfill" in error message

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -483,7 +483,7 @@ func (md *machineDeployment) validateVolumeConfig() error {
 				if len(missing) > 0 {
 					// TODO: May change this by a prompt to create new volumes right away (?)
 					return fmt.Errorf(
-						"Process group '%s' needs volumes with name '%s' to fullfill mounts defined in fly.toml; "+
+						"Process group '%s' needs volumes with name '%s' to fulfill mounts defined in fly.toml; "+
 							"Run `fly volume create %s -r REGION -n COUNT` for the following regions and counts: %s",
 						groupName, volSrc, volSrc, strings.Join(missing, " "),
 					)

--- a/test/preflight/fly_deploy_test.go
+++ b/test/preflight/fly_deploy_test.go
@@ -41,7 +41,7 @@ func TestFlyDeployHA(t *testing.T) {
 	`, f.ReadFile("fly.toml"))
 
 	x := f.FlyAllowExitFailure("deploy")
-	require.Contains(f, x.StdErrString(), `needs volumes with name 'data' to fullfill mounts defined in fly.toml`)
+	require.Contains(f, x.StdErrString(), `needs volumes with name 'data' to fulfill mounts defined in fly.toml`)
 
 	// Create two volumes because fly launch will start 2 machines because of HA setup
 	f.Fly("volume create -a %s -r %s -s 1 data -y", appName, f.PrimaryRegion())


### PR DESCRIPTION
### Change Summary

What and Why:

Fix spelling of "fulfill."

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
