### PR TITLE
prevent concurrent deployments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -269,4 +269,5 @@ require (
 replace (
 	github.com/loadsmart/calver-go => github.com/ndarilek/calver-go v0.0.0-20230710153822-893bbd83a936
 	github.com/nats-io/nats.go => github.com/btoews/nats.go v0.0.0-20240401180931-476bea7f4158
+// github.com/superfly/fly-go => ../fly-go
 )

--- a/internal/flyutil/client.go
+++ b/internal/flyutil/client.go
@@ -100,6 +100,9 @@ type Client interface {
 	UpdateRelease(ctx context.Context, input fly.UpdateReleaseInput) (*fly.UpdateReleaseResponse, error)
 	UnsetSecrets(ctx context.Context, appName string, keys []string) (*fly.Release, error)
 	ValidateWireGuardPeers(ctx context.Context, peerIPs []string) (invalid []string, err error)
+	LockApp(ctx context.Context, input fly.LockAppInput) (*fly.LockApp, error)
+	UnlockApp(ctx context.Context, input fly.UnlockAppInput) (*fly.App, error)
+	GetAppLock(ctx context.Context, name string) (*fly.App, error)
 }
 
 type contextKey string


### PR DESCRIPTION
### Change Summary
Current, we allow concurrent deployments which aside not being a good thing, also ends up in our machines api being hammered with lease calls. It could also results in inconsistencies among others.

This PR attempts to address this issue by 
- locking apps before a deployment 
- unlocking them after a deployment
- providing a command to unlock an app

```

	lock, err := bg.apiClient.LockApp(ctx, fly.LockAppInput{
		AppID: bg.appConfig.AppName,
	})

	if err != nil {
		tracing.RecordError(span, err, "failed to lock app")
		return err
	}

	_ = lock

	fmt.Println(lock, "locked app")

	app, err := bg.apiClient.GetAppLock(ctx, bg.appConfig.AppName)
	if err != nil {
		tracing.RecordError(span, err, "failed to unlock app")
		return err
	}

	fmt.Println(app.CurrentLock, "current_lock")

	if app.CurrentLock != nil {
		_, err = bg.apiClient.UnlockApp(ctx, fly.UnlockAppInput{
			AppID:  bg.appConfig.AppName,
			LockID: app.CurrentLock.LockID,
		})
		if err != nil {
			tracing.RecordError(span, err, "failed to unlock app")
			return err
		}

		fmt.Println("unlock app")
	}

	app, err = bg.apiClient.GetAppLock(ctx, bg.appConfig.AppName)
	if err != nil {
		tracing.RecordError(span, err, "failed to unlock app")
		return err
	}

	fmt.Println(app.CurrentLock, "current_lock_after_unlock")

	panic("")
```