### PR TITLE
fix: wait for builder machine to be started to prevent sending a bunch of restart requests

### DIFF
--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -394,6 +394,12 @@ func createBuilder(ctx context.Context, org *fly.Organization, region, builderNa
 		return nil, nil, retErr
 	}
 
+	retErr = flapsClient.Wait(ctx, mach, "started", 60*time.Second)
+	if retErr != nil {
+		tracing.RecordError(span, retErr, "error waiting for builder machine to start")
+		return nil, nil, retErr
+	}
+
 	return
 }
 

--- a/internal/build/imgsrc/ensure_builder_test.go
+++ b/internal/build/imgsrc/ensure_builder_test.go
@@ -217,6 +217,10 @@ func TestCreateBuilder(t *testing.T) {
 				State: "started",
 			}, nil
 		},
+		WaitFunc: func(ctx context.Context, machine *fly.Machine, state string, timeout time.Duration) (err error) {
+			time.Sleep(1 * time.Second)
+			return nil
+		},
 	}
 	ctx = flyutil.NewContextWithClient(ctx, &apiClient)
 	ctx = flapsutil.NewContextWithClient(ctx, &flapsClient)


### PR DESCRIPTION
### Change Summary

What and Why:

Currently, we create the builder machine but do not wait for it to be in a started state before continuing which then results in the validateBuilder function seeing it as not started which then sends a bunch of restart requests resulting in the builder never getting into a steady state for use.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
