### PR TITLE
update apps destroy for parity with machines destroy

### DIFF
--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -45,6 +45,10 @@ func RunDestroy(ctx context.Context) error {
 	apps := flag.Args(ctx)
 	client := flyutil.ClientFromContext(ctx)
 
+	if len(apps) == 0 {
+		return fmt.Errorf("no app names provided")
+	}
+
 	for _, appName := range apps {
 
 		if !flag.GetYes(ctx) {

--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -26,7 +26,7 @@ func newDestroy() *cobra.Command {
 	destroy := command.New(usage, short, long, RunDestroy,
 		command.RequireSession)
 
-	destroy.Args = cobra.ExactArgs(1)
+	destroy.Args = cobra.ArbitraryArgs
 
 	flag.Add(destroy,
 		flag.Yes(),
@@ -42,30 +42,33 @@ func newDestroy() *cobra.Command {
 func RunDestroy(ctx context.Context) error {
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
-	appName := flag.FirstArg(ctx)
+	apps := flag.Args(ctx)
 	client := flyutil.ClientFromContext(ctx)
 
-	if !flag.GetYes(ctx) {
-		const msg = "Destroying an app is not reversible."
-		fmt.Fprintln(io.ErrOut, colorize.Red(msg))
+	for _, appName := range apps {
 
-		switch confirmed, err := prompt.Confirmf(ctx, "Destroy app %s?", appName); {
-		case err == nil:
-			if !confirmed {
-				return nil
+		if !flag.GetYes(ctx) {
+			const msg = "Destroying an app is not reversible."
+			fmt.Fprintln(io.ErrOut, colorize.Red(msg))
+
+			switch confirmed, err := prompt.Confirmf(ctx, "Destroy app %s?", appName); {
+			case err == nil:
+				if !confirmed {
+					return nil
+				}
+			case prompt.IsNonInteractive(err):
+				return prompt.NonInteractiveError("yes flag must be specified when not running interactively")
+			default:
+				return err
 			}
-		case prompt.IsNonInteractive(err):
-			return prompt.NonInteractiveError("yes flag must be specified when not running interactively")
-		default:
+		}
+
+		if err := client.DeleteApp(ctx, appName); err != nil {
 			return err
 		}
-	}
 
-	if err := client.DeleteApp(ctx, appName); err != nil {
-		return err
+		fmt.Fprintf(io.Out, "Destroyed app %s\n", appName)
 	}
-
-	fmt.Fprintf(io.Out, "Destroyed app %s\n", appName)
 
 	return nil
 }

--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -17,10 +17,10 @@ import (
 
 func newDestroy() *cobra.Command {
 	const (
-		long = "Delete an application from the Fly platform."
+		long = "Delete one or more applications from the Fly platform."
 
-		short = "Permanently destroy an app."
-		usage = "destroy <app name>"
+		short = "Permanently destroy one or more appa."
+		usage = "destroy <app name(s)>"
 	)
 
 	destroy := command.New(usage, short, long, RunDestroy,


### PR DESCRIPTION
### Change Summary

What and Why: 

Currently `fly m destroy` accepts n-args; `fly apps destroy` does not. For consistency I think it'd make sense for these to behave in the same way

