### PR TITLE
`launch`: better incomplete manifest visibility

### DIFF
--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -88,7 +88,7 @@ func (r *recoverableErrorBuilder) tryRecover(e error) error {
 	return e
 }
 
-func (r *recoverableErrorBuilder) build() string {
+func (r *recoverableErrorBuilder) buildDisplayableErrorList() string {
 	if len(r.errors) == 0 {
 		return ""
 	}
@@ -98,6 +98,27 @@ func (r *recoverableErrorBuilder) build() string {
 		allErrors += fmt.Sprintf(" * %s\n", strings.ReplaceAll(err.String(), "\n", "\n   "))
 	}
 	return allErrors
+}
+
+func (r *recoverableErrorBuilder) toError() error {
+	if len(r.errors) == 0 {
+		return nil
+	}
+	return IncompleteManifestError{
+		debug: r.buildDisplayableErrorList(),
+	}
+}
+
+type IncompleteManifestError struct {
+	debug string
+}
+
+func (e IncompleteManifestError) Error() string {
+	return "launch can not continue with errors present"
+}
+
+func (e IncompleteManifestError) DebugInfo() string {
+	return e.debug
 }
 
 func buildManifest(ctx context.Context, recoverableErrors *recoverableErrorBuilder) (*LaunchManifest, *planBuildCache, error) {

--- a/internal/flyerr/flyerr.go
+++ b/internal/flyerr/flyerr.go
@@ -127,3 +127,17 @@ func IsCancelledError(err error) bool {
 
 	return false
 }
+
+// ErrorDebugInfo is an error with debug information that should be attached to metrics, logs, or sent to Sentry
+type ErrorDebugInfo interface {
+	error
+	DebugInfo() string
+}
+
+func GetErrorDebugInfo(err error) string {
+	var ferr ErrorDebugInfo
+	if errors.As(err, &ferr) {
+		return ferr.DebugInfo()
+	}
+	return ""
+}


### PR DESCRIPTION
### Change Summary

What and Why: Sends full list of launch issues when returning incomplete manifest - this should allow better visibility into what's causing specific `fly launch` problems

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
