### PR TITLE
Better recovery

### DIFF
--- a/internal/appconfig/remote.go
+++ b/internal/appconfig/remote.go
@@ -37,7 +37,7 @@ func getAppV2ConfigFromMachines(ctx context.Context, appName string) (*Config, e
 	if err != nil {
 		return nil, fmt.Errorf("error listing active machines for %s app: %w", appName, err)
 	}
-	machineSet := machine.NewMachineSet(flapsClient, io, activeMachines)
+	machineSet := machine.NewMachineSet(flapsClient, io, activeMachines, true)
 	appConfig, warnings, err := FromAppAndMachineSet(ctx, appName, machineSet)
 	if err != nil {
 		return nil, fmt.Errorf("failed to grab app config from existing machines, error: %w", err)

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -167,10 +167,10 @@ var CommonFlags = flag.Set{
 		Shorthand:   "s",
 		Description: "Signal to stop the machine with for bluegreen strategy (default: SIGINT)",
 	},
-	flag.Int{
+	flag.String{
 		Name:        "deploy-retries",
 		Description: "Number of times to retry a deployment if it fails",
-		Default:     0,
+		Default:     "auto",
 	},
 }
 
@@ -486,6 +486,28 @@ func deployToMachines(
 
 	status.FlyctlVersion = buildinfo.Info().Version.String()
 
+	retriesFlag := flag.GetString(ctx, "deploy-retries")
+	deployRetries := 0
+
+	switch retriesFlag {
+	case "auto":
+		ldClient := launchdarkly.ClientFromContext(ctx)
+		retries := ldClient.GetFeatureFlagValue("deploy-retries", 0.0).(float64)
+		deployRetries = int(retries)
+
+	default:
+		var invalidRetriesErr error = fmt.Errorf("--deploy-retries must be set to a positive integer, 0, or 'auto'")
+		retries, err := strconv.Atoi(retriesFlag)
+		if err != nil {
+			return invalidRetriesErr
+		}
+		if retries < 0 {
+			return invalidRetriesErr
+		}
+
+		deployRetries = retries
+	}
+
 	md, err := NewMachineDeployment(ctx, MachineDeploymentArgs{
 		AppCompact:            app,
 		DeploymentImage:       img.Tag,
@@ -513,7 +535,7 @@ func deployToMachines(
 		MaxConcurrent:         maxConcurrent,
 		VolumeInitialSize:     flag.GetInt(ctx, "volume-initial-size"),
 		ProcessGroups:         processGroups,
-		DeployRetries:         flag.GetInt(ctx, "deploy-retries"),
+		DeployRetries:         deployRetries,
 	})
 	if err != nil {
 		sentry.CaptureExceptionWithAppInfo(ctx, err, "deploy", app)

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -170,7 +170,7 @@ var CommonFlags = flag.Set{
 	flag.Int{
 		Name:        "deploy-retries",
 		Description: "Number of times to retry a deployment if it fails",
-		Default:     5,
+		Default:     0,
 	},
 }
 

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -167,6 +167,11 @@ var CommonFlags = flag.Set{
 		Shorthand:   "s",
 		Description: "Signal to stop the machine with for bluegreen strategy (default: SIGINT)",
 	},
+	flag.Int{
+		Name:        "deploy-retries",
+		Description: "Number of times to retry a deployment if it fails",
+		Default:     5,
+	},
 }
 
 type Command struct {
@@ -504,6 +509,7 @@ func deployToMachines(
 		MaxConcurrent:         maxConcurrent,
 		VolumeInitialSize:     flag.GetInt(ctx, "volume-initial-size"),
 		ProcessGroups:         processGroups,
+		DeployRetries:         flag.GetInt(ctx, "deploy-retries"),
 	})
 	if err != nil {
 		sentry.CaptureExceptionWithAppInfo(ctx, err, "deploy", app)

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -321,10 +321,14 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, userID i
 
 	// Fetch an image ref or build from source to get the final image reference to deploy
 	img, err := determineImage(ctx, appConfig, usingWireguard, recreateBuilder)
-	if err != nil && usingWireguard && httpFailover {
-		span.SetAttributes(attribute.String("builder.failover_error", err.Error()))
-		span.AddEvent("using http failover")
-		img, err = determineImage(ctx, appConfig, false, recreateBuilder)
+	if err != nil {
+		noBuilder := strings.Contains(err.Error(), "Could not find App")
+		recreateBuilder = recreateBuilder || noBuilder
+		if noBuilder || (usingWireguard && httpFailover) {
+			span.SetAttributes(attribute.String("builder.failover_error", err.Error()))
+			span.AddEvent("using http failover")
+			img, err = determineImage(ctx, appConfig, false, recreateBuilder)
+		}
 	}
 
 	if err != nil {

--- a/internal/command/deploy/machinebasedtest.go
+++ b/internal/command/deploy/machinebasedtest.go
@@ -3,7 +3,6 @@ package deploy
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -21,7 +20,26 @@ type createdTestMachine struct {
 	err  error
 }
 
-func (md *machineDeployment) runTestMachines(ctx context.Context, machineToTest *fly.Machine) (err error) {
+type machineTestErr struct {
+	testMachineLogs string
+	exitCode        int
+	machineID       string
+}
+
+func (e machineTestErr) Error() string {
+	return fmt.Sprintf("Error test command machine %s exited with non-zero status of %d", e.machineID, e.exitCode)
+}
+
+func (e machineTestErr) Description() string {
+	var desc string
+	desc += fmt.Sprintf("Error: test command failed running on machine %s with exit code %d.\n", e.machineID, e.exitCode)
+	desc += fmt.Sprintf("Check its logs: here's the last 100 lines below, or run 'fly logs -i %s':\n\n", e.machineID)
+	desc += e.testMachineLogs
+	return desc
+
+}
+
+func (md *machineDeployment) runTestMachines(ctx context.Context, machineToTest *fly.Machine, sl statuslogger.StatusLine) (err error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "run_test_machine")
 	var (
 		flaps = md.flapsClient
@@ -34,9 +52,13 @@ func (md *machineDeployment) runTestMachines(ctx context.Context, machineToTest 
 		span.End()
 	}()
 
+	if sl == nil {
+		return fmt.Errorf("bug: status logger is nil")
+	}
+
 	processGroup := machineToTest.ProcessGroup()
 	machineChecks := lo.FlatMap(md.appConfig.AllServices(), func(svc appconfig.Service, _ int) []*appconfig.ServiceMachineCheck {
-		matchesProcessGroup := lo.Contains(svc.Processes, processGroup)
+		matchesProcessGroup := lo.Contains(svc.Processes, processGroup) || len(svc.Processes) == 0
 		if matchesProcessGroup {
 			return svc.MachineChecks
 		} else {
@@ -55,11 +77,11 @@ func (md *machineDeployment) runTestMachines(ctx context.Context, machineToTest 
 		var err error
 		defer func() {
 			if err != nil {
-				statuslogger.Failed(ctx, err)
+				sl.Failed(err)
 			}
 		}()
 
-		mach, err = md.createTestMachine(ctx, machineCheck, machineToTest)
+		mach, err = md.createTestMachine(ctx, machineCheck, machineToTest, sl)
 		return createdTestMachine{mach, err}
 	})
 
@@ -74,13 +96,13 @@ func (md *machineDeployment) runTestMachines(ctx context.Context, machineToTest 
 	machineSet := machine.NewMachineSet(flaps, io, lo.FilterMap(machines, func(m createdTestMachine, _ int) (*fly.Machine, bool) {
 		if m.err != nil {
 			tracing.RecordError(span, m.err, "failed to create test machine")
-			statuslogger.LogStatus(ctx, statuslogger.StatusFailure, fmt.Sprintf("failed to create test machine: %s", m.err))
+			sl.LogStatus(statuslogger.StatusFailure, fmt.Sprintf("failed to create test machine: %s", m.err))
 		}
 		return m.mach, m.err == nil
-	}))
+	}), false)
 
 	// FIXME: consolidate this wait stuff with deploy waits? Especially once we improve the output
-	err = md.waitForTestMachinesToFinish(ctx, machineSet)
+	err = md.waitForTestMachinesToFinish(ctx, machineSet, sl)
 	if err != nil {
 		tracing.RecordError(span, err, "failed to wait for test cmd machine")
 		return err
@@ -89,7 +111,7 @@ func (md *machineDeployment) runTestMachines(ctx context.Context, machineToTest 
 	for _, testMachine := range machineSet.GetMachines() {
 		md.waitForLogs(ctx, testMachine.Machine(), 10*time.Second)
 
-		statuslogger.Logf(ctx, "Checking test command machine %s", md.colorize.Bold(testMachine.Machine().ID))
+		sl.Logf("Checking test command machine %s", md.colorize.Bold(testMachine.Machine().ID))
 		lastExitEvent, err := testMachine.WaitForEventType(ctx, "exit", md.releaseCmdTimeout, true)
 		if err != nil {
 			return fmt.Errorf("error finding the test command machine %s exit event: %w", testMachine.Machine().ID, err)
@@ -100,27 +122,22 @@ func (md *machineDeployment) runTestMachines(ctx context.Context, machineToTest 
 		}
 
 		if exitCode != 0 {
-			statuslogger.LogStatus(ctx, statuslogger.StatusFailure, "test command failed")
+			sl.LogStatus(statuslogger.StatusFailure, "test command failed")
 			// Preemptive cleanup of the logger so that the logs have a clean place to write to
 
-			fmt.Fprintf(md.io.ErrOut, "Error: test command failed running on machine %s with exit code %s.\n",
-				md.colorize.Bold(testMachine.Machine().ID), md.colorize.Red(strconv.Itoa(exitCode)))
-			fmt.Fprintf(md.io.ErrOut, "Check its logs: here's the last 100 lines below, or run 'fly logs -i %s':\n",
-				testMachine.Machine().ID)
 			testLogs, _, err := md.apiClient.GetAppLogs(ctx, md.app.Name, "", md.appConfig.PrimaryRegion, testMachine.Machine().ID)
-			if fly.IsNotAuthenticatedError(err) {
-				fmt.Fprintf(md.io.ErrOut, "Warn: not authorized to retrieve app logs (this can happen when using deploy tokens), so we can't show you what failed. Use `fly logs -i %s` or open the monitoring dashboard to see them: https://fly.io/apps/%s/monitoring?region=&instance=%s\n", testMachine.Machine().ID, md.appConfig.AppName, testMachine.Machine().ID)
-			} else {
-				if err != nil {
-					return fmt.Errorf("Error getting test command logs: %w", err)
-				}
+			if err == nil {
+				var logs string
 				for _, l := range testLogs {
-					fmt.Fprintf(md.io.ErrOut, "  %s\n", l.Message)
+					logs += l.Message + "\n"
 				}
+
+				return machineTestErr{machineID: testMachine.Machine().ID, exitCode: exitCode, testMachineLogs: logs}
 			}
+
 			return fmt.Errorf("Error test command machine %s exited with non-zero status of %d", testMachine.Machine().ID, exitCode)
 		}
-		statuslogger.LogfStatus(ctx,
+		sl.LogfStatus(
 			statuslogger.StatusSuccess,
 			"Test machine %s completed successfully",
 			md.colorize.Bold(testMachine.Machine().ID),
@@ -151,7 +168,7 @@ func (md *machineDeployment) waitForLogs(ctx context.Context, mach *fly.Machine,
 	}, backoff.WithContext(b, ctx))
 }
 
-func (md *machineDeployment) createTestMachine(ctx context.Context, svc *appconfig.ServiceMachineCheck, machineToTest *fly.Machine) (*fly.Machine, error) {
+func (md *machineDeployment) createTestMachine(ctx context.Context, svc *appconfig.ServiceMachineCheck, machineToTest *fly.Machine, sl statuslogger.StatusLine) (*fly.Machine, error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "create_test_machine")
 	defer span.End()
 
@@ -165,7 +182,7 @@ func (md *machineDeployment) createTestMachine(ctx context.Context, svc *appconf
 		return nil, fmt.Errorf("error creating a test machine: %w", err)
 	}
 
-	statuslogger.Logf(ctx, "Created test machine %s", md.colorize.Bold(testMachine.ID))
+	sl.Logf("Created test machine %s", md.colorize.Bold(testMachine.ID))
 	return testMachine, nil
 }
 
@@ -195,7 +212,7 @@ func (md *machineDeployment) launchInputForTestMachine(svc *appconfig.ServiceMac
 	}, nil
 }
 
-func (md *machineDeployment) waitForTestMachinesToFinish(ctx context.Context, testMachines machine.MachineSet) error {
+func (md *machineDeployment) waitForTestMachinesToFinish(ctx context.Context, testMachines machine.MachineSet, sl statuslogger.StatusLine) error {
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
 
@@ -224,7 +241,7 @@ func (md *machineDeployment) waitForTestMachinesToFinish(ctx context.Context, te
 		return m, err == nil
 	})
 	for _, mach := range machs {
-		statuslogger.Logf(ctx, "Test Machine %s: %s", colorize.Bold(mach.ID), mach.State)
+		sl.Logf("Test Machine %s: %s", colorize.Bold(mach.ID), mach.State)
 	}
 
 	return nil

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -72,6 +72,7 @@ type MachineDeploymentArgs struct {
 	VolumeInitialSize     int
 	RestartPolicy         *fly.MachineRestartPolicy
 	RestartMaxRetries     int
+	DeployRetries         int
 }
 
 type machineDeployment struct {
@@ -111,6 +112,7 @@ type machineDeployment struct {
 	processGroups         map[string]bool
 	maxConcurrent         int
 	volumeInitialSize     int
+	deployRetries         int
 }
 
 func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (_ MachineDeployment, err error) {
@@ -235,6 +237,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (_ Ma
 		maxConcurrent:         maxConcurrent,
 		volumeInitialSize:     args.VolumeInitialSize,
 		processGroups:         args.ProcessGroups,
+		deployRetries:         args.DeployRetries,
 	}
 	if err := md.setStrategy(); err != nil {
 		tracing.RecordError(span, err, "failed to set strategy")

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -375,12 +375,12 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 		}
 	}
 
-	md.machineSet = machine.NewMachineSet(md.flapsClient, md.io, machines)
+	md.machineSet = machine.NewMachineSet(md.flapsClient, md.io, machines, true)
 	var releaseCmdSet []*fly.Machine
 	if releaseCmdMachine != nil {
 		releaseCmdSet = []*fly.Machine{releaseCmdMachine}
 	}
-	md.releaseCommandMachine = machine.NewMachineSet(md.flapsClient, md.io, releaseCmdSet)
+	md.releaseCommandMachine = machine.NewMachineSet(md.flapsClient, md.io, releaseCmdSet, true)
 	return nil
 }
 

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -439,7 +439,16 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 
 	newAppState := *oldAppState
 	newAppState.Machines = lo.Map(updateEntries, func(e *machineUpdateEntry, _ int) *fly.Machine {
-		return e.leasableMachine.Machine()
+		newMach := e.leasableMachine.Machine()
+		if !e.launchInput.SkipLaunch {
+			newMach.State = "started"
+		}
+
+		if e.launchInput.RequiresReplacement {
+			newMach.State = "replacing"
+		}
+		newMach.Config = e.launchInput.Config
+		return newMach
 	})
 
 	switch md.strategy {

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -455,12 +455,12 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 		// TODO(billy) do machine checks here
 		return md.updateUsingBlueGreenStrategy(ctx, updateEntries)
 	case "immediate":
-		return md.updateMachines(ctx, oldAppState, &newAppState, true, nil, true)
+		return md.updateMachines(ctx, oldAppState, &newAppState, true, nil, true, true)
 	case "canary", "rolling":
 		// FIXME: CANARY!!!
 		fallthrough
 	default:
-		return md.updateMachines(ctx, oldAppState, &newAppState, true, nil, md.skipHealthChecks)
+		return md.updateMachines(ctx, oldAppState, &newAppState, true, nil, md.skipHealthChecks, md.skipSmokeChecks)
 	}
 }
 

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -1,9 +1,11 @@
 package deploy
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"slices"
 	"strconv"
@@ -13,6 +15,7 @@ import (
 	"github.com/cenkalti/backoff"
 	"github.com/miekg/dns"
 	"github.com/samber/lo"
+	"github.com/sourcegraph/conc/pool"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -90,6 +93,86 @@ func (md *machineDeployment) DeployMachinesApp(ctx context.Context) error {
 		tracing.RecordError(span, err, "failed to deploy machines")
 	}
 	return err
+}
+
+func (md *machineDeployment) updateMachine(ctx context.Context, e *machineUpdateEntry, sl statuslogger.StatusLine) error {
+	ctx, span := tracing.GetTracer().Start(ctx, "update_machine", trace.WithAttributes(
+		attribute.String("id", e.launchInput.ID),
+		attribute.Bool("requires_replacement", e.launchInput.RequiresReplacement),
+	))
+	defer span.End()
+
+	fmtID := e.leasableMachine.FormattedMachineId()
+
+	replaceMachine := func() error {
+		sl.Logf("Replacing %s by new machine", fmtID)
+		if err := md.updateMachineByReplace(ctx, e); err != nil {
+			return err
+		}
+		sl.Logf("Created machine %s", fmtID)
+		return nil
+	}
+
+	if e.launchInput.RequiresReplacement {
+		return replaceMachine()
+	}
+
+	sl.Logf("Updating %s", fmtID)
+	if err := md.updateMachineInPlace(ctx, e); err != nil {
+		switch {
+		case len(e.leasableMachine.Machine().Config.Mounts) > 0:
+			// Replacing a machine with a volume will cause the placement logic to pick wthe same host
+			// dismissing the value of replacing it in case of lack of host capacity
+			return err
+		case strings.Contains(err.Error(), "could not reserve resource for machine"),
+			strings.Contains(err.Error(), "deploys to this host are temporarily disabled"):
+			err := replaceMachine()
+			if err != nil {
+				span.RecordError(err)
+			}
+
+			return err
+		default:
+			span.RecordError(err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (md *machineDeployment) waitForMachine(ctx context.Context, e *machineUpdateEntry, sl statuslogger.StatusLine) error {
+	lm := e.leasableMachine
+	// Don't wait for SkipLaunch machines, they are updated but not started
+	if e.launchInput.SkipLaunch {
+		return nil
+	}
+
+	if !md.skipHealthChecks {
+		if err := lm.WaitForState(ctx, fly.MachineStateStarted, md.waitTimeout, false); err != nil {
+			err = suggestChangeWaitTimeout(err, "wait-timeout")
+			return err
+		}
+
+		if err := md.runTestMachines(ctx, e.leasableMachine.Machine(), sl); err != nil {
+			return err
+		}
+	}
+
+	if err := md.doSmokeChecks(ctx, lm, true); err != nil {
+		return err
+	}
+
+	if !md.skipHealthChecks {
+		// FIXME: combine this wait with the wait for start as one update line (or two per in noninteractive case)
+		if err := lm.WaitForHealthchecksToPass(ctx, md.waitTimeout); err != nil {
+			md.warnAboutIncorrectListenAddress(ctx, lm)
+			err = suggestChangeWaitTimeout(err, "wait-timeout")
+			return err
+		}
+	}
+
+	md.warnAboutIncorrectListenAddress(ctx, lm)
+	return nil
 }
 
 // restartMachinesApp only restarts existing machines but updates their release metadata
@@ -413,6 +496,48 @@ func suggestChangeWaitTimeout(err error, flagName string) error {
 }
 
 func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateEntries []*machineUpdateEntry) (err error) {
+	ctx, span := tracing.GetTracer().Start(ctx, "update_machines", trace.WithAttributes(
+		attribute.String("strategy", md.strategy),
+	))
+	defer func() {
+		if err != nil {
+			tracing.RecordError(span, err, "update failed")
+		}
+		span.End()
+	}()
+
+	if md.deployRetries > 0 {
+		return md.updateExistingMachinesWRecovery(ctx, updateEntries)
+	}
+
+	if len(updateEntries) == 0 {
+		return nil
+	}
+
+	if err := md.machineSet.AcquireLeases(ctx, md.leaseTimeout); err != nil {
+		tracing.RecordError(span, err, "failed to acquire lease")
+		return err
+	}
+	defer md.machineSet.ReleaseLeases(ctx) // skipcq: GO-S2307
+	md.machineSet.StartBackgroundLeaseRefresh(ctx, md.leaseTimeout, md.leaseDelayBetween)
+
+	fmt.Fprintf(md.io.Out, "Updating existing machines in '%s' with %s strategy\n", md.colorize.Bold(md.app.Name), md.strategy)
+
+	switch md.strategy {
+	case "bluegreen":
+		// TODO(billy) do machine checks here
+		return md.updateUsingBlueGreenStrategy(ctx, updateEntries)
+	case "immediate":
+		return md.updateUsingImmediateStrategy(ctx, updateEntries)
+	case "canary", "rolling":
+		fallthrough
+	default:
+		return md.updateUsingRollingStrategy(ctx, updateEntries)
+	}
+}
+
+// The code duplication is on purpose here. The plan is to completely move over to updateExistingMachinesWRecovery
+func (md *machineDeployment) updateExistingMachinesWRecovery(ctx context.Context, updateEntries []*machineUpdateEntry) (err error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "update_existing_machines", trace.WithAttributes(
 		attribute.String("strategy", md.strategy),
 	))
@@ -460,7 +585,7 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 		// TODO(billy) do machine checks here
 		return md.updateUsingBlueGreenStrategy(ctx, updateEntries)
 	case "immediate":
-		return md.updateMachines(ctx, oldAppState, &newAppState, nil, updateMachineSettings{
+		return md.updateMachinesWRecovery(ctx, oldAppState, &newAppState, nil, updateMachineSettings{
 			pushForward:          true,
 			skipHealthChecks:     true,
 			skipSmokeChecks:      true,
@@ -477,7 +602,7 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 		})
 		newCanaryAppState.Machines = []*fly.Machine{canaryMach}
 
-		if err := md.updateMachines(ctx, &canaryAppState, &newCanaryAppState, nil, updateMachineSettings{
+		if err := md.updateMachinesWRecovery(ctx, &canaryAppState, &newCanaryAppState, nil, updateMachineSettings{
 			pushForward:          true,
 			skipHealthChecks:     md.skipHealthChecks,
 			skipSmokeChecks:      md.skipSmokeChecks,
@@ -486,7 +611,7 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 			return err
 		}
 
-		return md.updateMachines(ctx, oldAppState, &newAppState, nil, updateMachineSettings{
+		return md.updateMachinesWRecovery(ctx, oldAppState, &newAppState, nil, updateMachineSettings{
 			pushForward:          true,
 			skipHealthChecks:     md.skipHealthChecks,
 			skipSmokeChecks:      md.skipSmokeChecks,
@@ -495,7 +620,7 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 	case "rolling":
 		fallthrough
 	default:
-		return md.updateMachines(ctx, oldAppState, &newAppState, nil, updateMachineSettings{
+		return md.updateMachinesWRecovery(ctx, oldAppState, &newAppState, nil, updateMachineSettings{
 			pushForward:          true,
 			skipHealthChecks:     md.skipHealthChecks,
 			skipSmokeChecks:      md.skipSmokeChecks,
@@ -517,6 +642,222 @@ func (md *machineDeployment) updateUsingBlueGreenStrategy(ctx context.Context, u
 		return suggestChangeWaitTimeout(err, "wait-timeout")
 	}
 	return nil
+}
+
+func (md *machineDeployment) updateUsingImmediateStrategy(parentCtx context.Context, updateEntries []*machineUpdateEntry) error {
+	parentCtx, span := tracing.GetTracer().Start(parentCtx, "immediate")
+	defer span.End()
+
+	sl := statuslogger.Create(parentCtx, len(updateEntries), true)
+	defer sl.Destroy(false)
+
+	updatesPool := pool.New().WithErrors().WithContext(parentCtx)
+	if md.maxConcurrent > 0 {
+		updatesPool = updatesPool.WithMaxGoroutines(md.maxConcurrent)
+	}
+
+	for i, e := range updateEntries {
+		e := e
+		eCtx := statuslogger.NewContext(parentCtx, sl.Line(i))
+		fmtID := e.leasableMachine.FormattedMachineId()
+		statusRunning := func() {
+			statuslogger.LogfStatus(eCtx,
+				statuslogger.StatusRunning,
+				"Updating %s",
+				md.colorize.Bold(fmtID),
+			)
+		}
+		statusFailure := func(err error) {
+			if errors.Is(err, context.Canceled) {
+				statuslogger.LogfStatus(eCtx,
+					statuslogger.StatusFailure,
+					"Machine %s update %s",
+					md.colorize.Bold(fmtID),
+					md.colorize.Red("canceled while it was in progress"),
+				)
+			} else {
+				statuslogger.LogfStatus(eCtx,
+					statuslogger.StatusFailure,
+					"Machine %s update %s: %s",
+					md.colorize.Bold(fmtID),
+					md.colorize.Red("failed"),
+					err.Error(),
+				)
+			}
+		}
+		statusSuccess := func() {
+			statuslogger.LogfStatus(eCtx,
+				statuslogger.StatusSuccess,
+				"Machine %s update %s",
+				md.colorize.Bold(fmtID),
+				md.colorize.Green("succeeded"),
+			)
+		}
+
+		updatesPool.Go(func(_ context.Context) error {
+			statusRunning()
+			if err := md.updateMachine(eCtx, e, sl.Line(i)); err != nil {
+				tracing.RecordError(span, err, "failed to update machine")
+				statusFailure(err)
+				return err
+			}
+			statusSuccess()
+			return nil
+		})
+	}
+
+	return updatesPool.Wait()
+}
+
+func (md *machineDeployment) updateUsingRollingStrategy(parentCtx context.Context, updateEntries []*machineUpdateEntry) error {
+	parentCtx, span := tracing.GetTracer().Start(parentCtx, "rolling", trace.WithAttributes(attribute.String("strategy", md.strategy)))
+	defer span.End()
+
+	sl := statuslogger.Create(parentCtx, len(updateEntries), true)
+	defer sl.Destroy(false)
+
+	// Rolling strategy
+	slices.SortFunc(updateEntries, func(a, b *machineUpdateEntry) int {
+		return cmp.Compare(a.leasableMachine.Machine().ID, b.leasableMachine.Machine().ID)
+	})
+
+	// Group updates by process group
+	entriesByGroup := lo.GroupBy(updateEntries, func(e *machineUpdateEntry) string {
+		return e.launchInput.Config.ProcessGroup()
+	})
+
+	startIdx := 0
+	groupsPool := pool.New().
+		WithErrors().
+		WithMaxGoroutines(rollingStrategyMaxConcurrentGroups).
+		WithContext(parentCtx).
+		WithCancelOnError()
+
+	for group, entries := range entriesByGroup {
+		entries := entries
+		startIdx += len(entries)
+		groupsPool.Go(func(ctx context.Context) error {
+			return md.updateEntriesGroup(ctx, group, entries, sl, startIdx-len(entries))
+		})
+	}
+
+	return groupsPool.Wait()
+}
+
+func (md *machineDeployment) updateEntriesGroup(parentCtx context.Context, group string, entries []*machineUpdateEntry, sl statuslogger.StatusLogger, startIdx int) error {
+	parentCtx, span := tracing.GetTracer().Start(parentCtx, "update_entries_in_group", trace.WithAttributes(
+		attribute.Int("start_id", startIdx),
+		attribute.String("group", group),
+		attribute.Int("max_unavailable", int(md.maxUnavailable)),
+	))
+	defer span.End()
+
+	var poolSize int
+	switch mu := md.maxUnavailable; {
+	case mu >= 1:
+		poolSize = int(mu)
+	case mu > 0:
+		poolSize = int(math.Ceil(float64(len(entries)) * mu))
+	default:
+		return fmt.Errorf("Invalid --max-unavailable value: %v", mu)
+	}
+
+	span.SetAttributes(attribute.Int("pool_size", poolSize))
+
+	updatePool := pool.New().
+		WithErrors().
+		WithMaxGoroutines(poolSize).
+		WithContext(parentCtx).
+		WithCancelOnError()
+
+	for idx, e := range entries {
+		e := e
+		eCtx := statuslogger.NewContext(parentCtx, sl.Line(startIdx+idx))
+		fmtID := e.leasableMachine.FormattedMachineId()
+
+		statusRunning := func() {
+			statuslogger.LogfStatus(eCtx,
+				statuslogger.StatusRunning,
+				"Updating %s",
+				md.colorize.Bold(fmtID),
+			)
+		}
+		statusFailure := func(err error) {
+			if errors.Is(err, context.Canceled) {
+				statuslogger.LogfStatus(eCtx,
+					statuslogger.StatusFailure,
+					"Machine %s update %s",
+					md.colorize.Bold(fmtID),
+					md.colorize.Red("canceled while it was in progress"),
+				)
+			} else {
+				statuslogger.LogfStatus(eCtx,
+					statuslogger.StatusFailure,
+					"Machine %s update %s: %s",
+					md.colorize.Bold(fmtID),
+					md.colorize.Red("failed"),
+					err.Error(),
+				)
+			}
+		}
+		statusSkipped := func() {
+			statuslogger.LogfStatus(eCtx,
+				statuslogger.StatusFailure,
+				"Machine %s update %s",
+				md.colorize.Bold(fmtID),
+				md.colorize.Yellow("canceled"),
+			)
+		}
+		statusSuccess := func() {
+			statuslogger.LogfStatus(eCtx,
+				statuslogger.StatusSuccess,
+				"Machine %s update %s",
+				md.colorize.Bold(fmtID),
+				md.colorize.Green("succeeded"),
+			)
+		}
+		updateFunc := func(poolCtx context.Context) error {
+			ctx, span := tracing.GetTracer().Start(eCtx, "update", trace.WithAttributes(
+				attribute.Int("id", idx),
+			))
+			defer span.End()
+
+			// If the pool context is done, it means some other machine update failed
+			select {
+			case <-poolCtx.Done():
+				statusSkipped()
+				return poolCtx.Err()
+			default:
+				statusRunning()
+			}
+
+			if err := md.updateMachine(ctx, e, sl.Line(startIdx+idx)); err != nil {
+				statusFailure(err)
+				tracing.RecordError(span, err, "failed to update machine")
+				return err
+			}
+			if err := md.waitForMachine(ctx, e, sl.Line(startIdx+idx)); err != nil {
+				tracing.RecordError(span, err, "failed to wait for machine")
+				statusFailure(err)
+				return err
+			}
+
+			statusSuccess()
+			return nil
+		}
+
+		// Slow start by updating one machine and then the rest in groups if the spearhead succeeded
+		if idx == 0 {
+			err := updateFunc(parentCtx)
+			if err != nil {
+				return err
+			}
+		} else {
+			updatePool.Go(updateFunc)
+		}
+	}
+
+	return updatePool.Wait()
 }
 
 func (md *machineDeployment) updateMachineByReplace(ctx context.Context, e *machineUpdateEntry) error {

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -1,11 +1,9 @@
 package deploy
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"slices"
 	"strconv"
@@ -314,12 +312,6 @@ func (md *machineDeployment) deployMachinesApp(ctx context.Context) error {
 		}
 	}
 
-	if err := md.machineSet.AcquireLeases(ctx, md.leaseTimeout); err != nil {
-		return err
-	}
-	defer md.machineSet.ReleaseLeases(ctx) // skipcq: GO-S2307
-	md.machineSet.StartBackgroundLeaseRefresh(ctx, md.leaseTimeout, md.leaseDelayBetween)
-
 	processGroupMachineDiff := md.resolveProcessGroupChanges()
 	md.warnAboutProcessGroupChanges(processGroupMachineDiff)
 
@@ -481,6 +473,19 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 
 	fmt.Fprintf(md.io.Out, "Updating existing machines in '%s' with %s strategy\n", md.colorize.Bold(md.app.Name), md.strategy)
 
+	ctx, span = tracing.GetTracer().Start(ctx, "rolling", trace.WithAttributes(attribute.String("strategy", md.strategy)))
+	defer span.End()
+
+	oldAppState, err := md.appState(ctx)
+	if err != nil {
+		return err
+	}
+
+	newAppState := *oldAppState
+	newAppState.Machines = lo.Map(updateEntries, func(e *machineUpdateEntry, _ int) *fly.Machine {
+		return e.leasableMachine.Machine()
+	})
+
 	switch md.strategy {
 	case "bluegreen":
 		// TODO(billy) do machine checks here
@@ -490,7 +495,7 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 	case "canary", "rolling":
 		fallthrough
 	default:
-		return md.updateUsingRollingStrategy(ctx, updateEntries)
+		return md.updateMachines(ctx, oldAppState, &newAppState)
 	}
 }
 
@@ -572,196 +577,6 @@ func (md *machineDeployment) updateUsingImmediateStrategy(parentCtx context.Cont
 	}
 
 	return updatesPool.Wait()
-}
-
-func (md *machineDeployment) updateUsingRollingStrategy(parentCtx context.Context, updateEntries []*machineUpdateEntry) error {
-	parentCtx, span := tracing.GetTracer().Start(parentCtx, "rolling", trace.WithAttributes(attribute.String("strategy", md.strategy)))
-	defer span.End()
-
-	sl := statuslogger.Create(parentCtx, len(updateEntries), true)
-	defer sl.Destroy(false)
-
-	// Rolling strategy
-	slices.SortFunc(updateEntries, func(a, b *machineUpdateEntry) int {
-		return cmp.Compare(a.leasableMachine.Machine().ID, b.leasableMachine.Machine().ID)
-	})
-
-	// Group updates by process group
-	entriesByGroup := lo.GroupBy(updateEntries, func(e *machineUpdateEntry) string {
-		return e.launchInput.Config.ProcessGroup()
-	})
-
-	startIdx := 0
-	groupsPool := pool.New().
-		WithErrors().
-		WithMaxGoroutines(rollingStrategyMaxConcurrentGroups).
-		WithContext(parentCtx).
-		WithCancelOnError()
-
-	for group, entries := range entriesByGroup {
-		entries := entries
-		startIdx += len(entries)
-		groupsPool.Go(func(ctx context.Context) error {
-			return md.updateEntriesGroup(ctx, group, entries, sl, startIdx-len(entries))
-		})
-	}
-
-	return groupsPool.Wait()
-}
-
-func (md *machineDeployment) updateEntriesGroup(parentCtx context.Context, group string, entries []*machineUpdateEntry, sl statuslogger.StatusLogger, startIdx int) error {
-	parentCtx, span := tracing.GetTracer().Start(parentCtx, "update_entries_in_group", trace.WithAttributes(
-		attribute.Int("start_id", startIdx),
-		attribute.String("group", group),
-		attribute.Int("max_unavailable", int(md.maxUnavailable)),
-	))
-	defer span.End()
-
-	var poolSize int
-	switch mu := md.maxUnavailable; {
-	case mu >= 1:
-		poolSize = int(mu)
-	case mu > 0:
-		poolSize = int(math.Ceil(float64(len(entries)) * mu))
-	default:
-		return fmt.Errorf("Invalid --max-unavailable value: %v", mu)
-	}
-
-	span.SetAttributes(attribute.Int("pool_size", poolSize))
-
-	updatePool := pool.New().
-		WithErrors().
-		WithMaxGoroutines(poolSize).
-		WithContext(parentCtx).
-		WithCancelOnError()
-
-	for idx, e := range entries {
-		e := e
-		eCtx := statuslogger.NewContext(parentCtx, sl.Line(startIdx+idx))
-		fmtID := e.leasableMachine.FormattedMachineId()
-
-		statusRunning := func() {
-			statuslogger.LogfStatus(eCtx,
-				statuslogger.StatusRunning,
-				"Updating %s",
-				md.colorize.Bold(fmtID),
-			)
-		}
-		statusFailure := func(err error) {
-			if errors.Is(err, context.Canceled) {
-				statuslogger.LogfStatus(eCtx,
-					statuslogger.StatusFailure,
-					"Machine %s update %s",
-					md.colorize.Bold(fmtID),
-					md.colorize.Red("canceled while it was in progress"),
-				)
-			} else {
-				statuslogger.LogfStatus(eCtx,
-					statuslogger.StatusFailure,
-					"Machine %s update %s: %s",
-					md.colorize.Bold(fmtID),
-					md.colorize.Red("failed"),
-					err.Error(),
-				)
-			}
-		}
-		statusSkipped := func() {
-			statuslogger.LogfStatus(eCtx,
-				statuslogger.StatusFailure,
-				"Machine %s update %s",
-				md.colorize.Bold(fmtID),
-				md.colorize.Yellow("canceled"),
-			)
-		}
-		statusSuccess := func() {
-			statuslogger.LogfStatus(eCtx,
-				statuslogger.StatusSuccess,
-				"Machine %s update %s",
-				md.colorize.Bold(fmtID),
-				md.colorize.Green("succeeded"),
-			)
-		}
-		updateFunc := func(poolCtx context.Context) error {
-			ctx, span := tracing.GetTracer().Start(eCtx, "update", trace.WithAttributes(
-				attribute.Int("id", idx),
-			))
-			defer span.End()
-
-			// If the pool context is done, it means some other machine update failed
-			select {
-			case <-poolCtx.Done():
-				statusSkipped()
-				return poolCtx.Err()
-			default:
-				statusRunning()
-			}
-
-			if err := md.updateMachine(ctx, e); err != nil {
-				statusFailure(err)
-				tracing.RecordError(span, err, "failed to update machine")
-				return err
-			}
-			if err := md.waitForMachine(ctx, e); err != nil {
-				tracing.RecordError(span, err, "failed to wait for machine")
-				statusFailure(err)
-				return err
-			}
-
-			statusSuccess()
-			return nil
-		}
-
-		// Slow start by updating one machine and then the rest in groups if the spearhead succeeded
-		if idx == 0 {
-			err := updateFunc(parentCtx)
-			if err != nil {
-				return err
-			}
-		} else {
-			updatePool.Go(updateFunc)
-		}
-	}
-
-	return updatePool.Wait()
-}
-
-func (md *machineDeployment) updateMachine(ctx context.Context, e *machineUpdateEntry) error {
-	ctx, span := tracing.GetTracer().Start(ctx, "update_machine", trace.WithAttributes(
-		attribute.String("id", e.launchInput.ID),
-		attribute.Bool("requires_replacement", e.launchInput.RequiresReplacement),
-	))
-	defer span.End()
-
-	fmtID := e.leasableMachine.FormattedMachineId()
-
-	replaceMachine := func() error {
-		statuslogger.Logf(ctx, "Replacing %s by new machine", md.colorize.Bold(fmtID))
-		if err := md.updateMachineByReplace(ctx, e); err != nil {
-			return err
-		}
-		statuslogger.Logf(ctx, "Created machine %s", md.colorize.Bold(fmtID))
-		return nil
-	}
-
-	if e.launchInput.RequiresReplacement {
-		return replaceMachine()
-	}
-
-	statuslogger.Logf(ctx, "Updating %s", md.colorize.Bold(fmtID))
-	if err := md.updateMachineInPlace(ctx, e); err != nil {
-		switch {
-		case len(e.leasableMachine.Machine().Config.Mounts) > 0:
-			// Replacing a machine with a volume will cause the placement logic to pick wthe same host
-			// dismissing the value of replacing it in case of lack of host capacity
-			return err
-		case strings.Contains(err.Error(), "could not reserve resource for machine"),
-			strings.Contains(err.Error(), "deploys to this host are temporarily disabled"):
-			return replaceMachine()
-		default:
-			return err
-		}
-	}
-	return nil
 }
 
 func (md *machineDeployment) updateMachineByReplace(ctx context.Context, e *machineUpdateEntry) error {

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -495,7 +495,7 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 	case "canary", "rolling":
 		fallthrough
 	default:
-		return md.updateMachines(ctx, oldAppState, &newAppState, true)
+		return md.updateMachines(ctx, oldAppState, &newAppState, true, nil)
 	}
 }
 

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -413,7 +413,7 @@ func suggestChangeWaitTimeout(err error, flagName string) error {
 }
 
 func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateEntries []*machineUpdateEntry) (err error) {
-	ctx, span := tracing.GetTracer().Start(ctx, "update_machines", trace.WithAttributes(
+	ctx, span := tracing.GetTracer().Start(ctx, "update_existing_machines", trace.WithAttributes(
 		attribute.String("strategy", md.strategy),
 	))
 	defer func() {
@@ -428,9 +428,6 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 	}
 
 	fmt.Fprintf(md.io.Out, "Updating existing machines in '%s' with %s strategy\n", md.colorize.Bold(md.app.Name), md.strategy)
-
-	ctx, span = tracing.GetTracer().Start(ctx, "rolling", trace.WithAttributes(attribute.String("strategy", md.strategy)))
-	defer span.End()
 
 	oldAppState, err := md.appState(ctx)
 	if err != nil {

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -820,7 +820,8 @@ func (md *machineDeployment) doSmokeChecks(ctx context.Context, lm machine.Leasa
 		return nil
 	}
 
-	if err = lm.WaitForSmokeChecksToPass(ctx); err == nil {
+	err = lm.WaitForSmokeChecksToPass(ctx)
+	if err == nil {
 		return nil
 	}
 

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -656,7 +656,7 @@ func (md *machineDeployment) spawnMachineInGroup(ctx context.Context, groupName 
 	}
 
 	// Otherwise wait for the machine to start
-	if err := md.doSmokeChecks(ctx, lm); err != nil {
+	if err := md.doSmokeChecks(ctx, lm, true); err != nil {
 		return nil, err
 	}
 
@@ -843,7 +843,30 @@ func (md *machineDeployment) warnAboutIncorrectListenAddress(ctx context.Context
 	fmt.Fprintf(md.io.ErrOut, "\n")
 }
 
-func (md *machineDeployment) doSmokeChecks(ctx context.Context, lm machine.LeasableMachine) (err error) {
+type smokeChecksError struct {
+	logs      string
+	machineID string
+	err       error
+}
+
+func (s smokeChecksError) Error() string {
+	return s.err.Error()
+}
+
+func (s smokeChecksError) Unwrap() error {
+	return s.err
+}
+
+func (s smokeChecksError) Suggestion() string {
+	var suggestion string
+	suggestion += fmt.Sprintf("Smoke checks for %s failed: %v\n", s.machineID, s.err)
+	suggestion += fmt.Sprintf("Check its logs: here's the last lines below, or run 'fly logs -i %s':\n", s.machineID)
+	suggestion += s.logs
+
+	return suggestion
+}
+
+func (md *machineDeployment) doSmokeChecks(ctx context.Context, lm machine.LeasableMachine, showLogs bool) (err error) {
 	if md.skipSmokeChecks {
 		return nil
 	}
@@ -852,23 +875,30 @@ func (md *machineDeployment) doSmokeChecks(ctx context.Context, lm machine.Leasa
 		return nil
 	}
 
-	resumeLogFn := statuslogger.Pause(ctx)
-	defer resumeLogFn()
+	if showLogs {
+		resumeLogFn := statuslogger.Pause(ctx)
+		defer resumeLogFn()
+	}
 
-	fmt.Fprintf(md.io.ErrOut, "Smoke checks for %s failed: %v\n", md.colorize.Bold(lm.Machine().ID), err)
-	fmt.Fprintf(md.io.ErrOut, "Check its logs: here's the last lines below, or run 'fly logs -i %s':\n", lm.Machine().ID)
 	logs, _, logErr := md.apiClient.GetAppLogs(ctx, md.app.Name, "", md.appConfig.PrimaryRegion, lm.Machine().ID)
-	if fly.IsNotAuthenticatedError(logErr) {
+	if fly.IsNotAuthenticatedError(logErr) && showLogs {
 		fmt.Fprintf(md.io.ErrOut, "Warn: not authorized to retrieve app logs (this can happen when using deploy tokens), so we can't show you what failed. Use `fly logs -i %s` or open the monitoring dashboard to see them: https://fly.io/apps/%s/monitoring?region=&instance=%s\n", lm.Machine().ID, md.appConfig.AppName, lm.Machine().ID)
 	} else {
 		if logErr != nil {
 			return fmt.Errorf("error getting logs for machine %s: %w", lm.Machine().ID, logErr)
 		}
+		var log string
 		for _, l := range logs {
 			// Ideally we should use InstanceID here, but it's not available in the logs.
 			if l.Timestamp >= lm.Machine().UpdatedAt {
-				fmt.Fprintf(md.io.ErrOut, "  %s\n", l.Message)
+				log += fmt.Sprintf("%s\n", l.Message)
 			}
+		}
+
+		return &smokeChecksError{
+			err:       err,
+			machineID: lm.Machine().ID,
+			logs:      log,
 		}
 	}
 

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -599,7 +599,7 @@ func (md *machineDeployment) updateMachineByReplace(ctx context.Context, e *mach
 		return err
 	}
 
-	lm = machine.NewLeasableMachine(md.flapsClient, md.io, newMachineRaw)
+	lm = machine.NewLeasableMachine(md.flapsClient, md.io, newMachineRaw, false)
 	defer lm.ReleaseLease(ctx)
 	e.leasableMachine = lm
 	return nil
@@ -676,7 +676,7 @@ func (md *machineDeployment) spawnMachineInGroup(ctx context.Context, groupName 
 		return nil, fmt.Errorf("error creating a new machine: %w%s", err, relCmdWarning)
 	}
 
-	lm := machine.NewLeasableMachine(md.flapsClient, md.io, newMachineRaw)
+	lm := machine.NewLeasableMachine(md.flapsClient, md.io, newMachineRaw, false)
 	statuslogger.Logf(ctx, "Machine %s was created", md.colorize.Bold(lm.FormattedMachineId()))
 	defer lm.ReleaseLease(ctx)
 

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -460,7 +460,12 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 		// TODO(billy) do machine checks here
 		return md.updateUsingBlueGreenStrategy(ctx, updateEntries)
 	case "immediate":
-		return md.updateMachines(ctx, oldAppState, &newAppState, true, nil, true, true)
+		return md.updateMachines(ctx, oldAppState, &newAppState, nil, updateMachineSettings{
+			pushForward:          true,
+			skipHealthChecks:     true,
+			skipSmokeChecks:      true,
+			skipLeaseAcquisition: false,
+		})
 	case "canary":
 		// create a new app state with just a single machine being updated, then the rest of the machines
 		canaryAppState := *oldAppState
@@ -472,15 +477,30 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 		})
 		newCanaryAppState.Machines = []*fly.Machine{canaryMach}
 
-		if err := md.updateMachines(ctx, &canaryAppState, &newCanaryAppState, true, nil, md.skipHealthChecks, md.skipSmokeChecks); err != nil {
+		if err := md.updateMachines(ctx, &canaryAppState, &newCanaryAppState, nil, updateMachineSettings{
+			pushForward:          true,
+			skipHealthChecks:     md.skipHealthChecks,
+			skipSmokeChecks:      md.skipSmokeChecks,
+			skipLeaseAcquisition: false,
+		}); err != nil {
 			return err
 		}
 
-		return md.updateMachines(ctx, oldAppState, &newAppState, true, nil, md.skipHealthChecks, md.skipSmokeChecks)
+		return md.updateMachines(ctx, oldAppState, &newAppState, nil, updateMachineSettings{
+			pushForward:          true,
+			skipHealthChecks:     md.skipHealthChecks,
+			skipSmokeChecks:      md.skipSmokeChecks,
+			skipLeaseAcquisition: false,
+		})
 	case "rolling":
 		fallthrough
 	default:
-		return md.updateMachines(ctx, oldAppState, &newAppState, true, nil, md.skipHealthChecks, md.skipSmokeChecks)
+		return md.updateMachines(ctx, oldAppState, &newAppState, nil, updateMachineSettings{
+			pushForward:          true,
+			skipHealthChecks:     md.skipHealthChecks,
+			skipSmokeChecks:      md.skipSmokeChecks,
+			skipLeaseAcquisition: false,
+		})
 	}
 }
 

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -429,7 +429,7 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 
 	fmt.Fprintf(md.io.Out, "Updating existing machines in '%s' with %s strategy\n", md.colorize.Bold(md.app.Name), md.strategy)
 
-	oldAppState, err := md.appState(ctx)
+	oldAppState, err := md.appState(ctx, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -495,7 +495,7 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 	case "canary", "rolling":
 		fallthrough
 	default:
-		return md.updateMachines(ctx, oldAppState, &newAppState)
+		return md.updateMachines(ctx, oldAppState, &newAppState, true)
 	}
 }
 

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -455,11 +455,12 @@ func (md *machineDeployment) updateExistingMachines(ctx context.Context, updateE
 		// TODO(billy) do machine checks here
 		return md.updateUsingBlueGreenStrategy(ctx, updateEntries)
 	case "immediate":
-		return md.updateUsingImmediateStrategy(ctx, updateEntries)
+		return md.updateMachines(ctx, oldAppState, &newAppState, true, nil, true)
 	case "canary", "rolling":
+		// FIXME: CANARY!!!
 		fallthrough
 	default:
-		return md.updateMachines(ctx, oldAppState, &newAppState, true, nil)
+		return md.updateMachines(ctx, oldAppState, &newAppState, true, nil, md.skipHealthChecks)
 	}
 }
 

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cenkalti/backoff"
 	"github.com/miekg/dns"
 	"github.com/samber/lo"
-	"github.com/sourcegraph/conc/pool"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -492,71 +491,6 @@ func (md *machineDeployment) updateUsingBlueGreenStrategy(ctx context.Context, u
 		return suggestChangeWaitTimeout(err, "wait-timeout")
 	}
 	return nil
-}
-
-func (md *machineDeployment) updateUsingImmediateStrategy(parentCtx context.Context, updateEntries []*machineUpdateEntry) error {
-	parentCtx, span := tracing.GetTracer().Start(parentCtx, "immediate")
-	defer span.End()
-
-	sl := statuslogger.Create(parentCtx, len(updateEntries), true)
-	defer sl.Destroy(false)
-
-	updatesPool := pool.New().WithErrors().WithContext(parentCtx)
-	if md.maxConcurrent > 0 {
-		updatesPool = updatesPool.WithMaxGoroutines(md.maxConcurrent)
-	}
-
-	for i, e := range updateEntries {
-		e := e
-		eCtx := statuslogger.NewContext(parentCtx, sl.Line(i))
-		fmtID := e.leasableMachine.FormattedMachineId()
-		statusRunning := func() {
-			statuslogger.LogfStatus(eCtx,
-				statuslogger.StatusRunning,
-				"Updating %s",
-				md.colorize.Bold(fmtID),
-			)
-		}
-		statusFailure := func(err error) {
-			if errors.Is(err, context.Canceled) {
-				statuslogger.LogfStatus(eCtx,
-					statuslogger.StatusFailure,
-					"Machine %s update %s",
-					md.colorize.Bold(fmtID),
-					md.colorize.Red("canceled while it was in progress"),
-				)
-			} else {
-				statuslogger.LogfStatus(eCtx,
-					statuslogger.StatusFailure,
-					"Machine %s update %s: %s",
-					md.colorize.Bold(fmtID),
-					md.colorize.Red("failed"),
-					err.Error(),
-				)
-			}
-		}
-		statusSuccess := func() {
-			statuslogger.LogfStatus(eCtx,
-				statuslogger.StatusSuccess,
-				"Machine %s update %s",
-				md.colorize.Bold(fmtID),
-				md.colorize.Green("succeeded"),
-			)
-		}
-
-		updatesPool.Go(func(_ context.Context) error {
-			statusRunning()
-			if err := md.updateMachine(eCtx, e, sl.Line(i)); err != nil {
-				tracing.RecordError(span, err, "failed to update machine")
-				statusFailure(err)
-				return err
-			}
-			statusSuccess()
-			return nil
-		})
-	}
-
-	return updatesPool.Wait()
 }
 
 func (md *machineDeployment) updateMachineByReplace(ctx context.Context, e *machineUpdateEntry) error {

--- a/internal/command/deploy/machines_releasecommand.go
+++ b/internal/command/deploy/machines_releasecommand.go
@@ -146,7 +146,7 @@ func (md *machineDeployment) createReleaseCommandMachine(ctx context.Context) er
 	}
 
 	statuslogger.Logf(ctx, "Created release_command machine %s", md.colorize.Bold(releaseCmdMachine.ID))
-	md.releaseCommandMachine = machine.NewMachineSet(md.flapsClient, md.io, []*fly.Machine{releaseCmdMachine})
+	md.releaseCommandMachine = machine.NewMachineSet(md.flapsClient, md.io, []*fly.Machine{releaseCmdMachine}, true)
 	return nil
 }
 

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -21,7 +21,7 @@ func stabMachineDeployment(appConfig *appconfig.Config) (*machineDeployment, err
 		},
 		img:        "super/balloon",
 		appConfig:  appConfig,
-		machineSet: machine.NewMachineSet(nil, nil, nil),
+		machineSet: machine.NewMachineSet(nil, nil, nil, true),
 	}
 	return md, nil
 }

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -196,7 +196,7 @@ func (e *unrecoverableError) Unwrap() error {
 }
 
 func compareConfigs(ctx context.Context, oldConfig, newConfig *fly.MachineConfig) bool {
-	ctx, span := tracing.GetTracer().Start(ctx, "compare_configs")
+	_, span := tracing.GetTracer().Start(ctx, "compare_configs")
 	defer span.End()
 
 	opt := cmp.FilterPath(func(p cmp.Path) bool {

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -251,14 +251,14 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 	}
 
 	// wait for the machine to reach the running state
-	sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach the 'started' state", oldMachine.ID))
+	sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach the 'started' state", machine.ID))
 	err = waitForMachineState(ctx, lm, []string{"started"}, 5*time.Minute, sl.Line(idx))
 	if err != nil {
 		return err
 	}
 
 	if !healthcheckResult.machineChecksPassed {
-		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Running machine checks on machine %s", oldMachine.ID))
+		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Running machine checks on machine %s", machine.ID))
 		err = md.runTestMachines(ctx, machine, sl.Line(idx))
 		if err != nil {
 			return &unrecoverableError{err: err}
@@ -267,7 +267,7 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 	}
 
 	if !healthcheckResult.regularChecksPassed {
-		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Checking health of machine %s", oldMachine.ID))
+		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Checking health of machine %s", machine.ID))
 		err = lm.WaitForHealthchecksToPass(ctx, 5*time.Minute)
 		if err != nil {
 			return &unrecoverableError{err: err}
@@ -275,7 +275,7 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 		healthcheckResult.regularChecksPassed = true
 	}
 
-	sl.Line(idx).LogStatus(statuslogger.StatusSuccess, fmt.Sprintf("Machine %s is now in a good state", oldMachine.ID))
+	sl.Line(idx).LogStatus(statuslogger.StatusSuccess, fmt.Sprintf("Machine %s is now in a good state", machine.ID))
 
 	return nil
 }

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -418,9 +418,7 @@ func (md *machineDeployment) updateMachineConfig(ctx context.Context, oldMachine
 		return nil, err
 	}
 	input.Config = newMachineConfig
-	if shouldReplace {
-		input.RequiresReplacement = shouldReplace
-	}
+	input.RequiresReplacement = input.RequiresReplacement || shouldReplace
 
 	lm := mach.NewLeasableMachine(md.flapsClient, md.io, oldMachine, false)
 	entry := &machineUpdateEntry{
@@ -431,7 +429,7 @@ func (md *machineDeployment) updateMachineConfig(ctx context.Context, oldMachine
 	if err != nil {
 		return nil, err
 	}
-	return lm.Machine(), nil
+	return entry.leasableMachine.Machine(), nil
 }
 
 func createMachine(ctx context.Context, machConfig *fly.MachineConfig, region string) (*fly.Machine, error) {
@@ -469,7 +467,7 @@ func (md *machineDeployment) updateMachine(ctx context.Context, e *machineUpdate
 		return replaceMachine()
 	}
 
-	sl.Logf("Updating %s", md.colorize.Bold(fmtID))
+	sl.Logf("Updating %s", fmtID)
 	if err := md.updateMachineInPlace(ctx, e); err != nil {
 		switch {
 		case len(e.leasableMachine.Machine().Config.Mounts) > 0:

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -1,0 +1,354 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	mach "github.com/superfly/flyctl/internal/machine"
+	"github.com/superfly/flyctl/internal/statuslogger"
+	"github.com/superfly/flyctl/internal/tracing"
+	"github.com/superfly/flyctl/iostreams"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
+)
+
+type AppState struct {
+	Machines []*fly.Machine
+	Volumes  []fly.Volume
+}
+
+type machinePairing struct {
+	oldMachine *fly.Machine
+	newMachine *fly.Machine
+}
+
+func (md *machineDeployment) appState(ctx context.Context) (*AppState, error) {
+	machines, err := md.flapsClient.List(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+	volumes, err := md.flapsClient.GetVolumes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	appState := &AppState{
+		Machines: machines,
+		Volumes:  volumes,
+	}
+
+	return appState, nil
+}
+
+func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, newAppState *AppState) error {
+	// make a map of [machineID] -> [machine]
+	oldMachines := make(map[string]*fly.Machine)
+	for _, machine := range oldAppState.Machines {
+		oldMachines[machine.ID] = machine
+	}
+	newMachines := make(map[string]*fly.Machine)
+	for _, machine := range newAppState.Machines {
+		newMachines[machine.ID] = machine
+	}
+	// First, we update the machines
+	// Create a list of tuples of old and new machines
+	machineTuples := make([]machinePairing, 0)
+
+	// TODO: a little tired rn, do we need to do this?
+	for _, oldMachine := range oldMachines {
+		// This means we want to update a machine
+		if newMachine, ok := newMachines[oldMachine.ID]; ok {
+			machineTuples = append(machineTuples, machinePairing{oldMachine: oldMachine, newMachine: newMachine})
+		} else {
+			// This means we should destroy the old machine
+			machineTuples = append(machineTuples, machinePairing{oldMachine: oldMachine, newMachine: nil})
+			return fmt.Errorf("Machine not found in new state")
+		}
+	}
+
+	for _, newMachine := range newMachines {
+		if _, ok := oldMachines[newMachine.ID]; !ok {
+			// This means we should create the new machine
+			machineTuples = append(machineTuples, machinePairing{oldMachine: nil, newMachine: newMachine})
+		}
+	}
+
+	sl := statuslogger.Create(ctx, len(machineTuples), true)
+	defer sl.Destroy(false)
+
+	group, ctx := errgroup.WithContext(ctx)
+	for idx, machPair := range machineTuples {
+		machPair := machPair
+		oldMachine := machPair.oldMachine
+		newMachine := machPair.newMachine
+
+		idx := idx
+		group.Go(func() error {
+			err := updateMachine(ctx, oldMachine, newMachine, idx, sl)
+			if err != nil {
+				sl.Line(idx).LogStatus(statuslogger.StatusFailure, err.Error())
+				return err
+			}
+
+			return nil
+
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		fmt.Println("Error updating machines", err)
+		return err
+	}
+
+	return nil
+}
+
+func updateMachine(ctx context.Context, oldMachine, newMachine *fly.Machine, idx int, sl statuslogger.StatusLogger) error {
+	var machine *fly.Machine
+	var lease *fly.MachineLease
+
+	// whether we need to create a new machine or update an existing one
+	if oldMachine != nil {
+		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Acquiring lease for %s", oldMachine.ID))
+		newLease, err := acquireMachineLease(ctx, oldMachine.ID)
+		if err != nil {
+			return err
+		}
+		lease = newLease
+
+		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Updating machine config for %s", oldMachine.ID))
+		newMach, err := updateMachineConfig(ctx, oldMachine.ID, lease, newMachine.Config)
+		if err != nil {
+			return err
+		}
+
+		machine = newMach
+	} else if newMachine != nil {
+		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Creating machine for %s", oldMachine.ID))
+		machine, err := createMachine(ctx, newMachine.Config, newMachine.Region)
+		if err != nil {
+			return err
+		}
+
+		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Acquiring lease for %s", oldMachine.ID))
+		newLease, err := acquireMachineLease(ctx, machine.ID)
+		if err != nil {
+			return err
+		}
+		lease = newLease
+	}
+	// even if we fail to update the machine, we need to clear the lease
+	defer func() {
+		// clear the existing lease
+		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Clearing the lease for %s", oldMachine.ID))
+		err := clearMachineLease(ctx, machine.ID, lease.Data.Nonce)
+		if err != nil {
+			sl.Line(idx).LogStatus(statuslogger.StatusFailure, fmt.Sprintf("Failed to clear lease for machine %s", oldMachine.ID))
+		}
+	}()
+
+	var err error
+
+	sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach stopped/started state", oldMachine.ID))
+	err = waitForMachineState(ctx, machine, []string{"stopped", "started", "suspended"}, 60*time.Second)
+	if err != nil {
+		return err
+	}
+
+	// start the machine
+	sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Starting machine %s", oldMachine.ID))
+	err = startMachine(ctx, machine.ID, lease.Data.Nonce)
+	if err != nil {
+		return err
+	}
+
+	// wait for the machine to reach the running state
+	sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach running state", oldMachine.ID))
+	err = waitForMachineState(ctx, machine, []string{"started"}, 60*time.Second)
+	if err != nil {
+		return err
+	}
+
+	// check health of the machine
+	sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Checking health of machine %s", oldMachine.ID))
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	io := iostreams.FromContext(ctx)
+	lm := mach.NewLeasableMachine(flapsClient, io, machine)
+
+	err = lm.WaitForHealthchecksToPass(ctx, 60*time.Second)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func detectMultipleImageVersions(ctx context.Context) ([]*fly.Machine, error) {
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	machines, err := flapsClient.List(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// First, we get the latest image
+	var latestImage string
+	var latestUpdated time.Time
+
+	for _, machine := range machines {
+		updated, err := time.Parse(time.RFC3339, machine.UpdatedAt)
+		if err != nil {
+			return nil, err
+		}
+
+		if updated.After(latestUpdated) {
+			latestUpdated = updated
+			latestImage = machine.Config.Image
+		}
+	}
+
+	var badMachines []*fly.Machine
+	// Next, we find any machines that are not using the latest image
+	for _, machine := range machines {
+		if machine.Config.Image != latestImage {
+			badMachines = append(badMachines, machine)
+		}
+	}
+
+	return badMachines, nil
+}
+
+func clearMachineLease(ctx context.Context, machID, leaseNonce string) error {
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	err := flapsClient.ReleaseLease(ctx, machID, leaseNonce)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func waitForMachineState(ctx context.Context, machine *fly.Machine, possibleStates []string, timeout time.Duration) error {
+	var mutex sync.Mutex
+
+	var waitErr error
+	var completed bool
+
+	for _, state := range possibleStates {
+		state := state
+		go func() {
+			flapsClient := flapsutil.ClientFromContext(ctx)
+			err := flapsClient.Wait(ctx, machine, state, timeout)
+			mutex.Lock()
+			defer mutex.Unlock()
+
+			if err != nil && !completed {
+				waitErr = err
+			} else {
+				completed = true
+			}
+
+		}()
+	}
+
+	for {
+		mutex.Lock()
+		if completed {
+			defer mutex.Unlock()
+			return waitErr
+		}
+		mutex.Unlock()
+	}
+}
+
+func acquireMachineLease(ctx context.Context, machID string) (*fly.MachineLease, error) {
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	lease, err := flapsClient.AcquireLease(ctx, machID, fly.IntPointer(3600))
+	if err != nil {
+		return nil, err
+	}
+
+	return lease, nil
+}
+
+func updateMachineConfig(ctx context.Context, machID string, lease *fly.MachineLease, machConfig *fly.MachineConfig) (*fly.Machine, error) {
+	// First, let's get a lease on the machine
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	mach, err := flapsClient.Update(ctx, fly.LaunchMachineInput{
+		Config: machConfig,
+		ID:     machID,
+	}, lease.Data.Nonce)
+	if err != nil {
+		return nil, err
+	}
+
+	return mach, nil
+}
+
+func createMachine(ctx context.Context, machConfig *fly.MachineConfig, region string) (*fly.Machine, error) {
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	machine, err := flapsClient.Launch(ctx, fly.LaunchMachineInput{
+		Config: machConfig,
+		Region: region,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return machine, nil
+}
+
+func (md *machineDeployment) updateMachine(ctx context.Context, e *machineUpdateEntry) error {
+	ctx, span := tracing.GetTracer().Start(ctx, "update_machine", trace.WithAttributes(
+		attribute.String("id", e.launchInput.ID),
+		attribute.Bool("requires_replacement", e.launchInput.RequiresReplacement),
+	))
+	defer span.End()
+
+	fmtID := e.leasableMachine.FormattedMachineId()
+
+	replaceMachine := func() error {
+		statuslogger.Logf(ctx, "Replacing %s by new machine", md.colorize.Bold(fmtID))
+		if err := md.updateMachineByReplace(ctx, e); err != nil {
+			return err
+		}
+		statuslogger.Logf(ctx, "Created machine %s", md.colorize.Bold(fmtID))
+		return nil
+	}
+
+	if e.launchInput.RequiresReplacement {
+		return replaceMachine()
+	}
+
+	statuslogger.Logf(ctx, "Updating %s", md.colorize.Bold(fmtID))
+	if err := md.updateMachineInPlace(ctx, e); err != nil {
+		switch {
+		case len(e.leasableMachine.Machine().Config.Mounts) > 0:
+			// Replacing a machine with a volume will cause the placement logic to pick wthe same host
+			// dismissing the value of replacing it in case of lack of host capacity
+			return err
+		case strings.Contains(err.Error(), "could not reserve resource for machine"):
+			return replaceMachine()
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
+func startMachine(ctx context.Context, machineID string, leaseNonce string) error {
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	_, err := flapsClient.Start(ctx, machineID, leaseNonce)
+	if err != nil {
+		fmt.Println("Failed to start machine", machineID, "due to error", err)
+		return err
+	}
+
+	return nil
+}

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -355,12 +355,6 @@ func acquireMachineLease(ctx context.Context, machID string) (*fly.MachineLease,
 }
 
 func updateMachineConfig(ctx context.Context, machID string, lease *fly.MachineLease, machConfig *fly.MachineConfig) (*fly.Machine, error) {
-	randNum := rand.Intn(30) + 1
-	if randNum == 5 {
-		time.Sleep(10 * time.Second)
-		return nil, fmt.Errorf("could not reserve resource for machine %s", machID)
-	}
-
 	// First, let's get a lease on the machine
 	flapsClient := flapsutil.ClientFromContext(ctx)
 	mach, err := flapsClient.Update(ctx, fly.LaunchMachineInput{

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -282,8 +282,9 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 				return err
 			}
 		}
-
 	}
+
+	md.warnAboutIncorrectListenAddress(ctx, lm)
 
 	if !healthcheckResult.smokeChecksPassed {
 		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Running smoke checks on machine %s", machine.ID))

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -72,9 +72,10 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 		if newMachine, ok := newMachines[oldMachine.ID]; ok {
 			machineTuples = append(machineTuples, machinePairing{oldMachine: oldMachine, newMachine: newMachine})
 		} else {
+			// FIXME: this would currently delete unmanaged machines! no bueno
+			// fmt.Println("Deleting machine", oldMachine.ID)
 			// This means we should destroy the old machine
-			machineTuples = append(machineTuples, machinePairing{oldMachine: oldMachine, newMachine: nil})
-			return fmt.Errorf("Machine not found in new state")
+			// machineTuples = append(machineTuples, machinePairing{oldMachine: oldMachine, newMachine: nil})
 		}
 	}
 
@@ -103,7 +104,6 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 			}
 
 			return nil
-
 		})
 	}
 

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -57,12 +57,19 @@ type healthcheckResult struct {
 
 var healthChecksPassed = sync.Map{}
 
-func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, newAppState *AppState, pushForward bool, statusLogger statuslogger.StatusLogger, skipHealthChecks bool, skipSmokeChecks bool) error {
+type updateMachineSettings struct {
+	pushForward          bool
+	skipHealthChecks     bool
+	skipSmokeChecks      bool
+	skipLeaseAcquisition bool
+}
+
+func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, newAppState *AppState, statusLogger statuslogger.StatusLogger, settings updateMachineSettings) error {
 	ctx, span := tracing.GetTracer().Start(
 		ctx, "update_machines",
-		trace.WithAttributes(attribute.Bool("push_forward", pushForward)),
-		trace.WithAttributes(attribute.Bool("skip_health_checks", skipHealthChecks)),
-		trace.WithAttributes(attribute.Bool("skip_smoke_checks", skipSmokeChecks)),
+		trace.WithAttributes(attribute.Bool("push_forward", settings.pushForward)),
+		trace.WithAttributes(attribute.Bool("skip_health_checks", settings.skipHealthChecks)),
+		trace.WithAttributes(attribute.Bool("skip_smoke_checks", settings.skipSmokeChecks)),
 	)
 	defer span.End()
 	ctx, cancel := context.WithCancel(ctx)
@@ -83,9 +90,9 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 		// This means we want to update a machine
 		if newMachine, ok := newMachines[oldMachine.ID]; ok {
 			healthChecksPassed.LoadOrStore(oldMachine.ID, &healthcheckResult{
-				regularChecksPassed: skipHealthChecks,
-				machineChecksPassed: skipHealthChecks,
-				smokeChecksPassed:   skipSmokeChecks,
+				regularChecksPassed: settings.skipHealthChecks,
+				machineChecksPassed: settings.skipHealthChecks,
+				smokeChecksPassed:   settings.skipSmokeChecks,
 			})
 			machineTuples = append(machineTuples, machinePairing{oldMachine: oldMachine, newMachine: newMachine})
 		}
@@ -95,9 +102,9 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 		if _, ok := oldMachines[newMachine.ID]; !ok {
 			// This means we should create the new machine
 			healthChecksPassed.LoadOrStore(newMachine.ID, &healthcheckResult{
-				regularChecksPassed: skipHealthChecks,
-				machineChecksPassed: skipHealthChecks,
-				smokeChecksPassed:   skipSmokeChecks,
+				regularChecksPassed: settings.skipHealthChecks,
+				machineChecksPassed: settings.skipHealthChecks,
+				smokeChecksPassed:   settings.skipSmokeChecks,
 			})
 			machineTuples = append(machineTuples, machinePairing{oldMachine: nil, newMachine: newMachine})
 		}
@@ -131,76 +138,206 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 		return fmt.Errorf("Invalid --max-unavailable value: %v", mu)
 	}
 
-	group := errgroup.Group{}
-	group.SetLimit(poolSize)
+	if !settings.skipLeaseAcquisition {
+		attempts := 0
+
+		defer func() {
+			span.SetAttributes(attribute.Int("lease_attempts", attempts))
+		}()
+
+		for {
+			err := md.acquireLeases(ctx, machineTuples, poolSize, sl)
+			if err == nil {
+				break
+			}
+			attempts += 1
+
+			var unrecoverableErr *unrecoverableError
+			if attempts > md.deployRetries || errors.As(err, &unrecoverableErr) || errors.Is(err, context.Canceled) {
+				span.RecordError(err)
+				return fmt.Errorf("failed to acquire leases: %w", err)
+			}
+		}
+
+		defer func() {
+			ctx := context.WithoutCancel(ctx)
+			err := md.releaseLeases(ctx, machineTuples, sl)
+			if err != nil {
+				fmt.Fprintln(md.io.ErrOut, "Failed to release leases:", err)
+				span.RecordError(err)
+			}
+		}()
+	}
+
 	idx := 0
+	// We want to update by process group
 	for _, machineTuples := range machPairByProcessGroup {
+		group := errgroup.Group{}
+		group.SetLimit(poolSize)
+
 		for _, machPair := range machineTuples {
 			machPair := machPair
 			oldMachine := machPair.oldMachine
 			newMachine := machPair.newMachine
 
-			idx := idx
+			idxCopy := idx
+			idx += 1
 			group.Go(func() error {
 				checkResult, _ := healthChecksPassed.Load(machPair.oldMachine.ID)
 				machineCheckResult := checkResult.(*healthcheckResult)
-				err := md.updateMachineWChecks(ctx, oldMachine, newMachine, idx, sl, md.io, machineCheckResult)
+				err := md.updateMachineWChecks(ctx, oldMachine, newMachine, sl.Line(idxCopy), md.io, machineCheckResult)
 				if err != nil {
-					sl.Line(idx).LogStatus(statuslogger.StatusFailure, err.Error())
+					sl.Line(idxCopy).LogStatus(statuslogger.StatusFailure, err.Error())
 					span.RecordError(err)
 					return fmt.Errorf("failed to update machine %s: %w", oldMachine.ID, err)
 				}
 				return nil
 			})
-			idx += 1
-		}
-	}
-
-	if updateErr := group.Wait(); updateErr != nil {
-		if !pushForward {
-			span.RecordError(updateErr)
-			return updateErr
 		}
 
-		var unrecoverableErr *unrecoverableError
-		if errors.As(updateErr, &unrecoverableErr) || errors.Is(updateErr, context.Canceled) {
-			span.RecordError(updateErr)
-			return updateErr
-		}
-
-		attempts := 0
-		// if we fail to update the machines, we should push the state forward if possible
-		for {
-			defer func() {
-				span.SetAttributes(attribute.Int("attempts", attempts))
-			}()
-
-			if attempts > md.deployRetries {
+		if updateErr := group.Wait(); updateErr != nil {
+			if !settings.pushForward {
+				span.RecordError(updateErr)
 				return updateErr
 			}
 
-			currentState, err := md.appState(ctx)
-			if err != nil {
+			var unrecoverableErr *unrecoverableError
+			if errors.As(updateErr, &unrecoverableErr) || errors.Is(updateErr, context.Canceled) {
 				span.RecordError(updateErr)
-				return err
+				return updateErr
 			}
-			err = md.updateMachines(ctx, currentState, newAppState, false, sl, skipHealthChecks, skipSmokeChecks)
-			if err == nil {
-				break
-			} else if errors.Is(err, context.Canceled) {
-				span.RecordError(updateErr)
-				return err
-			} else {
-				if errors.As(err, &unrecoverableErr) || errors.Is(err, context.Canceled) {
+
+			attempts := 0
+			// if we fail to update the machines, we should push the state forward if possible
+			for {
+				defer func() {
+					span.SetAttributes(attribute.Int("update_attempts", attempts))
+				}()
+
+				if attempts > md.deployRetries {
+					return updateErr
+				}
+
+				currentState, err := md.appState(ctx)
+				if err != nil {
 					span.RecordError(updateErr)
 					return err
 				}
-				fmt.Fprintln(md.io.ErrOut, "Failed to update machines:", err, ". Retrying...")
+				err = md.updateMachines(ctx, currentState, newAppState, sl, updateMachineSettings{
+					pushForward:          false,
+					skipHealthChecks:     settings.skipHealthChecks,
+					skipSmokeChecks:      settings.skipSmokeChecks,
+					skipLeaseAcquisition: true,
+				})
+				if err == nil {
+					break
+				} else if errors.Is(err, context.Canceled) {
+					span.RecordError(updateErr)
+					return err
+				} else {
+					if errors.As(err, &unrecoverableErr) || errors.Is(err, context.Canceled) {
+						span.RecordError(updateErr)
+						return err
+					}
+					fmt.Fprintln(md.io.ErrOut, "Failed to update machines:", err, ". Retrying...")
+				}
+				attempts += 1
+				time.Sleep(1 * time.Second)
 			}
-			attempts += 1
-			time.Sleep(1 * time.Second)
 		}
+	}
 
+	return nil
+}
+
+func (md *machineDeployment) acquireLeases(ctx context.Context, machineTuples []machinePairing, poolSize int, statusLogger statuslogger.StatusLogger) error {
+	ctx, span := tracing.GetTracer().Start(ctx, "acquire_leases")
+
+	leaseGroup := errgroup.Group{}
+	leaseGroup.SetLimit(poolSize)
+
+	for idx, machineTuple := range machineTuples {
+		machineTuple := machineTuple
+		idx := idx
+
+		leaseGroup.Go(func() error {
+			sl := statusLogger.Line(idx)
+
+			var machine *fly.Machine
+			if machineTuple.oldMachine != nil {
+				machine = machineTuple.oldMachine
+			} else if machineTuple.newMachine != nil {
+				machine = machineTuple.newMachine
+			} else {
+				return nil
+			}
+			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Acquiring lease for %s", machine.ID))
+
+			if machine.LeaseNonce == "" {
+				sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for job %s", machine.ID))
+			}
+
+			lease, err := md.acquireMachineLease(ctx, machine.ID)
+			if err != nil {
+				sl.LogStatus(statuslogger.StatusFailure, fmt.Sprintf("Failed to acquire lease for %s: %v", machine.ID, err))
+				return err
+			}
+
+			machine.LeaseNonce = lease.Data.Nonce
+			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for job %s", machine.ID))
+			return nil
+		})
+	}
+
+	if err := leaseGroup.Wait(); err != nil {
+		span.RecordError(err)
+		return err
+	}
+
+	return nil
+}
+
+func (md *machineDeployment) releaseLeases(ctx context.Context, machineTuples []machinePairing, statusLogger statuslogger.StatusLogger) error {
+	ctx, span := tracing.GetTracer().Start(ctx, "release_leases")
+	defer span.End()
+
+	leaseGroup := errgroup.Group{}
+	leaseGroup.SetLimit(len(machineTuples))
+
+	for idx, machineTuple := range machineTuples {
+		machineTuple := machineTuple
+		idx := idx
+
+		leaseGroup.Go(func() error {
+			sl := statusLogger.Line(idx)
+
+			var machine *fly.Machine
+			if machineTuple.oldMachine != nil {
+				machine = machineTuple.oldMachine
+			} else if machineTuple.newMachine != nil {
+				machine = machineTuple.newMachine
+			} else {
+				return nil
+			}
+
+			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Clearing lease for %s", machine.ID))
+			if machine.LeaseNonce == "" {
+				sl.LogStatus(statuslogger.StatusSuccess, fmt.Sprintf("Cleared lease for %s", machine.ID))
+				return nil
+			}
+			err := md.clearMachineLease(ctx, machine.ID, machine.LeaseNonce)
+			if err != nil {
+				sl.LogStatus(statuslogger.StatusFailure, fmt.Sprintf("Failed to clear lease for %s: %v", machine.ID, err))
+				return err
+			}
+
+			sl.LogStatus(statuslogger.StatusSuccess, fmt.Sprintf("Cleared lease for %s", machine.ID))
+			return nil
+		})
+	}
+
+	if err := leaseGroup.Wait(); err != nil {
+		span.RecordError(err)
 		return nil
 	}
 
@@ -238,7 +375,7 @@ func compareConfigs(ctx context.Context, oldConfig, newConfig *fly.MachineConfig
 	return isEqual
 }
 
-func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachine, newMachine *fly.Machine, idx int, sl statuslogger.StatusLogger, io *iostreams.IOStreams, healthcheckResult *healthcheckResult) error {
+func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachine, newMachine *fly.Machine, sl statuslogger.StatusLine, io *iostreams.IOStreams, healthcheckResult *healthcheckResult) error {
 	ctx, span := tracing.GetTracer().Start(ctx, "update_machine_w_checks", trace.WithAttributes(
 		attribute.Bool("smoke_checks", healthcheckResult.smokeChecksPassed),
 		attribute.Bool("machine_checks", healthcheckResult.machineChecksPassed),
@@ -246,27 +383,12 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 	))
 	defer span.End()
 
-	var machine *fly.Machine = oldMachine
+	var machine *fly.Machine
 	var lease *fly.MachineLease
-
-	defer func() {
-		if machine == nil || lease == nil {
-			span.AddEvent("no lease to clear")
-			return
-		}
-
-		// even if we fail to update the machine, we need to clear the lease
-		ctx := context.WithoutCancel(ctx)
-		err := md.clearMachineLease(ctx, machine.ID, lease.Data.Nonce)
-		if err != nil {
-			span.RecordError(err)
-			sl.Line(idx).LogStatus(statuslogger.StatusFailure, fmt.Sprintf("Failed to clear lease for machine %s", machine.ID))
-		}
-	}()
 
 	var err error
 
-	machine, lease, err = md.updateOrCreateMachine(ctx, oldMachine, newMachine, sl.Line(idx))
+	machine, lease, err = md.updateOrCreateMachine(ctx, oldMachine, newMachine, sl)
 	// if machine is nil and the lease is nil, it means we don't need to check on this machine
 	if err != nil || (machine == nil && lease == nil) {
 		span.RecordError(err)
@@ -279,28 +401,29 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 	span.SetAttributes(attribute.Bool("should_start", shouldStart))
 
 	if !shouldStart {
-		sl.Line(idx).LogStatus(statuslogger.StatusSuccess, fmt.Sprintf("Machine %s is now in a good state", machine.ID))
+		sl.LogStatus(statuslogger.StatusSuccess, fmt.Sprintf("Machine %s is now in a good state", machine.ID))
 		return nil
 	}
 
 	if !healthcheckResult.machineChecksPassed || !healthcheckResult.smokeChecksPassed {
-		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach a good state", oldMachine.ID))
-		state, err := waitForMachineState(ctx, lm, []string{"stopped", "started", "suspended"}, md.waitTimeout, sl.Line(idx))
+		sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach a good state", oldMachine.ID))
+		state, err := waitForMachineState(ctx, lm, []string{"stopped", "started", "suspended"}, md.waitTimeout, sl)
 		if err != nil {
 			span.RecordError(err)
 			return err
 		}
 
+		fmt.Println(state)
 		if state != "started" {
-			sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Starting machine %s", oldMachine.ID))
+			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Starting machine %s", oldMachine.ID))
 			err = md.startMachine(ctx, machine.ID, lease.Data.Nonce)
 			if err != nil {
 				span.RecordError(err)
 				return err
 			}
 
-			sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach the 'started' state", machine.ID))
-			_, err = waitForMachineState(ctx, lm, []string{"started", "stopped"}, md.waitTimeout, sl.Line(idx))
+			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach the 'started' state", machine.ID))
+			_, err = waitForMachineState(ctx, lm, []string{"started", "stopped"}, md.waitTimeout, sl)
 			if err != nil {
 				span.RecordError(err)
 				return err
@@ -311,7 +434,7 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 	md.warnAboutIncorrectListenAddress(ctx, lm)
 
 	if !healthcheckResult.smokeChecksPassed {
-		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Running smoke checks on machine %s", machine.ID))
+		sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Running smoke checks on machine %s", machine.ID))
 		err = md.doSmokeChecks(ctx, lm, false)
 		if err != nil {
 			span.RecordError(err)
@@ -321,8 +444,8 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 	}
 
 	if !healthcheckResult.machineChecksPassed {
-		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Running machine checks on machine %s", machine.ID))
-		err = md.runTestMachines(ctx, machine, sl.Line(idx))
+		sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Running machine checks on machine %s", machine.ID))
+		err = md.runTestMachines(ctx, machine, sl)
 		if err != nil {
 			span.RecordError(err)
 			return &unrecoverableError{err: err}
@@ -331,7 +454,7 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 	}
 
 	if !healthcheckResult.regularChecksPassed {
-		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Checking health of machine %s", machine.ID))
+		sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Checking health of machine %s", machine.ID))
 		err = lm.WaitForHealthchecksToPass(ctx, md.waitTimeout)
 		if err != nil {
 			span.RecordError(err)
@@ -340,7 +463,7 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 		healthcheckResult.regularChecksPassed = true
 	}
 
-	sl.Line(idx).LogStatus(statuslogger.StatusSuccess, fmt.Sprintf("Machine %s is now in a good state", machine.ID))
+	sl.LogStatus(statuslogger.StatusSuccess, fmt.Sprintf("Machine %s is now in a good state", machine.ID))
 
 	return nil
 }
@@ -351,28 +474,25 @@ func (md *machineDeployment) updateOrCreateMachine(ctx context.Context, oldMachi
 
 	if oldMachine != nil {
 		span.AddEvent("Old machine exists")
-		sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Acquiring lease for %s", oldMachine.ID))
-		lease, err := md.acquireMachineLease(ctx, oldMachine.ID)
-		if err != nil {
-			span.RecordError(err)
-			return nil, nil, err
-		}
-
 		if newMachine == nil {
 			span.AddEvent("Destroying old machine")
-			err := md.destroyMachine(ctx, oldMachine.ID, lease.Data.Nonce)
+			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Destroying machine %s", oldMachine.ID))
+
+			err := md.destroyMachine(ctx, oldMachine.ID, oldMachine.LeaseNonce)
 			span.RecordError(err)
+
+			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Destroyed machine %s", oldMachine.ID))
 			return nil, nil, err
 		} else {
 			span.AddEvent("Updating old machine")
-			oldMachine.LeaseNonce = lease.Data.Nonce
 			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Updating machine config for %s", oldMachine.ID))
 			machine, err := md.updateMachineConfig(ctx, oldMachine, newMachine.Config, sl, newMachine.State == "replacing")
 			if err != nil {
-				return oldMachine, lease, err
+				return oldMachine, nil, err
 			}
+			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Updated machine config for %s", oldMachine.ID))
 
-			return machine, lease, nil
+			return machine, nil, nil
 		}
 	} else if newMachine != nil {
 		span.AddEvent("Creating a new machine")
@@ -387,6 +507,7 @@ func (md *machineDeployment) updateOrCreateMachine(ctx context.Context, oldMachi
 		if err != nil {
 			return nil, nil, err
 		}
+		sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Acquired lease for %s", newMachine.ID))
 
 		return machine, lease, nil
 	} else {

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -207,6 +207,7 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 	var err error
 
 	machine, lease, err = md.updateOrCreateMachine(ctx, oldMachine, newMachine, sl.Line(idx))
+	// if machine is nil and the lease is nil, it means we don't need to check on this machine
 	if err != nil || (machine == nil && lease == nil) {
 		return err
 	}
@@ -330,7 +331,7 @@ func destroyMachine(ctx context.Context, machineID string, lease string) error {
 }
 
 func clearMachineLease(ctx context.Context, machID, leaseNonce string) error {
-	// TODO: remove this when valentin's work is done
+	// TODO: remove this when the flaps retry work is done:w
 	flapsClient := flapsutil.ClientFromContext(ctx)
 	attempts := 0
 	for {

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -138,7 +138,6 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 
 			currentState, err := md.appState(ctx)
 			if err != nil {
-				fmt.Println("Failed to get current state:", err)
 				return err
 			}
 			err = md.updateMachines(ctx, currentState, newAppState, false, sl, skipHealthChecks, skipSmokeChecks)
@@ -430,14 +429,6 @@ func (md *machineDeployment) updateMachineConfig(ctx context.Context, oldMachine
 	}
 	err = md.updateMachine(ctx, entry, sl)
 	if err != nil {
-		if strings.Contains(err.Error(), "deploys to this host are temporarily disabled") {
-			err := md.updateMachine(ctx, entry, sl)
-
-			if err != nil {
-				return nil, err
-			}
-		}
-
 		return nil, err
 	}
 	return lm.Machine(), nil

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -228,11 +228,11 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 		}
 	} else if newMachine != nil {
 		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Creating machine for %s", newMachine.ID))
-		var err error
-		machine, err = createMachine(ctx, newMachine.Config, newMachine.Region)
+		newMachine, err := createMachine(ctx, newMachine.Config, newMachine.Region)
 		if err != nil {
 			return err
 		}
+		machine = newMachine
 
 		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Acquiring lease for %s", newMachine.ID))
 		newLease, err := acquireMachineLease(ctx, machine.ID)
@@ -247,24 +247,26 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 	flapsClient := flapsutil.ClientFromContext(ctx)
 	lm := mach.NewLeasableMachine(flapsClient, io, machine, false)
 
-	sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach a good state", oldMachine.ID))
-	err = waitForMachineState(ctx, lm, []string{"stopped", "started", "suspended"}, md.waitTimeout, sl.Line(idx))
-	if err != nil {
-		return err
-	}
+	if !healthcheckResult.machineChecksPassed || !healthcheckResult.smokeChecksPassed {
+		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach a good state", oldMachine.ID))
+		err = waitForMachineState(ctx, lm, []string{"stopped", "started", "suspended"}, md.waitTimeout, sl.Line(idx))
+		if err != nil {
+			return err
+		}
 
-	// start the machine
-	sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Starting machine %s", oldMachine.ID))
-	err = startMachine(ctx, machine.ID, lease.Data.Nonce)
-	if err != nil {
-		return err
-	}
+		// start the machine
+		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Starting machine %s", oldMachine.ID))
+		err = startMachine(ctx, machine.ID, lease.Data.Nonce)
+		if err != nil {
+			return err
+		}
 
-	// wait for the machine to reach the running state
-	sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach the 'started' state", machine.ID))
-	err = waitForMachineState(ctx, lm, []string{"started"}, md.waitTimeout, sl.Line(idx))
-	if err != nil {
-		return err
+		// wait for the machine to reach the running state
+		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach the 'started' state", machine.ID))
+		err = waitForMachineState(ctx, lm, []string{"started"}, md.waitTimeout, sl.Line(idx))
+		if err != nil {
+			return err
+		}
 	}
 
 	if !healthcheckResult.smokeChecksPassed {

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -67,7 +67,6 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 	}
 
 	machineTuples := make([]machinePairing, 0)
-	// TODO: a little tired rn, do we need to do this?
 	for _, oldMachine := range oldMachines {
 		// This means we want to update a machine
 		if newMachine, ok := newMachines[oldMachine.ID]; ok {

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -178,7 +178,6 @@ func updateMachine(ctx context.Context, oldMachine, newMachine *fly.Machine, idx
 		// even if we fail to update the machine, we need to clear the lease
 		// clear the existing lease
 		ctx := context.WithoutCancel(ctx)
-		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Clearing the lease for %s", machine.ID))
 		err := clearMachineLease(ctx, machine.ID, lease.Data.Nonce)
 		if err != nil {
 			fmt.Println("Failed to clear lease for machine", machine.ID, "due to error", err)
@@ -402,7 +401,7 @@ func createMachine(ctx context.Context, machConfig *fly.MachineConfig, region st
 	return machine, nil
 }
 
-func (md *machineDeployment) updateMachine(ctx context.Context, e *machineUpdateEntry) error {
+func (md *machineDeployment) updateMachine(ctx context.Context, e *machineUpdateEntry, sl statuslogger.StatusLine) error {
 	ctx, span := tracing.GetTracer().Start(ctx, "update_machine", trace.WithAttributes(
 		attribute.String("id", e.launchInput.ID),
 		attribute.Bool("requires_replacement", e.launchInput.RequiresReplacement),
@@ -424,7 +423,7 @@ func (md *machineDeployment) updateMachine(ctx context.Context, e *machineUpdate
 		return replaceMachine()
 	}
 
-	statuslogger.Logf(ctx, "Updating %s", md.colorize.Bold(fmtID))
+	sl.Logf("Updating %s", md.colorize.Bold(fmtID))
 	if err := md.updateMachineInPlace(ctx, e); err != nil {
 		switch {
 		case len(e.leasableMachine.Machine().Config.Mounts) > 0:

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -129,8 +129,13 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 			return updateErr
 		}
 
+		attempts := 0
 		// if we fail to update the machines, we should revert the state back if possible
 		for {
+			if attempts > md.deployRetries {
+				return updateErr
+			}
+
 			currentState, err := md.appState(ctx)
 			if err != nil {
 				fmt.Println("Failed to get current state:", err)
@@ -147,6 +152,7 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 				}
 				fmt.Println("Failed to update machines:", err, ". Retrying...")
 			}
+			attempts += 1
 			time.Sleep(1 * time.Second)
 		}
 

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -208,7 +208,6 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 	if updateErr := pgroup.Wait(); updateErr != nil {
 		var unrecoverableErr *unrecoverableError
 		if !settings.pushForward || errors.As(updateErr, &unrecoverableErr) || errors.Is(updateErr, context.Canceled) {
-			fmt.Fprintln(md.io.ErrOut, "Failed to update machines:", updateErr)
 			span.RecordError(updateErr)
 			return updateErr
 		}
@@ -246,7 +245,7 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 					span.RecordError(updateErr)
 					return err
 				}
-				fmt.Fprintln(md.io.ErrOut, "Failed to update machines:", err, ". Retrying...")
+				fmt.Fprintln(md.io.ErrOut, "Failed to update machines:", err, "Retrying...")
 			}
 			attempts += 1
 			time.Sleep(1 * time.Second)

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -197,7 +197,6 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 		}
 
 		// even if we fail to update the machine, we need to clear the lease
-		// clear the existing lease
 		ctx := context.WithoutCancel(ctx)
 		err := clearMachineLease(ctx, machine.ID, lease.Data.Nonce)
 		if err != nil {
@@ -206,50 +205,17 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 		}
 	}()
 
-	// whether we need to create a new machine or update an existing one
-	if oldMachine != nil {
-		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Acquiring lease for %s", oldMachine.ID))
-		newLease, err := acquireMachineLease(ctx, oldMachine.ID)
-		if err != nil {
-			return err
-		}
-		lease = newLease
-
-		if newMachine == nil {
-			return destroyMachine(ctx, oldMachine.ID, lease.Data.Nonce)
-		} else {
-			machine.LeaseNonce = lease.Data.Nonce
-			// if the config hasn't changed, we don't need to update the machine
-			sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Updating machine config for %s", oldMachine.ID))
-			updatedMachine, err := md.updateMachineConfig(ctx, oldMachine, newMachine.Config, sl.Line(idx), newMachine.State == "replacing")
-			newMachine.State = "started"
-			if err != nil {
-				return err
-			}
-			machine = updatedMachine
-		}
-	} else if newMachine != nil {
-		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Creating machine for %s", newMachine.ID))
-		newMachine, err := createMachine(ctx, newMachine.Config, newMachine.Region)
-		if err != nil {
-			return err
-		}
-		machine = newMachine
-
-		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Acquiring lease for %s", newMachine.ID))
-		newLease, err := acquireMachineLease(ctx, machine.ID)
-		if err != nil {
-			return err
-		}
-		lease = newLease
-	}
-
 	var err error
 
-	shouldStart := newMachine.State == "started"
+	machine, lease, err = md.updateOrCreateMachine(ctx, oldMachine, newMachine, sl.Line(idx))
+	if err != nil || (machine == nil && lease == nil) {
+		return err
+	}
 
 	flapsClient := flapsutil.ClientFromContext(ctx)
 	lm := mach.NewLeasableMachine(flapsClient, io, machine, false)
+
+	shouldStart := newMachine.State == "started" || newMachine.State == "replacing"
 
 	if !shouldStart {
 		sl.Line(idx).LogStatus(statuslogger.StatusSuccess, fmt.Sprintf("Machine %s is now in a good state", machine.ID))
@@ -309,6 +275,46 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 	sl.Line(idx).LogStatus(statuslogger.StatusSuccess, fmt.Sprintf("Machine %s is now in a good state", machine.ID))
 
 	return nil
+}
+
+func (md *machineDeployment) updateOrCreateMachine(ctx context.Context, oldMachine, newMachine *fly.Machine, sl statuslogger.StatusLine) (*fly.Machine, *fly.MachineLease, error) {
+	if oldMachine != nil {
+		sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Acquiring lease for %s", oldMachine.ID))
+		lease, err := acquireMachineLease(ctx, oldMachine.ID)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if newMachine == nil {
+			return nil, nil, destroyMachine(ctx, oldMachine.ID, lease.Data.Nonce)
+		} else {
+			oldMachine.LeaseNonce = lease.Data.Nonce
+			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Updating machine config for %s", oldMachine.ID))
+			machine, err := md.updateMachineConfig(ctx, oldMachine, newMachine.Config, sl, newMachine.State == "replacing")
+			if err != nil {
+				return oldMachine, lease, err
+			}
+
+			return machine, lease, nil
+		}
+	} else if newMachine != nil {
+		sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Creating machine for %s", newMachine.ID))
+		machine, err := createMachine(ctx, newMachine.Config, newMachine.Region)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Acquiring lease for %s", newMachine.ID))
+		lease, err := acquireMachineLease(ctx, machine.ID)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return machine, lease, nil
+	} else {
+		// both old and new machines are nil, so just a noop
+		return nil, nil, nil
+	}
 }
 
 func destroyMachine(ctx context.Context, machineID string, lease string) error {

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -264,7 +264,7 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 
 	if !healthcheckResult.smokeChecksPassed {
 		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Running smoke checks on machine %s", machine.ID))
-		err = md.doSmokeChecks(ctx, lm)
+		err = md.doSmokeChecks(ctx, lm, false)
 		if err != nil {
 			return &unrecoverableError{err: err}
 		}

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -64,6 +64,8 @@ type updateMachineSettings struct {
 	skipLeaseAcquisition bool
 }
 
+const rollingStrategyMaxConcurrentGroups = 16
+
 func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, newAppState *AppState, statusLogger statuslogger.StatusLogger, settings updateMachineSettings) error {
 	ctx, span := tracing.GetTracer().Start(
 		ctx, "update_machines",
@@ -169,82 +171,100 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 		}()
 	}
 
-	idx := 0
+	statusLines := map[string]statuslogger.StatusLine{}
+	for idx, machPair := range machineTuples {
+		statusLines[machPair.oldMachine.ID] = sl.Line(idx)
+	}
+
+	pgroup, ctx := errgroup.WithContext(ctx)
+	pgroup.SetLimit(rollingStrategyMaxConcurrentGroups)
+
 	// We want to update by process group
 	for _, machineTuples := range machPairByProcessGroup {
-		group := errgroup.Group{}
-		group.SetLimit(poolSize)
+		machineTuples := machineTuples
+		pgroup.Go(func() error {
+			return md.updateProcessGroup(ctx, machineTuples, statusLines, poolSize)
+		})
+	}
 
-		for _, machPair := range machineTuples {
-			machPair := machPair
-			oldMachine := machPair.oldMachine
-			newMachine := machPair.newMachine
+	attempts := 0
+	if updateErr := pgroup.Wait(); updateErr != nil {
+		var unrecoverableErr *unrecoverableError
+		if !settings.pushForward || errors.As(updateErr, &unrecoverableErr) || errors.Is(updateErr, context.Canceled) {
+			span.RecordError(updateErr)
+			return updateErr
+		}
 
-			idxCopy := idx
-			idx += 1
-			group.Go(func() error {
-				checkResult, _ := healthChecksPassed.Load(machPair.oldMachine.ID)
-				machineCheckResult := checkResult.(*healthcheckResult)
-				err := md.updateMachineWChecks(ctx, oldMachine, newMachine, sl.Line(idxCopy), md.io, machineCheckResult)
-				if err != nil {
-					sl.Line(idxCopy).LogStatus(statuslogger.StatusFailure, err.Error())
-					span.RecordError(err)
-					return fmt.Errorf("failed to update machine %s: %w", oldMachine.ID, err)
-				}
-				return nil
+		// if we fail to update the machines, we should push the state forward if possible
+		for {
+			defer func() {
+				span.SetAttributes(attribute.Int("update_attempts", attempts))
+			}()
+
+			if attempts > md.deployRetries {
+				return updateErr
+			}
+
+			currentState, err := md.appState(ctx)
+			if err != nil {
+				span.RecordError(updateErr)
+				return err
+			}
+			err = md.updateMachines(ctx, currentState, newAppState, sl, updateMachineSettings{
+				pushForward:          false,
+				skipHealthChecks:     settings.skipHealthChecks,
+				skipSmokeChecks:      settings.skipSmokeChecks,
+				skipLeaseAcquisition: true,
 			})
-		}
-
-		if updateErr := group.Wait(); updateErr != nil {
-			if !settings.pushForward {
+			if err == nil {
+				break
+			} else if errors.Is(err, context.Canceled) {
 				span.RecordError(updateErr)
-				return updateErr
-			}
-
-			var unrecoverableErr *unrecoverableError
-			if errors.As(updateErr, &unrecoverableErr) || errors.Is(updateErr, context.Canceled) {
-				span.RecordError(updateErr)
-				return updateErr
-			}
-
-			attempts := 0
-			// if we fail to update the machines, we should push the state forward if possible
-			for {
-				defer func() {
-					span.SetAttributes(attribute.Int("update_attempts", attempts))
-				}()
-
-				if attempts > md.deployRetries {
-					return updateErr
-				}
-
-				currentState, err := md.appState(ctx)
-				if err != nil {
+				return err
+			} else {
+				if errors.As(err, &unrecoverableErr) || errors.Is(err, context.Canceled) {
 					span.RecordError(updateErr)
 					return err
 				}
-				err = md.updateMachines(ctx, currentState, newAppState, sl, updateMachineSettings{
-					pushForward:          false,
-					skipHealthChecks:     settings.skipHealthChecks,
-					skipSmokeChecks:      settings.skipSmokeChecks,
-					skipLeaseAcquisition: true,
-				})
-				if err == nil {
-					break
-				} else if errors.Is(err, context.Canceled) {
-					span.RecordError(updateErr)
-					return err
-				} else {
-					if errors.As(err, &unrecoverableErr) || errors.Is(err, context.Canceled) {
-						span.RecordError(updateErr)
-						return err
-					}
-					fmt.Fprintln(md.io.ErrOut, "Failed to update machines:", err, ". Retrying...")
-				}
-				attempts += 1
-				time.Sleep(1 * time.Second)
+				fmt.Fprintln(md.io.ErrOut, "Failed to update machines:", err, ". Retrying...")
 			}
+			attempts += 1
+			time.Sleep(1 * time.Second)
 		}
+	}
+
+	return nil
+}
+
+func (md *machineDeployment) updateProcessGroup(ctx context.Context, machineTuples []machinePairing, statusLines map[string]statuslogger.StatusLine, poolSize int) error {
+	ctx, span := tracing.GetTracer().Start(ctx, "update_process_group")
+	defer span.End()
+
+	group := errgroup.Group{}
+	group.SetLimit(poolSize)
+
+	for _, machPair := range machineTuples {
+		machPair := machPair
+		oldMachine := machPair.oldMachine
+		newMachine := machPair.newMachine
+
+		group.Go(func() error {
+			checkResult, _ := healthChecksPassed.Load(machPair.oldMachine.ID)
+			machineCheckResult := checkResult.(*healthcheckResult)
+			sl := statusLines[machPair.oldMachine.ID]
+			err := md.updateMachineWChecks(ctx, oldMachine, newMachine, sl, md.io, machineCheckResult)
+			if err != nil {
+				sl.LogStatus(statuslogger.StatusFailure, err.Error())
+				span.RecordError(err)
+				return fmt.Errorf("failed to update machine %s: %w", oldMachine.ID, err)
+			}
+			return nil
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		span.RecordError(err)
+		return err
 	}
 
 	return nil
@@ -413,7 +433,6 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 			return err
 		}
 
-		fmt.Println(state)
 		if state != "started" {
 			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Starting machine %s", oldMachine.ID))
 			err = md.startMachine(ctx, machine.ID, lease.Data.Nonce)

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -185,7 +184,7 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 					span.RecordError(updateErr)
 					return err
 				}
-				fmt.Fprintln(os.Stderr, "Failed to update machines:", err, ". Retrying...")
+				fmt.Fprintln(md.io.ErrOut, "Failed to update machines:", err, ". Retrying...")
 			}
 			attempts += 1
 			time.Sleep(1 * time.Second)
@@ -577,7 +576,7 @@ func (md *machineDeployment) startMachine(ctx context.Context, machineID string,
 		if strings.Contains(err.Error(), "machine still active") {
 			return nil
 		}
-		fmt.Fprintln(os.Stderr, "Failed to start machine", machineID, "due to error", err)
+		fmt.Fprintln(md.io.ErrOut, "Failed to start machine", machineID, "due to error", err)
 		return err
 	}
 

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -216,7 +216,7 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 		lease = newLease
 
 		if newMachine == nil {
-			destroyMachine(ctx, oldMachine.ID, lease.Data.Nonce)
+			return destroyMachine(ctx, oldMachine.ID, lease.Data.Nonce)
 		} else {
 			machine.LeaseNonce = lease.Data.Nonce
 			// if the config hasn't changed, we don't need to update the machine

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -113,23 +113,23 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 
 		// if we fail to update the machines, we should revert the state back if possible
 		ctx := context.WithoutCancel(ctx)
-		currentState, err := md.appState(ctx)
-		if err != nil {
-			fmt.Println("Failed to get current state", err)
-			return err
-		}
-		fmt.Println("Reverting to previous state")
-		sl.Destroy(false)
 
-		err = md.updateMachines(ctx, currentState, oldAppState)
 		for {
+			currentState, err := md.appState(ctx)
+			if err != nil {
+				fmt.Println("Failed to get current state", err)
+				return err
+			}
+			fmt.Println("Reverting to previous state")
+			sl.Destroy(false)
+
+			err = md.updateMachines(ctx, currentState, oldAppState)
 			if err == nil {
 				break
 			}
 			fmt.Println("Failed to revert to previous state", err)
 			time.Sleep(10 * time.Second)
 			sl.Destroy(true)
-			err = md.updateMachines(ctx, currentState, oldAppState)
 		}
 
 		// TODO tell the user we managed to revert to a previous state

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -210,7 +210,7 @@ func updateMachine(ctx context.Context, oldMachine, newMachine *fly.Machine, idx
 	lm := mach.NewLeasableMachine(flapsClient, io, machine, false)
 
 	sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach a good state", oldMachine.ID))
-	err = waitForMachineState(ctx, lm, []string{"stopped", "started", "suspended"}, 10*time.Second)
+	err = waitForMachineState(ctx, lm, []string{"stopped", "started", "suspended"}, 60*time.Second)
 	if err != nil {
 		return err
 	}
@@ -224,7 +224,7 @@ func updateMachine(ctx context.Context, oldMachine, newMachine *fly.Machine, idx
 
 	// wait for the machine to reach the running state
 	sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach running state", oldMachine.ID))
-	err = waitForMachineState(ctx, lm, []string{"started"}, 10*time.Second)
+	err = waitForMachineState(ctx, lm, []string{"started"}, 60*time.Second)
 	if err != nil {
 		return err
 	}

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -474,7 +474,17 @@ func (md *machineDeployment) updateMachine(ctx context.Context, e *machineUpdate
 
 	sl.Logf("Updating %s", md.colorize.Bold(fmtID))
 	if err := md.updateMachineInPlace(ctx, e); err != nil {
-		return err
+		switch {
+		case len(e.leasableMachine.Machine().Config.Mounts) > 0:
+			// Replacing a machine with a volume will cause the placement logic to pick wthe same host
+			// dismissing the value of replacing it in case of lack of host capacity
+			return err
+		case strings.Contains(err.Error(), "could not reserve resource for machine"),
+			strings.Contains(err.Error(), "deploys to this host are temporarily disabled"):
+			return replaceMachine()
+		default:
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -466,11 +466,11 @@ func (md *machineDeployment) updateMachine(ctx context.Context, e *machineUpdate
 	fmtID := e.leasableMachine.FormattedMachineId()
 
 	replaceMachine := func() error {
-		statuslogger.Logf(ctx, "Replacing %s by new machine", md.colorize.Bold(fmtID))
+		sl.Logf("Replacing %s by new machine", fmtID)
 		if err := md.updateMachineByReplace(ctx, e); err != nil {
 			return err
 		}
-		statuslogger.Logf(ctx, "Created machine %s", md.colorize.Bold(fmtID))
+		sl.Logf("Created machine %s", fmtID)
 		return nil
 	}
 

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -101,6 +101,7 @@ func (md *machineDeployment) updateMachines(ctx context.Context, oldAppState, ne
 	}
 
 	group := errgroup.Group{}
+	group.SetLimit(md.maxConcurrent)
 	for idx, machPair := range machineTuples {
 		machPair := machPair
 		oldMachine := machPair.oldMachine
@@ -281,7 +282,7 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 
 	if !healthcheckResult.regularChecksPassed {
 		sl.Line(idx).LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Checking health of machine %s", machine.ID))
-		err = lm.WaitForHealthchecksToPass(ctx, 5*time.Minute)
+		err = lm.WaitForHealthchecksToPass(ctx, md.waitTimeout)
 		if err != nil {
 			return &unrecoverableError{err: err}
 		}

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -13,7 +13,6 @@ import (
 	"github.com/samber/lo"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/ctrlc"
-	"github.com/superfly/flyctl/internal/flapsutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/statuslogger"
 	"github.com/superfly/flyctl/internal/tracing"
@@ -250,8 +249,7 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 		return err
 	}
 
-	flapsClient := flapsutil.ClientFromContext(ctx)
-	lm := mach.NewLeasableMachine(flapsClient, io, machine, false)
+	lm := mach.NewLeasableMachine(md.flapsClient, io, machine, false)
 
 	shouldStart := lo.Contains([]string{"started", "replacing"}, newMachine.State)
 	span.SetAttributes(attribute.Bool("should_start", shouldStart))

--- a/internal/command/deploy/plan_test.go
+++ b/internal/command/deploy/plan_test.go
@@ -70,7 +70,7 @@ func TestAppState(t *testing.T) {
 	md := &machineDeployment{
 		flapsClient: flapsClient,
 	}
-	appState, error := md.appState(ctx)
+	appState, error := md.appState(ctx, nil)
 	assert.NoError(t, error)
 
 	assert.Equal(t, appState.Machines, machines)

--- a/internal/command/deploy/plan_test.go
+++ b/internal/command/deploy/plan_test.go
@@ -293,7 +293,7 @@ func TestUpdateMachines(t *testing.T) {
 	}
 
 	acquiredLeases = sync.Map{}
-	err := md.updateMachines(ctx, oldAppState, newAppState, nil, settings)
+	err := md.updateMachinesWRecovery(ctx, oldAppState, newAppState, nil, settings)
 	assert.NoError(t, err)
 
 	// let's make sure we retry deploys a few times
@@ -314,14 +314,14 @@ func TestUpdateMachines(t *testing.T) {
 		}, nil
 	}
 	acquiredLeases = sync.Map{}
-	err = md.updateMachines(ctx, oldAppState, newAppState, nil, settings)
+	err = md.updateMachinesWRecovery(ctx, oldAppState, newAppState, nil, settings)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, numFailures)
 
 	numFailures = 0
 	maxNumFailures = 10
 	acquiredLeases = sync.Map{}
-	err = md.updateMachines(ctx, oldAppState, newAppState, nil, settings)
+	err = md.updateMachinesWRecovery(ctx, oldAppState, newAppState, nil, settings)
 	assert.Error(t, err)
 
 	var sentUnrecoverable atomic.Bool
@@ -339,7 +339,7 @@ func TestUpdateMachines(t *testing.T) {
 		}
 	}
 	acquiredLeases = sync.Map{}
-	err = md.updateMachines(ctx, oldAppState, newAppState, nil, settings)
+	err = md.updateMachinesWRecovery(ctx, oldAppState, newAppState, nil, settings)
 	assert.Error(t, err)
 	var unrecoverableErr *unrecoverableError
 	assert.ErrorAs(t, err, &unrecoverableErr)

--- a/internal/command/deploy/plan_test.go
+++ b/internal/command/deploy/plan_test.go
@@ -2,6 +2,7 @@ package deploy
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -202,8 +203,14 @@ func TestUpdateMachines(t *testing.T) {
 		}
 	})
 
+	acquiredLeases := sync.Map{}
+
 	flapsClient := &mock.FlapsClient{
 		AcquireLeaseFunc: func(ctx context.Context, machineID string, ttl *int) (*fly.MachineLease, error) {
+			if _, ok := acquiredLeases.Load(machineID); ok {
+				return nil, assert.AnError
+			}
+			acquiredLeases.Store(machineID, true)
 			return &fly.MachineLease{
 				Data: &fly.MachineLeaseData{
 					Nonce: "nonce",
@@ -228,8 +235,12 @@ func TestUpdateMachines(t *testing.T) {
 			}, nil
 		},
 		WaitFunc: func(ctx context.Context, machine *fly.Machine, state string, timeout time.Duration) (err error) {
-			machine.State = state
-			return nil
+			if state == "started" {
+				machine.State = "started"
+				return nil
+			} else {
+				return assert.AnError
+			}
 		},
 		ListFunc: func(ctx context.Context, state string) ([]*fly.Machine, error) {
 			return oldMachines, nil
@@ -255,10 +266,10 @@ func TestUpdateMachines(t *testing.T) {
 		app: &fly.AppCompact{
 			Name: "myapp",
 		},
-		appConfig:     &appconfig.Config{AppName: "myapp"},
-		maxConcurrent: 3,
-		waitTimeout:   10 * time.Second,
-		deployRetries: 5,
+		appConfig:      &appconfig.Config{AppName: "myapp"},
+		waitTimeout:    10 * time.Second,
+		deployRetries:  5,
+		maxUnavailable: 3,
 	}
 
 	oldAppState := &AppState{
@@ -267,7 +278,15 @@ func TestUpdateMachines(t *testing.T) {
 	newAppState := &AppState{
 		Machines: newMachines,
 	}
-	err := md.updateMachines(ctx, oldAppState, newAppState, true, nil, false, false)
+	settings := updateMachineSettings{
+		pushForward:          true,
+		skipHealthChecks:     false,
+		skipSmokeChecks:      false,
+		skipLeaseAcquisition: false,
+	}
+
+	acquiredLeases = sync.Map{}
+	err := md.updateMachines(ctx, oldAppState, newAppState, nil, settings)
 	assert.NoError(t, err)
 
 	// let's make sure we retry deploys a few times
@@ -287,13 +306,15 @@ func TestUpdateMachines(t *testing.T) {
 			State:  "started",
 		}, nil
 	}
-	err = md.updateMachines(ctx, oldAppState, newAppState, true, nil, false, false)
+	acquiredLeases = sync.Map{}
+	err = md.updateMachines(ctx, oldAppState, newAppState, nil, settings)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, numFailures)
 
 	numFailures = 0
 	maxNumFailures = 10
-	err = md.updateMachines(ctx, oldAppState, newAppState, true, nil, false, false)
+	acquiredLeases = sync.Map{}
+	err = md.updateMachines(ctx, oldAppState, newAppState, nil, settings)
 	assert.Error(t, err)
 
 	var sentUnrecoverable atomic.Bool
@@ -310,7 +331,8 @@ func TestUpdateMachines(t *testing.T) {
 			}, nil
 		}
 	}
-	err = md.updateMachines(ctx, oldAppState, newAppState, true, nil, false, false)
+	acquiredLeases = sync.Map{}
+	err = md.updateMachines(ctx, oldAppState, newAppState, nil, settings)
 	assert.Error(t, err)
 	var unrecoverableErr *unrecoverableError
 	assert.ErrorAs(t, err, &unrecoverableErr)
@@ -323,13 +345,11 @@ func TestUpdateOrCreateMachine(t *testing.T) {
 	io := iostreams.System()
 	ctx = iostreams.NewContext(ctx, io)
 
-	acquiredLease := false
 	destroyedMachine := false
 	updatedMachine := false
 	createMachine := false
 
 	reset := func() {
-		acquiredLease = false
 		destroyedMachine = false
 		updatedMachine = false
 		createMachine = false
@@ -337,7 +357,6 @@ func TestUpdateOrCreateMachine(t *testing.T) {
 
 	flapsClient := &mock.FlapsClient{
 		AcquireLeaseFunc: func(ctx context.Context, machineID string, ttl *int) (*fly.MachineLease, error) {
-			acquiredLease = true
 			return &fly.MachineLease{
 				Data: &fly.MachineLeaseData{
 					Nonce: "nonce",
@@ -351,17 +370,19 @@ func TestUpdateOrCreateMachine(t *testing.T) {
 		UpdateFunc: func(ctx context.Context, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error) {
 			updatedMachine = true
 			return &fly.Machine{
-				ID:     builder.ID,
-				Config: builder.Config,
-				State:  "started",
+				ID:         builder.ID,
+				Config:     builder.Config,
+				State:      "started",
+				LeaseNonce: "nonce",
 			}, nil
 		},
 		LaunchFunc: func(ctx context.Context, builder fly.LaunchMachineInput) (out *fly.Machine, err error) {
 			createMachine = true
 			return &fly.Machine{
-				ID:     builder.ID,
-				Config: builder.Config,
-				State:  "started",
+				ID:         builder.ID,
+				Config:     builder.Config,
+				State:      "started",
+				LeaseNonce: "nonce",
 			}, nil
 		},
 	}
@@ -371,12 +392,14 @@ func TestUpdateOrCreateMachine(t *testing.T) {
 		Config: &fly.MachineConfig{
 			Image: "image1",
 		},
+		LeaseNonce: "nonce",
 	}
 	newMachine := &fly.Machine{
 		ID: "machine1",
 		Config: &fly.MachineConfig{
 			Image: "image2",
 		},
+		LeaseNonce: "nonce",
 	}
 
 	md := &machineDeployment{
@@ -395,7 +418,6 @@ func TestUpdateOrCreateMachine(t *testing.T) {
 	reset()
 	mach, lease, err := md.updateOrCreateMachine(ctx, oldMachine, nil, sl)
 	assert.NoError(t, err)
-	assert.True(t, acquiredLease)
 	assert.True(t, destroyedMachine)
 	assert.Nil(t, mach)
 	assert.Nil(t, lease)
@@ -404,17 +426,15 @@ func TestUpdateOrCreateMachine(t *testing.T) {
 	reset()
 	mach, lease, err = md.updateOrCreateMachine(ctx, oldMachine, newMachine, sl)
 	assert.NoError(t, err)
-	assert.True(t, acquiredLease)
 	assert.True(t, updatedMachine)
 	assert.NotNil(t, mach)
-	assert.NotNil(t, lease)
+	assert.Nil(t, lease)
 	assert.Equal(t, mach.Config, newMachine.Config)
 
 	// create new machine
 	reset()
 	mach, lease, err = md.updateOrCreateMachine(ctx, nil, newMachine, sl)
 	assert.NoError(t, err)
-	assert.True(t, acquiredLease)
 	assert.True(t, createMachine)
 	assert.NotNil(t, mach)
 	assert.NotNil(t, lease)
@@ -424,7 +444,6 @@ func TestUpdateOrCreateMachine(t *testing.T) {
 	reset()
 	mach, lease, err = md.updateOrCreateMachine(ctx, nil, nil, sl)
 	assert.NoError(t, err)
-	assert.False(t, acquiredLease)
 	assert.False(t, destroyedMachine)
 	assert.False(t, updatedMachine)
 	assert.False(t, createMachine)

--- a/internal/command/deploy/plan_test.go
+++ b/internal/command/deploy/plan_test.go
@@ -1,0 +1,313 @@
+package deploy
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/mock"
+	"github.com/superfly/flyctl/internal/statuslogger"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func TestCompareConfig(t *testing.T) {
+	t.Parallel()
+
+	// Test that two identical configs are equal
+	config1 := &fly.MachineConfig{
+		Image: "image1",
+		Metadata: map[string]string{
+			"fly_flyctl_version": "v1",
+		},
+	}
+	config2 := &fly.MachineConfig{
+		Image: "image1",
+		Metadata: map[string]string{
+			"fly_flyctl_version": "v1",
+		},
+	}
+
+	assert.True(t, compareConfigs(config1, config2))
+
+	// Test that fly_flyctl_version is ignored
+	config2.Metadata["fly_flyctl_version"] = "v2"
+	assert.True(t, compareConfigs(config1, config2))
+
+	// Test that different images are not equal
+	config2.Image = "image2"
+	assert.False(t, compareConfigs(config1, config2))
+}
+
+func TestAppState(t *testing.T) {
+	t.Parallel()
+
+	machines := []*fly.Machine{
+		{
+			ID:    "machine1",
+			State: "started",
+		},
+		{
+			ID:    "machine2",
+			State: "started",
+		},
+	}
+
+	flapsClient := &mock.FlapsClient{
+		ListFunc: func(ctx context.Context, state string) ([]*fly.Machine, error) {
+			return machines, nil
+		},
+	}
+
+	ctx := context.Background()
+	md := &machineDeployment{
+		flapsClient: flapsClient,
+	}
+	appState, error := md.appState(ctx)
+	assert.NoError(t, error)
+
+	assert.Equal(t, appState.Machines, machines)
+
+}
+
+func TestUpdateMachineConfig(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	io := iostreams.System()
+	ctx = iostreams.NewContext(ctx, io)
+
+	oldMachine := &fly.Machine{
+		ID: "machine1",
+		Config: &fly.MachineConfig{
+			Image: "image1",
+			Metadata: map[string]string{
+				"fly_flyctl_version": "v1",
+			},
+		},
+		LeaseNonce: "hi",
+	}
+	newMachineConfig := &fly.MachineConfig{
+		Image: "image1",
+		Metadata: map[string]string{
+			"fly_flyctl_version": "v1",
+		},
+	}
+
+	statuslogger := statuslogger.Create(ctx, 1, false)
+	sl := statuslogger.Line(0)
+
+	badFlapsClient := &mock.FlapsClient{
+		UpdateFunc: func(ctx context.Context, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error) {
+			return nil, assert.AnError
+		},
+	}
+	md := &machineDeployment{
+		flapsClient: badFlapsClient,
+		io:          io,
+		app: &fly.AppCompact{
+			Name: "myapp",
+		},
+		appConfig: &appconfig.Config{AppName: "myapp"},
+	}
+	_, err := md.updateMachineConfig(ctx, oldMachine, newMachineConfig, sl, false)
+	// updating a config with the same config should result in a noop, and shouldn't even use flaps
+	assert.NoError(t, err)
+
+	destroyedMachine := false
+	// recreate machines when we specify that
+	flapsClient := &mock.FlapsClient{
+		DestroyFunc: func(ctx context.Context, input fly.RemoveMachineInput, nonce string) (err error) {
+			destroyedMachine = true
+			return nil
+		},
+		UpdateFunc: func(ctx context.Context, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error) {
+			return &fly.Machine{
+				ID:     builder.ID,
+				Config: builder.Config,
+			}, nil
+		},
+		LaunchFunc: func(ctx context.Context, builder fly.LaunchMachineInput) (out *fly.Machine, err error) {
+			return &fly.Machine{
+				ID:     builder.ID,
+				Config: builder.Config,
+			}, nil
+		},
+
+		ReleaseLeaseFunc: func(ctx context.Context, machineID, nonce string) error {
+			return nil
+		},
+	}
+
+	newMachineConfig.Image = "image2"
+	md.flapsClient = flapsClient
+
+	// ensure that we're actually creating a new machine when we replace it
+	machine, err := md.updateMachineConfig(ctx, oldMachine, newMachineConfig, sl, true)
+	assert.NoError(t, err)
+	assert.Equal(t, machine.Config, newMachineConfig)
+	assert.NotEqual(t, machine.ID, "machine2")
+	assert.True(t, destroyedMachine)
+
+	// just a regular machine update
+	machine, err = md.updateMachineConfig(ctx, oldMachine, newMachineConfig, sl, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, machine)
+	assert.Equal(t, machine.Config, newMachineConfig)
+}
+
+func TestUpdateMachines(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	io := iostreams.System()
+	ctx = iostreams.NewContext(ctx, io)
+
+	oldMachines := []*fly.Machine{
+		{
+			ID:    "machine1",
+			State: "started",
+			Config: &fly.MachineConfig{
+				Image: "image1",
+			},
+		},
+		{
+			ID:    "machine2",
+			State: "started",
+			Config: &fly.MachineConfig{
+				Image: "image1",
+			},
+		},
+		{
+			ID:    "machine3",
+			State: "started",
+			Config: &fly.MachineConfig{
+				Image: "image1",
+			},
+		},
+	}
+	newMachines := lo.Map(oldMachines, func(m *fly.Machine, _ int) *fly.Machine {
+		return &fly.Machine{
+			ID:    m.ID,
+			State: "started",
+			Config: &fly.MachineConfig{
+				Image: "image2",
+			},
+		}
+	})
+
+	flapsClient := &mock.FlapsClient{
+		AcquireLeaseFunc: func(ctx context.Context, machineID string, ttl *int) (*fly.MachineLease, error) {
+			return &fly.MachineLease{
+				Data: &fly.MachineLeaseData{
+					Nonce: "nonce",
+				},
+			}, nil
+		},
+		ReleaseLeaseFunc: func(ctx context.Context, machineID, nonce string) error {
+			return nil
+		},
+		UpdateFunc: func(ctx context.Context, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error) {
+			return &fly.Machine{
+				ID:     builder.ID,
+				Config: builder.Config,
+				State:  "started",
+			}, nil
+		},
+		LaunchFunc: func(ctx context.Context, builder fly.LaunchMachineInput) (out *fly.Machine, err error) {
+			return &fly.Machine{
+				ID:     builder.ID,
+				Config: builder.Config,
+				State:  "started",
+			}, nil
+		},
+		WaitFunc: func(ctx context.Context, machine *fly.Machine, state string, timeout time.Duration) (err error) {
+			machine.State = state
+			return nil
+		},
+		ListFunc: func(ctx context.Context, state string) ([]*fly.Machine, error) {
+			return oldMachines, nil
+		},
+		StartFunc: func(ctx context.Context, machineID string, nonce string) (out *fly.MachineStartResponse, err error) {
+			return &fly.MachineStartResponse{}, nil
+		},
+		GetFunc: func(ctx context.Context, machineID string) (*fly.Machine, error) {
+			newMachine, _ := lo.Find(newMachines, func(m *fly.Machine) bool {
+				return m.ID == machineID
+			})
+			return newMachine, nil
+		},
+	}
+
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
+	md := &machineDeployment{
+		flapsClient: flapsClient,
+		io:          io,
+		app: &fly.AppCompact{
+			Name: "myapp",
+		},
+		appConfig:     &appconfig.Config{AppName: "myapp"},
+		maxConcurrent: 3,
+		waitTimeout:   10 * time.Second,
+		deployRetries: 5,
+	}
+
+	oldAppState := &AppState{
+		Machines: oldMachines,
+	}
+	newAppState := &AppState{
+		Machines: newMachines,
+	}
+	err := md.updateMachines(ctx, oldAppState, newAppState, true, nil, false, false)
+	assert.NoError(t, err)
+
+	// let's make sure we retry deploys a few times
+	numFailures := 0
+	maxNumFailures := 3
+	flapsClient.UpdateFunc = func(ctx context.Context, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error) {
+		if builder.ID == "machine2" {
+			numFailures++
+			if numFailures < maxNumFailures {
+				return nil, assert.AnError
+			}
+		}
+
+		return &fly.Machine{
+			ID:     builder.ID,
+			Config: builder.Config,
+			State:  "started",
+		}, nil
+	}
+	err = md.updateMachines(ctx, oldAppState, newAppState, true, nil, false, false)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, numFailures)
+
+	numFailures = 0
+	maxNumFailures = 10
+	err = md.updateMachines(ctx, oldAppState, newAppState, true, nil, false, false)
+	assert.Error(t, err)
+
+	var sentUnrecoverable atomic.Bool
+	// we only return a single unrecoverable error, but that's enough to fail the deploy
+	flapsClient.UpdateFunc = func(ctx context.Context, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error) {
+		if !sentUnrecoverable.Load() {
+			sentUnrecoverable.Store(true)
+			return nil, &unrecoverableError{err: assert.AnError}
+		} else {
+			return &fly.Machine{
+				ID:     builder.ID,
+				Config: builder.Config,
+				State:  "started",
+			}, nil
+		}
+	}
+	err = md.updateMachines(ctx, oldAppState, newAppState, true, nil, false, false)
+	assert.Error(t, err)
+	var unrecoverableErr *unrecoverableError
+	assert.ErrorAs(t, err, &unrecoverableErr)
+}

--- a/internal/command/deploy/plan_test.go
+++ b/internal/command/deploy/plan_test.go
@@ -243,6 +243,9 @@ func TestUpdateMachines(t *testing.T) {
 			})
 			return newMachine, nil
 		},
+		GetProcessesFunc: func(ctx context.Context, machineID string) (fly.MachinePsResponse, error) {
+			return fly.MachinePsResponse{}, nil
+		},
 	}
 
 	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)

--- a/internal/command/deploy/plan_test.go
+++ b/internal/command/deploy/plan_test.go
@@ -257,6 +257,13 @@ func TestUpdateMachines(t *testing.T) {
 		GetProcessesFunc: func(ctx context.Context, machineID string) (fly.MachinePsResponse, error) {
 			return fly.MachinePsResponse{}, nil
 		},
+		RefreshLeaseFunc: func(ctx context.Context, machineID string, ttl *int, nonce string) (*fly.MachineLease, error) {
+			return &fly.MachineLease{
+				Data: &fly.MachineLeaseData{
+					Nonce: "nonce",
+				},
+			}, nil
+		},
 	}
 
 	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)

--- a/internal/command/deploy/plan_test.go
+++ b/internal/command/deploy/plan_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestCompareConfig(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	// Test that two identical configs are equal
 	config1 := &fly.MachineConfig{
@@ -33,15 +34,15 @@ func TestCompareConfig(t *testing.T) {
 		},
 	}
 
-	assert.True(t, compareConfigs(config1, config2))
+	assert.True(t, compareConfigs(ctx, config1, config2))
 
 	// Test that fly_flyctl_version is ignored
 	config2.Metadata["fly_flyctl_version"] = "v2"
-	assert.True(t, compareConfigs(config1, config2))
+	assert.True(t, compareConfigs(ctx, config1, config2))
 
 	// Test that different images are not equal
 	config2.Image = "image2"
-	assert.False(t, compareConfigs(config1, config2))
+	assert.False(t, compareConfigs(ctx, config1, config2))
 }
 
 func TestAppState(t *testing.T) {

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -159,7 +159,7 @@ func (bg *blueGreen) CreateGreenMachines(ctx context.Context) error {
 				return err
 			}
 
-			greenMachine := machine.NewLeasableMachine(bg.flaps, bg.io, newMachineRaw)
+			greenMachine := machine.NewLeasableMachine(bg.flaps, bg.io, newMachineRaw, true)
 			defer greenMachine.ReleaseLease(ctx)
 
 			lock.Lock()

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -265,7 +265,9 @@ func (lm *leasableMachine) WaitForSmokeChecksToPass(ctx context.Context) error {
 		Jitter: true,
 	}
 
-	statuslogger.Logf(ctx, "Checking that %s is up and running", lm.colorize.Bold(lm.FormattedMachineId()))
+	if lm.showLogs {
+		statuslogger.Logf(ctx, "Checking that %s is up and running", lm.colorize.Bold(lm.FormattedMachineId()))
+	}
 
 	for {
 		machine, err := lm.flapsClient.Get(waitCtx, lm.Machine().ID)

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -162,7 +162,9 @@ func (lm *leasableMachine) Start(ctx context.Context) error {
 	if lm.HasLease() {
 		return fmt.Errorf("error cannot start machine %s because it has a lease", lm.machine.ID)
 	}
-	lm.logStatusWaiting(ctx, fly.MachineStateStarted)
+	if lm.showLogs {
+		lm.logStatusWaiting(ctx, fly.MachineStateStarted)
+	}
 	_, err := lm.flapsClient.Start(ctx, lm.machine.ID, "")
 	if err != nil {
 		return err

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -358,7 +358,9 @@ func (lm *leasableMachine) WaitForEventType(ctx context.Context, eventType strin
 		Factor: 2,
 		Jitter: true,
 	}
-	statuslogger.Logf(ctx, "Waiting for %s to get %s event", lm.colorize.Bold(lm.FormattedMachineId()), lm.colorize.Yellow(eventType))
+	if lm.showLogs {
+		statuslogger.Logf(ctx, "Waiting for %s to get %s event", lm.colorize.Bold(lm.FormattedMachineId()), lm.colorize.Yellow(eventType))
+	}
 	for {
 		updateMachine, err := lm.flapsClient.Get(waitCtx, lm.Machine().ID)
 		switch {

--- a/internal/machine/machine_set.go
+++ b/internal/machine/machine_set.go
@@ -31,10 +31,10 @@ type machineSet struct {
 	machines []LeasableMachine
 }
 
-func NewMachineSet(flapsClient flapsutil.FlapsClient, io *iostreams.IOStreams, machines []*fly.Machine) *machineSet {
+func NewMachineSet(flapsClient flapsutil.FlapsClient, io *iostreams.IOStreams, machines []*fly.Machine, showLogs bool) *machineSet {
 	leaseMachines := make([]LeasableMachine, 0)
 	for _, m := range machines {
-		leaseMachines = append(leaseMachines, NewLeasableMachine(flapsClient, io, m, true))
+		leaseMachines = append(leaseMachines, NewLeasableMachine(flapsClient, io, m, showLogs))
 	}
 	return &machineSet{
 		machines: leaseMachines,

--- a/internal/machine/machine_set.go
+++ b/internal/machine/machine_set.go
@@ -34,7 +34,7 @@ type machineSet struct {
 func NewMachineSet(flapsClient flapsutil.FlapsClient, io *iostreams.IOStreams, machines []*fly.Machine) *machineSet {
 	leaseMachines := make([]LeasableMachine, 0)
 	for _, m := range machines {
-		leaseMachines = append(leaseMachines, NewLeasableMachine(flapsClient, io, m))
+		leaseMachines = append(leaseMachines, NewLeasableMachine(flapsClient, io, m, true))
 	}
 	return &machineSet{
 		machines: leaseMachines,


### PR DESCRIPTION
### Change Summary

What and Why:
This PR focuses on trying to change how machine updates work. Instead of failing whenever one machine isn't able to update, we instead try again, making sure to not redo any work that we'd already completed. We do this by keeping track of 'app state', which is basically a list of all the machines we have in our app. This works great since it includes machine states, machine configs, and mounts.

Sometimes, certain errors aren't worth retrying. For example, if we aren't able to acquire a lease on your machine because it's already being held, then it's more likely than not that retrying won't do any good. In that case, we return an 'unrecoverable error', and choose to completely fail the deploy. In certain cases, we could try rolling back to how we were (for example, if health checks fail we could rollback), though I'm saving that implementation for a future PR

How:
We will continue to try to finish a deploy a few times, until either:
a. the deploy completes successfully, meaning we transitioned from the old app state to the new app state
b. we've exhausted a certain number of attempts to complete a deploy without success
c. we encountered an unrecoverable error, meaning that flyctl doesn't think it's worth attempting a retry

In the first case, flyctl is much more resilient to intermittent platform errors, which can happen pretty often. In the second case, it's likely that there's something wrong with either the user's environment or the platform itself. If it's the former, then @rugwirobaker 's work to move orchestration logic into a new fly machine will help with those cases in the future. If it's the latter, we're working on setting up alerting to try and learn about these cases sooner. In the third case, the goal in the future is to add suggestions to the user to help recover from these sorts of issues.

The bulk of the code is in `internal/command/deploy/plan.go`

Related to:
https://flyio.discourse.team/t/deployments-roadmap-discussion/6326
https://flyio.discourse.team/t/deployments-roadmap-redux/6451
https://flyio.discourse.team/t/deployment-recoverability/6441
---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
