### PR TITLE
Allow machine checks without a service

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -58,6 +58,8 @@ type Config struct {
 	Files            []File                    `toml:"files,omitempty" json:"files,omitempty"`
 	HostDedicationID string                    `toml:"host_dedication_id,omitempty" json:"host_dedication_id,omitempty"`
 
+	MachineChecks []*ServiceMachineCheck `toml:"machine_checks,omitempty" json:"machine_checks,omitempty"`
+
 	Restart []Restart `toml:"restart,omitempty" json:"restart,omitempty"`
 
 	Compute []*Compute `toml:"vm,omitempty" json:"vm,omitempty"`

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -237,6 +237,15 @@ func TestToDefinition(t *testing.T) {
 				},
 			},
 		},
+		"machine_checks": []any{
+			map[string]any{
+				"command":      []any{"curl", "https://fly.io"},
+				"image":        "curlimages/curl",
+				"entrypoint":   []any{"/bin/sh"},
+				"kill_signal":  "SIGKILL",
+				"kill_timeout": "5s",
+			},
+		},
 		"experimental": map[string]any{
 			"cmd":           []any{"cmd"},
 			"entrypoint":    []any{"entrypoint"},

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -464,6 +464,16 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 			},
 		},
 
+		MachineChecks: []*ServiceMachineCheck{
+			{
+				Command:     []string{"curl", "https://fly.io"},
+				Entrypoint:  []string{"/bin/sh"},
+				Image:       "curlimages/curl",
+				KillSignal:  fly.StringPointer("SIGKILL"),
+				KillTimeout: fly.MustParseDuration("5s"),
+			},
+		},
+
 		Statics: []Static{
 			{
 				GuestPath:     "/path/to/statics",

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -162,6 +162,13 @@ host_dedication_id = "06031957"
     Content-Type = "application/json"
     Authorization = "super-duper-secret"
 
+[[machine_checks]]
+   command = ["curl", "https://fly.io"]
+   image = "curlimages/curl"
+   entrypoint = ["/bin/sh"]
+   kill_timeout = "5s"
+   kill_signal = "SIGKILL"
+
 [[services]]
   internal_port = 8081
   protocol = "tcp"

--- a/internal/command/deploy/machinebasedtest.go
+++ b/internal/command/deploy/machinebasedtest.go
@@ -43,6 +43,7 @@ func (md *machineDeployment) runTestMachines(ctx context.Context, machineToTest 
 			return nil
 		}
 	})
+	machineChecks = append(machineChecks, md.appConfig.MachineChecks...)
 
 	if len(machineChecks) == 0 {
 		span.AddEvent("no machine checks")

--- a/test/preflight/fly_deploy_test.go
+++ b/test/preflight/fly_deploy_test.go
@@ -257,8 +257,8 @@ func TestFlyDeploy_NoServiceDeployMachinesCheck(t *testing.T) {
 	appConfig := f.ReadFile("fly.toml")
 	appConfig += `
 		[[machine_checks]]
-            image = "curlimages/curl"
-   			entrypoint = ["/bin/sh", "-c"]
+			image = "curlimages/curl"
+			entrypoint = ["/bin/sh", "-c"]
 			command = ["curl http://[$FLY_TEST_MACHINE_IP]:80"]
 		`
 	f.WriteFlyToml(appConfig)


### PR DESCRIPTION
### Change Summary

What and Why:
Some customers want to be able to use machine checks for apps that only use private communications, which is a very fair use case.

How:
 In order to allow for this, we just allow putting machine_checks at the top level of a fly.toml

Related to:
https://github.com/superfly/customer-help/issues/55

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
