### PR TITLE
if a launch source and target is specified, use org from currrent app

### DIFF
--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -24,10 +24,6 @@ func (state *launchState) Launch(ctx context.Context) error {
 
 	io := iostreams.FromContext(ctx)
 
-	// TODO(Allison): are we still supporting the launch-into usecase?
-	// I'm assuming *not* for now, because it's confusing UX and this
-	// is the perfect time to remove it.
-
 	if err := state.updateComputeFromDeprecatedGuestFields(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
Source can be --from or --image
Target is --into
This only applies if there is a fly.toml in the current working directory