### PR TITLE
Orgs on a 'paid plan' (read: launch or scale) get shared-8x 8GB builders

### DIFF
--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -287,6 +287,13 @@ func createBuilder(ctx context.Context, org *fly.Organization, region, builderNa
 		CPUs:     4,
 		MemoryMB: 4096,
 	}
+	if org.PaidPlan {
+		guest = fly.MachineGuest{
+			CPUKind:  "shared",
+			CPUs:     8,
+			MemoryMB: 8192,
+		}
+	}
 
 	retErr = flapsClient.WaitForApp(ctx, app.Name)
 	if retErr != nil {


### PR DESCRIPTION
### Change Summary

If the org in question is on the Launch or Scale plan, they should get an shared-cpu-8x 8GB builder

What and Why:

How:

Related to:

https://community.fly.io/t/remote-builder-out-of-memory-4gb/12842/2

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
