### PR TITLE
feat: add confirmation step to secrets set

### DIFF
--- a/internal/command/secrets/set.go
+++ b/internal/command/secrets/set.go
@@ -63,6 +63,14 @@ func runSet(ctx context.Context) (err error) {
 		return errors.New("requires at least one SECRET=VALUE pair")
 	}
 
+	fmt.Printf("You are about to set secrets at `%s`. Is this correct? (y/N): ", appName)
+	var response string
+	_, err = fmt.Scanln(&response)
+	if err != nil || (response != "y" && response != "Y") {
+		fmt.Println("Aborted setting secrets.")
+		return nil
+	}
+
 	return SetSecretsAndDeploy(ctx, app, secrets, flag.GetBool(ctx, "stage"), flag.GetBool(ctx, "detach"))
 }
 


### PR DESCRIPTION
### Change Summary

What and Why:
When publishing secrets to our apps, there's currently no confirmation step. This led to an incident where secrets were accidentally overwritten on the main app instead of the staging app due to a missing `--app` flag, causing the main app to break.

How:
Implement a confirmation prompt when publishing secrets. This will require users to explicitly confirm their action before secrets are published, reducing the risk of accidental overwrites.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
