### PR TITLE
Grab the closest region when creating the depot builder

### DIFF
--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -186,6 +186,14 @@ func initBuilder(ctx context.Context, buildState *build, appName string, streams
 
 	apiClient := flyutil.ClientFromContext(ctx)
 	region := os.Getenv("FLY_REMOTE_BUILDER_REGION")
+
+	if region == "" {
+		closestRegion, err := apiClient.GetNearestRegion(ctx)
+		if err == nil {
+			region = closestRegion.Code
+		}
+	}
+
 	if region != "" {
 		region = "fly-" + region
 	}


### PR DESCRIPTION
### Change Summary

What and Why:
This will help us to avoid asking for the invalid `fly-chi` region, and more accurately getting the closest region to the user

How:
Call the GetNearestRegion web ( :( ) query

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
