### PR TITLE
fix typo on internal/command/apps/destroy.go

### DIFF
--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -19,7 +19,7 @@ func newDestroy() *cobra.Command {
 	const (
 		long = "Delete one or more applications from the Fly platform."
 
-		short = "Permanently destroy one or more appa."
+		short = "Permanently destroy one or more apps."
 		usage = "destroy <app name(s)>"
 	)
 


### PR DESCRIPTION
### Change Summary

What and Why: s/appa/apps on internal/command/apps/destroy.go

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
