### PR TITLE
Machine lease UX improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.1.21
+	github.com/superfly/fly-go v0.1.22-0.20240802153530-1487eea07345
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.14-0.20240702184853-b8ac52a1fc77
@@ -272,5 +272,5 @@ require (
 replace (
 	github.com/loadsmart/calver-go => github.com/ndarilek/calver-go v0.0.0-20230710153822-893bbd83a936
 	github.com/nats-io/nats.go => github.com/btoews/nats.go v0.0.0-20240401180931-476bea7f4158
-	github.com/superfly/fly-go => github.com/superfly/fly-go v0.1.21
+	github.com/superfly/fly-go => github.com/superfly/fly-go v0.1.22-0.20240802153530-1487eea07345
 )

--- a/go.sum
+++ b/go.sum
@@ -629,8 +629,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.21 h1:+UEmy+4jZ0f/lUWxF1u/y54qbodOCqcrvuL92ANMePo=
-github.com/superfly/fly-go v0.1.21/go.mod h1:JQke/BwoZqrWurqYkypSlcSo7bIUgCI3eVnqMC6AUj0=
+github.com/superfly/fly-go v0.1.22-0.20240802153530-1487eea07345 h1:4/khSPMwvoXgTyj8cKTu54dSFuIPkK0sTrMysTYa7+4=
+github.com/superfly/fly-go v0.1.22-0.20240802153530-1487eea07345/go.mod h1:JQke/BwoZqrWurqYkypSlcSo7bIUgCI3eVnqMC6AUj0=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -323,10 +323,6 @@ func (md *machineDeployment) acquireLeases(ctx context.Context, machineTuples []
 			}
 			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Acquiring lease for %s", machine.ID))
 
-			if machine.LeaseNonce == "" {
-				sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for job %s", machine.ID))
-			}
-
 			lease, err := md.acquireMachineLease(ctx, machine.ID)
 			if err != nil {
 				sl.LogStatus(statuslogger.StatusFailure, fmt.Sprintf("Failed to acquire lease for %s: %v", machine.ID, err))
@@ -336,7 +332,7 @@ func (md *machineDeployment) acquireLeases(ctx context.Context, machineTuples []
 			machine.LeaseNonce = lease.Data.Nonce
 			lm := mach.NewLeasableMachine(md.flapsClient, md.io, machine, false)
 			lm.StartBackgroundLeaseRefresh(ctx, md.leaseTimeout, md.leaseDelayBetween)
-			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for job %s", machine.ID))
+			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Acquired lease for %s", machine.ID))
 			return nil
 		})
 	}

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -321,6 +321,12 @@ func (md *machineDeployment) acquireLeases(ctx context.Context, machineTuples []
 			} else {
 				return nil
 			}
+
+			if machine.LeaseNonce != "" {
+				sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Already have lease for %s", machine.ID))
+				return nil
+			}
+
 			sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Acquiring lease for %s", machine.ID))
 
 			lease, err := md.acquireMachineLease(ctx, machine.ID)

--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -115,6 +115,9 @@ func runImport(ctx context.Context) error {
 		return fmt.Errorf("no machines are available on this app %s", appName)
 	}
 	leader, _ := machinesNodeRoles(ctx, machines)
+	if leader == nil {
+		return fmt.Errorf("no active leader found")
+	}
 	machineID := leader.ID
 
 	// Resolve region


### PR DESCRIPTION
This fixes a few papercuts around machine leases

- e6a8540876a636ea8bcd688613e4bd13cc2ae7e9 pulls in https://github.com/superfly/fly-go/pull/89 which cancels our attempt to acquire leases if the context has been cancelled (e.g. by `^C` from the user).
- c1aa843c1f3e96fc0579a43c433c3b97dad2ec98 prints a status update if we're still waiting to acquire a lease after 2s
- c1aa843c1f3e96fc0579a43c433c3b97dad2ec98 ensures that we still attempt to release leases if the command was aborted (e.g. by `^C` from the user).