### PR TITLE
return after a successful builder machine restart

### DIFF
--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -73,6 +73,7 @@ func EnsureBuilder(ctx context.Context, org *fly.Organization, region string, re
 					return nil, nil, err
 				}
 			}
+			return builderMachine, builderApp, nil
 		}
 
 		if validateBuilderErr != NoBuilderApp {


### PR DESCRIPTION
### Change Summary

What and Why:

We're currently checking if the `restartBuilderMachine` errored but if it doesn't then we continue on to replace the builder with an entirely new app. The changes here returns if the machine builder restart was successful and in a known good state.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
