### PR TITLE
Allow manually triggering the github autorelease

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,6 +3,7 @@ name: Automatically release a new version of flyctl
 on:
   schedule:
     - cron: "0 19 * * MON-THU" # Runs at 3 PM Eastern Daylight Time Monday Through Thursday (8 PM UTC)
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
