### PR TITLE
When defaulting to Depot builders, fall back to standard remote builders for buildpacks

### DIFF
--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -245,7 +245,7 @@ func (r *Resolver) BuildImage(ctx context.Context, streams *iostreams.IOStreams,
 
 	if r.dockerFactory.mode.UseNixpacks() {
 		strategies = append(strategies, &nixpacksBuilder{})
-	} else if r.dockerFactory.mode.UseDepot() {
+	} else if r.dockerFactory.mode.UseDepot() && len(opts.Buildpacks) == 0 {
 		strategies = append(strategies, &DepotBuilder{Scope: builderScope})
 	} else {
 		strategies = []imageBuilder{


### PR DESCRIPTION
Depot doesn't support buildpacks yet.