### PR TITLE
feat: show unhandled panics as is

### DIFF
--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -185,11 +185,9 @@ func printError(v interface{}) {
 
 	fmt.Fprintln(&buf, aurora.Red("Oops, something went wrong! Could you try that again?"))
 
-	if buildinfo.IsDev() {
-		fmt.Fprintln(&buf)
-		fmt.Fprintln(&buf, v)
-		fmt.Fprintln(&buf, string(debug.Stack()))
-	}
+	fmt.Fprintln(&buf)
+	fmt.Fprintln(&buf, v)
+	fmt.Fprintln(&buf, string(debug.Stack()))
 
 	buf.WriteTo(os.Stdout)
 }


### PR DESCRIPTION
"Oops, something went wrong!" is really hard to debug. It is better to show unhandled panics as is.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
