### PR TITLE
handle error in retainLogs

### DIFF
--- a/internal/logger/logfile/fs.go
+++ b/internal/logger/logfile/fs.go
@@ -46,6 +46,9 @@ func retainLogs(logsDir string) error {
 
 	// Iterate through the log directory, and take note of all log files fitting the flyctl-*.log pattern.
 	err := filepath.Walk(logsDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if filepath.Ext(path) == ".log" && strings.HasPrefix(info.Name(), "flyctl-") {
 			date, err := parseLogName(info.Name())
 			if err != nil {


### PR DESCRIPTION
`filepath.Walk()` may return an unhandled `err` (for some separate issue with the directory), causing a 'nil pointer dereference' panic because `info` is `nil` in this case.

We want to handle the error by returning it, instead of a panic.

<details>
<summary>Example stacktrace</summary>
<pre><code class="codeblock">panic: runtime error: invalid memory address or nil pointer dereference
panic({0x10618bb20?, 0x107546d10?})
        runtime/panic.go:770 +0x124
github.com/superfly/flyctl/internal/logger/logfile.retainLogs.func1({0x14000a0e140, 0x3b}, {0x0, 0x0}, {0x140001bf068?, 0x16?})
        github.com/superfly/flyctl/internal/logger/logfile/fs.go:49 +0xa4
path/filepath.walk({0x140001bf068, 0x16}, {0x1064b5ba8, 0x14000121930}, 0x1400079dae8)
        path/filepath/path.go:498 +0x16c
path/filepath.Walk({0x140001bf068, 0x16}, 0x1400079dae8)
        path/filepath/path.go:560 +0x6c
github.com/superfly/flyctl/internal/logger/logfile.retainLogs({0x140001bf068?, 0x3b?})
        github.com/superfly/flyctl/internal/logger/logfile/fs.go:48 +0x44
github.com/superfly/flyctl/internal/logger/logfile.CreateLogFile()
        github.com/superfly/flyctl/internal/logger/logfile/fs.go:95 +0x84
github.com/superfly/flyctl/internal/logger.InitLogFile()
        github.com/superfly/flyctl/internal/logger/global_logfile.go:17 +0x28
github.com/superfly/flyctl/internal/cli.Run({0x1064aea90?, 0x14000ab4580?}, 0x14000488140, {0x140001e0010, 0xa, 0xa})
        github.com/superfly/flyctl/internal/cli/cli.go:46 +0x7c
main.run()
        github.com/superfly/flyctl/main.go:47 +0x174
main.main()
        github.com/superfly/flyctl/main.go:26 +0x20
</code></pre>
</details>
