### PR TITLE
allow specifying builder scope for a single app or an org

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.1.25
+	github.com/superfly/fly-go v0.1.26
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.14-0.20240702184853-b8ac52a1fc77
@@ -269,5 +269,3 @@ replace (
 	github.com/loadsmart/calver-go => github.com/ndarilek/calver-go v0.0.0-20230710153822-893bbd83a936
 	github.com/nats-io/nats.go => github.com/btoews/nats.go v0.0.0-20240401180931-476bea7f4158
 )
-
-replace github.com/superfly/fly-go => github.com/superfly/fly-go v0.1.26-0.20240814214740-435a794a210d

--- a/go.mod
+++ b/go.mod
@@ -269,3 +269,5 @@ replace (
 	github.com/loadsmart/calver-go => github.com/ndarilek/calver-go v0.0.0-20230710153822-893bbd83a936
 	github.com/nats-io/nats.go => github.com/btoews/nats.go v0.0.0-20240401180931-476bea7f4158
 )
+
+replace github.com/superfly/fly-go => github.com/superfly/fly-go v0.1.26-0.20240814214740-435a794a210d

--- a/go.sum
+++ b/go.sum
@@ -621,8 +621,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.25 h1:h3kfSXREYRSlY1y5bKxxrql+nIvtEE2C6Wr0n1lg70o=
-github.com/superfly/fly-go v0.1.25/go.mod h1:JQke/BwoZqrWurqYkypSlcSo7bIUgCI3eVnqMC6AUj0=
+github.com/superfly/fly-go v0.1.26-0.20240814214740-435a794a210d h1:01xhjoTgeJyOvo0mB4T3mgo+RmzwNHTrQDH4i9iqvNg=
+github.com/superfly/fly-go v0.1.26-0.20240814214740-435a794a210d/go.mod h1:JQke/BwoZqrWurqYkypSlcSo7bIUgCI3eVnqMC6AUj0=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/go.sum
+++ b/go.sum
@@ -621,8 +621,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.26-0.20240814214740-435a794a210d h1:01xhjoTgeJyOvo0mB4T3mgo+RmzwNHTrQDH4i9iqvNg=
-github.com/superfly/fly-go v0.1.26-0.20240814214740-435a794a210d/go.mod h1:JQke/BwoZqrWurqYkypSlcSo7bIUgCI3eVnqMC6AUj0=
+github.com/superfly/fly-go v0.1.26 h1:X0d6aeNNCQAyHgOigbIqTwloBRXJEW5pRFjwT53GY4g=
+github.com/superfly/fly-go v0.1.26/go.mod h1:JQke/BwoZqrWurqYkypSlcSo7bIUgCI3eVnqMC6AUj0=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -51,8 +51,7 @@ func (s depotBuilderScope) String() string {
 	}
 }
 
