### PR TITLE
show kubernetes in fly ext help

### DIFF
--- a/internal/command/extensions/kubernetes/kubernetes.go
+++ b/internal/command/extensions/kubernetes/kubernetes.go
@@ -15,6 +15,6 @@ func New() (cmd *cobra.Command) {
 	cmd = command.New("kubernetes", short, long, nil)
 	cmd.Aliases = []string{"k8s"}
 	cmd.AddCommand(create(), destroy(), list(), kubectlToken(), saveKubeconfig())
-	cmd.Hidden = true
+	cmd.Hidden = false
 	return cmd
 }


### PR DESCRIPTION
### Change Summary

What and Why:

The kubernetes command was hidden. It shouldn't be.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
