### PR TITLE
`fly launch` from a template repo and clone submodules

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -77,11 +77,6 @@ func New() (cmd *cobra.Command) {
 			Description: "A github repo URL to use as a template for the new app",
 		},
 		flag.Bool{
-			Name:        "submodules",
-			Description: "Used in conjunction with the `--from` flag, recursively clone git submodules in the template repo",
-			Default:     false,
-		},
-		flag.Bool{
 			Name:        "manifest",
 			Description: "Output the generated manifest to stdout",
 			Hidden:      true,
@@ -149,7 +144,6 @@ func setupFromTemplate(ctx context.Context) (context.Context, error) {
 	if from == "" {
 		return ctx, nil
 	}
-	submodules := flag.GetBool(ctx, "submodules")
 
 	entries, err := os.ReadDir(".")
 	if err != nil {
@@ -161,11 +155,7 @@ func setupFromTemplate(ctx context.Context) (context.Context, error) {
 
 	fmt.Printf("Launching from git repo %s\n", from)
 
-	cmdArgs := []string{"clone", from, "."}
-	if submodules {
-		cmdArgs = append(cmdArgs, "--recurse-submodules")
-	}
-	cmd := exec.Command("git", cmdArgs...)
+	cmd := exec.Command("git", "clone", "--recurse-submodules", from, ".")
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -77,6 +77,11 @@ func New() (cmd *cobra.Command) {
 			Description: "A github repo URL to use as a template for the new app",
 		},
 		flag.Bool{
+			Name:        "submodules",
+			Description: "Used in conjunction with the `--from` flag, recursively clone git submodules in the template repo",
+			Default:     false,
+		},
+		flag.Bool{
 			Name:        "manifest",
 			Description: "Output the generated manifest to stdout",
 			Hidden:      true,
@@ -144,6 +149,7 @@ func setupFromTemplate(ctx context.Context) (context.Context, error) {
 	if from == "" {
 		return ctx, nil
 	}
+	submodules := flag.GetBool(ctx, "submodules")
 
 	entries, err := os.ReadDir(".")
 	if err != nil {
@@ -155,7 +161,11 @@ func setupFromTemplate(ctx context.Context) (context.Context, error) {
 
 	fmt.Printf("Launching from git repo %s\n", from)
 
-	cmd := exec.Command("git", "clone", from, ".")
+	cmdArgs := []string{"clone", from, "."}
+	if submodules {
+		cmdArgs = append(cmdArgs, "--recurse-submodules")
+	}
+	cmd := exec.Command("git", cmdArgs...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
### Change Summary

What and Why:

Used in conjunction with the `--from` flag when running `fly launch`, a user can optionally specify a bool flag of `--submodules` to recursively clone a git repo's submodules.

How:

```
fly launch --submodules --from <REPO_URL>
```

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