-
-type DepotBuilder struct{
+type DepotBuilder struct {
 	Scope depotBuilderScope
 }
 
@@ -182,8 +181,8 @@ func initBuilder(ctx context.Context, buildState *build, appName string, streams
 	defer buildState.BuilderInitFinish()
 
 	buildInfo, err := apiClient.EnsureDepotRemoteBuilder(ctx, &fly.EnsureDepotRemoteBuilderInput{
-		AppName: &appName,
-		Region:  &region,
+		AppName:      &appName,
+		Region:       &region,
 		BuilderScope: fly.StringPointer(builderScope.String()),
 	})
 	if err != nil {

--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -33,7 +33,28 @@ import (
 
 var _ imageBuilder = (*DepotBuilder)(nil)
 
-type DepotBuilder struct{}
+type depotBuilderScope int
+
+const (
+	DepotBuilderScopeOrganization depotBuilderScope = iota
+	DepotBuilderScopeApp
+)
+
+func (s depotBuilderScope) String() string {
+	switch s {
+	case DepotBuilderScopeOrganization:
+		return "organization"
+	case DepotBuilderScopeApp:
+		return "app"
+	default:
+		return "unknown"
+	}
+}
+
+
+type DepotBuilder struct{
+	Scope depotBuilderScope
+}
 
 func (d *DepotBuilder) Name() string { return "depot.dev" }
 
@@ -81,7 +102,7 @@ func (d *DepotBuilder) Run(ctx context.Context, _ *dockerClientFactory, streams 
 
 	build.ImageBuildStart()
 
-	image, err := depotBuild(ctx, streams, opts, dockerfile, build)
+	image, err := depotBuild(ctx, streams, opts, dockerfile, build, d.Scope)
 	if err != nil {
 		metrics.SendNoData(ctx, "remote_builder_failure")
 		build.ImageBuildFinish()
@@ -98,7 +119,7 @@ func (d *DepotBuilder) Run(ctx context.Context, _ *dockerClientFactory, streams 
 	return image, "", nil
 }
 
-func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOptions, dockerfilePath string, buildState *build) (*DeploymentImage, error) {
+func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOptions, dockerfilePath string, buildState *build, scope depotBuilderScope) (*DeploymentImage, error) {
 	buildState.BuilderInitStart()
 	buildState.SetBuilderMetaPart1(depotBuilderType, "", "")
 
@@ -111,7 +132,7 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 		}
 	}
 
-	buildkit, build, buildErr := initBuilder(ctx, buildState, opts.AppName, streams)
+	buildkit, build, buildErr := initBuilder(ctx, buildState, opts.AppName, streams, scope)
 	if buildErr != nil {
 		streams.StopProgressIndicator()
 		return nil, buildErr
@@ -151,7 +172,7 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 	return newDeploymentImage(res, opts.Tag)
 }
 
-func initBuilder(ctx context.Context, buildState *build, appName string, streams *iostreams.IOStreams) (*depotmachine.Machine, *depotbuild.Build, error) {
+func initBuilder(ctx context.Context, buildState *build, appName string, streams *iostreams.IOStreams, builderScope depotBuilderScope) (*depotmachine.Machine, *depotbuild.Build, error) {
 	apiClient := flyutil.ClientFromContext(ctx)
 	region := os.Getenv("FLY_REMOTE_BUILDER_REGION")
 	if region != "" {
@@ -163,6 +184,7 @@ func initBuilder(ctx context.Context, buildState *build, appName string, streams
 	buildInfo, err := apiClient.EnsureDepotRemoteBuilder(ctx, &fly.EnsureDepotRemoteBuilderInput{
 		AppName: &appName,
 		Region:  &region,
+		BuilderScope: fly.StringPointer(builderScope.String()),
 	})
 	if err != nil {
 		streams.StopProgressIndicator()

--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -149,7 +149,11 @@ const (
 )
 
 func validateBuilder(ctx context.Context, app *fly.App) (*fly.Machine, error) {
-	ctx, span := tracing.GetTracer().Start(ctx, "validate_builder", trace.WithAttributes(attribute.String("builder_app", lo.Ternary(app != nil, app.Name, ""))))
+	var builderAppName string
+	if app != nil {
+		builderAppName = app.Name
+	}
+	ctx, span := tracing.GetTracer().Start(ctx, "validate_builder", trace.WithAttributes(attribute.String("builder_app", builderAppName)))
 	defer span.End()
 
 	if app == nil {

--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -14,6 +14,8 @@ import (
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/haikunator"
 	"github.com/superfly/flyctl/internal/tracing"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func EnsureBuilder(ctx context.Context, org *fly.Organization, region string, recreateBuilder bool) (*fly.Machine, *fly.App, error) {
@@ -23,6 +25,7 @@ func EnsureBuilder(ctx context.Context, org *fly.Organization, region string, re
 	if !recreateBuilder {
 		builderApp := org.RemoteBuilderApp
 		if builderApp != nil {
+			span.SetAttributes(attribute.String("builder_app", builderApp.Name))
 			flaps, err := flapsutil.NewClientWithOptions(ctx, flaps.NewClientOpts{
 				AppName: builderApp.Name,
 				// TOOD(billy) make a utility function for App -> AppCompact
@@ -99,6 +102,7 @@ func EnsureBuilder(ctx context.Context, org *fly.Organization, region string, re
 	}
 
 	builderName := "fly-builder-" + haikunator.Haikunator().Build()
+	span.SetAttributes(attribute.String("builder_name", builderName))
 	// we want to lauch the machine to the builder
 	flapsClient, err := flapsutil.NewClientWithOptions(ctx, flaps.NewClientOpts{
 		AppName: builderName,
@@ -145,7 +149,7 @@ const (
 )
 
 func validateBuilder(ctx context.Context, app *fly.App) (*fly.Machine, error) {
-	ctx, span := tracing.GetTracer().Start(ctx, "validate_builder")
+	ctx, span := tracing.GetTracer().Start(ctx, "validate_builder", trace.WithAttributes(attribute.String("builder_app", lo.Ternary(app != nil, app.Name, ""))))
 	defer span.End()
 
 	if app == nil {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -51,6 +51,7 @@ var CommonFlags = flag.Set{
 	flag.BuildTarget(),
 	flag.NoCache(),
 	flag.Depot(),
+	flag.DepotScope(),
 	flag.Nixpacks(),
 	flag.BuildOnly(),
 	flag.BpDockerHost(),

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -560,6 +560,14 @@ func Depot() Bool {
 	}
 }
 
+func DepotScope() String {
+	return String{
+		Name:        "depot-scope",
+		Description: "The scope of the Depot builder's cache to use (organization or app)",
+		Default:     "organization",
+	}
+}
+
 func Nixpacks() Bool {
 	return Bool{
 		Name:        "nixpacks",

--- a/test/preflight/fly_logs_test.go
+++ b/test/preflight/fly_logs_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 )
 
-
 func TestFlyLogsMachineFlagBehavior(t *testing.T) {
 	// Test `flyctl logs` with different flag combinations
 
@@ -28,16 +27,16 @@ func TestFlyLogsMachineFlagBehavior(t *testing.T) {
 
 	// Test if --machine works, should not throw an error
 	t.Run("TestRunsWhenMachineFlagProvided", func(tt *testing.T) {
-		f.Fly("logs --app "+appName+" --no-tail --machine " + machineId)
+		f.Fly("logs --app " + appName + " --no-tail --machine " + machineId)
 	})
 
 	// Test if --instance works, should not throw an error
 	t.Run("TestRunsWhenInstanceFlagProvided", func(tt *testing.T) {
-		f.Fly("logs  --app "+appName+" --no-tail --instance " + machineId)
+		f.Fly("logs  --app " + appName + " --no-tail --instance " + machineId)
 	})
 
 	// Test if alias shorthand -i works, should not throw an error
 	t.Run("TestRunsWhenInstanceShorthandProvided", func(tt *testing.T) {
-		f.Fly("logs --app "+appName+" --no-tail -i " + machineId)
+		f.Fly("logs --app " + appName + " --no-tail -i " + machineId)
 	})
 }


### PR DESCRIPTION
### Change Summary

What and Why:
you can now specify --depot-scope=app to make sure your app's builder cache isn't shared by other apps

How:
Just added another field to the mutation. most of the 'work' is in web

Related to:

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
