### PR TITLE
fly deploy --flycast

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -183,24 +183,32 @@ func (c *Config) SetConfigFilePath(configFilePath string) {
 	c.configFilePath = configFilePath
 }
 
-func (c *Config) HasNonHttpAndHttpsStandardServices() bool {
+func (c *Config) DetermineIPType(ipType string) string {
+	// If the app is a flycast app, then it requires a private IP
+	if ipType == "private" {
+		return "private"
+	}
+
+	// If there is a service that is not http or https on standard points, then it requires a dedicated IP
 	for _, service := range c.Services {
 		switch service.Protocol {
 		case "udp":
-			return true
+			return "dedicated"
 		case "tcp":
 			for _, p := range service.Ports {
 				if p.HasNonHttpPorts() {
-					return true
+					return "dedicated"
 				} else if p.ContainsPort(80) && !reflect.DeepEqual(p.Handlers, []string{"http"}) {
-					return true
+					return "dedicated"
 				} else if p.ContainsPort(443) && !(reflect.DeepEqual(p.Handlers, []string{"http", "tls"}) || reflect.DeepEqual(p.Handlers, []string{"tls", "http"})) {
-					return true
+					return "dedicated"
 				}
 			}
 		}
 	}
-	return false
+
+	// Use shared IP if there are no services that require a dedicated IP
+	return "shared"
 }
 
 // IsUsingGPU returns true if any VMs have a gpu-kind set.

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -153,7 +153,7 @@ func TestCloneAppconfig(t *testing.T) {
 		"expected deep copy, but cloned object was modified by change to original config")
 }
 
-func TestHasNonHttpAndHttpsStandardServices(t *testing.T) {
+func TestDetermineIPType(t *testing.T) {
 	port80 := 80
 	port443 := 443
 
@@ -161,37 +161,39 @@ func TestHasNonHttpAndHttpsStandardServices(t *testing.T) {
 	cfg1.Services = []Service{{Protocol: "tcp", Ports: []fly.MachinePort{
 		{Port: &port80, Handlers: []string{"http"}},
 	}}}
-	assert.False(t, cfg1.HasNonHttpAndHttpsStandardServices())
+	assert.Equal(t, "shared", cfg1.DetermineIPType("public"))
+	assert.Equal(t, "private", cfg1.DetermineIPType("private"))
 
 	cfg2 := NewConfig()
 	cfg2.Services = []Service{{Protocol: "tcp", Ports: []fly.MachinePort{
 		{Port: &port443, Handlers: []string{"tls", "http"}},
 	}}}
-	assert.False(t, cfg2.HasNonHttpAndHttpsStandardServices())
+	assert.Equal(t, "shared", cfg2.DetermineIPType("public"))
 
 	cfg3 := NewConfig()
 	cfg3.Services = []Service{{Protocol: "tcp", Ports: []fly.MachinePort{
 		{Port: &port443, Handlers: []string{"http", "tls"}},
 	}}}
-	assert.False(t, cfg3.HasNonHttpAndHttpsStandardServices())
+	assert.Equal(t, "shared", cfg3.DetermineIPType("public"))
 
 	cfg4 := NewConfig()
 	cfg4.Services = []Service{{Protocol: "tcp", Ports: []fly.MachinePort{
 		{Port: &port443, Handlers: []string{"tls", "weird"}},
 	}}}
-	assert.True(t, cfg4.HasNonHttpAndHttpsStandardServices())
+	assert.Equal(t, "dedicated", cfg4.DetermineIPType("public"))
+	assert.Equal(t, "private", cfg4.DetermineIPType("private"))
 
 	cfg5 := NewConfig()
 	cfg5.Services = []Service{{Protocol: "tcp", Ports: []fly.MachinePort{
 		{Port: &port443, Handlers: []string{"tls"}},
 	}}}
-	assert.True(t, cfg5.HasNonHttpAndHttpsStandardServices())
+	assert.Equal(t, "dedicated", cfg5.DetermineIPType("public"))
 
 	cfg6 := NewConfig()
 	cfg6.Services = []Service{{Protocol: "udp", Ports: []fly.MachinePort{
 		{Port: &port443, Handlers: []string{"tls", "http"}},
 	}}}
-	assert.True(t, cfg6.HasNonHttpAndHttpsStandardServices())
+	assert.Equal(t, "dedicated", cfg6.DetermineIPType("public"))
 }
 
 func TestURL(t *testing.T) {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -110,6 +110,10 @@ var CommonFlags = flag.Set{
 		Name:        "no-public-ips",
 		Description: "Do not allocate any new public IP addresses",
 	},
+	flag.Bool{
+		Name:        "flycast",
+		Description: "Allocate a private IPv6 addresses",
+	},
 	flag.StringArray{
 		Name:        "file-local",
 		Description: "Set of files in the form of /path/inside/machine=<local/path> pairs. Can be specified multiple times.",
@@ -508,6 +512,13 @@ func deployToMachines(
 		deployRetries = retries
 	}
 
+	var ip = "public"
+	if flag.GetBool(ctx, "flycast") {
+		ip = "private"
+	} else if flag.GetBool(ctx, "no-public-ips") {
+		ip = "none"
+	}
+
 	md, err := NewMachineDeployment(ctx, MachineDeploymentArgs{
 		AppCompact:            app,
 		DeploymentImage:       img.Tag,
@@ -525,7 +536,8 @@ func deployToMachines(
 		MaxUnavailable:        maxUnavailable,
 		Guest:                 guest,
 		IncreasedAvailability: flag.GetBool(ctx, "ha"),
-		AllocPublicIP:         !flag.GetBool(ctx, "no-public-ips"),
+		AllocIP:               ip,
+		Org:                   app.Organization.Slug,
 		UpdateOnly:            flag.GetBool(ctx, "update-only"),
 		Files:                 files,
 		ExcludeRegions:        excludeRegions,

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -60,7 +60,8 @@ type MachineDeploymentArgs struct {
 	ReleaseCmdTimeout     *time.Duration
 	Guest                 *fly.MachineGuest
 	IncreasedAvailability bool
-	AllocPublicIP         bool
+	AllocIP               string
+	Org                   string
 	UpdateOnly            bool
 	Files                 []*fly.File
 	ExcludeRegions        map[string]bool
@@ -261,7 +262,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (_ Ma
 	}
 
 	// Provisioning must come after setVolumes
-	if err := md.provisionFirstDeploy(ctx, args.AllocPublicIP); err != nil {
+	if err := md.provisionFirstDeploy(ctx, args.AllocIP, args.Org); err != nil {
 		tracing.RecordError(span, err, "failed to provision first depoloy")
 		return nil, err
 	}


### PR DESCRIPTION
(also applies to fly launch)

Go from two strategies (dedicated and shared) to three (add private).

The purpose of this change is to help streamline deployment of flycast applications.