### PR TITLE
`fly machines`: release leases even on error

### DIFF
--- a/internal/command/machine/cordon.go
+++ b/internal/command/machine/cordon.go
@@ -47,10 +47,10 @@ func runMachineCordon(ctx context.Context) (err error) {
 	}
 
 	machines, release, err := mach.AcquireLeases(ctx, machines)
+	defer release()
 	if err != nil {
 		return err
 	}
-	defer release()
 
 	flapsClient := flapsutil.ClientFromContext(ctx)
 

--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -80,10 +80,10 @@ func runMachineDestroy(ctx context.Context) (err error) {
 		}
 
 		machines, release, err := mach.AcquireLeases(ctx, machinesToBeDeleted)
+		defer release()
 		if err != nil {
 			return err
 		}
-		defer release()
 
 		confirmed, err := prompt.Confirm(ctx, fmt.Sprintf("%d Machines (%s) will be destroyed, continue?", len(machines), strings.Join(ids, ",")))
 		if err != nil {
@@ -106,10 +106,10 @@ func runMachineDestroy(ctx context.Context) (err error) {
 			return err
 		}
 		machine, release, err := mach.AcquireLease(ctx, machine)
+		defer release()
 		if err != nil {
 			return err
 		}
-		defer release()
 
 		err = singleDestroyRun(ctx, machine)
 		if err != nil {
@@ -122,10 +122,10 @@ func runMachineDestroy(ctx context.Context) (err error) {
 		}
 
 		machines, release, err := mach.AcquireLeases(ctx, machines)
+		defer release()
 		if err != nil {
 			return err
 		}
-		defer release()
 
 		for _, machine := range machines {
 			err = singleDestroyRun(ctx, machine)

--- a/internal/command/machine/start.go
+++ b/internal/command/machine/start.go
@@ -52,10 +52,10 @@ func runMachineStart(ctx context.Context) (err error) {
 	}
 
 	machines, release, err := mach.AcquireLeases(ctx, machines)
+	defer release()
 	if err != nil {
 		return err
 	}
-	defer release()
 
 	for _, machine := range machines {
 		if err = Start(ctx, machine); err != nil {

--- a/internal/command/machine/stop.go
+++ b/internal/command/machine/stop.go
@@ -69,10 +69,10 @@ func runMachineStop(ctx context.Context) (err error) {
 	}
 
 	machines, release, err := mach.AcquireLeases(ctx, machines)
+	defer release()
 	if err != nil {
 		return err
 	}
-	defer release()
 
 	for _, machine := range machines {
 		fmt.Fprintf(io.Out, "Sending kill signal to machine %s...\n", machine.ID)

--- a/internal/command/machine/uncordon.go
+++ b/internal/command/machine/uncordon.go
@@ -47,10 +47,10 @@ func runMachineUncordon(ctx context.Context) (err error) {
 	}
 
 	machines, release, err := mach.AcquireLeases(ctx, machines)
+	defer release()
 	if err != nil {
 		return err
 	}
-	defer release()
 
 	flapsClient := flapsutil.ClientFromContext(ctx)
 


### PR DESCRIPTION
### Change Summary

The returned release function should be called even on error, because it will release any leases that *were* successfully obtained before the error happened (see review comments on #3633).

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
