### PR TITLE
Enable ObjectStorage plan for Laravel Apps!

### DIFF
--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -173,10 +173,10 @@ func LaravelCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan,
 		args = append(args, "--skip")
 	}
 	
-	// Add object storage( Tigris )
+	/*// Add object storage( Tigris )
 	if plan.ObjectStorage.Provider() != nil {
 		args = append(args, "--tigris")
-	}
+	}*/
 
 	// Add additional flags from launch command
 	if len(flags) > 0 {

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -25,7 +25,7 @@ func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 
 	// Laravel projects contain the `artisan` command
 	if !checksPass(sourceDir, fileExists("artisan")) {
-		return nil, nil 
+		return nil, nil
 	}
 
 	s := &SourceInfo{
@@ -92,7 +92,7 @@ func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 
 	// Enable Object Storage( Tigris ) when
 	// * league/flysystem-aws-s3* found in composer.json
-	if checksPass(sourceDir, dirContains("composer.json", "league/flysystem-aws-s3")){
+	if checksPass(sourceDir, dirContains("composer.json", "league/flysystem-aws-s3")) {
 		s.ObjectStorageDesired = true
 	}
 
@@ -172,7 +172,7 @@ func LaravelCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan,
 	if dockerfileExists {
 		args = append(args, "--skip")
 	}
-	
+
 	/*// Add object storage( Tigris )
 	if plan.ObjectStorage.Provider() != nil {
 		args = append(args, "--tigris")

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -93,7 +93,6 @@ func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 	// Enable Object Storage( Tigris ) when
 	// * league/flysystem-aws-s3* found in composer.json
 	if checksPass(sourceDir, dirContains("composer.json", "league/flysystem-aws-s3")){
-		fmt.Println( "found!")
 		s.ObjectStorageDesired = true
 	}
 

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -22,9 +22,10 @@ import (
 
 // setup Laravel with a sqlite database
 func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
+
 	// Laravel projects contain the `artisan` command
 	if !checksPass(sourceDir, fileExists("artisan")) {
-		return nil, nil
+		return nil, nil 
 	}
 
 	s := &SourceInfo{
@@ -87,6 +88,13 @@ func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 	s.RedisDesired = redis
 	if db != 0 {
 		s.DatabaseDesired = db
+	}
+
+	// Enable Object Storage( Tigris ) when
+	// * league/flysystem-aws-s3* found in composer.json
+	if checksPass(sourceDir, dirContains("composer.json", "league/flysystem-aws-s3")){
+		fmt.Println( "found!")
+		s.ObjectStorageDesired = true
 	}
 
 	return s, nil
@@ -160,12 +168,18 @@ func LaravelCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan,
 		}
 	}
 
+	// Add skip flag if dockerfile already exists
 	args := []string{vendorPath, "generate"}
 	if dockerfileExists {
 		args = append(args, "--skip")
 	}
+	
+	// Add object storage( Tigris )
+	if plan.ObjectStorage.Provider() != nil {
+		args = append(args, "--tigris")
+	}
 
-	// add additional flags from launch command
+	// Add additional flags from launch command
 	if len(flags) > 0 {
 		args = append(args, flags...)
 	}


### PR DESCRIPTION

### Change Summary

What and Why:
Enable ObjectStorage plan for Laravel apps so that users deploying their Laravel apps to Fly.io can automatically get Tigris configured for their Fly app.

 
How:
Scan for aws s3 usage in composer.json file and if found:
1.  Set ObjectStorageDesired to true
 
Related to:
https://flyio.slack.com/archives/C042W39VAMB/p1721229461279579
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
