### PR TITLE
change incident json url

### DIFF
--- a/internal/incidents/statuspage.go
+++ b/internal/incidents/statuspage.go
@@ -40,7 +40,7 @@ func getStatuspageUnresolvedIncidentsUrl() string {
 		return url
 	}
 
-	return "https://status.flyio.net/api/v2/incidents/unresolved.json"
+	return "https://incidents.flyio.net/v1/incidents"
 }
 
 func QueryStatuspageIncidents(ctx context.Context) {


### PR DESCRIPTION
### Change Summary

What and Why:
Change the url we hit for incidents from statuspage directly to a proxy. Do this so we can better filter out incidents that don't need to be announced on the CLI

### Related to:

https://flyio.discourse.team/t/things-that-were-saying-that-may-be-hurting-our-reliability-rep/6515/22

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
