### PR TITLE
Make the actual release creation workflow happen when we finish tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
   workflow_run:
     workflows: ["Automatically release a new version of flyctl"]
+    types:
+      - completed
 
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - v**
 
+  workflow_run:
+    workflows: ["Automatically release a new version of flyctl"]
+
+  workflow_dispatch:
+
   # need this until this file is on the default branch so tag creates are picked up
   workflow_call:
 


### PR DESCRIPTION
Also allow manually creating a new release

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
