### PR TITLE
add fly scale count --env

### DIFF
--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -66,11 +66,7 @@ func New() *cobra.Command {
 			Shorthand:   "i",
 			Description: "image to use (default: current release)",
 		},
-		flag.StringArray{
-			Name:        "env",
-			Shorthand:   "e",
-			Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
-		},
+		flag.Env(),
 		flag.String{
 			Name:        "entrypoint",
 			Description: "ENTRYPOINT replacement",

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -59,11 +59,7 @@ var CommonFlags = flag.Set{
 	flag.RecreateBuilder(),
 	flag.Yes(),
 	flag.VMSizeFlags,
-	flag.StringArray{
-		Name:        "env",
-		Shorthand:   "e",
-		Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
-	},
+	flag.Env(),
 	flag.String{
 		Name:        "wait-timeout",
 		Description: "Time duration to wait for individual machines to transition states and become healthy.",

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -39,11 +39,7 @@ var sharedFlags = flag.Set{
 	For example: --port 80/tcp --port 443:80/tcp:http:tls --port 5432/tcp:pg_tls
 	To remove a port mapping use '-' as handler. For example: --port 80/tcp:-`,
 	},
-	flag.StringArray{
-		Name:        "env",
-		Shorthand:   "e",
-		Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
-	},
+	flag.Env(),
 	flag.String{
 		Name:        "entrypoint",
 		Description: "The command to override the Docker ENTRYPOINT.",

--- a/internal/command/scale/count.go
+++ b/internal/command/scale/count.go
@@ -41,6 +41,7 @@ For pricing, see https://fly.io/docs/about/pricing/`
 		flag.Bool{Name: "with-new-volumes", Description: "New machines each get a new volumes even if there are unattached volumes available"},
 		flag.String{Name: "from-snapshot", Description: "New volumes are restored from snapshot, use 'last' for most recent snapshot. The default is an empty volume"},
 		flag.VMSizeFlags,
+		flag.Env(),
 	)
 	return cmd
 }

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -78,9 +78,6 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 		}
 		lo.ForEach(actions, func(plan *planItem, _ int) {
 			c := plan.LaunchMachineInput.Config
-			if c.Env == nil {
-				c.Env = make(map[string]string)
-			}
 			c.Env = lo.Assign(c.Env, parsedEnv)
 		})
 	}

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -662,3 +662,11 @@ func ExtraArgsFromContext(ctx context.Context) []string {
 
 	return []string{}
 }
+
+func Env() StringArray {
+	return StringArray{
+		Name:        "env",
+		Shorthand:   "e",
+		Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
+	}
+}


### PR DESCRIPTION
### Change Summary

What and Why:

Support environment-variable overrides (`--env`) when using `fly scale count`. I have a use-case for this that involves scaling up an extra machine encoded with another specific machine's ID in its environment (so it can recover specific data during a host failure), and it seemed like a generally-useful flag for consistency with other machine-creation commands.

How:

Add some code to add env variable overrides to the launch configs, plus cleaning up other uses of `env` into a helper function (`flag.Env()` to remove some code duplication.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
