### PR TITLE
Add link to fly apps move doc

### DIFF
--- a/internal/command/apps/move.go
+++ b/internal/command/apps/move.go
@@ -21,7 +21,7 @@ func newMove() *cobra.Command {
 	const (
 		long = `Move an application to another
 organization the current user belongs to.
-`
+For details, see https://fly.io/docs/apps/move-app-org/.`
 		short = "Move an app to another organization."
 		usage = "move <app name>"
 	)


### PR DESCRIPTION
### Change Summary

What and Why:

There's a new doc that explains more about the `fly apps move` command so we're gonna link to it from the help.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a
