### PR TITLE
feat: remove `fly domains register` and `fly domains disable`

### DIFF
--- a/internal/command/domains/root.go
+++ b/internal/command/domains/root.go
@@ -2,12 +2,10 @@ package domains
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -33,8 +31,6 @@ You can still view existing domains, but registration is no longer possible.`
 	cmd.AddCommand(
 		newDomainsList(),
 		newDomainsShow(),
-		newDomainsAdd(),
-		newDomainsRegister(),
 	)
 	cmd.Hidden = true
 	return cmd
@@ -67,36 +63,6 @@ func newDomainsShow() *cobra.Command {
 		flag.JSONOutput(),
 	)
 	cmd.Args = cobra.ExactArgs(1)
-	return cmd
-}
-
-func newDomainsAdd() *cobra.Command {
-	const (
-		short = "Add a domain"
-		long  = `Add a domain to an organization`
-	)
-	cmd := command.New("disable", short, long, runDomainsCreate,
-		command.RequireSession,
-	)
-	cmd.Args = cobra.MaximumNArgs(2)
-	return cmd
-}
-
-func newDomainsRegister() *cobra.Command {
-	const (
-		short = "Register a domain"
-		long  = `Register a new domain in an organization`
-	)
-	cmd := command.New("register [org] [name]", short, long, runDomainsRegister,
-		command.RequireSession,
-		command.RequireAppName,
-	)
-	flag.Add(cmd,
-		flag.App(),
-		flag.JSONOutput(),
-	)
-	cmd.Args = cobra.MaximumNArgs(2)
-	cmd.Hidden = true
 	return cmd
 }
 
@@ -177,51 +143,4 @@ func runDomainsShow(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-func runDomainsCreate(ctx context.Context) error {
-	io := iostreams.FromContext(ctx)
-	apiClient := flyutil.ClientFromContext(ctx)
-
-	var org *fly.Organization
-	var name string
-	var err error
-
-	args := flag.Args(ctx)
-
-	if len(args) == 0 {
-		org, err = prompt.Org(ctx)
-		if err != nil {
-			return err
-		}
-
-		if err := prompt.String(ctx, &name, "Domain name to add", "", true); err != nil {
-			return err
-		}
-
-		// TODO: Add some domain validation here
-	} else if len(args) == 2 {
-		org, err = apiClient.GetOrganizationBySlug(ctx, args[0])
-		if err != nil {
-			return err
-		}
-		name = args[1]
-	} else {
-		return errors.New("specify all arguments (or no arguments to be prompted)")
-	}
-
-	fmt.Printf("Creating domain %s in organization %s\n", name, org.Slug)
-
-	domain, err := apiClient.CreateDomain(org.ID, name)
-	if err != nil {
-		return err
-	}
-
-	fmt.Fprintln(io.Out, "Created domain", domain.Name)
-
-	return nil
-}
-
-func runDomainsRegister(_ context.Context) error {
-	return fmt.Errorf("This command is no longer supported.\n")
 }


### PR DESCRIPTION
`register` is already no-op. `disable` is actually adding a new domain.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
