### PR TITLE
Do not consider volumes on unreachable nodes

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -395,7 +395,7 @@ func (md *machineDeployment) setVolumes(ctx context.Context) error {
 	}
 
 	unattached := lo.Filter(volumes, func(v fly.Volume, _ int) bool {
-		return v.AttachedAllocation == nil && v.AttachedMachine == nil
+		return v.AttachedAllocation == nil && v.AttachedMachine == nil && v.HostStatus == "ok"
 	})
 
 	md.volumes = lo.GroupBy(unattached, func(v fly.Volume) string {


### PR DESCRIPTION
### Change Summary

What and Why: When deploying an app, the list of existing unattached volumes may include entries from hosts that are not reachable effectively blocking the deploy

How: Consider "ok" volumes only

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
