### PR TITLE
Read the `--org` flag when running the `flyctl tokens list` command

### DIFF
--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -12,6 +12,8 @@ import (
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
+
+	fly "github.com/superfly/fly-go"
 )
 
 func newList() *cobra.Command {
@@ -35,6 +37,7 @@ func newList() *cobra.Command {
 			Description: "either 'app' or 'org'",
 			Default:     "app",
 		},
+		flag.Org(),
 	)
 
 	return cmd
@@ -45,7 +48,55 @@ func runList(ctx context.Context) (err error) {
 	out := iostreams.FromContext(ctx).Out
 	var rows [][]string
 
-	scope := flag.GetString(ctx, "scope")
+	// Get flags
+	
+	// Organization Name
+	orgFlag := flag.GetString(ctx, "org")
+	var org *fly.Organization
+	var scope string
+	if orgFlag!=""{
+		// Get the org name if flag indicated
+		org, err = orgs.OrgFromEnvVarOrFirstArgOrSelect(ctx)
+		if err != nil {
+			return fmt.Errorf("failed retrieving org %w", err)
+		}
+		scope = "org"
+	}
+	fmt.Println( "ORG IS: ")
+	fmt.Println( org)
+
+	// App Name
+	appFlag := flag.GetString(ctx, "app")
+	var appName string
+	if orgFlag == "" || appFlag!="" {
+		// BY default( orgflag not passed ), OR when --a passed
+		appName = appconfig.NameFromContext(ctx)
+		if appName == ""{
+			return command.ErrRequireAppName
+		}
+
+		// Check if app belongs to org if it exists
+		if org != nil {
+			app, err := apiClient.GetAppCompact(ctx, appName)
+			if err != nil {
+				return fmt.Errorf("failed retrieving app %s: %w", appName, err)
+			}
+			fmt.Println("checking app's org: ")
+			fmt.Println(app)
+
+			
+			if app.Organization.Name != org.Name {
+				return fmt.Errorf("APp does not belong to org!")
+			}else{
+				scope = "org"
+			}
+
+		}else{
+			scope = "app"
+		}
+	}
+
+	
 	switch scope {
 	case "app":
 		appName := appconfig.NameFromContext(ctx)

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -115,9 +115,9 @@ func determineScope(scopeStr string, appFlagStr string, orgFlagStr string, confi
 	// the default scope, when all else fails, is app scope
 	if appFlagStr != "" || configFlagStr != "" || scopeStr == "app" {
 		return "app", nil
-	}else if orgFlagStr != "" || scopeStr == "org" {
+	} else if orgFlagStr != "" || scopeStr == "org" {
 		return "org", nil
-	} else if scopeStr != "" && scopeStr !="app" && scopeStr!="org" {
+	} else if scopeStr != "" && scopeStr != "app" && scopeStr != "org" {
 		return "", fmt.Errorf("Please provide a valid scope: \"app\" or \"org\".")
 	} else {
 		return "app", nil

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -41,8 +41,6 @@ func newList() *cobra.Command {
 	return cmd
 }
 
-
-
 func runList(ctx context.Context) (err error) {
 	apiClient := flyutil.ClientFromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
@@ -53,8 +51,8 @@ func runList(ctx context.Context) (err error) {
 	appFlag := flag.GetString(ctx, "app")
 	configFlag := flag.GetString(ctx, "config")
 	orgFlag := flag.GetString(ctx, "org")
-	scope, err = determineScope( scope, appFlag, orgFlag, configFlag )
-	if err!= nil{
+	scope, err = determineScope(scope, appFlag, orgFlag, configFlag)
+	if err != nil {
 		return fmt.Errorf("failed retrieving scope: %w", err)
 	}
 
@@ -81,7 +79,7 @@ func runList(ctx context.Context) (err error) {
 
 			// Throw an error if app's org slug does not match --org slug
 			if app.Organization.Slug != org.Slug {
-				return fmt.Errorf("failed to retrieve tokens, selected application \"%s\" does not belong to selected organization \"%s\"", appName, org.Slug )
+				return fmt.Errorf("failed to retrieve tokens, selected application \"%s\" does not belong to selected organization \"%s\"", appName, org.Slug)
 			}
 		}
 		tokens, err := apiClient.GetAppLimitedAccessTokens(ctx, appName)
@@ -89,7 +87,7 @@ func runList(ctx context.Context) (err error) {
 			return fmt.Errorf("failed retrieving tokens for app %s: %w", appName, err)
 		}
 
-		fmt.Fprintln(out, "Tokens for app \""+ appName+"\":" )
+		fmt.Fprintln(out, "Tokens for app \""+appName+"\":")
 		for _, token := range tokens {
 			rows = append(rows, []string{token.Id, token.Name, token.User.Email, token.ExpiresAt.String()})
 		}
@@ -100,7 +98,7 @@ func runList(ctx context.Context) (err error) {
 			return fmt.Errorf("failed retrieving org %w", err)
 		}
 
-		fmt.Fprintln(out, "Tokens for app \""+ org.Slug+"\":" )
+		fmt.Fprintln(out, "Tokens for app \""+org.Slug+"\":")
 		for _, token := range org.LimitedAccessTokens.Nodes {
 			rows = append(rows, []string{token.Id, token.Name, token.User.Email, token.ExpiresAt.String()})
 		}
@@ -110,18 +108,18 @@ func runList(ctx context.Context) (err error) {
 	return nil
 }
 
-func determineScope(scopeStr string, appFlagStr string , orgFlagStr string, configFlagStr string) (scope string, err error){
+func determineScope(scopeStr string, appFlagStr string, orgFlagStr string, configFlagStr string) (scope string, err error) {
 	// --scope is prioritized,
 	// secondly --app or --config flags,
 	// --org flag is only used when there are no other flags provided but it
-	if scopeStr!=""{
-		if scopeStr!="app" && scopeStr!="org"{
+	if scopeStr != "" {
+		if scopeStr != "app" && scopeStr != "org" {
 			return "", fmt.Errorf("Please provide a valid scope: \"app\" or \"org\"")
 		}
 		return scopeStr, nil
-	}else if orgFlagStr != "" && appFlagStr =="" && configFlagStr == ""{
+	} else if orgFlagStr != "" && appFlagStr == "" && configFlagStr == "" {
 		return "org", nil
-	}else{
+	} else {
 		return "app", nil
 	}
 }

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -12,8 +12,6 @@ import (
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
-
-	fly "github.com/superfly/fly-go"
 )
 
 func newList() *cobra.Command {
@@ -35,7 +33,7 @@ func newList() *cobra.Command {
 			Name:        "scope",
 			Shorthand:   "s",
 			Description: "either 'app' or 'org'",
-			Default:     "app",
+			Default:     "",
 		},
 		flag.Org(),
 	)
@@ -43,79 +41,94 @@ func newList() *cobra.Command {
 	return cmd
 }
 
+
+
 func runList(ctx context.Context) (err error) {
 	apiClient := flyutil.ClientFromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
 	var rows [][]string
-	var scope = "app"
 
-
-	// Get Organization Name, if org flag passed 
-	orgFlag := flag.GetString(ctx, "org")
-	var org *fly.Organization
-	if orgFlag!=""{
-		// Get the org name if flag indicated
-		org, err = orgs.OrgFromEnvVarOrFirstArgOrSelect(ctx)
-		if err != nil {
-			return fmt.Errorf("failed retrieving org %w", err)
-		}
-		scope = "org"
-	}
-	
-	// Get App Name, if no org flag, OR if app flag passed
-	// Make sure app belongs to a selected org, else return error
+	// Determine scope based on flags passed 
+	scope := flag.GetString(ctx, "scope")
 	appFlag := flag.GetString(ctx, "app")
-	var appName string
-	if orgFlag == "" || appFlag!="" {
-		
-		appName = appconfig.NameFromContext(ctx)
-		if appName == ""{
-			return command.ErrRequireAppName
-		}
-
-		// Check if app belongs to org if it was selected
-		if org != nil {
-			app, err := apiClient.GetAppCompact(ctx, appName)
-			if err != nil {
-				return fmt.Errorf("failed retrieving app %s: %w", appName, err)
-			}
-
-			if app.Organization.Slug != org.Slug {
-				return fmt.Errorf("failed to retrieve tokens, selected application \"%s\" does not belong to selected organization \"%s\"!", appName, org.Slug )
-			}
-		}
-
-		// Scope would be app, even when its organization is passed
-		scope = "app"
-		
+	configFlag := flag.GetString(ctx, "config")
+	orgFlag := flag.GetString(ctx, "org")
+	scope, err = determineScope( scope, appFlag, orgFlag, configFlag )
+	if err!= nil{
+		return fmt.Errorf("failed retrieving scope: %w", err)
 	}
-	
+
+	// Apply scope to filter list of tokens to display
 	switch scope {
 	case "app":
 		appName := appconfig.NameFromContext(ctx)
 		if appName == "" {
 			return command.ErrRequireAppName
 		}
+		
+		// --org passed must match the selected app's org
+		if orgFlag != "" {
+			
+			// Get app details, so we can identify its organization slug
+			app, err := apiClient.GetAppCompact(ctx, appName)
+			if err != nil {
+				return fmt.Errorf("failed retrieving app %s: %w", appName, err)
+			}
 
+			// Get organization details, so we can get its slug 
+			org, err := orgs.OrgFromEnvVarOrFirstArgOrSelect(ctx)
+			if err != nil {
+				return fmt.Errorf("failed retrieving org %w", err)
+			}
+
+			// Throw an error if app's org slug does not match --org slug
+			if app.Organization.Slug != org.Slug {
+				return fmt.Errorf("failed to retrieve tokens, selected application \"%s\" does not belong to selected organization \"%s\"", appName, org.Slug )
+			}
+		}
+		
 		tokens, err := apiClient.GetAppLimitedAccessTokens(ctx, appName)
 		if err != nil {
 			return fmt.Errorf("failed retrieving tokens for app %s: %w", appName, err)
 		}
 
+		fmt.Fprintln(out, "Tokens for app \""+ appName+"\":" )
 		for _, token := range tokens {
 			rows = append(rows, []string{token.Id, token.Name, token.User.Email, token.ExpiresAt.String()})
 		}
 
 	case "org":
+		
 		org, err := orgs.OrgFromEnvVarOrFirstArgOrSelect(ctx)
 		if err != nil {
 			return fmt.Errorf("failed retrieving org %w", err)
 		}
 
+		fmt.Fprintln(out, "Tokens for app \""+ org.Slug+"\":" )
 		for _, token := range org.LimitedAccessTokens.Nodes {
 			rows = append(rows, []string{token.Id, token.Name, token.User.Email, token.ExpiresAt.String()})
 		}
 	}
+
 	_ = render.Table(out, "", rows, "ID", "Name", "Created By", "Expires At")
 	return nil
+}
+
+func determineScope(scopeStr string, appFlagStr string , orgFlagStr string, configFlagStr string) (scope string, err error){
+	// --scope is prioritized, 
+	// secondly --app or --config flags, 
+	// --org flag is only used when there are no other flags provided but it
+	
+	if scopeStr!=""{
+		if scopeStr!="app" && scopeStr!="org"{
+			return "", fmt.Errorf("Please provide a valid scope: \"app\" or \"org\"")
+		}
+		return scopeStr, nil
+
+	}else if orgFlagStr != "" && appFlagStr =="" && configFlagStr == ""{
+		return "org", nil
+	}else{
+		return "app", nil
+	}	
+
 }

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -67,7 +67,6 @@ func runList(ctx context.Context) (err error) {
 		}
 		// --org passed must match the selected app's org
 		if orgFlag != "" {
-			
 			// Get app details, so we can identify its organization slug
 			app, err := apiClient.GetAppCompact(ctx, appName)
 			if err != nil {
@@ -85,7 +84,6 @@ func runList(ctx context.Context) (err error) {
 				return fmt.Errorf("failed to retrieve tokens, selected application \"%s\" does not belong to selected organization \"%s\"", appName, org.Slug )
 			}
 		}
-		
 		tokens, err := apiClient.GetAppLimitedAccessTokens(ctx, appName)
 		if err != nil {
 			return fmt.Errorf("failed retrieving tokens for app %s: %w", appName, err)
@@ -97,7 +95,6 @@ func runList(ctx context.Context) (err error) {
 		}
 
 	case "org":
-		
 		org, err := orgs.OrgFromEnvVarOrFirstArgOrSelect(ctx)
 		if err != nil {
 			return fmt.Errorf("failed retrieving org %w", err)
@@ -117,13 +114,11 @@ func determineScope(scopeStr string, appFlagStr string , orgFlagStr string, conf
 	// --scope is prioritized,
 	// secondly --app or --config flags,
 	// --org flag is only used when there are no other flags provided but it
-	
 	if scopeStr!=""{
 		if scopeStr!="app" && scopeStr!="org"{
 			return "", fmt.Errorf("Please provide a valid scope: \"app\" or \"org\"")
 		}
 		return scopeStr, nil
-
 	}else if orgFlagStr != "" && appFlagStr =="" && configFlagStr == ""{
 		return "org", nil
 	}else{

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -123,5 +123,5 @@ func determineScope(scopeStr string, appFlagStr string , orgFlagStr string, conf
 		return "org", nil
 	}else{
 		return "app", nil
-	}	
+	}
 }

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -65,8 +65,6 @@ func runList(ctx context.Context) (err error) {
 		if appName == "" {
 			return command.ErrRequireAppName
 		}
-		
-		
 		// --org passed must match the selected app's org
 		if orgFlag != "" {
 			

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -48,7 +48,7 @@ func runList(ctx context.Context) (err error) {
 	out := iostreams.FromContext(ctx).Out
 	var rows [][]string
 
-	// Determine scope based on flags passed 
+	// Determine scope based on flags passed
 	scope := flag.GetString(ctx, "scope")
 	appFlag := flag.GetString(ctx, "app")
 	configFlag := flag.GetString(ctx, "config")
@@ -75,7 +75,7 @@ func runList(ctx context.Context) (err error) {
 				return fmt.Errorf("failed retrieving app %s: %w", appName, err)
 			}
 
-			// Get organization details, so we can get its slug 
+			// Get organization details, so we can get its slug
 			org, err := orgs.OrgFromEnvVarOrFirstArgOrSelect(ctx)
 			if err != nil {
 				return fmt.Errorf("failed retrieving org %w", err)
@@ -115,8 +115,8 @@ func runList(ctx context.Context) (err error) {
 }
 
 func determineScope(scopeStr string, appFlagStr string , orgFlagStr string, configFlagStr string) (scope string, err error){
-	// --scope is prioritized, 
-	// secondly --app or --config flags, 
+	// --scope is prioritized,
+	// secondly --app or --config flags,
 	// --org flag is only used when there are no other flags provided but it
 	
 	if scopeStr!=""{
@@ -130,5 +130,4 @@ func determineScope(scopeStr string, appFlagStr string , orgFlagStr string, conf
 	}else{
 		return "app", nil
 	}	
-
 }

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -66,6 +66,7 @@ func runList(ctx context.Context) (err error) {
 			return command.ErrRequireAppName
 		}
 		
+		
 		// --org passed must match the selected app's org
 		if orgFlag != "" {
 			

--- a/test/preflight/fly_tokens_test.go
+++ b/test/preflight/fly_tokens_test.go
@@ -36,17 +36,17 @@ func TestTokensListDeterminesScopeApp(t *testing.T){
 		// --config flag only
 		"tokens list -c fly.toml",
 		// --app flag, with --org flag 
-		"tokens list -a "+appName+" -o kathryn-tan",
+		"tokens list -a "+appName+" -o "+f.OrgSlug(),
 		// --config flag, with --org flag 
-		"tokens list -c fly.toml -o kathryn-tan",
+		"tokens list -c fly.toml -o "+f.OrgSlug(),
 		// --scope is app 
 		"tokens list -s app -a "+appName,
 		// --scope is app, with --org flag
-		"tokens list -s app -a "+appName+" -o kathryn-tan",
+		"tokens list -s app -a "+appName+" -o "+f.OrgSlug(),
 		// --scope is org, but --config flag added
-		"tokens list -s app -c fly.toml -o kathryn-tan",
+		"tokens list -s app -c fly.toml -o "+f.OrgSlug(),
 		// --scope is org, but --app flag added
-		"tokens list -s org kathryn-tan -a "+appName,
+		"tokens list -s org "+f.OrgSlug()+" -a "+appName,
 	}
 
 	for _, cmd_:= range commandList {
@@ -67,9 +67,9 @@ func TestTokensListDeterminesScopeOrg(t *testing.T){
 	// List of commands to verify scope org is selected for
 	commandList := [2](string){
 		// --org flag alone
-		"tokens list --org kathryn-tan", 
+		"tokens list --org "+f.OrgSlug(), 
 		// --scope org
-		"tokens list --scope org kathryn-tan",
+		"tokens list --scope org "+f.OrgSlug(),
 	}
 
 	for _, cmd_:= range commandList {

--- a/test/preflight/fly_tokens_test.go
+++ b/test/preflight/fly_tokens_test.go
@@ -1,11 +1,10 @@
 package preflight
 
 import (
-	
-	"testing"
-
 	"github.com/stretchr/testify/require"
 	"github.com/superfly/flyctl/test/preflight/testlib"
+	"os"
+	"testing"
 )
 
 // TODO: list of things to test
@@ -28,6 +27,7 @@ func TestTokensListDeterminesScopeApp(t *testing.T){
 		f.OrgSlug(), appName, f.PrimaryRegion(),
 	)
 
+	// List of commands to verify scope app is selected for
 	commandList := [9](string){
 		// default, no flags
 		"tokens list", 
@@ -64,6 +64,7 @@ func TestTokensListDeterminesScopeOrg(t *testing.T){
 		t.Skip()
 	}
 
+	// List of commands to verify scope org is selected for
 	commandList := [2](string){
 		// --org flag alone
 		"tokens list --org kathryn-tan", 
@@ -75,4 +76,38 @@ func TestTokensListDeterminesScopeOrg(t *testing.T){
 		console_out := f.Fly(cmd_).StdOutString()
 		require.Contains(f, console_out, `Tokens for organization`)
 	}
+}
+
+func TestTokensListPrioritizesAppFromFlagOverToml(t *testing.T){
+	// Get library from preflight test lib using env variables form  .direnv/preflight
+	f := testlib.NewTestEnvFromEnv(t)
+	// No need to run this on alternate sizes as it only tests the generated config.
+	if f.VMSize != "" {
+		t.Skip()
+	}
+
+	// Create fly.toml in current directory
+	// Get this appName for verifying that the flag is prioritized over toml appname content
+	appNameA := f.CreateRandomAppName()
+	f.Fly(
+		"launch --now --org %s --name %s --region %s --image nginx --internal-port 80 --ha=false",
+		f.OrgSlug(), appNameA, f.PrimaryRegion(),
+	)
+	
+	// Delete this first app's toml file, so we can create a new one
+	os.Remove(f.WorkDir()+"/fly.toml") 
+	appNameB := f.CreateRandomAppName()
+	f.Fly(
+		"launch --now --org %s --name %s --region %s --image nginx --internal-port 80 --ha=false",
+		f.OrgSlug(), appNameB, f.PrimaryRegion(),
+	)
+	// By default use the app name found in the current dir should be used ( appNameB )
+	console_out := f.Fly("tokens list").StdOutString()
+	require.Contains(f, console_out, `Tokens for app "`+appNameB+`"`)
+	
+
+	// But, the app name passed in --app should be prioritized over the toml appname ( appNameA )
+	console_out = f.Fly("tokens list --app "+appNameA).StdOutString()
+	require.Contains(f, console_out, `Tokens for app "`+appNameA+`"`)
+
 }

--- a/test/preflight/fly_tokens_test.go
+++ b/test/preflight/fly_tokens_test.go
@@ -12,7 +12,7 @@ import (
 // - Org scope is properly determined
 // - App identified by flag is prioritized over the fly.toml file, because it's more visible
 
-func TestTokensListDeterminesScopeApp(t *testing.T){
+func TestTokensListDeterminesScopeApp(t *testing.T) {
 	// Get library from preflight test lib using env variables form  .direnv/preflight
 	f := testlib.NewTestEnvFromEnv(t)
 	// No need to run this on alternate sizes as it only tests the generated config.
@@ -30,33 +30,32 @@ func TestTokensListDeterminesScopeApp(t *testing.T){
 	// List of commands to verify scope app is selected for
 	commandList := [9](string){
 		// default, no flags
-		"tokens list", 
+		"tokens list",
 		// --app flag only
-		"tokens list -a "+appName, 
+		"tokens list -a " + appName,
 		// --config flag only
 		"tokens list -c fly.toml",
-		// --app flag, with --org flag 
-		"tokens list -a "+appName+" -o "+f.OrgSlug(),
-		// --config flag, with --org flag 
-		"tokens list -c fly.toml -o "+f.OrgSlug(),
-		// --scope is app 
-		"tokens list -s app -a "+appName,
+		// --app flag, with --org flag
+		"tokens list -a " + appName + " -o " + f.OrgSlug(),
+		// --config flag, with --org flag
+		"tokens list -c fly.toml -o " + f.OrgSlug(),
+		// --scope is app
+		"tokens list -s app -a " + appName,
 		// --scope is app, with --org flag
-		"tokens list -s app -a "+appName+" -o "+f.OrgSlug(),
+		"tokens list -s app -a " + appName + " -o " + f.OrgSlug(),
 		// --scope is org, but --config flag added
-		"tokens list -s app -c fly.toml -o "+f.OrgSlug(),
+		"tokens list -s app -c fly.toml -o " + f.OrgSlug(),
 		// --scope is org, but --app flag added
-		"tokens list -s org "+f.OrgSlug()+" -a "+appName,
+		"tokens list -s org " + f.OrgSlug() + " -a " + appName,
 	}
 
-	for _, cmd_:= range commandList {
+	for _, cmd_ := range commandList {
 		console_out := f.Fly(cmd_).StdOutString()
 		require.Contains(f, console_out, `Tokens for app`)
 	}
 }
 
-
-func TestTokensListDeterminesScopeOrg(t *testing.T){
+func TestTokensListDeterminesScopeOrg(t *testing.T) {
 	// Get library from preflight test lib using env variables form  .direnv/preflight
 	f := testlib.NewTestEnvFromEnv(t)
 	// No need to run this on alternate sizes as it only tests the generated config.
@@ -67,18 +66,18 @@ func TestTokensListDeterminesScopeOrg(t *testing.T){
 	// List of commands to verify scope org is selected for
 	commandList := [2](string){
 		// --org flag alone
-		"tokens list --org "+f.OrgSlug(), 
+		"tokens list --org " + f.OrgSlug(),
 		// --scope org
-		"tokens list --scope org "+f.OrgSlug(),
+		"tokens list --scope org " + f.OrgSlug(),
 	}
 
-	for _, cmd_:= range commandList {
+	for _, cmd_ := range commandList {
 		console_out := f.Fly(cmd_).StdOutString()
 		require.Contains(f, console_out, `Tokens for organization`)
 	}
 }
 
-func TestTokensListPrioritizesAppFromFlagOverToml(t *testing.T){
+func TestTokensListPrioritizesAppFromFlagOverToml(t *testing.T) {
 	// Get library from preflight test lib using env variables form  .direnv/preflight
 	f := testlib.NewTestEnvFromEnv(t)
 	// No need to run this on alternate sizes as it only tests the generated config.
@@ -93,9 +92,9 @@ func TestTokensListPrioritizesAppFromFlagOverToml(t *testing.T){
 		"launch --now --org %s --name %s --region %s --image nginx --internal-port 80 --ha=false",
 		f.OrgSlug(), appNameA, f.PrimaryRegion(),
 	)
-	
+
 	// Delete this first app's toml file, so we can create a new one
-	os.Remove(f.WorkDir()+"/fly.toml") 
+	os.Remove(f.WorkDir() + "/fly.toml")
 	appNameB := f.CreateRandomAppName()
 	f.Fly(
 		"launch --now --org %s --name %s --region %s --image nginx --internal-port 80 --ha=false",
@@ -104,10 +103,8 @@ func TestTokensListPrioritizesAppFromFlagOverToml(t *testing.T){
 	// By default use the app name found in the current dir should be used ( appNameB )
 	console_out := f.Fly("tokens list").StdOutString()
 	require.Contains(f, console_out, `Tokens for app "`+appNameB+`"`)
-	
 
 	// But, the app name passed in --app should be prioritized over the toml appname ( appNameA )
-	console_out = f.Fly("tokens list --app "+appNameA).StdOutString()
+	console_out = f.Fly("tokens list --app " + appNameA).StdOutString()
 	require.Contains(f, console_out, `Tokens for app "`+appNameA+`"`)
-
 }

--- a/test/preflight/fly_tokens_test.go
+++ b/test/preflight/fly_tokens_test.go
@@ -1,0 +1,78 @@
+package preflight
+
+import (
+	
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/flyctl/test/preflight/testlib"
+)
+
+// TODO: list of things to test
+// - App scope is properly determined
+// - Org scope is properly determined
+// - App identified by flag is prioritized over the fly.toml file, because it's more visible
+
+func TestTokensListDeterminesScopeApp(t *testing.T){
+	// Get library from preflight test lib using env variables form  .direnv/preflight
+	f := testlib.NewTestEnvFromEnv(t)
+	// No need to run this on alternate sizes as it only tests the generated config.
+	if f.VMSize != "" {
+		t.Skip()
+	}
+
+	// Create fly.toml in current directory for the purpose of testing --config purposes
+	appName := f.CreateRandomAppName()
+	f.Fly(
+		"launch --now --org %s --name %s --region %s --image nginx --internal-port 80 --ha=false",
+		f.OrgSlug(), appName, f.PrimaryRegion(),
+	)
+
+	commandList := [9](string){
+		// default, no flags
+		"tokens list", 
+		// --app flag only
+		"tokens list -a "+appName, 
+		// --config flag only
+		"tokens list -c fly.toml",
+		// --app flag, with --org flag 
+		"tokens list -a "+appName+" -o kathryn-tan",
+		// --config flag, with --org flag 
+		"tokens list -c fly.toml -o kathryn-tan",
+		// --scope is app 
+		"tokens list -s app -a "+appName,
+		// --scope is app, with --org flag
+		"tokens list -s app -a "+appName+" -o kathryn-tan",
+		// --scope is org, but --config flag added
+		"tokens list -s app -c fly.toml -o kathryn-tan",
+		// --scope is org, but --app flag added
+		"tokens list -s org kathryn-tan -a "+appName,
+	}
+
+	for _, cmd_:= range commandList {
+		console_out := f.Fly(cmd_).StdOutString()
+		require.Contains(f, console_out, `Tokens for app`)
+	}
+}
+
+
+func TestTokensListDeterminesScopeOrg(t *testing.T){
+	// Get library from preflight test lib using env variables form  .direnv/preflight
+	f := testlib.NewTestEnvFromEnv(t)
+	// No need to run this on alternate sizes as it only tests the generated config.
+	if f.VMSize != "" {
+		t.Skip()
+	}
+
+	commandList := [2](string){
+		// --org flag alone
+		"tokens list --org kathryn-tan", 
+		// --scope org
+		"tokens list --scope org kathryn-tan",
+	}
+
+	for _, cmd_:= range commandList {
+		console_out := f.Fly(cmd_).StdOutString()
+		require.Contains(f, console_out, `Tokens for organization`)
+	}
+}

--- a/test/preflight/fly_tokens_test.go
+++ b/test/preflight/fly_tokens_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package preflight
 
 import (


### PR DESCRIPTION
### Change Summary

**What:**
This PR updates a part of the logic when `flyctl tokens list` is run:
1. Read the organization name from the argument passed for `--org`
2. Determine the "scope" ( either filter by app, or by org ) of  tokens to display based on the flags passed:
    <table> 
      <thead><th>--app || --config</th><th>--org</th><th>--scope</th><th>Filtered by</th><th>Example</th><th>Scope</th></thead>

      <tbody>
       <tr><td>none</td><td>none</td><td>none</td><td>from-tomlfile</td><td>tokens list</td><td><b>APP</b></td><tr>
      <tr><td>Specified</td><td>none</td><td>none</td><td>--app | --config</td><td>tokens list --app myAppName</td><td><b>APP</b></td><tr>
       <tr><td>Specified</td><td>Specified</td><td>none</td><td>--app | --config</td><td>tokens list --app myAppName --org personal</td><td><b>APP</b></td><tr>
       <tr><td>none</td><td>Specified</td><td>none</td><td>--org</td><td>tokens list --org personal</td><td><b>ORG</b></td><tr>
         <tr><td>none</td><td>none</td><td>org</td><td>argument passed after org sub command</td><td> tokens list  --scope org personal</td><td><b>ORG</b></td><tr>
      </tbody>  
   </table>
   
**Why:**
1. For **consistency with the manner of retrieving the organization name** from the user: 
> Other sub commands under `flyctl tokens` can read the organization name through reading the `--org` flag . i.e. `flyctl tokens create org` 
2. For **consistency with how the scope of filtering the list of tokens** be specified by the user:
> The `flyctl tokens list` has two scopes of filtering the tokens it displays: a) by app( default ) b) by organization
> The `flyctl tokens list` already filters the list of tokens by the app simply by reading the app name from the `--app flag`. 
> Allowing it to read the `--org` flag, and filtering the tokens by organization can comply with the syntax used for filtering by app.

**How:**

- [x]  [Include `fly.Org()` ](https://github.com/superfly/flyctl/pull/3799/files#diff-90bba296cee5f809e2a648da1b6945b862c0305ea842303b94e1901366fe57dcR38)to the flags for the `flyctl tokens list` command
- [x] [Detect scope ](https://github.com/superfly/flyctl/pull/3799/files#diff-90bba296cee5f809e2a648da1b6945b862c0305ea842303b94e1901366fe57dcR111)to filter list of tokens based on the combination( or lack of ) of `--app`,  `--config`, `--org`, `--scope` flags passed
- [x] [Provide compatibility with previous syntax](https://github.com/superfly/flyctl/pull/3799/files#diff-90bba296cee5f809e2a648da1b6945b862c0305ea842303b94e1901366fe57dcR50) that used `--scope` flag to avoid breaking existing automated user code that makes use of that syntax
- [x] Provide test cases for determining scope [app](https://github.com/superfly/flyctl/pull/3799/files#diff-98ac32129c22de521f38d91e3ddd22b5b1bf81af6fcd732d96f21fd3ee88d679R18), [org](https://github.com/superfly/flyctl/pull/3799/files#diff-98ac32129c22de521f38d91e3ddd22b5b1bf81af6fcd732d96f21fd3ee88d679R61)


**Related to:**
Discourse post:  https://flyio.discourse.team/t/approach-to-inconsistency-in-reading-organization-name-input-for-subcommands-in-flyctl-tokens/6612

**How to Test Manually:**
- first pull the pr with `gh pr checkout 3799`
- Build the changes to a local flyctl with: `go build -o bin/flyctl.exe .`
- Run commands that combine `flyctl tokens list` with --org:
```
bin/flyctl.exe tokens list --org <my_org>
```
 and other flags that help identify scope, like  `--app`, `-- `--config` and `--scope`. 
 The [preflight test](https://github.com/superfly/flyctl/pull/3799/files#diff-98ac32129c22de521f38d91e3ddd22b5b1bf81af6fcd732d96f21fd3ee88d679R38) created for this PR should contain [these combinations ](https://github.com/superfly/flyctl/pull/3799/files#diff-98ac32129c22de521f38d91e3ddd22b5b1bf81af6fcd732d96f21fd3ee88d679R38)btw!




---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
