### PR TITLE
Allow specifying org name when launching

### DIFF
--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -604,11 +604,15 @@ func determineOrg(ctx context.Context, config *appconfig.Config) (*fly.Organizat
 	for _, o := range orgs {
 		bySlug[o.Slug] = o
 	}
+	byName := make(map[string]fly.Organization, len(orgs))
+	for _, o := range orgs {
+		byName[o.Name] = o
+	}
 
 	personal, foundPersonal := bySlug["personal"]
 
-	orgSlug := flag.GetOrg(ctx)
-	if orgSlug == "" {
+	orgRequested := flag.GetOrg(ctx)
+	if orgRequested == "" {
 		if !foundPersonal {
 			if len(orgs) == 0 {
 				return nil, "", errors.New("no organizations found. Please create one from your fly dashboard first.")
@@ -621,13 +625,17 @@ func determineOrg(ctx context.Context, config *appconfig.Config) (*fly.Organizat
 		return &personal, "fly launch defaults to the personal org", nil
 	}
 
-	org, foundSlug := bySlug[orgSlug]
+	org, foundSlug := bySlug[orgRequested]
 	if !foundSlug {
+		if org, foundName := byName[orgRequested]; foundName {
+			return &org, "specified on the command line", nil
+		}
+
 		if !foundPersonal {
 			return nil, "", errors.New("no personal organization found")
 		}
 
-		return &personal, recoverableSpecifyInUi, recoverableInUiError{fmt.Errorf("organization '%s' not found", orgSlug)}
+		return &personal, recoverableSpecifyInUi, recoverableInUiError{fmt.Errorf("organization '%s' not found", orgRequested)}
 	}
 
 	return &org, "specified on the command line", nil


### PR DESCRIPTION
### Change Summary

What and Why:
Allowing the user to specify the org's name makes since, since the org's slug is more of an internal thing.

How:
Try to match the name of the org if we can't find a slug we're trying to launch to (backwards compatibility).

Related to:

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
