### PR TITLE
Make sure to wait before restarting the remote builder

### DIFF
--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -15,8 +15,6 @@ import (
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/haikunator"
 	"github.com/superfly/flyctl/internal/tracing"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 func EnsureBuilder(ctx context.Context, org *fly.Organization, region string, recreateBuilder bool) (*fly.Machine, *fly.App, error) {
@@ -148,7 +146,7 @@ const (
 )
 
 func validateBuilder(ctx context.Context, app *fly.App) (*fly.Machine, error) {
-	ctx, span := tracing.GetTracer().Start(ctx, "validate_builder", trace.WithAttributes(attribute.String("bulder_app", app.Name)))
+	ctx, span := tracing.GetTracer().Start(ctx, "validate_builder")
 	defer span.End()
 
 	if app == nil {

--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/haikunator"
+	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/tracing"
 )
 
@@ -410,6 +411,8 @@ func restartBuilderMachine(ctx context.Context, builderMachine *fly.Machine) err
 	defer span.End()
 
 	flapsClient := flapsutil.ClientFromContext(ctx)
+
+	mach.WaitForAnyMachineState(ctx, builderMachine, []string{"started", "stopped"}, 60*time.Second, nil)
 
 	if err := flapsClient.Restart(ctx, fly.RestartMachineInput{
 		ID: builderMachine.ID,

--- a/internal/build/imgsrc/ensure_builder_test.go
+++ b/internal/build/imgsrc/ensure_builder_test.go
@@ -265,7 +265,7 @@ func TestRestartBuilderMachine(t *testing.T) {
 	ctx := context.Background()
 
 	couldNotReserveResources := false
-	waitedForStartOrStop := true
+	waitedForStartOrStop := false
 	flapsClient := mock.FlapsClient{
 		RestartFunc: func(ctx context.Context, input fly.RestartMachineInput, nonce string) error {
 			if couldNotReserveResources {

--- a/internal/build/imgsrc/ensure_builder_test.go
+++ b/internal/build/imgsrc/ensure_builder_test.go
@@ -265,34 +265,23 @@ func TestRestartBuilderMachine(t *testing.T) {
 	ctx := context.Background()
 
 	couldNotReserveResources := false
-	waitedForStartOrStop := false
 	flapsClient := mock.FlapsClient{
-		RestartFunc: func(ctx context.Context, input fly.RestartMachineInput, nonce string) error {
+		StartFunc: func(ctx context.Context, machineID string, nonce string) (*fly.MachineStartResponse, error) {
 			if couldNotReserveResources {
-				return &flaps.FlapsError{
+				return nil, &flaps.FlapsError{
 					OriginalError: fmt.Errorf("failed to restart VM xyzabc: unknown: could not reserve resource for machine: insufficient memory available to fulfill request"),
 				}
 			}
-			return nil
-		},
-		WaitFunc: func(ctx context.Context, machine *fly.Machine, state string, timeout time.Duration) (err error) {
-			if state == "started" || state == "stopped" {
-				waitedForStartOrStop = true
-			}
-
-			return nil
+			return nil, nil
 		},
 	}
 
 	ctx = flapsutil.NewContextWithClient(ctx, &flapsClient)
 	err := startBuilder(ctx, &fly.Machine{ID: "bigmachine"})
 	assert.NoError(t, err)
-	assert.True(t, waitedForStartOrStop)
 
-	waitedForStartOrStop = false
 	couldNotReserveResources = true
 	err = startBuilder(ctx, &fly.Machine{ID: "bigmachine"})
-	assert.True(t, waitedForStartOrStop)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ShouldReplaceBuilderMachine)
 

--- a/internal/build/imgsrc/ensure_builder_test.go
+++ b/internal/build/imgsrc/ensure_builder_test.go
@@ -285,13 +285,13 @@ func TestRestartBuilderMachine(t *testing.T) {
 	}
 
 	ctx = flapsutil.NewContextWithClient(ctx, &flapsClient)
-	err := restartBuilderMachine(ctx, &fly.Machine{ID: "bigmachine"})
+	err := startBuilder(ctx, &fly.Machine{ID: "bigmachine"})
 	assert.NoError(t, err)
 	assert.True(t, waitedForStartOrStop)
 
 	waitedForStartOrStop = false
 	couldNotReserveResources = true
-	err = restartBuilderMachine(ctx, &fly.Machine{ID: "bigmachine"})
+	err = startBuilder(ctx, &fly.Machine{ID: "bigmachine"})
 	assert.True(t, waitedForStartOrStop)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ShouldReplaceBuilderMachine)

--- a/internal/command/deploy/plan_test.go
+++ b/internal/command/deploy/plan_test.go
@@ -239,7 +239,7 @@ func TestUpdateMachines(t *testing.T) {
 				machine.State = "started"
 				return nil
 			} else {
-				return assert.AnError
+				return nil
 			}
 		},
 		ListFunc: func(ctx context.Context, state string) ([]*fly.Machine, error) {

--- a/internal/machine/wait.go
+++ b/internal/machine/wait.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jpillora/backoff"
@@ -13,6 +14,10 @@ import (
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyerr"
+	"github.com/superfly/flyctl/internal/statuslogger"
+	"github.com/superfly/flyctl/internal/tracing"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func WaitForStartOrStop(ctx context.Context, machine *fly.Machine, action string, timeout time.Duration) error {
@@ -62,6 +67,71 @@ func WaitForStartOrStop(ctx context.Context, machine *fly.Machine, action string
 			}
 			time.Sleep(b.Duration())
 		}
+	}
+}
+
+// returns when the machine is in one of the possible states, or after passing the timeout threshold
+func WaitForAnyMachineState(ctx context.Context, mach *fly.Machine, possibleStates []string, timeout time.Duration, sl statuslogger.StatusLine) (string, error) {
+	ctx, span := tracing.GetTracer().Start(ctx, "wait_for_machine_state", trace.WithAttributes(
+		attribute.StringSlice("possible_states", possibleStates),
+	))
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	flapsClient := flapsutil.ClientFromContext(ctx)
+
+	var mutex sync.Mutex
+
+	var waitErr error
+	numCompleted := 0
+	var successfulState string
+
+	for _, state := range possibleStates {
+		state := state
+		go func() {
+			err := flapsClient.Wait(ctx, mach, state, timeout)
+			mutex.Lock()
+			defer func() {
+				numCompleted += 1
+				mutex.Unlock()
+			}()
+
+			if successfulState != "" {
+				return
+			}
+
+			if sl != nil {
+				sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Machine %s reached %s state", mach.ID, state))
+			}
+
+			if err != nil {
+				waitErr = err
+			} else {
+				successfulState = state
+			}
+		}()
+	}
+
+	// TODO(billy): i'm sure we can use channels here
+	for {
+		mutex.Lock()
+		if successfulState != "" || numCompleted == len(possibleStates) {
+			defer mutex.Unlock()
+			if successfulState != "" {
+				span.SetAttributes(attribute.String("state", successfulState))
+			}
+
+			if waitErr != nil {
+				span.RecordError(waitErr)
+			}
+
+			return successfulState, waitErr
+		}
+		mutex.Unlock()
+
+		time.Sleep(1 * time.Second)
 	}
 }
 


### PR DESCRIPTION
### Change Summary

What and Why:

If the remote builder is in the 'created' or 'migrating' state, then we won't be able to restart it. By making sure to wait for one of those two states, we can avoid errors like:

`failed to fetch an image or build from source: failed to restart VM asfijsdoif: failed_precondition: unable to restart machine, not currently started or stopped`

How:
make sure that the builder machine is either in the started or stopped state before calling the 'restart' API

Related to:

---

### Documentation

- [x] Fresh Produce (i'm gonna fix a few more remote builder issues before FP)
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
