### PR TITLE
Support for scanners to add custom key name to replace an extension's secret key name

### DIFF
--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -40,8 +40,8 @@ type ExtensionParams struct {
 	ErrorCaptureCallback func(ctx context.Context, provisioningError error, params *ExtensionParams) error
 
 	// Surely there's a nicer way to do this, but this gets `fly launch` unblocked on launching exts
-	OverrideRegion string
-	OverrideName   *string
+	OverrideRegion                  string
+	OverrideName                    *string
 	OverrideExtensionSecretKeyNames map[string]map[string]string
 }
 
@@ -242,7 +242,7 @@ func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension 
 
 	// Also take into consideration custom key names to replace extension's default secret key names
 	overrideSecretKeyNamesMap := params.OverrideExtensionSecretKeyNames[params.Provider]
-	setSecretsFromExtension(ctx, &targetApp, &extension, overrideSecretKeyNamesMap )
+	setSecretsFromExtension(ctx, &targetApp, &extension, overrideSecretKeyNamesMap)
 
 	return extension, nil
 }
@@ -477,11 +477,11 @@ func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *E
 			AppId: app.Id,
 		}
 		for _, key := range keys {
-			if customKeyName, exists := overrideSecretKeyNamesMap[key]; exists{
+			if customKeyName, exists := overrideSecretKeyNamesMap[key]; exists {
 				// If a custom key name is identified for the extension's secret key, use that custom key
 				input.Secrets = append(input.Secrets, gql.SecretInput{Key: customKeyName, Value: secrets[key].(string)})
 				fmt.Fprintf(io.Out, "%s: %s\n", customKeyName, secrets[key].(string))
-			}else{
+			} else {
 				// Use the default secret key name
 				input.Secrets = append(input.Secrets, gql.SecretInput{Key: key, Value: secrets[key].(string)})
 				fmt.Fprintf(io.Out, "%s: %s\n", key, secrets[key].(string))

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -42,6 +42,7 @@ type ExtensionParams struct {
 	// Surely there's a nicer way to do this, but this gets `fly launch` unblocked on launching exts
 	OverrideRegion string
 	OverrideName   *string
+	OverrideExtensionSecretKeyNames map[string]map[string]string
 }
 
 // Common flags that should be used for all extension commands
@@ -239,7 +240,9 @@ func ProvisionExtension(ctx context.Context, params ExtensionParams) (extension 
 			colorize.Green(primaryRegion), provider.DisplayName)
 	}
 
-	setSecretsFromExtension(ctx, &targetApp, &extension)
+	// Also take into consideration custom key names to replace extension's default secret key names
+	overrideSecretKeyNamesMap := params.OverrideExtensionSecretKeyNames[params.Provider]
+	setSecretsFromExtension(ctx, &targetApp, &extension, overrideSecretKeyNamesMap )
 
 	return extension, nil
 }
@@ -426,7 +429,7 @@ func Discover(ctx context.Context, provider gql.AddOnType) (addOn *gql.AddOnData
 	return
 }
 
-func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *Extension) (err error) {
+func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *Extension, overrideSecretKeyNamesMap map[string]string) (err error) {
 	var (
 		io              = iostreams.FromContext(ctx)
 		client          = flyutil.ClientFromContext(ctx).GenqClient()
@@ -434,6 +437,7 @@ func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *E
 	)
 
 	environment := extension.Data.Environment
+
 	if environment == nil || reflect.ValueOf(environment).IsNil() {
 		return nil
 	}
@@ -473,8 +477,15 @@ func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *E
 			AppId: app.Id,
 		}
 		for _, key := range keys {
-			input.Secrets = append(input.Secrets, gql.SecretInput{Key: key, Value: secrets[key].(string)})
-			fmt.Fprintf(io.Out, "%s: %s\n", key, secrets[key].(string))
+			if customKeyName, exists := overrideSecretKeyNamesMap[key]; exists{
+				// If a custom key name is identified for the extension's secret key, use that custom key
+				input.Secrets = append(input.Secrets, gql.SecretInput{Key: customKeyName, Value: secrets[key].(string)})
+				fmt.Fprintf(io.Out, "%s: %s\n", customKeyName, secrets[key].(string))
+			}else{
+				// Use the default secret key name
+				input.Secrets = append(input.Secrets, gql.SecretInput{Key: key, Value: secrets[key].(string)})
+				fmt.Fprintf(io.Out, "%s: %s\n", key, secrets[key].(string))
+			}
 		}
 
 		fmt.Fprintln(io.Out)

--- a/internal/command/launch/launch_databases.go
+++ b/internal/command/launch/launch_databases.go
@@ -242,6 +242,7 @@ func (state *launchState) createTigrisObjectStorage(ctx context.Context) error {
 				"domain_name": tigrisPlan.WebsiteDomainName,
 			},
 		},
