### PR TITLE
Don't ignore result of confirmation prompt when updating Postgres config

### DIFF
--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -314,7 +314,7 @@ func resolveConfigChanges(ctx context.Context, app *fly.AppCompact, manager stri
 			switch confirmed, err := prompt.Confirmf(ctx, msg); {
 			case err == nil:
 				if !confirmed {
-					return false, nil, nil
+					return false, nil, fmt.Errorf("cancelled")
 				}
 			case prompt.IsNonInteractive(err):
 				return false, nil, prompt.NonInteractiveError("yes flag must be specified when not running interactively")


### PR DESCRIPTION
### Change Summary

* Don't ignore result of confirmation prompt when updating Postgres config

Related to: https://github.com/superfly/postgres-stub/issues/59

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
