### PR TITLE
Fix panic when cloning a standby machine

### DIFF
--- a/internal/command/machine/clone.go
+++ b/internal/command/machine/clone.go
@@ -250,7 +250,9 @@ func runMachineClone(ctx context.Context) (err error) {
 			}
 		}
 		targetConfig.Standbys = lo.Ternary(len(standbys) > 0, standbys, nil)
-		targetConfig.Env["FLY_STANDBY_FOR"] = strings.Join(standbys, ",")
+		targetConfig.Env = lo.Assign(targetConfig.Env,
+			map[string]string{"FLY_STANDBY_FOR": strings.Join(standbys, ",")},
+		)
 	}
 
 	input := fly.LaunchMachineInput{


### PR DESCRIPTION
### Change Summary

<img width="1102" alt="image" src="https://github.com/user-attachments/assets/f9184a79-2482-4126-b004-c081ecff4263">


What and Why: Fix panic 

How: Initialize machine Env if not set.

Related to: https://github.com/superfly/flyctl/pull/3800

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
