### PR TITLE
Enable Tigris support for Laravel apps

### DIFF
--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -95,10 +95,10 @@ func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 		s.ObjectStorageDesired = true
 		s.OverrideExtensionSecretKeyNames = make(map[string]map[string]string)
 		s.OverrideExtensionSecretKeyNames["tigris"] = make(map[string]string)
-		
-       	// Replace the following secret key names set from the tigris extension provisioning
-       	// With their custom secret key name vales
-        s.OverrideExtensionSecretKeyNames["tigris"]["AWS_REGION"] = "AWS_DEFAULT_REGION"
+
+		// Replace the following secret key names set from the tigris extension provisioning
+		// With their custom secret key name vales
+		s.OverrideExtensionSecretKeyNames["tigris"]["AWS_REGION"] = "AWS_DEFAULT_REGION"
 		s.OverrideExtensionSecretKeyNames["tigris"]["BUCKET_NAME"] = "AWS_BUCKET"
 		s.OverrideExtensionSecretKeyNames["tigris"]["AWS_ENDPOINT_URL_S3"] = "AWS_ENDPOINT"
 	}

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -89,6 +89,20 @@ func configureLaravel(sourceDir string, config *ScannerConfig) (*SourceInfo, err
 		s.DatabaseDesired = db
 	}
 
+	// Enable Object Storage( Tigris ) when
+	// * league/flysystem-aws-s3* found in composer.json
+	if checksPass(sourceDir, dirContains("composer.json", "league/flysystem-aws-s3")) {
+		s.ObjectStorageDesired = true
+		s.OverrideExtensionSecretKeyNames = make(map[string]map[string]string)
+		s.OverrideExtensionSecretKeyNames["tigris"] = make(map[string]string)
+		
+       	// Replace the following secret key names set from the tigris extension provisioning
+       	// With their custom secret key name vales
+        s.OverrideExtensionSecretKeyNames["tigris"]["AWS_REGION"] = "AWS_DEFAULT_REGION"
+		s.OverrideExtensionSecretKeyNames["tigris"]["BUCKET_NAME"] = "AWS_BUCKET"
+		s.OverrideExtensionSecretKeyNames["tigris"]["AWS_ENDPOINT_URL_S3"] = "AWS_ENDPOINT"
+	}
+
 	return s, nil
 }
 


### PR DESCRIPTION


### Change Summary

**What and Why:**
Enable tigris extension for Laravel fly apps, and use the [proper secret names](https://fly.io/docs/laravel/the-basics/laravel-tigris-file-storage/#integrating-laravel-with-tigris) for integrating the extension. 

 This PR is created so that users deploying their Laravel apps to Fly.io can automatically get Tigris configured for their Fly app.
 
**How:**
1. Scan for the aws s3 package in a project's composer.json file
2. Enable Tigris support for the Laravel FLy app by:
    - setting ObjectStorageDesired = true
    - setting the needed custom secret key names in the OverrideExtensionSecretKeyNames map

**Related to:**
https://github.com/superfly/flyctl/pull/3833
https://flyio.slack.com/archives/C042W39VAMB/p1721229461279579
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
