### PR TITLE
Add the write-contents permission for autorelease

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 19 * * MON-THU" # Runs at 3 PM Eastern Daylight Time Monday Through Thursday (8 PM UTC)
 
+permissions:
+  contents: write
+
 jobs:
   run_script:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Change Summary

What and Why:
To fix autorelease when it comes to new security settings

How:
Add the specific permissions in use

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
