### PR TITLE
add FLY_STANDBY_FOR environment variable to standby machine

### DIFF
--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/samber/lo"
 	fly "github.com/superfly/fly-go"
@@ -51,6 +52,7 @@ func (md *machineDeployment) launchInputForLaunch(processGroup string, guest *fl
 
 	if len(standbyFor) > 0 {
 		mConfig.Standbys = standbyFor
+		mConfig.Env["FLY_STANDBY_FOR"] = strings.Join(standbyFor, ",")
 	}
 
 	if hdid := md.appConfig.HostDedicationID; hdid != "" {
@@ -148,6 +150,7 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *fly.Machine) (
 	// the standbys list.
 	if len(mConfig.Services) > 0 && len(mConfig.Standbys) > 0 {
 		mConfig.Standbys = nil
+		delete(mConfig.Env, "FLY_STANDBY_FOR")
 	}
 
 	if hdid := md.appConfig.HostDedicationID; hdid != "" && hdid != origMachineRaw.Config.Guest.HostDedicationID {

--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -245,6 +245,7 @@ func runMachineClone(ctx context.Context) (err error) {
 			}
 		}
 		targetConfig.Standbys = lo.Ternary(len(standbys) > 0, standbys, nil)
+		targetConfig.Env["FLY_STANDBY_FOR"] = strings.Join(standbys, ",")
 	}
 
 	input := fly.LaunchMachineInput{

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -804,6 +804,7 @@ func determineMachineConfig(
 	if flag.IsSpecified(ctx, "standby-for") {
 		standbys := flag.GetStringSlice(ctx, "standby-for")
 		machineConf.Standbys = lo.Ternary(len(standbys) > 0, standbys, nil)
+		machineConf.Env["FLY_STANDBY_FOR"] = strings.Join(standbys, ",")
 	}
 
 	machineFiles, err := command.FilesFromCommand(ctx)

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -272,6 +272,7 @@ func computeActions(machines []*fly.Machine, expectedGroupCounts map[string]int,
 		mConfig := groupMachines[0].Config
 		// Nullify standbys, no point on having more than one
 		mConfig.Standbys = nil
+		delete(mConfig.Env, "FLY_STANDBY_FOR")
 
 		for region, delta := range regionDiffs {
 			actions = append(actions, &planItem{


### PR DESCRIPTION
### Change Summary

What and Why:

Adds a `FLY_STANDBY_FOR` environment variable to standby machines based on the `--standby-for` option provided to `fly machine run`, `fly machine clone`, or the `fly launch` default configuration.

Applications wishing to support custom standby-machine logic (e.g., to perform custom operations to failover/recover state from a target machine that went down) may read this environment variable to find out that the current-running machine is an activated standby, and the machine ID(s) of its target(s).

(Though less common, a standby machine can have >1 comma-delimited target machines listed and the machine will be started when only one of them is down. An application could confirm which machine is down through 6pn in this case.)

How:

Sets/deletes the `MachineConfig.Env["FLY_STANDBY_FOR"]` value anywhere `MachineConfig.Standbys` is currently set/cleared.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
