### PR TITLE
refresh info about unattached vols each update retry

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         vm_size: [""]
         parallelism: [20]
-        index: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
+        index: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         vm_size: [""]
         parallelism: [20]
-        index: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]
+        index: [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -300,6 +300,11 @@ func (md *machineDeployment) updateMachinesWRecovery(ctx context.Context, oldApp
 				span.RecordError(updateErr)
 				return fmt.Errorf("failed to get current app state: %w", err)
 			}
+			// we need to refresh information about the state of unattached volumes in the app
+			err = md.setVolumes(ctx)
+			if err != nil {
+				return err
+			}
 			err = md.updateMachinesWRecovery(ctx, currentState, newAppState, sl, updateMachineSettings{
 				pushForward:          false,
 				skipHealthChecks:     settings.skipHealthChecks,


### PR DESCRIPTION
### Change Summary

What and Why:

One way to add Volumes to an App is by adding `[mounts]`, creating a volume, then running fly deploy. (This is documented [here](https://fly.io/docs/launch/volume-storage/#add-volumes-to-an-existing-app.))

In the current build of flyctl, this fails with error messages that look like: `Failed to update machines: failed to update machine <machine_id>: machine in group 'app' needs an unattached volume named '<volume>' in region '<region>' Retrying...`.

This PR attempts to fix that.

How:

The issue seems to be that during deployment, machines in an app are getting run through a method [launchInputForUpdate](https://github.com/superfly/flyctl/blob/3382f713e605d4a91bb7293801836b30d7b9e102/internal/command/deploy/machines_launchinput.go#L67) at least twice (first [here](https://github.com/superfly/flyctl/blob/3382f713e605d4a91bb7293801836b30d7b9e102/internal/command/deploy/machines_deploymachinesapp.go#L424) in the codepath common to both the old and new versions of machine updating, and then again [here](https://github.com/superfly/flyctl/blob/3382f713e605d4a91bb7293801836b30d7b9e102/internal/command/deploy/plan.go#L743) in the new codepath for updating machines, on each retry). 

This method uses stack/pop semantics to associate machines with unattached volumes in the app, so as the machine deployment object storing the app's info gets mutated, we can run into the observed error even when there are enough unattached volumes eligible to be attached to the updated machines.

This PR attempts to fix this by refreshing information about available unattached volumes at the beginning of each attempt to update the machine's volumes.

---

### Documentation

- [x] n/a - (this should help flyctl to behave in the way the documentation already says it should)
