### PR TITLE
show proper count of machines to be deleted when using fly machines destroy --force --image

### DIFF
--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -81,7 +81,7 @@ func runMachineDestroy(ctx context.Context) (err error) {
 
 		confirmed, err := prompt.Confirm(ctx,
 			fmt.Sprintf("%d Machines (%s) will be destroyed, continue?",
-				len(machines),
+				len(machinesToBeDeleted),
 				strings.Join(ids, ","),
 			))
 		if err != nil {


### PR DESCRIPTION
### Change Summary
`fly machines destroy --force --image=library/redis:latest` was returning bad counts, for machines to be deleted and wasn't instilling alot of confidence in users. This was caused by a tiny bug introduced in https://github.com/superfly/flyctl/pull/3840/