### PR TITLE
test: make volume tests more reliable and faster

### DIFF
--- a/test/preflight/fly_volume_test.go
+++ b/test/preflight/fly_volume_test.go
@@ -13,7 +13,31 @@ import (
 	"github.com/superfly/flyctl/test/preflight/testlib"
 )
 
-func TestFlyVolumeExtend(t *testing.T) {
+// testLogger adds timestamps to t.Logf().
+// This would be helpful to find slow operations.
+type testLogger struct {
+	testing.TB
+}
+
+func (t testLogger) Logf(format string, args ...interface{}) {
+	ts := time.Now().Format("15:04:05 ")
+	t.TB.Logf(ts+format, args...)
+}
+
+func WithParallel(f func(*testing.T)) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+		f(t)
+	}
+}
+
+func TestVolume(t *testing.T) {
+	t.Run("Extend", WithParallel(testVolumeExtend))
+	t.Run("List", WithParallel(testVolumeLs))
+	t.Run("CreateFromDestroyedVolSnapshot", WithParallel(testVolumeCreateFromDestroyedVolSnapshot))
+}
+
+func testVolumeExtend(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
 
@@ -58,49 +82,68 @@ primary_region = "%s"
 	}, 10*time.Second, 2*time.Second)
 }
 
-func TestFlyVolumeLs(t *testing.T) {
+func testVolumeLs(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
-	v1Res := f.Fly("vol create -s 1 -a %s -r %s --yes --json test_keep", appName, f.PrimaryRegion())
-	var v1 *fly.Volume
-	v1Res.StdOutJSON(&v1)
-	v2Res := f.Fly("vol create -s 1 -a %s -r %s --yes --json test_destroy", appName, f.PrimaryRegion())
-	var v2 *fly.Volume
-	v2Res.StdOutJSON(&v2)
-	f.Fly("vol destroy -y %s", v2.ID)
-	lsRes := f.Fly("vol ls -a %s --json", appName)
-	var ls []*fly.Volume
-	lsRes.StdOutJSON(&ls)
-	require.Len(f, ls, 1)
-	require.Equal(f, v1.ID, ls[0].ID)
-	lsAllRes := f.Fly("vol ls --all -a %s --json", appName)
-	var lsAll []*fly.Volume
-	lsAllRes.StdOutJSON(&lsAll)
-	require.Len(f, lsAll, 2)
-	var lsAllIds []string
-	for _, v := range lsAll {
-		lsAllIds = append(lsAllIds, v.ID)
-	}
-	require.Contains(f, lsAllIds, v1.ID)
-	require.Contains(f, lsAllIds, v2.ID)
+
+	var kept *fly.Volume
+	j := f.Fly("vol create -s 1 -a %s -r %s --yes --json test_keep", appName, f.PrimaryRegion())
+	j.StdOutJSON(&kept)
+
+	var destroyed *fly.Volume
+	j = f.Fly("vol create -s 1 -a %s -r %s --yes --json test_destroy", appName, f.PrimaryRegion())
+	j.StdOutJSON(&destroyed)
+	f.Fly("vol destroy -y %s", destroyed.ID)
+
+	// Deleted volumes shouldn't be shown.
+	assert.EventuallyWithT(f, func(c *assert.CollectT) {
+		lsRes := f.Fly("vol ls -a %s --json", appName)
+		var ls []*fly.Volume
+		lsRes.StdOutJSON(&ls)
+		assert.Lenf(f, ls, 1, "volume %s is still visible", destroyed.ID)
+		assert.Equal(f, kept.ID, ls[0].ID)
+	}, 5*time.Minute, 10*time.Second)
+
+	// Deleted volumes should be shown with --all.
+	assert.EventuallyWithT(f, func(c *assert.CollectT) {
+		lsAllRes := f.Fly("vol ls --all -a %s --json", appName)
+
+		var lsAll []*fly.Volume
+		lsAllRes.StdOutJSON(&lsAll)
+
+		assert.Len(f, lsAll, 2)
+
+		var lsAllIds []string
+		for _, v := range lsAll {
+			lsAllIds = append(lsAllIds, v.ID)
+		}
+		assert.Contains(f, lsAllIds, kept.ID)
+		assert.Contains(f, lsAllIds, destroyed.ID)
+	}, 5*time.Minute, 10*time.Second)
 }
 
-func TestFlyVolume_CreateFromDestroyedVolSnapshot(t *testing.T) {
+func testVolumeCreateFromDestroyedVolSnapshot(tt *testing.T) {
+	t := testLogger{tt}
+
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
 	createRes := f.Fly("vol create -s 1 -a %s -r %s --yes --json test_destroy", appName, f.PrimaryRegion())
 	var vol *fly.Volume
 	createRes.StdOutJSON(&vol)
+	t.Logf("Start a machine under app %s", appName)
 	f.Fly("m run --org %s -a %s -r %s -v %s:/data --build-remote-only nginx", f.OrgSlug(), appName, f.PrimaryRegion(), vol.ID)
 	machine := f.MachinesList(appName)[0]
 	require.Eventually(f, func() bool {
 		machines := f.MachinesList(appName)
 		return len(machines) == 1 && machines[0].State == "started"
 	}, 1*time.Minute, 1*time.Second, "machine %s never started", machine.ID)
+
 	f.Fly("m destroy --force %s", machine.ID)
 	require.Eventually(f, func() bool {
 		return len(f.MachinesList(appName)) == 0
-	}, 1*time.Minute, 1*time.Second, "machine %s never destroyed", machine.ID)
+	}, 5*time.Minute, 10*time.Second, "machine %s never destroyed", machine.ID)
+
+	t.Logf("machine %s is destroyed; Snapshot volume %s", machine.ID, vol.ID)
 	f.Fly("vol snapshot create --json %s", vol.ID)
 	var snapshot *fly.VolumeSnapshot
 	require.Eventually(f, func() bool {
@@ -115,16 +158,19 @@ func TestFlyVolume_CreateFromDestroyedVolSnapshot(t *testing.T) {
 		}
 		return false
 	}, 1*time.Minute, 1*time.Second, "snapshot never made it to created state")
+
+	t.Logf("Destroy volume %s", vol.ID)
 	f.Fly("vol destroy -y %s", vol.ID)
-	require.Eventually(f, func() bool {
-		lsRes := f.Fly("vol ls -a %s --all --json", appName)
+	require.EventuallyWithT(f, func(t *assert.CollectT) {
 		var ls []*fly.Volume
-		lsRes.StdOutJSON(&ls)
-		if len(ls) == 1 {
-			return ls[0].State == "pending_destroy"
-		}
-		return false
-	}, 1*time.Minute, 1*time.Second, "volume %s never made it to pending_destroy state", vol.ID)
+
+		j := f.Fly("vol ls -a %s --all --json", appName)
+		j.StdOutJSON(&ls)
+
+		assert.Equal(t, "pending_destroy", ls[0].State)
+		assert.Len(t, ls, 1)
+	}, 5*time.Minute, 10*time.Second, "volume %s never made it to pending_destroy state", vol.ID)
+
 	ls := f.Fly("vol snapshot ls --json %s", vol.ID)
 	var snapshots2 []*fly.VolumeSnapshot
 	ls.StdOutJSON(&snapshots2)
@@ -132,18 +178,16 @@ func TestFlyVolume_CreateFromDestroyedVolSnapshot(t *testing.T) {
 	require.Equal(f, snapshot.ID, snapshots2[0].ID)
 	require.Equal(f, snapshot.Size, snapshots2[0].Size)
 	require.Equal(f, snapshot.CreatedAt, snapshots2[0].CreatedAt)
-	fromDestroyedRes := f.Fly("vol create -s 1 -a %s -r %s --yes --json --snapshot-id %s test", appName, f.PrimaryRegion(), snapshot.ID)
-	var fromDestroyed *fly.Volume
-	fromDestroyedRes.StdOutJSON(&fromDestroyed)
-	require.Eventually(f, func() bool {
-		lsRes := f.Fly("vol ls -a %s --all --json", appName)
+
+	t.Logf("Create volume from %s", snapshot.ID)
+	f.Fly("vol create -s 1 -a %s -r %s --yes --json --snapshot-id %s test", appName, f.PrimaryRegion(), snapshot.ID)
+
+	assert.EventuallyWithT(f, func(t *assert.CollectT) {
 		var ls []*fly.Volume
-		lsRes.StdOutJSON(&ls)
-		for _, s := range ls {
-			if s.State == "created" {
-				return true
-			}
-		}
-		return false
-	}, 1*time.Minute, 1*time.Second, "final volume %s never made it to created state", vol.ID)
+		j := f.Fly("vol ls -a %s --json", appName)
+		j.StdOutJSON(&ls)
+
+		assert.Len(t, ls, 1)
+		assert.Equal(t, "created", ls[0].State)
+	}, 5*time.Minute, 10*time.Second, "final volume %s never made it to created state", vol.ID)
 }

--- a/test/preflight/testlib/test_env.go
+++ b/test/preflight/testlib/test_env.go
@@ -102,7 +102,7 @@ func NewTestEnvFromEnv(t testing.TB) *FlyctlTestEnv {
 	env.Setenv("FLY_GHA_ERROR_ANNOTATION", "1")
 	env.Setenv("GITHUB_ACTIONS", os.Getenv("GITHUB_ACTIONS"))
 
-	fmt.Println("workdir", env.workDir)
+	t.Logf("workdir %s", env.workDir)
 	return env
 }
 


### PR DESCRIPTION
Using Eventually helpers makes the tests more reliable. t.Parallel() runs these three slow (~50-200 seconds) in parallel.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
