### PR TITLE
move some of plan.go into a proper FSM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/prometheus/blackbox_exporter v0.25.0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/client_model v0.6.1
+	github.com/qmuntal/stateless v1.7.0
 	github.com/r3labs/diff v1.1.0
 	github.com/samber/lo v1.47.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966

--- a/go.sum
+++ b/go.sum
@@ -548,6 +548,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
+github.com/qmuntal/stateless v1.7.0 h1:Gzw/TUfmSQxoof7TSQ4kCa4DYwnDD5szeAI29BAR/jY=
+github.com/qmuntal/stateless v1.7.0/go.mod h1:n1HjRBM/cq4uCr3rfUjaMkgeGcd+ykAZwkjLje6jGBM=
 github.com/r3labs/diff v1.1.0 h1:V53xhrbTHrWFWq3gI4b94AjgEJOerO1+1l0xyHOBi8M=
 github.com/r3labs/diff v1.1.0/go.mod h1:7WjXasNzi0vJetRcB/RqNl5dlIsmXcTTLmF5IoH6Xig=
 github.com/rivo/tview v0.0.0-20220307222120-9994674d60a8 h1:xe+mmCnDN82KhC010l3NfYlA8ZbOuzbXAzSYBa6wbMc=

--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -116,6 +116,7 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 		streams.StopProgressIndicator()
 		return nil, buildErr
 	}
+	buildState.BuilderMeta.DepotBuildId = build.ID
 	defer func() {
 		buildkit.Release()
 		build.Finish(buildErr)

--- a/internal/command/deploy/plan_test.go
+++ b/internal/command/deploy/plan_test.go
@@ -73,7 +73,7 @@ func TestAppState(t *testing.T) {
 	appState, error := md.appState(ctx, nil)
 	assert.NoError(t, error)
 
-	assert.Equal(t, appState.Machines, machines)
+	assert.Equal(t, appState.Machines, machineSliceToMap(machines))
 
 }
 
@@ -293,10 +293,10 @@ func TestUpdateMachines(t *testing.T) {
 	}
 
 	oldAppState := &AppState{
-		Machines: oldMachines,
+		Machines: machineSliceToMap(oldMachines),
 	}
 	newAppState := &AppState{
-		Machines: newMachines,
+		Machines: machineSliceToMap(newMachines),
 	}
 	settings := updateMachineSettings{
 		pushForward:          true,


### PR DESCRIPTION
this doesn't involve too many code changes, more just shifting code around. the reason for doing this is that, if we can move as many partso f deploys as possible into an FSM, it lets us more easily resume deploys that failed, or from midway through a canceled deploy, or anywhere else in a deploy.

I want to make more granular FSM transitions for each individual machine too, which I'll either do in a future commit or a future PR. The more individual FSM states we can retry, the more granular 'resuming' we can do. If we can move other parts of deploys into an FSM, it also gives us the ability to resume *those* parts as well. Plus some extra super powers like easily cloning apps, more granular view of deploy failures in a way that we can retry locally, declaratively configuring a fly app, etc.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
