### PR TITLE
scale count/show: exclude Machines on unavailable hosts

### DIFF
--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -31,6 +31,10 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 		return err
 	}
 
+	machines = lo.Filter(machines, func(m *fly.Machine, _ int) bool {
+		return m.Config != nil
+	})
+
 	var latestCompleteRelease fly.Release
 	switch releases, err := apiClient.GetAppReleasesMachines(ctx, appName, "complete", 1); {
 	case err != nil:

--- a/internal/command/scale/show_machines.go
+++ b/internal/command/scale/show_machines.go
@@ -34,6 +34,10 @@ func runMachinesScaleShow(ctx context.Context) error {
 		return err
 	}
 
+	machines = lo.Filter(machines, func(m *fly.Machine, _ int) bool {
+		return m.Config != nil
+	})
+
 	machineGroups := lo.GroupBy(machines, func(m *fly.Machine) string {
 		return m.ProcessGroup()
 	})


### PR DESCRIPTION
### Change Summary

What and Why:

Filter unavailable machines from `scale count` and `scale show`, since these commands require a valid `Machine.Config`.
This fixes a panic when running `fly scale count` on an app with a machine on an unavailable host, on any flyctl version since #3840 ([v0.2.112](https://github.com/superfly/flyctl/releases/tag/v0.2.112)).

Related to our host-issue troubleshooting docs which include `fly scale count` in recovery instructions.

How:

`lo.Filter` command that selects only machines with `m.Config != nil`.

Related to:

#3840

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a (bugfix)
