### PR TITLE
Update fly auth token desc

### DIFF
--- a/internal/command/auth/token.go
+++ b/internal/command/auth/token.go
@@ -19,7 +19,7 @@ func newToken() *cobra.Command {
 		long = `Shows the authentication token that is currently in use by flyctl.
 The auth token used by flyctl may expire quickly and shouldn't be used in places
 where the token needs to keep working for a long time. For API authentication, you
-can use `fly tokens create` instead, to create narrowly-scoped tokens with 
+can use the fly tokens create command instead, to create narrowly-scoped tokens with
 a custom expiry.`
 
 		short = "Show the current auth token in use by flyctl."

--- a/internal/command/auth/token.go
+++ b/internal/command/auth/token.go
@@ -16,11 +16,13 @@ import (
 
 func newToken() *cobra.Command {
 	const (
-		long = `Shows the authentication token that is currently in use.
-This can be used as an authentication token with API services,
-independent of flyctl.
-`
-		short = "Show the current auth token"
+		long = `Shows the authentication token that is currently in use by flyctl.
+The auth token used by flyctl may expire quickly and shouldn't be used in places
+where the token needs to keep working for a long time. For API authentication, you
+can use `fly tokens create` instead, to create narrowly-scoped tokens with 
+a custom expiry.`
+
+		short = "Show the current auth token in use by flyctl."
 	)
 
 	cmd := command.New("token", short, long, runAuthToken,

--- a/internal/command/auth/token.go
+++ b/internal/command/auth/token.go
@@ -19,7 +19,7 @@ func newToken() *cobra.Command {
 		long = `Shows the authentication token that is currently in use by flyctl.
 The auth token used by flyctl may expire quickly and shouldn't be used in places
 where the token needs to keep working for a long time. For API authentication, you
-can use the fly tokens create command instead, to create narrowly-scoped tokens with
+can use the "fly tokens create" command instead, to create narrowly-scoped tokens with
 a custom expiry.`
 
 		short = "Show the current auth token in use by flyctl."


### PR DESCRIPTION
### Change Summary

What and Why:

See https://github.com/superfly/docs/pull/1741 for context. Suggest using an org token for API auth in the `fly auth token` help docs.

How:

Update desc text

Related to:

https://github.com/superfly/docs/pull/1741

---

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a
