### PR TITLE
Ask launchdarkly whether to use Depot as our default builder

### DIFF
--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -119,6 +119,9 @@ func (d *DepotBuilder) Run(ctx context.Context, _ *dockerClientFactory, streams 
 }
 
 func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOptions, dockerfilePath string, buildState *build, scope depotBuilderScope) (*DeploymentImage, error) {
+	ctx, span := tracing.GetTracer().Start(ctx, "depot_build", trace.WithAttributes(opts.ToSpanAttributes()...))
+	defer span.End()
+
 	buildState.BuilderInitStart()
 	buildState.SetBuilderMetaPart1(depotBuilderType, "", "")
 
@@ -134,6 +137,7 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 	buildkit, build, buildErr := initBuilder(ctx, buildState, opts.AppName, streams, scope)
 	if buildErr != nil {
 		streams.StopProgressIndicator()
+		span.RecordError(buildErr)
 		return nil, buildErr
 	}
 	defer func() {
@@ -144,10 +148,12 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 	connectCtx, cancelConnect := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancelConnect()
 
+	span.AddEvent("connecting to buildkit")
 	var buildkitClient *client.Client
 	buildkitClient, buildErr = buildkit.Connect(connectCtx)
 	if buildErr != nil {
 		streams.StopProgressIndicator()
+		span.RecordError(buildErr)
 		return nil, buildErr
 	}
 
@@ -161,6 +167,7 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 	res, buildErr := buildImage(ctx, buildkitClient, opts, dockerfilePath)
 	if buildErr != nil {
 		buildState.BuildAndPushFinish()
+		span.RecordError(buildErr)
 		return nil, buildErr
 	}
 	buildState.BuildAndPushFinish()
@@ -172,13 +179,17 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 }
 
 func initBuilder(ctx context.Context, buildState *build, appName string, streams *iostreams.IOStreams, builderScope depotBuilderScope) (*depotmachine.Machine, *depotbuild.Build, error) {
+	ctx, span := tracing.GetTracer().Start(ctx, "init_depot_build")
+	defer span.End()
+
+	defer buildState.BuilderInitFinish()
+
 	apiClient := flyutil.ClientFromContext(ctx)
 	region := os.Getenv("FLY_REMOTE_BUILDER_REGION")
 	if region != "" {
 		region = "fly-" + region
 	}
-
-	defer buildState.BuilderInitFinish()
+	span.SetAttributes(attribute.String("depot_builder_region", region))
 
 	buildInfo, err := apiClient.EnsureDepotRemoteBuilder(ctx, &fly.EnsureDepotRemoteBuilderInput{
 		AppName:      &appName,
@@ -198,11 +209,13 @@ func initBuilder(ctx context.Context, buildState *build, appName string, streams
 	// Set the buildErr to any error that represents the build failing.
 	var buildErr error
 
+	span.AddEvent("Acquiring Depot machine")
 	var buildkit *depotmachine.Machine
 	buildkit, buildErr = depotmachine.Acquire(ctx, build.ID, build.Token, "amd64")
 	if buildErr != nil {
 		build.Finish(buildErr)
 		streams.StopProgressIndicator()
+		span.RecordError(buildErr)
 		return nil, nil, buildErr
 	}
 
@@ -210,6 +223,9 @@ func initBuilder(ctx context.Context, buildState *build, appName string, streams
 }
 
 func buildImage(ctx context.Context, buildkitClient *client.Client, opts ImageOptions, dockerfilePath string) (*client.SolveResponse, error) {
+	ctx, span := tracing.GetTracer().Start(ctx, "depot_build_image", trace.WithAttributes(opts.ToSpanAttributes()...))
+	defer span.End()
+
 	var (
 		res *client.SolveResponse
 		err error
@@ -280,6 +296,7 @@ func buildImage(ctx context.Context, buildkitClient *client.Client, opts ImageOp
 	})
 
 	if err := eg.Wait(); err != nil {
+		span.RecordError(err)
 		return nil, err
 	}
 

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/launchdarkly"
 	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/internal/state"
@@ -54,8 +55,21 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config, useWG, rec
 
 	span.SetAttributes(attribute.Bool("builder.using_wireguard", useWG))
 
+	ldClient := launchdarkly.ClientFromContext(ctx)
+	depotBool := ldClient.GetFeatureFlagValue("use-depot-for-builds", true).(bool)
+
+	switch flag.GetString(ctx, "depot") {
+	case "", "true":
+		depotBool = true
+	case "false":
+		depotBool = false
+	case "auto":
+	default:
+		return nil, fmt.Errorf("invalid falue for the 'depot' flag. must be 'true', 'false', or ''")
+	}
+
 	tb := render.NewTextBlock(ctx, "Building image")
-	daemonType := imgsrc.NewDockerDaemonType(!flag.GetRemoteOnly(ctx), !flag.GetLocalOnly(ctx), env.IsCI(), flag.GetBool(ctx, "depot"), flag.GetBool(ctx, "nixpacks"))
+	daemonType := imgsrc.NewDockerDaemonType(!flag.GetRemoteOnly(ctx), !flag.GetLocalOnly(ctx), env.IsCI(), depotBool, flag.GetBool(ctx, "nixpacks"))
 
 	client := flyutil.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -552,10 +552,11 @@ func BuildTarget() String {
 	}
 }
 
-func Depot() Bool {
-	return Bool{
+func Depot() String {
+	return String{
 		Name:        "depot",
-		Default:     false,
+		Default:     "auto",
+		NoOptDefVal: "true",
 		Description: "Deploy using depot to build the image",
 	}
 }


### PR DESCRIPTION
### Change Summary

What and Why:
Added a flag to LD to set Depot as the remote builder to use. Currently the rollout is set to 0%, but I plan on slowly rolling out over the course of a week.

i changed the depot flag to be a string, specifically since just saying that the default is false isn't quite right. like with deploy-retries, the default value of the flag is going to be set to "auto". In order to be backwards compatible, we make just using the `--depot` flag be equal to true.

How:

Related to:

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
