### PR TITLE
Improve telemetry around docker usage

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -135,20 +135,25 @@ const (
 )
 
 func (t DockerDaemonType) String() string {
-	switch t {
-	case DockerDaemonTypeLocal:
-		return "local"
-	case DockerDaemonTypeRemote:
-		return "remote"
-	case DockerDaemonTypeNone:
-		return "none"
-	case DockerDaemonTypePrefersLocal:
-		return "prefers-local"
-	case DockerDaemonTypeNixpacks:
-		return "nix-packs"
-	default:
+	strs := []string{}
+
+	if t&DockerDaemonTypeLocal != 0 {
+		strs = append(strs, "local")
+	}
+	if t&DockerDaemonTypeRemote != 0 {
+		strs = append(strs, "remote")
+	}
+	if t&DockerDaemonTypePrefersLocal != 0 {
+		strs = append(strs, "prefers-local")
+	}
+	if t&DockerDaemonTypeNixpacks != 0 {
+		strs = append(strs, "nix-packs")
+	}
+	if len(strs) == 0 {
 		return "none"
 	}
+
+	return strings.Join(strs, ", ")
 }
 
 func (t DockerDaemonType) AllowLocal() bool {

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -133,6 +134,7 @@ func InitTraceProvider(ctx context.Context, appName string) (*sdktrace.TracerPro
 		attribute.String("build.info.os", buildinfo.OS()),
 		attribute.String("build.info.arch", buildinfo.Arch()),
 		attribute.String("build.info.commit", buildinfo.Commit()),
+		attribute.Bool("is_ci", env.IsCI()),
 	}
 
 	if appName != "" {


### PR DESCRIPTION
The `daemon_type` span attribute is always `none` because we aren't accounting for `DockerDaemonType` being a bitmask. It's also hard to gauge whether flyctl is running in a CI environment. I'm fixing the `func (DockerDaemonType) String() string` method and adding a `is_ci` attribute on the root span.