### PR TITLE
add better output for private networking

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -347,9 +347,18 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, userID i
 	if err := deployToMachines(ctx, appConfig, appCompact, img); err != nil {
 		return err
 	}
-
-	if appURL := appConfig.URL(); appURL != nil {
+	var ip = "public"
+	if flag.GetBool(ctx, "flycast") {
+		ip = "private"
+	} else if flag.GetBool(ctx, "no-public-ips") {
+		ip = "none"
+	}
+	if appURL := appConfig.URL(); appURL != nil && ip == "public" {
 		fmt.Fprintf(io.Out, "\nVisit your newly deployed app at %s\n", appURL)
+	} else if ip == "private" {
+		fmt.Fprintf(io.Out, "\nYour your newly deployed app is available in the organizations' private network under http://%s.flycast\n", appName)
+	} else if ip == "none" {
+		fmt.Fprintf(io.Out, "\nYour app is deployed but does not have a public or private IP address\n")
 	}
 
 	return err


### PR DESCRIPTION
### Change Summary

For both `flycast` and `no-public-ips` flag it makes sense to not mention the app is publicly available

closes #3781 and #3772 
