### PR TITLE
Initialize empty options map if nil, and set the default plan for redis update

### DIFF
--- a/internal/command/extensions/tigris/update.go
+++ b/internal/command/extensions/tigris/update.go
@@ -66,6 +66,7 @@ func runUpdate(ctx context.Context) (err error) {
 	addOn := response.AddOn
 
 	options, _ := addOn.Options.(map[string]interface{})
+
 	if options == nil {
 		options = make(map[string]interface{})
 	}

--- a/internal/command/redis/list.go
+++ b/internal/command/redis/list.go
@@ -45,6 +45,10 @@ func runList(ctx context.Context) (err error) {
 
 	for _, addon := range response.AddOns.Nodes {
 		options, _ := addon.Options.(map[string]interface{})
+
+		if options == nil {
+			options = make(map[string]interface{})
+		}
 		eviction := "Disabled"
 
 		if options["eviction"] != nil && options["eviction"].(bool) {

--- a/internal/command/redis/status.go
+++ b/internal/command/redis/status.go
@@ -54,6 +54,10 @@ func runStatus(ctx context.Context) (err error) {
 
 	options, _ := addOn.Options.(map[string]interface{})
 
+	if options == nil {
+		options = make(map[string]interface{})
+	}
+
 	evictionStatus := "Disabled"
 
 	if options["eviction"] != nil && options["eviction"].(bool) {

--- a/internal/command/redis/update.go
+++ b/internal/command/redis/update.go
@@ -62,6 +62,7 @@ func runUpdate(ctx context.Context) (err error) {
 
 	var index int
 	var promptOptions []string
+	var promptDefault string
 
 	result, err := gql.ListAddOnPlans(ctx, client, gql.AddOnTypeUpstashRedis)
 	if err != nil {
@@ -70,9 +71,13 @@ func runUpdate(ctx context.Context) (err error) {
 
 	for _, plan := range result.AddOnPlans.Nodes {
 		promptOptions = append(promptOptions, fmt.Sprintf("%s: %s", plan.DisplayName, plan.Description))
+		if addOn.AddOnPlan.Id == plan.Id {
+			promptDefault = fmt.Sprintf("%s: %s", plan.DisplayName, plan.Description)
+		}
 	}
 
-	err = prompt.Select(ctx, &index, "Select an Upstash Redis plan", "", promptOptions...)
+	fmt.Println(addOn)
+	err = prompt.Select(ctx, &index, "Select an Upstash Redis plan", promptDefault, promptOptions...)
 
 	if err != nil {
 		return fmt.Errorf("failed to select a plan: %w", err)
@@ -85,6 +90,10 @@ func runUpdate(ctx context.Context) (err error) {
 	// options := &Options{}
 
 	options, _ := addOn.Options.(map[string]interface{})
+
+	if options == nil {
+		options = make(map[string]interface{})
+	}
 
 	if err != nil {
 		return


### PR DESCRIPTION
### Change Summary

if the options map is nil this panic's and we don't set the default plan on redis update.

What and Why:


https://github.com/user-attachments/assets/122cd620-64d3-4bfc-bc2d-ae85c43613b3

Upstash had a nil options and crashed.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
