### PR TITLE
[fix] support files in release command machines

### DIFF
--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -59,6 +59,10 @@ func (c *Config) ToReleaseMachineConfig() (*fly.MachineConfig, error) {
 	// StopConfig
 	c.tomachineSetStopConfig(mConfig)
 
+	// Files
+	mConfig.Files = nil
+	fly.MergeFiles(mConfig, c.MergedFiles)
+
 	return mConfig, nil
 }
 


### PR DESCRIPTION
### Change Summary

What and Why:

Currently, if a user wants to rely on any `files` defined in `fly.toml` for the release command it fails because it is not included in the machine config.

How:

Use the same logic for defining files on the machine config for release command machines as we do for "normal" machines.

Related to:

Customer Ticket

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
