### PR TITLE
test: run slow deploy-related tests in parallel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/chzyer/readline v1.5.1
 	github.com/cli/safeexec v1.0.1
 	github.com/coder/websocket v1.8.12
+	github.com/containerd/continuity v0.4.3
 	github.com/depot/depot-go v0.3.0
 	github.com/docker/docker v26.1.4+incompatible
 	github.com/docker/go-connections v0.5.0
@@ -148,7 +149,6 @@ require (
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/containerd/console v1.0.4 // indirect
 	github.com/containerd/containerd v1.7.16 // indirect
-	github.com/containerd/continuity v0.4.3 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.15.1 // indirect
 	github.com/containerd/ttrpc v1.2.3 // indirect

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -416,6 +416,11 @@ func TestLaunchDetach(t *testing.T) {
 }
 
 func TestDeployDetach(t *testing.T) {
+	t.Run("Simple", WithParallel(testDeployDetach))
+	t.Run("Batching", WithParallel(testDeployDetachBatching))
+}
+
+func testDeployDetach(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 
@@ -428,7 +433,7 @@ func TestDeployDetach(t *testing.T) {
 	require.Contains(f, res.StdOutString(), "started")
 }
 
-func TestDeployDetachBatching(t *testing.T) {
+func testDeployDetachBatching(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppName()
 

--- a/test/preflight/fly_deploy_test.go
+++ b/test/preflight/fly_deploy_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	//"github.com/samber/lo"
+	"github.com/containerd/continuity/fs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -169,14 +170,20 @@ func getRootPath() string {
 	return filepath.Dir(b)
 }
 
-func copyFixtureIntoWorkDir(workDir, name string, exclusion []string) error {
+func copyFixtureIntoWorkDir(workDir, name string) error {
 	src := fmt.Sprintf("%s/fixtures/%s", getRootPath(), name)
-	return testlib.CopyDir(src, workDir, exclusion)
+	return fs.CopyDir(workDir, src)
 }
 
-func TestFlyDeployNodeAppWithRemoteBuilder(t *testing.T) {
+func TestDeployNodeApp(t *testing.T) {
+	t.Run("With Wireguard", WithParallel(testDeployNodeAppWithRemoteBuilder))
+	t.Run("Without Wireguard", WithParallel(testDeployNodeAppWithRemoteBuilderWithoutWireguard))
+	t.Run("With Depot", WithParallel(testDeployNodeAppWithDepotRemoteBuilder))
+}
+
+func testDeployNodeAppWithRemoteBuilder(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
-	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node", []string{})
+	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node")
 	require.NoError(t, err)
 
 	flyTomlPath := fmt.Sprintf("%s/fly.toml", f.WorkDir())
@@ -203,7 +210,7 @@ func TestFlyDeployNodeAppWithRemoteBuilder(t *testing.T) {
 	require.Contains(t, string(body), fmt.Sprintf("Hello, World! %s", f.ID()))
 }
 
-func TestFlyDeployNodeAppWithRemoteBuilderWithoutWireguard(t *testing.T) {
+func testDeployNodeAppWithRemoteBuilderWithoutWireguard(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
 
 	// Since this uses a fixture with a size, no need to run it on alternate
@@ -212,7 +219,7 @@ func TestFlyDeployNodeAppWithRemoteBuilderWithoutWireguard(t *testing.T) {
 		t.Skip()
 	}
 
-	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node", []string{})
+	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node")
 	require.NoError(t, err)
 
 	flyTomlPath := fmt.Sprintf("%s/fly.toml", f.WorkDir())
@@ -237,9 +244,9 @@ func TestFlyDeployNodeAppWithRemoteBuilderWithoutWireguard(t *testing.T) {
 	require.Contains(t, string(body), fmt.Sprintf("Hello, World! %s", f.ID()))
 }
 
-func TestFlyDeployNodeAppWithDepotRemoteBuilder(t *testing.T) {
+func testDeployNodeAppWithDepotRemoteBuilder(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
-	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node", []string{})
+	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node")
 	require.NoError(t, err)
 
 	flyTomlPath := fmt.Sprintf("%s/fly.toml", f.WorkDir())
@@ -274,7 +281,7 @@ func TestFlyDeployBasicNodeWithWGEnabled(t *testing.T) {
 		t.Skip()
 	}
 
-	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node", []string{})
+	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node")
 	require.NoError(t, err)
 
 	flyTomlPath := fmt.Sprintf("%s/fly.toml", f.WorkDir())

--- a/test/preflight/fly_launch_test.go
+++ b/test/preflight/fly_launch_test.go
@@ -298,7 +298,7 @@ RUN --mount=type=secret,id=secret1 cat /run/secrets/secret1 > /tmp/secrets.txt
 
 func TestFlyLaunchBasicNodeApp(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
-	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node", []string{})
+	err := copyFixtureIntoWorkDir(f.WorkDir(), "deploy-node")
 	require.NoError(t, err)
 
 	flyTomlPath := fmt.Sprintf("%s/fly.toml", f.WorkDir())

--- a/test/preflight/testlib/helpers.go
+++ b/test/preflight/testlib/helpers.go
@@ -16,7 +16,6 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -111,75 +110,6 @@ func tryToStopAgentsInOriginalHomeDir(flyctlBin string) {
 
 func tryToStopAgentsFromPastPreflightTests(t testing.TB, flyctlBin string) {
 	// FIXME: make something like ps au | grep flyctl | grep $TMPDIR | grep agent, then kill those procs?
-}
-
-func CopyDir(src, dst string, exclusion []string) error {
-	// Get the file info for the source directory
-	srcInfo, err := os.Stat(src)
-	if err != nil {
-		return err
-	}
-
-	// Create the destination directory with the same permissions as the source directory
-	if err := os.MkdirAll(dst, srcInfo.Mode()); err != nil {
-		return err
-	}
-
-	// Get the list of files and directories in the source directory
-	entries, err := os.ReadDir(src)
-	if err != nil {
-		return err
-	}
-
-	// Iterate through each entry in the source directory
-	for _, entry := range entries {
-		if slices.Contains(exclusion, entry.Name()) {
-			continue
-		}
-
-		srcPath := filepath.Join(src, entry.Name())
-		dstPath := filepath.Join(dst, entry.Name())
-
-		if entry.IsDir() {
-			// If the entry is a directory, recursively copy it to the destination directory
-			if err := CopyDir(srcPath, dstPath, exclusion); err != nil {
-				return err
-			}
-		} else {
-			// If the entry is a file, copy it to the destination directory
-			if err := copyFile(srcPath, dstPath); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func copyFile(src, dst string) error {
-	// Open the source file for reading
-	srcFile, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer srcFile.Close()
-
-	// Create the destination file
-	dstFile, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer dstFile.Close()
-
-	// Copy the content from the source file to the destination file
-	_, err = io.Copy(dstFile, srcFile)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("[copy] %s -> %s\n", src, dst)
-
-	return nil
 }
 
 // RunHealthcheck verifies if an app was deployed successfully.


### PR DESCRIPTION
All of them are slow (~100 seconds).

In addition to that, our own chatty CopyDir is replaced by containerd's one.
Raw Printf is hard to attribute to when multiple tests are running.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
