### PR TITLE
Add helper to simplify Flex version checks.

### DIFF
--- a/internal/command/postgres/backup.go
+++ b/internal/command/postgres/backup.go
@@ -112,7 +112,7 @@ func runBackupRestore(ctx context.Context) error {
 	}
 
 	// Ensure the the app has the required flex version.
-	if err := hasRequiredVersionOnMachines(appName, machines, "", backupVersion, ""); err != nil {
+	if err := hasRequiredFlexVersionOnMachines(appName, machines, backupVersion); err != nil {
 		return err
 	}
 
@@ -237,7 +237,7 @@ func runBackupCreate(ctx context.Context) error {
 		return fmt.Errorf("No active machines")
 	}
 
-	if err := hasRequiredVersionOnMachines(appName, machines, "", backupVersion, ""); err != nil {
+	if err := hasRequiredFlexVersionOnMachines(appName, machines, backupVersion); err != nil {
 		return err
 	}
 
@@ -330,7 +330,7 @@ func runBackupEnable(ctx context.Context) error {
 		return fmt.Errorf("No active machines")
 	}
 
-	if err := hasRequiredVersionOnMachines(appName, machines, "", backupVersion, ""); err != nil {
+	if err := hasRequiredFlexVersionOnMachines(appName, machines, backupVersion); err != nil {
 		return err
 	}
 
@@ -422,7 +422,7 @@ func runBackupList(ctx context.Context) error {
 		return fmt.Errorf("No active machines")
 	}
 
-	if err = hasRequiredVersionOnMachines(appName, machines, "", backupVersion, ""); err != nil {
+	if err = hasRequiredFlexVersionOnMachines(appName, machines, backupVersion); err != nil {
 		return err
 	}
 
@@ -566,7 +566,7 @@ func runBackupConfigShow(ctx context.Context) error {
 	}
 
 	// Ensure the the app has the required flex version.
-	if err := hasRequiredVersionOnMachines(appName, machines, "", backupConfigVersion, ""); err != nil {
+	if err := hasRequiredFlexVersionOnMachines(appName, machines, backupConfigVersion); err != nil {
 		return err
 	}
 
@@ -595,7 +595,7 @@ func runBackupConfigUpdate(ctx context.Context) error {
 	}
 
 	// Ensure the the app has the required flex version.
-	if err := hasRequiredVersionOnMachines(appName, machines, "", backupConfigVersion, ""); err != nil {
+	if err := hasRequiredFlexVersionOnMachines(appName, machines, backupConfigVersion); err != nil {
 		return err
 	}
 

--- a/internal/command/postgres/postgres.go
+++ b/internal/command/postgres/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/go-version"
 	"github.com/spf13/cobra"
@@ -113,6 +114,14 @@ func hasRequiredVersionOnMachines(appName string, machines []*fly.Machine, clust
 
 	}
 	return nil
+}
+
+func hasRequiredFlexVersionOnMachines(appName string, machines []*fly.Machine, flexVersion string) error {
+	err := hasRequiredVersionOnMachines(appName, machines, "", flexVersion, "")
+	if strings.Contains(err.Error(), "Malformed version") {
+		return fmt.Errorf("This image is not compatible with this feature. Please attempt an update with `fly image update -a %s`", appName)
+	}
+	return err
 }
 
 func IsFlex(machine *fly.Machine) bool {

--- a/internal/command/postgres/postgres.go
+++ b/internal/command/postgres/postgres.go
@@ -127,7 +127,7 @@ func hasRequiredFlexVersionOnMachines(appName string, machines []*fly.Machine, f
 
 	err := hasRequiredVersionOnMachines(appName, machines, "", flexVersion, "")
 	if strings.Contains(err.Error(), "Malformed version") {
-		return fmt.Errorf("This image is not compatible with this feature. Please attempt an update with `fly image update -a %s`", appName)
+		return fmt.Errorf("This image is not compatible with this feature.")
 	}
 	return err
 }

--- a/internal/command/postgres/postgres.go
+++ b/internal/command/postgres/postgres.go
@@ -117,6 +117,14 @@ func hasRequiredVersionOnMachines(appName string, machines []*fly.Machine, clust
 }
 
 func hasRequiredFlexVersionOnMachines(appName string, machines []*fly.Machine, flexVersion string) error {
+	if len(machines) == 0 {
+		return fmt.Errorf("no machines provided")
+	}
+
+	if !IsFlex(machines[0]) {
+		return fmt.Errorf("not a Flex cluster")
+	}
+
 	err := hasRequiredVersionOnMachines(appName, machines, "", flexVersion, "")
 	if strings.Contains(err.Error(), "Malformed version") {
 		return fmt.Errorf("This image is not compatible with this feature. Please attempt an update with `fly image update -a %s`", appName)


### PR DESCRIPTION
### Change Summary

* Simplify Postgres cluster version checks when comparing Flex versions, and assume malformed versions are likely resolvable by image updates.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
