### PR TITLE
Hide `fly pg barman` and explicitly point to `fly pg backup`.

### DIFF
--- a/internal/command/postgres/barman.go
+++ b/internal/command/postgres/barman.go
@@ -39,11 +39,12 @@ var (
 
 func newBarman() *cobra.Command {
 	const (
-		short = "Manage databases in a cluster (Deprecated)"
+		short = "Manage databases in a cluster (Deprecated, use `fly pg backup` instead)"
 		long  = short + "\n"
 	)
 
 	cmd := command.New("barman", short, long, nil)
+	cmd.Hidden = true
 
 	cmd.AddCommand(
 		newCreateBarman(),


### PR DESCRIPTION
### Change Summary

Hide `fly pg barman`, directing users to `fly pg backup` in its help text.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
