### PR TITLE
Support `master` branch name in Actions workflow

### DIFF
--- a/scanner/templates/github/.github/workflows/fly-deploy.yml
+++ b/scanner/templates/github/.github/workflows/fly-deploy.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - master
 jobs:
   deploy:
     name: Deploy app


### PR DESCRIPTION
### Change Summary

What and Why: should be self-evident - folks who haven't/forgot to/etc. configure `init.defaultBranch` to `main` will be bit by this, i.e. the workflow will not run.

How: we do the thing. Note that I did not test this.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
