### PR TITLE
pad bluegreen health-check status to 15 chars

### DIFF
--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -304,7 +304,7 @@ func (bg *blueGreen) renderMachineHealthchecks(state map[string]*fly.HealthCheck
 				status = fmt.Sprintf("%d/%d passing", value.Passing, value.Total)
 			}
 
-			currentView[id] = status
+			currentView[id] = fmt.Sprintf("%15s", status)
 			rows = append(rows, fmt.Sprintf("  Machine %s - %s", bg.colorize.Bold(id), bg.colorize.Green(status)))
 		}
 		bg.healthLock.RUnlock()


### PR DESCRIPTION
Prevent mixed-status lines (`uncheckedng`) as the health-check status is updated during a bluegreen deploy by padding each status string to 15 chars (enough to cover `xxx/xxx passing`).