### PR TITLE
Initial fly launch plan implementation

### DIFF
--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -9,6 +9,7 @@ import (
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command/launch/plan"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"github.com/superfly/flyctl/internal/flapsutil"
@@ -43,7 +44,9 @@ func (state *launchState) Launch(ctx context.Context) error {
 		state.warnedNoCcHa = true
 	}
 
-	if !flag.GetBool(ctx, "no-create") {
+	planStep := plan.GetPlanStep(ctx)
+
+	if !flag.GetBool(ctx, "no-create") && (planStep == "" || planStep == "create") {
 		app, err := state.createApp(ctx)
 		if err != nil {
 			return err
@@ -52,12 +55,20 @@ func (state *launchState) Launch(ctx context.Context) error {
 		fmt.Fprintf(io.Out, "Created app '%s' in organization '%s'\n", app.Name, app.Organization.Slug)
 		fmt.Fprintf(io.Out, "Admin URL: https://fly.io/apps/%s\n", app.Name)
 		fmt.Fprintf(io.Out, "Hostname: %s.fly.dev\n", app.Name)
+
+		if planStep == "create" {
+			return nil
+		}
 	}
 
 	// TODO: ideally this would be passed as a part of the plan to the Launch UI
 	// and allow choices of what actions are desired to be make there.
 	if state.sourceInfo != nil && state.sourceInfo.GitHubActions.Deploy {
-		state.setupGitHubActions(ctx, state.Plan.AppName)
+		if planStep == "" || planStep == "generate" {
+			if err = state.setupGitHubActions(ctx, state.Plan.AppName); err != nil {
+				return err
+			}
+		}
 	}
 
 	if err = state.satisfyScannerBeforeDb(ctx); err != nil {
@@ -66,16 +77,23 @@ func (state *launchState) Launch(ctx context.Context) error {
 	// TODO: Return rich info about provisioned DBs, including things
 	//       like public URLs.
 
-	if !flag.GetBool(ctx, "no-create") {
+	if !flag.GetBool(ctx, "no-create") && planStep != "generate" {
 		if err = state.createDatabases(ctx); err != nil {
 			return err
 		}
 	}
-	if err = state.satisfyScannerAfterDb(ctx); err != nil {
-		return err
+
+	if planStep != "" && planStep != "deploy" && planStep != "generate" {
+		return nil
 	}
-	if err = state.createDockerIgnore(ctx); err != nil {
-		return err
+
+	if planStep == "" || planStep == "generate" {
+		if err = state.satisfyScannerAfterDb(ctx); err != nil {
+			return err
+		}
+		if err = state.createDockerIgnore(ctx); err != nil {
+			return err
+		}
 	}
 
 	// Override internal port if requested using --internal-port flag

--- a/internal/command/launch/launch_databases.go
+++ b/internal/command/launch/launch_databases.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/gql"
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/command/extensions/supabase"
+	"github.com/superfly/flyctl/internal/command/launch/plan"
 	"github.com/superfly/flyctl/internal/command/postgres"
 	"github.com/superfly/flyctl/internal/command/redis"
 	"github.com/superfly/flyctl/internal/flyutil"
@@ -19,7 +20,9 @@ import (
 
 // createDatabases creates databases requested by the plan
 func (state *launchState) createDatabases(ctx context.Context) error {
-	if state.Plan.Postgres.FlyPostgres != nil {
+	planStep := plan.GetPlanStep(ctx)
+
+	if state.Plan.Postgres.FlyPostgres != nil && (planStep == "" || planStep == "postgres") {
 		err := state.createFlyPostgres(ctx)
 		if err != nil {
 			// TODO(Ali): Make error printing here better.
@@ -27,7 +30,7 @@ func (state *launchState) createDatabases(ctx context.Context) error {
 		}
 	}
 
-	if state.Plan.Postgres.SupabasePostgres != nil {
+	if state.Plan.Postgres.SupabasePostgres != nil && (planStep == "" || planStep == "postgres") {
 		err := state.createSupabasePostgres(ctx)
 		if err != nil {
 			// TODO(Ali): Make error printing here better.
@@ -35,7 +38,7 @@ func (state *launchState) createDatabases(ctx context.Context) error {
 		}
 	}
 
-	if state.Plan.Redis.UpstashRedis != nil {
+	if state.Plan.Redis.UpstashRedis != nil && (planStep == "" || planStep == "redis") {
 		err := state.createUpstashRedis(ctx)
 		if err != nil {
 			// TODO(Ali): Make error printing here better.
@@ -43,7 +46,7 @@ func (state *launchState) createDatabases(ctx context.Context) error {
 		}
 	}
 
-	if state.Plan.ObjectStorage.TigrisObjectStorage != nil {
+	if state.Plan.ObjectStorage.TigrisObjectStorage != nil && (planStep == "" || planStep == "tigris") {
 		err := state.createTigrisObjectStorage(ctx)
 		if err != nil {
 			// TODO(Ali): Make error printing here better.
@@ -52,7 +55,7 @@ func (state *launchState) createDatabases(ctx context.Context) error {
 	}
 
 	// Run any initialization commands required for Postgres if it was installed
-	if state.Plan.Postgres.Provider() != nil && state.sourceInfo != nil {
+	if state.Plan.Postgres.Provider() != nil && state.sourceInfo != nil && (planStep == "" || planStep == "postgres") {
 		for _, cmd := range state.sourceInfo.PostgresInitCommands {
 			if cmd.Condition {
 				if err := execInitCommand(ctx, cmd); err != nil {

--- a/internal/command/launch/plan/context.go
+++ b/internal/command/launch/plan/context.go
@@ -1,0 +1,16 @@
+package plan
+
+import "context"
+
+type contextKey string
+
+const PlanStepKey contextKey = "planStep"
+
+func GetPlanStep(ctx context.Context) string {
+	step := ctx.Value(PlanStepKey)
+	if step == nil {
+		return ""
+	} else {
+		return step.(string)
+	}
+}

--- a/internal/command/launch/plan_commands.go
+++ b/internal/command/launch/plan_commands.go
@@ -10,7 +10,7 @@ import (
 )
 
 func NewPlan() *cobra.Command {
-	const desc = `Granular subcommands for creating and configuring apps`
+	const desc = `[experimental] Granular subcommands for creating and configuring apps`
 
 	cmd := command.New("plan", desc, desc, nil, command.RequireSession, command.LoadAppConfigIfPresent)
 	cmd.Args = cobra.NoArgs
@@ -29,7 +29,7 @@ func NewPlan() *cobra.Command {
 }
 
 func newPropose() *cobra.Command {
-	const desc = "propose a plan based on scanning the source code or Dockerfile"
+	const desc = "[experimental] propose a plan based on scanning the source code or Dockerfile"
 	cmd := command.New("propose", desc, desc, runPropose)
 
 	flag.Add(cmd,
@@ -55,7 +55,7 @@ func newPropose() *cobra.Command {
 }
 
 func newCreate() *cobra.Command {
-	const desc = "create application"
+	const desc = "[experimental] create application"
 	cmd := command.New("create", desc, desc, runCreate)
 	cmd.Args = cobra.ExactArgs(1)
 
@@ -73,7 +73,7 @@ func newCreate() *cobra.Command {
 }
 
 func newPostgres() *cobra.Command {
-	const desc = "create postgres database"
+	const desc = "[experimental] create postgres database"
 	cmd := command.New("postgres", desc, desc, runPostgres)
 	cmd.Args = cobra.ExactArgs(1)
 
@@ -91,7 +91,7 @@ func newPostgres() *cobra.Command {
 }
 
 func newRedis() *cobra.Command {
-	const desc = "create redis database"
+	const desc = "[experimental] create redis database"
 	cmd := command.New("redis", desc, desc, runRedis)
 	cmd.Args = cobra.ExactArgs(1)
 
@@ -109,7 +109,7 @@ func newRedis() *cobra.Command {
 }
 
 func newTigris() *cobra.Command {
-	const desc = "create tigris database"
+	const desc = "[experimental] create tigris database"
 	cmd := command.New("tigris", desc, desc, runTigris)
 	cmd.Args = cobra.ExactArgs(1)
 
@@ -127,7 +127,7 @@ func newTigris() *cobra.Command {
 }
 
 func newGenerate() *cobra.Command {
-	const desc = "generate Dockerfile and other configuration files based on the plan"
+	const desc = "[experimental] generate Dockerfile and other configuration files based on the plan"
 	cmd := command.New("generate", desc, desc, runGenerate)
 	cmd.Args = cobra.ExactArgs(1)
 

--- a/internal/command/launch/plan_commands.go
+++ b/internal/command/launch/plan_commands.go
@@ -1,0 +1,201 @@
+package launch
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/command/launch/plan"
+	"github.com/superfly/flyctl/internal/flag"
+)
+
+func NewPlan() *cobra.Command {
+	const desc = `Granular subcommands for creating and configuring apps`
+
+	cmd := command.New("plan", desc, desc, nil, command.RequireSession, command.LoadAppConfigIfPresent)
+	cmd.Args = cobra.NoArgs
+
+	cmd.AddCommand(newPropose())
+	cmd.AddCommand(newCreate())
+	cmd.AddCommand(newPostgres())
+	cmd.AddCommand(newRedis())
+	cmd.AddCommand(newTigris())
+	cmd.AddCommand(newGenerate())
+
+	// Don't advertise this command yet
+	cmd.Hidden = true
+
+	return cmd
+}
+
+func newPropose() *cobra.Command {
+	const desc = "propose a plan based on scanning the source code or Dockerfile"
+	cmd := command.New("propose", desc, desc, runPropose)
+
+	flag.Add(cmd,
+		flag.String{
+			Name:        "from",
+			Description: "A github repo URL to use as a template for the new app",
+		},
+		flag.Bool{
+			Name:        "no-create",
+			Description: "Don't create an app",
+			Default:     true,
+			Hidden:      true,
+		},
+		flag.Bool{
+			Name:        "manifest",
+			Description: "Output the proposed manifest",
+			Default:     true,
+			Hidden:      true,
+		},
+	)
+
+	return cmd
+}
+
+func newCreate() *cobra.Command {
+	const desc = "create application"
+	cmd := command.New("create", desc, desc, runCreate)
+	cmd.Args = cobra.ExactArgs(1)
+
+	flag.Add(cmd,
+		flag.String{
+			Name:        "manifest-path",
+			Shorthand:   "p",
+			Description: "Path to read the manifest from",
+			Default:     "",
+			Hidden:      true,
+		},
+	)
+
+	return cmd
+}
+
+func newPostgres() *cobra.Command {
+	const desc = "create postgres database"
+	cmd := command.New("postgres", desc, desc, runPostgres)
+	cmd.Args = cobra.ExactArgs(1)
+
+	flag.Add(cmd,
+		flag.String{
+			Name:        "manifest-path",
+			Shorthand:   "p",
+			Description: "Path to read the manifest from",
+			Default:     "",
+			Hidden:      true,
+		},
+	)
+
+	return cmd
+}
+
+func newRedis() *cobra.Command {
+	const desc = "create redis database"
+	cmd := command.New("redis", desc, desc, runRedis)
+	cmd.Args = cobra.ExactArgs(1)
+
+	flag.Add(cmd,
+		flag.String{
+			Name:        "manifest-path",
+			Shorthand:   "p",
+			Description: "Path to read the manifest from",
+			Default:     "",
+			Hidden:      true,
+		},
+	)
+
+	return cmd
+}
+
+func newTigris() *cobra.Command {
+	const desc = "create tigris database"
+	cmd := command.New("tigris", desc, desc, runTigris)
+	cmd.Args = cobra.ExactArgs(1)
+
+	flag.Add(cmd,
+		flag.String{
+			Name:        "manifest-path",
+			Shorthand:   "p",
+			Description: "Path to read the manifest from",
+			Default:     "",
+			Hidden:      true,
+		},
+	)
+
+	return cmd
+}
+
+func newGenerate() *cobra.Command {
+	const desc = "generate Dockerfile and other configuration files based on the plan"
+	cmd := command.New("generate", desc, desc, runGenerate)
+	cmd.Args = cobra.ExactArgs(1)
+
+	flag.Add(cmd,
+		flag.App(),
+		flag.Region(),
+		flag.Org(),
+		flag.AppConfig(),
+		flag.Bool{
+			Name:        "no-deploy",
+			Description: "Don't deploy the app",
+			Default:     true,
+			Hidden:      true,
+		},
+		flag.Int{
+			Name:        "internal-port",
+			Description: "Set internal_port for all services in the generated fly.toml",
+			Default:     -1,
+			Hidden:      true,
+		},
+		flag.String{
+			Name:        "manifest-path",
+			Shorthand:   "p",
+			Description: "Path to read the manifest from",
+			Default:     "",
+			Hidden:      true,
+		},
+	)
+
+	return cmd
+}
+
+func RunPlan(ctx context.Context, step string) error {
+	ctx = context.WithValue(ctx, plan.PlanStepKey, step)
+	return run(ctx)
+}
+
+func runPropose(ctx context.Context) error {
+	RunPlan(ctx, "propose")
+	return nil
+}
+
+func runCreate(ctx context.Context) error {
+	flag.SetString(ctx, "manifest-path", flag.FirstArg(ctx))
+	RunPlan(ctx, "create")
+	return nil
+}
+
+func runPostgres(ctx context.Context) error {
+	flag.SetString(ctx, "manifest-path", flag.FirstArg(ctx))
+	RunPlan(ctx, "postgres")
+	return nil
+}
+
+func runRedis(ctx context.Context) error {
+	flag.SetString(ctx, "manifest-path", flag.FirstArg(ctx))
+	RunPlan(ctx, "redis")
+	return nil
+}
+
+func runTigris(ctx context.Context) error {
+	flag.SetString(ctx, "manifest-path", flag.FirstArg(ctx))
+	RunPlan(ctx, "tigris")
+	return nil
+}
+
+func runGenerate(ctx context.Context) error {
+	flag.SetString(ctx, "manifest-path", flag.FirstArg(ctx))
+	RunPlan(ctx, "generate")
+	return nil
+}

--- a/internal/command/launch/sourceinfo.go
+++ b/internal/command/launch/sourceinfo.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cavaliergopher/grab/v3"
 	"github.com/logrusorgru/aurora"
 	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command/launch/plan"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/scanner"
@@ -62,7 +63,12 @@ func determineSourceInfo(ctx context.Context, appConfig *appconfig.Config, copyC
 		return srcInfo, appConfig.Build, nil
 	}
 
-	fmt.Fprintln(io.Out, "Scanning source code")
+	planStep := plan.GetPlanStep(ctx)
+
+	if planStep == "" || planStep == "generate" {
+		fmt.Fprintln(io.Out, "Scanning source code")
+	}
+
 	srcInfo, err = scanner.Scan(workingDir, scannerConfig)
 	if err != nil {
 		return nil, nil, err
@@ -78,7 +84,9 @@ func determineSourceInfo(ctx context.Context, appConfig *appconfig.Config, copyC
 		appType = appType + " " + srcInfo.Version
 	}
 
-	fmt.Fprintf(io.Out, "Detected %s %s app\n", articleFor(srcInfo.Family), aurora.Green(appType))
+	if planStep == "" || planStep == "generate" {
+		fmt.Fprintf(io.Out, "Detected %s %s app\n", articleFor(srcInfo.Family), aurora.Green(appType))
+	}
 
 	if srcInfo.Builder != "" {
 		fmt.Fprintln(io.Out, "Using the following build configuration:")


### PR DESCRIPTION
```
% ~/git/flyctl/bin/flyctl launch plan
Granular subcommands for creating and configuring apps

Usage:
  fly launch plan [command]

Available Commands:
  create      create application
  generate    generate Dockerfile and other configuration files based on the plan
  postgres    create postgres database
  propose     propose a plan based on scanning the source code or Dockerfile
  redis       create redis database
  tigris      create tigris database
```