### PR TITLE
Restrict synthetic monitoring targets to Fly infra hosts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/pkg/sftp v1.13.6
 	github.com/prometheus/blackbox_exporter v0.25.0
 	github.com/prometheus/client_golang v1.19.1
+	github.com/prometheus/client_model v0.6.1
 	github.com/r3labs/diff v1.1.0
 	github.com/samber/lo v1.46.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
@@ -223,7 +224,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.52.2 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rivo/tview v0.0.0-20220307222120-9994674d60a8 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,7 +174,7 @@ func (cfg *Config) applyFile(path string) (err error) {
 	}
 	w.SendMetrics = true
 	w.AutoUpdate = true
-	w.SyntheticsAgent = false
+	w.SyntheticsAgent = true
 
 	if err = unmarshal(path, &w); err == nil {
 		cfg.Tokens = tokens.ParseFromFile(w.AccessToken, path)

--- a/internal/metrics/synthetics/agent.go
+++ b/internal/metrics/synthetics/agent.go
@@ -4,16 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
+	"net/url"
 	"os"
 	"time"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
-	"github.com/prometheus/blackbox_exporter/config"
-	"github.com/prometheus/blackbox_exporter/prober"
-	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/superfly/flyctl/internal/logger"
-	"nhooyr.io/websocket"
 )
 
 func RunAgent(ctx context.Context) error {
@@ -66,37 +64,9 @@ func RunAgent(ctx context.Context) error {
 		}
 	}()
 
-	go listen(ctx, ws)
+	go ws.listen(ctx)
 
 	return nil
-}
-
-func listen(ctx context.Context, ws *SyntheticsWs) error {
-	logger := logger.FromContext(ctx)
-	logger.Debug("start listening for probes")
-	for ctx.Err() == nil {
-		ws.lock.RLock()
-		c := ws.wsConn
-		ws.lock.RUnlock()
-
-		_, message, err := c.Read(ctx)
-		if err != nil {
-			logger.Error("read error: ", err)
-			ws.resetConn(c, err)
-			continue
-		}
-
-		logger.Debug("received from server", string(message))
-
-		err = processProbe(ctx, message, ws)
-		if err != nil {
-			logger.Error("failed processing probe", err)
-		}
-
-	}
-	logger.Debug("stop listening for probes")
-
-	return ctx.Err()
 }
 
 type ProbeMessage struct {
@@ -105,55 +75,35 @@ type ProbeMessage struct {
 	IPProtocol string `json:"ip_protocol"`
 }
 
-func processProbe(ctx context.Context, jsonMessage []byte, ws *SyntheticsWs) error {
+func processProbe(ctx context.Context, probeMessageJSON []byte, ws *SyntheticsWs) error {
 	logger := logger.FromContext(ctx)
 	logger.Debug("proccessing probes")
 
 	probeMessage := ProbeMessage{}
-	err := json.Unmarshal(jsonMessage, &probeMessage)
+	err := json.Unmarshal(probeMessageJSON, &probeMessage)
 	if err != nil {
 		logger.Error("JSON parse error:", err)
 		return err
 	}
 
-	probeSuccessGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "probe_success",
-		Help: "Displays whether or not the probe was a success",
-	})
-	probeDurationGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "probe_duration_seconds",
-		Help: "Returns how long the probe took to complete in seconds",
-	})
+	var (
+		buf    bytes.Buffer
+		mfs    []*dto.MetricFamily
+		logBuf bytes.Buffer
+	)
 
-	module := config.Module{}
-	module.HTTP = config.DefaultHTTPProbe
-
-	module.HTTP.IPProtocol = probeMessage.IPProtocol
-
-	var logBuf bytes.Buffer
 	sl := log.NewLogfmtLogger(log.NewSyncWriter(&logBuf))
 