+		OverrideExtensionSecretKeyNames: state.sourceInfo.OverrideExtensionSecretKeyNames,
 	}
 
 	_, err = extensions_core.ProvisionExtension(ctx, params)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -57,6 +57,7 @@ type SourceInfo struct {
 	SwapSizeMB                   int
 	Buildpacks                   []string
 	Secrets                      []Secret
+	 
 	Files                        []SourceFile
 	Port                         int
 	Env                          map[string]string
@@ -75,6 +76,7 @@ type SourceInfo struct {
 	RedisDesired                 bool
 	GitHubActions                GitHubActionsStruct
 	ObjectStorageDesired         bool
+	OverrideExtensionSecretKeyNames map[string]map[string]string      
 	Concurrency                  map[string]int
 	Callback                     func(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan, flags []string) error
 	HttpCheckPath                string

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -45,47 +45,47 @@ const (
 )
 
 type SourceInfo struct {
-	Family                       string
-	Version                      string
-	DockerfilePath               string
-	BuildArgs                    map[string]string
-	Builder                      string
-	ReleaseCmd                   string
-	DockerCommand                string
-	DockerEntrypoint             string
-	KillSignal                   string
-	SwapSizeMB                   int
-	Buildpacks                   []string
-	Secrets                      []Secret
-	 
-	Files                        []SourceFile
-	Port                         int
-	Env                          map[string]string
-	Statics                      []Static
-	Processes                    map[string]string
-	DeployDocs                   string
-	Notice                       string
-	SkipDeploy                   bool
-	SkipDatabase                 bool
-	Volumes                      []Volume
-	DockerfileAppendix           []string
-	InitCommands                 []InitCommand
-	PostgresInitCommands         []InitCommand
-	PostgresInitCommandCondition bool
-	DatabaseDesired              DatabaseKind
-	RedisDesired                 bool
-	GitHubActions                GitHubActionsStruct
-	ObjectStorageDesired         bool
-	OverrideExtensionSecretKeyNames map[string]map[string]string      
-	Concurrency                  map[string]int
-	Callback                     func(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan, flags []string) error
-	HttpCheckPath                string
-	HttpCheckHeaders             map[string]string
-	ConsoleCommand               string
-	MergeConfig                  *MergeConfigStruct
-	AutoInstrumentErrors         bool
-	FailureCallback              func(err error) error
-	Runtime                      plan.RuntimeStruct
+	Family           string
+	Version          string
+	DockerfilePath   string
+	BuildArgs        map[string]string
+	Builder          string
+	ReleaseCmd       string
+	DockerCommand    string
+	DockerEntrypoint string
+	KillSignal       string
+	SwapSizeMB       int
+	Buildpacks       []string
+	Secrets          []Secret
+
+	Files                           []SourceFile
+	Port                            int
+	Env                             map[string]string
+	Statics                         []Static
+	Processes                       map[string]string
+	DeployDocs                      string
+	Notice                          string
+	SkipDeploy                      bool
+	SkipDatabase                    bool
+	Volumes                         []Volume
+	DockerfileAppendix              []string
+	InitCommands                    []InitCommand
+	PostgresInitCommands            []InitCommand
+	PostgresInitCommandCondition    bool
+	DatabaseDesired                 DatabaseKind
+	RedisDesired                    bool
+	GitHubActions                   GitHubActionsStruct
+	ObjectStorageDesired            bool
+	OverrideExtensionSecretKeyNames map[string]map[string]string
+	Concurrency                     map[string]int
+	Callback                        func(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan, flags []string) error
+	HttpCheckPath                   string
+	HttpCheckHeaders                map[string]string
+	ConsoleCommand                  string
+	MergeConfig                     *MergeConfigStruct
+	AutoInstrumentErrors            bool
+	FailureCallback                 func(err error) error
+	Runtime                         plan.RuntimeStruct
 }
 
 type SourceFile struct {


### PR DESCRIPTION
### Change Summary

**What and Why:**
This PR allows framework scanners to specify custom key names that will be used to replace an extension's secret key name that are set for an app during `fly launch`.

**How:**
1. Include an additional attribute "[OverrideExtensionSecretKeyNames](https://github.com/superfly/flyctl/pull/3851/files#diff-7d1df5e49f35d124e1d892865498cde1749af35afbb0f0022499a4b1b09a91eaR79)" that will hold a map with this structure:
```
{
  "extension_name":{
      "secret_key_name_to_be_replaced": "new_secret_key_name_to_replace_the_default_secret_key_name"
   },
}
```
2. Pass this map from [sourceInfo](https://github.com/superfly/flyctl/pull/3851/files#diff-7d1df5e49f35d124e1d892865498cde1749af35afbb0f0022499a4b1b09a91eaR79) created by a scanner until the [setSecretsFromExtension](https://github.com/superfly/flyctl/pull/3851/files#diff-fe8032b4743c1ac65a8319a27d5b0a869782aedc86233aa5e0e326da785fe6e2R245)() which is used to set secrets for an app that are  relavant to an extension that was provided.

3. During setting of extension secrets for an app,[ replace any secret key name using their matching custom secret key name](https://github.com/superfly/flyctl/pull/3851/files#diff-fe8032b4743c1ac65a8319a27d5b0a869782aedc86233aa5e0e326da785fe6e2R480) specified in OverrideExtensionSecretKeyNames, if they have any

**Related to:**

This would allow the Laravel Scanner to specify the correct secret key names to be set for it which are needed in its [integration with the Tigris Object Storage extension.](https://fly.io/docs/laravel/the-basics/laravel-tigris-file-storage/#:~:text=additional%20env%20variables)

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
