### PR TITLE
fix downtime causing bug during rolling deployments

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -758,9 +758,49 @@ func (md *machineDeployment) updateUsingRollingStrategy(parentCtx context.Contex
 
 	for group, entries := range entriesByGroup {
 		entries := entries
-		startIdx += len(entries)
+
+		warmMachines := lo.Filter(entries, func(e *machineUpdateEntry, i int) bool {
+			return e.leasableMachine.Machine().State == "started"
+		})
+		coldMachines := lo.Filter(entries, func(e *machineUpdateEntry, i int) bool {
+			return e.leasableMachine.Machine().State != "started"
+		})
+
 		groupsPool.Go(func(ctx context.Context) error {
-			return md.updateEntriesGroup(ctx, group, entries, sl, startIdx-len(entries))
+			errChan := make(chan error, 2)
+			defer close(errChan)
+
+			go func() {
+				// for cold machines, we can update all of them at once.
+				// there's no need for protection against downtime since the machines are already stopped
+				startIdx += len(coldMachines)
+				poolSize := len(coldMachines)
+				if poolSize >= 50 {
+					poolSize = 50
+				}
+
+				errChan <- md.updateEntriesGroup(ctx, group, coldMachines, sl, startIdx-len(coldMachines), poolSize)
+			}()
+
+			go func() {
+				// for warm machines, we update them in chunks of size, md.maxUnavailable.
+				// this is to prevent downtime/low-latency during deployments
+				startIdx += len(warmMachines)
+				poolSize := md.getPoolSize(len(warmMachines))
+				errChan <- md.updateEntriesGroup(ctx, group, warmMachines, sl, startIdx-len(warmMachines), poolSize)
+			}()
+
+			err := <-errChan
+			if err != nil {
+				return err
+			}
+
+			err = <-errChan
+			if err != nil {
+				return err
+			}
+
+			return nil
 		})
 	}
 
@@ -768,28 +808,28 @@ func (md *machineDeployment) updateUsingRollingStrategy(parentCtx context.Contex
 	if err != nil {
 		span.RecordError(err)
 	}
+
+	fmt.Println("updatecomplete", err)
 	return err
 }
 
-func (md *machineDeployment) updateEntriesGroup(parentCtx context.Context, group string, entries []*machineUpdateEntry, sl statuslogger.StatusLogger, startIdx int) error {
+func (md *machineDeployment) getPoolSize(totalMachines int) int {
+	switch mu := md.maxUnavailable; {
+	case mu >= 1:
+		return int(mu)
+	default:
+		return int(math.Ceil(float64(totalMachines) * mu))
+	}
+}
+
+func (md *machineDeployment) updateEntriesGroup(parentCtx context.Context, group string, entries []*machineUpdateEntry, sl statuslogger.StatusLogger, startIdx int, poolSize int) error {
 	parentCtx, span := tracing.GetTracer().Start(parentCtx, "update_entries_in_group", trace.WithAttributes(
 		attribute.Int("start_id", startIdx),
 		attribute.String("group", group),
 		attribute.Int("max_unavailable", int(md.maxUnavailable)),
+		attribute.Int("pool_size", poolSize),
 	))
 	defer span.End()
-
-	var poolSize int
-	switch mu := md.maxUnavailable; {
-	case mu >= 1:
-		poolSize = int(mu)
-	case mu > 0:
-		poolSize = int(math.Ceil(float64(len(entries)) * mu))
-	default:
-		return fmt.Errorf("Invalid --max-unavailable value: %v", mu)
-	}
-
-	span.SetAttributes(attribute.Int("pool_size", poolSize))
 
 	updatePool := pool.New().
 		WithErrors().
@@ -801,6 +841,7 @@ func (md *machineDeployment) updateEntriesGroup(parentCtx context.Context, group
 		e := e
 		eCtx := statuslogger.NewContext(parentCtx, sl.Line(startIdx+idx))
 		fmtID := e.leasableMachine.FormattedMachineId()
+		span.SetAttributes(attribute.String("state", e.leasableMachine.Machine().State))
 
 		statusRunning := func() {
 			statuslogger.LogfStatus(eCtx,

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -196,14 +196,68 @@ func (md *machineDeployment) updateMachinesWRecovery(ctx context.Context, oldApp
 	for _, machineTuples := range machPairByProcessGroup {
 		machineTuples := machineTuples
 		pgroup.Go(func() error {
-			err := md.updateProcessGroup(ctx, machineTuples, statusLines, poolSize)
-			if err != nil && strings.Contains(err.Error(), "lease currently held by") {
-				err := &unrecoverableError{err: err}
+
+			warmError := make(chan error, 1)
+			coldError := make(chan error, 1)
+
+			// defer close(coldError)
+			// defer close(warmError)
+
+			warmMachines := lo.Filter(machineTuples, func(e machinePairing, i int) bool {
+				if e.oldMachine != nil && e.oldMachine.State == "started" {
+					return true
+				}
+				if e.newMachine != nil && e.newMachine.State == "started" {
+					return true
+				}
+				return false
+			})
+
+			coldMachines := lo.Filter(machineTuples, func(e machinePairing, i int) bool {
+				if e.oldMachine != nil && e.oldMachine.State != "started" {
+					return true
+				}
+				if e.newMachine != nil && e.newMachine.State != "started" {
+					return true
+				}
+				return false
+			})
+
+			fmt.Println("length of warmMachines", len(warmMachines))
+			fmt.Println("length of coldMachines", len(coldMachines))
+
+			go func() {
+				// for warm machines, we update them in chunks of size, md.maxUnavailable.
+				// this is to prevent downtime/low-latency during deployments
+				poolSize := md.getPoolSize(len(warmMachines))
+				fmt.Println("poolSize", poolSize)
+				warmError <- md.updateProcessGroup(ctx, warmMachines, statusLines, poolSize)
+			}()
+
+			go func() {
+				// for cold machines, we can update all of them at once.
+				// there's no need for protection against downtime since the machines are already stopped
+				poolSize := len(coldMachines)
+				if poolSize >= 50 {
+					poolSize = 50
+				}
+				coldError <- md.updateProcessGroup(ctx, coldMachines, statusLines, poolSize)
+			}()
+
+			var err error
+			select {
+			case err = <-warmError:
+			case err = <-coldError:
+			}
+
+			if err != nil {
 				span.RecordError(err)
+				if strings.Contains(err.Error(), "lease currently held by") {
+					err = &unrecoverableError{err: err}
+				}
 				return err
 			}
 
-			span.RecordError(err)
 			return err
 		})
 	}


### PR DESCRIPTION
### Change Summary
Previously, we were lumping started & stopped machines during rolling deployments.  When the number of started machines is larger than that of stopped machines, deployments worked fine with 0 downtime. However, when stopped > started, you could run into cases where all your started machines end up in an update pool, causing downtime.

This PR fixes this by updating started & stopped machines differently. 
- Started machines are updated in batches of 33%, which means at any point, you'll have at most 33% unavailable machines.
- stopped machines are updated in batches >= 30. 

With these changes, deployments with many stopped machines will see a reduction in deployment time, since we are now concurrently updating all stopped machines in large batches.

Fixes https://github.com/superfly/customer-help/issues/73
