### PR TITLE
Option to launch without creating an app

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -106,6 +106,10 @@ func New() (cmd *cobra.Command) {
 			Name:        "yaml",
 			Description: "Generate configuration in YAML format",
 		},
+		flag.Bool{
+			Name:        "no-create",
+			Description: "Do not create an app, only generate configuration files",
+		},
 	)
 
 	return
@@ -187,20 +191,22 @@ func run(ctx context.Context) (err error) {
 
 	var state *launchState = nil
 
-	defer func() {
-		if err != nil {
-			tracing.RecordError(span, err, "launch failed")
-			status.Error = err.Error()
+	if !flag.GetBool(ctx, "no-create") {
+		defer func() {
+			if err != nil {
+				tracing.RecordError(span, err, "launch failed")
+				status.Error = err.Error()
 
-			if state != nil && state.sourceInfo != nil && state.sourceInfo.FailureCallback != nil {
-				err = state.sourceInfo.FailureCallback(err)
+				if state != nil && state.sourceInfo != nil && state.sourceInfo.FailureCallback != nil {
+					err = state.sourceInfo.FailureCallback(err)
+				}
 			}
-		}
 
-		status.TraceID = span.SpanContext().TraceID().String()
-		status.Duration = time.Since(startTime)
-		metrics.LaunchStatus(ctx, status)
-	}()
+			status.TraceID = span.SpanContext().TraceID().String()
+			status.Duration = time.Since(startTime)
+			metrics.LaunchStatus(ctx, status)
+		}()
+	}
 
 	if err := warnLegacyBehavior(ctx); err != nil {
 		return err

--- a/internal/command/launch/deploy.go
+++ b/internal/command/launch/deploy.go
@@ -27,6 +27,7 @@ func (state *launchState) firstDeploy(ctx context.Context) error {
 	}
 
 	// TODO(Allison): Do we want to make the executive decision to just *always* deploy?
+	// Feedback(Sam): scanners need the abiiity to abort the deploy if they detect a problem
 
 	deployNow := true
 	// deployNow := false
@@ -40,6 +41,10 @@ func (state *launchState) firstDeploy(ctx context.Context) error {
 	if flag.GetBool(ctx, "now") {
 		deployNow = true
 		// promptForDeploy = false
+	}
+
+	if flag.GetBool(ctx, "no-create") {
+		deployNow = false
 	}
 
 	/*


### PR DESCRIPTION
If --no-create is specified, it won't create an app, won't create databases, and won't deploy.

Note: you will still be prompted if you wish to tweak your settings as any changes you make there can potentially change what outputs are generated.  Furthermore, retaining this is useful for exercising the launch UI.  This can be avoided by adding a --yes flag.