### PR TITLE
fix: m.Config could be nil

### DIFF
--- a/internal/command/scale/machine_defaults.go
+++ b/internal/command/scale/machine_defaults.go
@@ -25,7 +25,7 @@ type defaultValues struct {
 func newDefaults(appConfig *appconfig.Config, latest fly.Release, machines []*fly.Machine, volumes []fly.Volume, snapshotID string, withNewVolumes bool, fallbackGuest *fly.MachineGuest) *defaultValues {
 	guestPerGroup := lo.Associate(
 		lo.Filter(machines, func(m *fly.Machine, _ int) bool {
-			return m.Config.Guest != nil
+			return m.Config != nil && m.Config.Guest != nil
 		}),
 		func(m *fly.Machine) (string, *fly.MachineGuest) {
 			return m.ProcessGroup(), m.Config.Guest


### PR DESCRIPTION
Check m.Config first to prevent a panic.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
