### PR TITLE
refactor: bye golang.org/x/exp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/superfly/flyctl
 
-go 1.22.0
-
-toolchain go1.22.6
+go 1.23.1
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
@@ -84,7 +82,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.30.0
 	go.opentelemetry.io/otel/trace v1.30.0
 	golang.org/x/crypto v0.27.0
-	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa
 	golang.org/x/mod v0.21.0
 	golang.org/x/net v0.29.0
 	golang.org/x/sync v0.8.0
@@ -254,6 +251,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.30.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/tools v0.24.0 // indirect

--- a/internal/command/command_run.go
+++ b/internal/command/command_run.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/samber/lo"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/iostreams"
-	"golang.org/x/exp/slices"
 
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/build/imgsrc"

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -26,7 +27,6 @@ import (
 	"github.com/superfly/flyctl/terminal"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/exp/maps"
 )
 
 const (
@@ -404,7 +404,7 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 			s = "s"
 		}
 
-		filtersAppliedStr := strings.Join(maps.Keys(filtersApplied), "/")
+		filtersAppliedStr := strings.Join(slices.Collect(maps.Keys(filtersApplied)), "/")
 
 		fmt.Fprintf(md.io.ErrOut, "%s filter%s applied, deploying to %d/%d machines\n", filtersAppliedStr, s, len(machines), nMachines)
 	}

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"net"
 	"slices"
@@ -31,7 +32,6 @@ import (
 	"github.com/superfly/flyctl/terminal"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -281,9 +281,8 @@ func (md *machineDeployment) deployCanaryMachines(ctx context.Context) (err erro
 func (md *machineDeployment) deployCreateMachinesForGroups(ctx context.Context, processGroupMachineDiff ProcessGroupsDiff) (err error) {
 	groupsWithAutostopEnabled := make(map[string]bool)
 	groupsWithAutosuspendEnabled := make(map[string]bool)
-	groups := maps.Keys(processGroupMachineDiff.groupsNeedingMachines)
+	groups := slices.Sorted(maps.Keys(processGroupMachineDiff.groupsNeedingMachines))
 	total := len(groups)
-	slices.Sort(groups)
 
 	sl := statuslogger.Create(ctx, total, true)
 	defer sl.Destroy(false)

--- a/internal/command/platform/regions.go
+++ b/internal/command/platform/regions.go
@@ -3,10 +3,10 @@ package platform
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 
 	"github.com/superfly/flyctl/iostreams"
 

--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"

--- a/internal/command/scale/count.go
+++ b/internal/command/scale/count.go
@@ -3,6 +3,7 @@ package scale
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -16,7 +17,6 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flag/completion"
 	"github.com/superfly/flyctl/internal/flapsutil"
-	"golang.org/x/exp/maps"
 )
 
 func newScaleCount() *cobra.Command {
@@ -75,7 +75,7 @@ func runScaleCount(ctx context.Context) error {
 		return err
 	}
 
-	unknownNames := lo.Filter(maps.Keys(groups), func(x string, _ int) bool {
+	unknownNames := lo.Filter(slices.Collect(maps.Keys(groups)), func(x string, _ int) bool {
 		return !slices.Contains(processNames, x)
 	})
 	if len(unknownNames) > 0 {

--- a/internal/command/version/upgrade.go
+++ b/internal/command/version/upgrade.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/terminal"
-	"golang.org/x/exp/slices"
 
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/cache"

--- a/internal/config/tokens.go
+++ b/internal/config/tokens.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strconv"
 	"sync"
@@ -17,7 +18,6 @@ import (
 	"github.com/superfly/flyctl/internal/task"
 	"github.com/superfly/macaroon"
 	"github.com/superfly/macaroon/flyio"
-	"golang.org/x/exp/maps"
 )
 
 // UserURLCallback is a function that opens a URL in the user's browser. This is
@@ -272,7 +272,7 @@ func doFetchOrgTokens(ctx context.Context, t *tokens.Tokens, fetchOrgs orgFetche
 		defer wgLock.Unlock()
 		macToks = append(macToks, m)
 	}
-	for _, graphID := range maps.Values(graphIDByNumericID) {
+	for graphID := range maps.Values(graphIDByNumericID) {
 		graphID := graphID
 
 		wg.Add(1)

--- a/internal/haikunator/haikunator.go
+++ b/internal/haikunator/haikunator.go
@@ -4,11 +4,11 @@ import (
 	"crypto/rand"
 	"math/big"
 	rand2 "math/rand"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/superfly/flyctl/helpers"
-	"golang.org/x/exp/slices"
 )
 
 var adjectives = strings.Fields(`

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/jpillora/backoff"
@@ -18,7 +20,6 @@ import (
 	"github.com/superfly/flyctl/terminal"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"golang.org/x/exp/maps"
 )
 
 type LeasableMachine interface {
@@ -316,7 +317,7 @@ func (lm *leasableMachine) WaitForHealthchecksToPass(ctx context.Context, timeou
 	waitCtx, cancel := ctrlc.HookCancelableContext(context.WithTimeout(ctx, timeout))
 	defer cancel()
 
-	checkDefs := maps.Values(lm.Machine().Config.Checks)
+	checkDefs := slices.Colect(maps.Values(lm.Machine().Config.Checks))
 	for _, s := range lm.Machine().Config.Services {
 		checkDefs = append(checkDefs, s.Checks...)
 	}

--- a/internal/machine/update.go
+++ b/internal/machine/update.go
@@ -3,6 +3,7 @@ package machine
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/watch"
 	"github.com/superfly/flyctl/iostreams"
-	"golang.org/x/exp/maps"
 )
 
 var cpusPerKind = map[string][]int{

--- a/internal/set/set_test.go
+++ b/internal/set/set_test.go
@@ -1,10 +1,10 @@
 package set
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/slices"
 )
 
 func TestSet(t *testing.T) {

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -3,12 +3,12 @@ package version
 import (
 	"encoding/json"
 	"math/rand"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestEncode(t *testing.T) {


### PR DESCRIPTION
After Go 1.23, the standard library provides what we use from the exp package.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
