### PR TITLE
return error message for machines list failure

### DIFF
--- a/internal/command/machine/list.go
+++ b/internal/command/machine/list.go
@@ -65,7 +65,7 @@ func runMachineList(ctx context.Context) (err error) {
 
 	machines, err := flapsClient.List(ctx, "")
 	if err != nil {
-		return fmt.Errorf("machines could not be retrieved")
+		return err
 	}
 
 	if cfg.JSONOutput {


### PR DESCRIPTION
Replaces the opaque `machines could not be retrieved` with a more informative `failed to list VMs: app not found (Request ID: [...])`. 
Helpful context when an app name is typed incorrectly (instead of some other API error).