-	start := time.Now()
-	registry := prometheus.NewRegistry()
-	registry.MustRegister(probeSuccessGauge)
-	registry.MustRegister(probeDurationGauge)
-	success := prober.ProbeHTTP(ctx, probeMessage.Target, module, registry, sl)
-	duration := time.Since(start).Seconds()
-	probeDurationGauge.Set(duration)
-
-	if success {
-		probeSuccessGauge.Set(1)
-		level.Info(sl).Log("msg", "Probe succeeded", "duration_seconds", duration)
+	if !isFlyInfraTarget(probeMessage.Target) {
+		logger.Warnf("skipping probe message for non-fly infra endpoint %s", probeMessage.Target)
 	} else {
-		level.Error(sl).Log("msg", "Probe failed", "duration_seconds", duration)
+		mfs, err = probeHTTP(ctx, probeMessage, sl)
+		if err != nil {
+			logger.Errorf("error processing probe for endpoint %s. error: %v", probeMessage.Target, err)
+			return err
+		}
 	}
 
-	mfs, err := registry.Gather()
-	if err != nil {
-		return err
-	}
-
-	var buf bytes.Buffer
 	encoder := json.NewEncoder(&buf)
 	err = encoder.Encode(mfs)
 	if err != nil {
@@ -161,18 +111,35 @@ func processProbe(ctx context.Context, jsonMessage []byte, ws *SyntheticsWs) err
 	}
 
 	data := buf.Bytes()
-
-	ws.lock.RLock()
-	c := ws.wsConn
-	ws.lock.RUnlock()
-
-	err = c.Write(ctx, websocket.MessageText, data)
+	err = ws.write(ctx, data)
 	if err != nil {
-		logger.Error("write error: ", err)
-		ws.resetConn(c, err)
 		return err
 	}
+
 	logger.Debugf("probe result sent to server. log: %s", &logBuf)
 
 	return nil
+}
+
+func isFlyInfraTarget(target string) bool {
+	var flyInfraHosts = map[string]bool{
+		"api.fly.io":       true,
+		"api.machines.dev": true,
+		"fly.io":           true,
+		"registry.fly.io":  true,
+	}
+
+	parsedURL, err := url.Parse(target)
+	if err != nil {
+		return false
+	}
+
+	host, _, err := net.SplitHostPort(parsedURL.Host)
+	if err != nil {
+		host = parsedURL.Host
+	}
+
+	_, existsInFlyInfraDomains := flyInfraHosts[host]
+
+	return existsInFlyInfraDomains
 }

--- a/internal/metrics/synthetics/prober.go
+++ b/internal/metrics/synthetics/prober.go
@@ -1,0 +1,51 @@
+package synthetics
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/blackbox_exporter/config"
+	"github.com/prometheus/blackbox_exporter/prober"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func probeHTTP(ctx context.Context, probeMessage ProbeMessage, sl log.Logger) (mfs []*dto.MetricFamily, err error) {
+	probeSuccessGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "probe_success",
+		Help: "Displays whether or not the probe was a success",
+	})
+	probeDurationGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "probe_duration_seconds",
+		Help: "Returns how long the probe took to complete in seconds",
+	})
+
+	module := config.Module{}
+	module.HTTP = config.DefaultHTTPProbe
+
+	module.HTTP.IPProtocol = probeMessage.IPProtocol
+
+	start := time.Now()
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(probeSuccessGauge)
+	registry.MustRegister(probeDurationGauge)
+	success := prober.ProbeHTTP(ctx, probeMessage.Target, module, registry, sl)
+	duration := time.Since(start).Seconds()
+	probeDurationGauge.Set(duration)
+
+	if success {
+		probeSuccessGauge.Set(1)
+		level.Info(sl).Log("msg", "Probe succeeded", "duration_seconds", duration)
+	} else {
+		level.Error(sl).Log("msg", "Probe failed", "duration_seconds", duration)
+	}
+
+	mfs, err = registry.Gather()
+	if err != nil {
+		return nil, err
+	}
+
+	return mfs, nil
+}


### PR DESCRIPTION
### Change Summary

What and Why:

Because of the concerns raised after [Fresh Produce](https://community.fly.io/t/we-are-building-synthetic-monitoring-would-you-help-us/20929) we are restricting the synthetic monitoring to Fly infra by now ([context](https://flyio.discourse.team/t/pitch-synthetic-monitoring/6334/13?u=aschiavo))

TL;DR We are enabling the synthetics agent by default and restricting the probes to Fly hosts that are already being used by the CLI.

