### PR TITLE
surface idle timeout functionality

### DIFF
--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -203,7 +203,8 @@ func TestToDefinition(t *testing.T) {
 				"default_self_signed": false,
 			},
 			"http_options": map[string]any{
-				"compress": true,
+				"compress":     true,
+				"idle_timeout": int64(600),
 				"response": map[string]any{
 					"headers": map[string]any{
 						"fly-request-id": false,
@@ -340,10 +341,13 @@ func TestToDefinition(t *testing.T) {
 				},
 				"ports": []any{
 					map[string]any{
-						"port":        int64(80),
-						"start_port":  int64(100),
-						"end_port":    int64(200),
-						"handlers":    []any{"https"},
+						"port":       int64(80),
+						"start_port": int64(100),
+						"end_port":   int64(200),
+						"handlers":   []any{"https"},
+						"http_options": map[string]any{
+							"idle_timeout": int64(600),
+						},
 						"force_https": true,
 					},
 				},

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -430,7 +430,8 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 				DefaultSelfSigned: fly.Pointer(false),
 			},
 			HTTPOptions: &fly.HTTPOptions{
-				Compress: fly.Pointer(true),
+				Compress:    fly.Pointer(true),
+				IdleTimeout: UintPointer(600),
 				Response: &fly.HTTPResponseOptions{
 					Headers: map[string]any{
 						"fly-request-id": false,
@@ -553,6 +554,9 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 						EndPort:    fly.Pointer(200),
 						Handlers:   []string{"https"},
 						ForceHTTPS: true,
+						HTTPOptions: &fly.HTTPOptions{
+							IdleTimeout: UintPointer(600),
+						},
 					},
 				},
 
@@ -683,4 +687,8 @@ func TestYAMLPrettyPrint(t *testing.T) {
 	assert.Contains(t, string(buf), "\napp: foo\n")
 	assert.Contains(t, string(buf), "\n\nexperimental:\n  cmd:\n    - cmd\n")
 	assert.Contains(t, string(buf), "\n    processes:\n      - web\n")
+}
+
+func UintPointer(v uint32) *uint32 {
+	return &v
 }

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -94,6 +94,7 @@ host_dedication_id = "06031957"
   # https://community.fly.io/t/new-feature-basic-http-response-header-modification/3594
   [http_service.http_options]
     compress = true
+    idle_timeout = 600
 
   [http_service.http_options.response.headers]
     fly-request-id = false
@@ -188,6 +189,9 @@ host_dedication_id = "06031957"
     end_port = 200
     handlers = ["https"]
     force_https = true
+
+    [services.ports.http_options]
+      idle_timeout = 600
 
   [[services.tcp_checks]]
     interval = "21s"


### PR DESCRIPTION
### Change Summary
We now support users setting a custom idle timeout for their services. This is not documented anywhere or unearthed in flyctl either. I'm gonna make a fresh produce and also update our documentation.

### Documentation
- [x] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
