### PR TITLE
Show errors when BG Health Checks Fail

### DIFF
--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -151,6 +151,8 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 }
 
 func initBuilder(ctx context.Context, buildState *build, appName string, streams *iostreams.IOStreams) (*depotmachine.Machine, *depotbuild.Build, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
 	apiClient := flyutil.ClientFromContext(ctx)
 	region := os.Getenv("FLY_REMOTE_BUILDER_REGION")
 	if region != "" {
@@ -168,15 +170,22 @@ func initBuilder(ctx context.Context, buildState *build, appName string, streams
 		return nil, nil, err
 	}
 
+	fmt.Println("creating a build from an existing one")
 	build, err := depotbuild.FromExistingBuild(ctx, *buildInfo.EnsureDepotRemoteBuilder.BuildId, *buildInfo.EnsureDepotRemoteBuilder.BuildToken)
 	if err != nil {
+		fmt.Println("failed to create a build from an existing one")
+		streams.StopProgressIndicator()
 		return nil, nil, err
 	}
+	fmt.Println("created a build from an existing one")
 
 	// Set the buildErr to any error that represents the build failing.
+	fmt.Println("huh")
 	var buildErr error
 
+	fmt.Println("wut")
 	var buildkit *depotmachine.Machine
+	fmt.Println("get")
 	buildkit, buildErr = depotmachine.Acquire(ctx, build.ID, build.Token, "amd64")
 	if buildErr != nil {
 		build.Finish(buildErr)
@@ -184,7 +193,7 @@ func initBuilder(ctx context.Context, buildState *build, appName string, streams
 		return nil, nil, buildErr
 	}
 
-	return buildkit, &build, err
+	return buildkit, &build, nil
 }
 
 func buildImage(ctx context.Context, buildkitClient *client.Client, opts ImageOptions, dockerfilePath string) (*client.SolveResponse, error) {

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -401,19 +401,10 @@ func (bg *blueGreen) WaitForGreenMachinesToBeHealthy(ctx context.Context) error 
 
 			time.Sleep(gracePeriod)
 
-			numRetries := 0
 			for {
 				updateMachine, err := bg.flaps.Get(waitCtx, m.Machine().ID)
 
 				switch {
-				// context.DeadlineExceeded usually happens when the platform fails to respond to a Get in time. We should retry these
-				case errors.Is(err, context.DeadlineExceeded) && numRetries < 3:
-					waitCtx = context.WithoutCancel(ctx)
-					waitCtx, cancel = context.WithTimeout(waitCtx, bg.timeout)
-					defer cancel()
-
-					numRetries += 1
-					continue
 				case waitCtx.Err() != nil:
 					machineIDToHealthStatus[m.FormattedMachineId()] = healthCheckStatusResult{
 						err: waitCtx.Err(),

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -400,7 +400,9 @@ func (bg *blueGreen) WaitForGreenMachinesToBeHealthy(ctx context.Context) error 
 		go func(m machine.LeasableMachine) {
 			ctx, span := tracing.GetTracer().Start(ctx, "green_machine_health_check", trace.WithAttributes(
 				attribute.String("machine_id", m.FormattedMachineId()),
+				attribute.Int("bg_timeout_ms", int(bg.timeout.Milliseconds())),
 			))
+			defer span.End()
 
 			waitCtx, cancel := context.WithTimeout(ctx, bg.timeout)
 			defer cancel()

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -401,10 +401,19 @@ func (bg *blueGreen) WaitForGreenMachinesToBeHealthy(ctx context.Context) error 
 
 			time.Sleep(gracePeriod)
 
+			numRetries := 0
 			for {
 				updateMachine, err := bg.flaps.Get(waitCtx, m.Machine().ID)
 
 				switch {
+				// context.DeadlineExceeded usually happens when the platform fails to respond to a Get in time. We should retry these
+				case errors.Is(err, context.DeadlineExceeded) && numRetries < 3:
+					waitCtx = context.WithoutCancel(ctx)
+					waitCtx, cancel = context.WithTimeout(waitCtx, bg.timeout)
+					defer cancel()
+
+					numRetries += 1
+					continue
 				case waitCtx.Err() != nil:
 					machineIDToHealthStatus[m.FormattedMachineId()] = healthCheckStatusResult{
 						err: waitCtx.Err(),


### PR DESCRIPTION
### Change Summary

What and Why:
When we aren't able to get info about a machine during a health check, we don't change any statuses, we just show 'unchecked'. Showing an error is more useful to the user.

How:
Change "unchecked" to whatever error happened, if applicable.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
