### PR TITLE
switch http -> https when getting builder settings

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -245,7 +245,7 @@ func newRemoteDockerClient(ctx context.Context, apiClient flyutil.Client, appNam
 		}
 
 		url := fmt.Sprintf("https://%s.fly.dev/flyio/v1/settings", app.Name)
-		// url := fmt.Sprintf("https://%s.fly.dev/flyio/v1/prune?since='12h'", app.Name)
+		
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -244,8 +244,8 @@ func newRemoteDockerClient(ctx context.Context, apiClient flyutil.Client, appNam
 			},
 		}
 
-		url := fmt.Sprintf("http://%s.fly.dev/flyio/v1/settings", app.Name)
-		// url := fmt.Sprintf("http://%s.fly.dev/flyio/v1/prune?since='12h'", app.Name)
+		url := fmt.Sprintf("https://%s.fly.dev/flyio/v1/settings", app.Name)
+		// url := fmt.Sprintf("https://%s.fly.dev/flyio/v1/prune?since='12h'", app.Name)
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -245,7 +245,6 @@ func newRemoteDockerClient(ctx context.Context, apiClient flyutil.Client, appNam
 		}
 
 		url := fmt.Sprintf("https://%s.fly.dev/flyio/v1/settings", app.Name)
-		
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {


### PR DESCRIPTION
### Change Summary

What and Why:
When we GET builder settings, we should do it over https, since it's not prone to MitM

How:
http -> https

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
