### PR TITLE
Update fly org command output for payg plan

### DIFF
--- a/internal/command/orgs/create.go
+++ b/internal/command/orgs/create.go
@@ -56,7 +56,7 @@ func runCreate(ctx context.Context) error {
 	name = flag.FirstArg(ctx)
 
 	if user.EnablePaidHobby {
-		fmt.Fprintf(io.Out, "New organizations start on the $5/mo Hobby Plan.\n\n")
+		fmt.Fprintf(io.Out, "New organizations start on the Pay As You Go plan.\n\n")
 
 		if name == "" {
 			confirmed, err := prompt.Confirm(ctx, "Do you still want to create the organization?")


### PR DESCRIPTION
### Change Summary

What and Why:
The command output when you create an org with `fly orgs create` says you'll be on the paid hobby plan.

How:
update text

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
