### PR TITLE
Add a version ref to the auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -2,7 +2,7 @@ name: Automatically release a new version of flyctl
 
 on:
   schedule:
-    - cron: '0 19 * * MON-THU'  # Runs at 3 PM Eastern Daylight Time Monday Through Thursday (8 PM UTC)
+    - cron: "0 19 * * MON-THU" # Runs at 3 PM Eastern Daylight Time Monday Through Thursday (8 PM UTC)
 
 jobs:
   run_script:
@@ -12,11 +12,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-tags: true
-          fetch-depth: '0'
+          fetch-depth: "0"
 
       - name: Bump version
-        uses: superfly/github-tag-action
+        uses: superfly/github-tag-action@v1.67.0-fork
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
-          DEFAULT_BUMP: 'minor'
+          DEFAULT_BUMP: "minor"


### PR DESCRIPTION
### Change Summary

What and Why:

The auto-release action broke [after we switched to our fork](https://github.com/superfly/flyctl/actions/runs/9599887034): 
```
the `uses' attribute must be a path, a Docker image, or owner/repo@ref
```
I released [a version for our fork](https://github.com/superfly/github-tag-action/releases/tag/v1.67.0-fork) and updated the workflow to use that version. 

VS-Code linted some changes for the workflow too. 

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
