### PR TITLE
Replace the machine if the host isn't accpepting inplace updates

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -730,7 +730,8 @@ func (md *machineDeployment) updateMachine(ctx context.Context, e *machineUpdate
 			// Replacing a machine with a volume will cause the placement logic to pick wthe same host
 			// dismissing the value of replacing it in case of lack of host capacity
 			return err
-		case strings.Contains(err.Error(), "could not reserve resource for machine"):
+		case strings.Contains(err.Error(), "could not reserve resource for machine"),
+			strings.Contains(err.Error(), "deploys to this host are temporarily disabled"):
 			return replaceMachine()
 		default:
 			return err


### PR DESCRIPTION
### Change Summary

What and Why: Machines whose hosts are under maintenance can't be updated in-place causing the whole deployment to fail

```
failed to update VM 148e290xxxx948: unavailable: deploys to this host are temporarily disabled, please try again later or check the status page: https://status.flyio.net/
```

How: Replace the whole machine instead of updating it in-place, it is a bit slower but gets the deployment going. 

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
