### PR TITLE
don't pin debian version

### DIFF
--- a/scanner/templates/python-docker/Dockerfile
+++ b/scanner/templates/python-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:{{ .pyVersion }}-bookworm AS builder
+FROM python:{{ .pyVersion }} AS builder
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
@@ -25,7 +25,7 @@ COPY requirements.txt ./
 RUN .venv/bin/pip install -r requirements.txt
 {{ end -}}
 
-FROM python:{{ .pyVersion }}-slim-bookworm
+FROM python:{{ .pyVersion }}-slim
 WORKDIR /app
 COPY --from=builder /app/.venv .venv/
 COPY . .


### PR DESCRIPTION
Use the debian version selected by the python packagers

See https://community.fly.io/t/error-running-fly-launch-for-the-first-time-cant-fetch-python-3-10-6-bookworm-image/21220