### PR TITLE
Ensure that errors building with Depot are properly captured

### DIFF
--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -115,8 +115,10 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 		streams.StopProgressIndicator()
 		return nil, buildErr
 	}
-	defer build.Finish(buildErr)
-	defer buildkit.Release()
+	defer func() {
+		buildkit.Release()
+		build.Finish(buildErr)
+	}()
 
 	connectCtx, cancelConnect := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancelConnect()


### PR DESCRIPTION
### Change Summary

This was a bug in our `depot-go` example code too, but `defer build.Finish(buildErr)` captures the value of `buildErr` at the time the `defer` is defined (so `nil`), meaning that errors are never actually reported.

This PR changes the `defer` to use a closure so that the value of `buildErr` can accurately be read when the build completes.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
