### PR TITLE
fix: fly volume fork --require-unique-zone should be default

### DIFF
--- a/internal/command/volumes/fork.go
+++ b/internal/command/volumes/fork.go
@@ -105,11 +105,6 @@ func runFork(ctx context.Context) error {
 		machinesOnly = fly.Pointer(flag.GetBool(ctx, "machines-only"))
 	}
 
-	var requireUniqueZone *bool
-	if flag.IsSpecified(ctx, "require-unique-zone") {
-		requireUniqueZone = fly.Pointer(flag.GetBool(ctx, "require-unique-zone"))
-	}
-
 	region := flag.GetString(ctx, "region")
 
 	var attachedMachineImage string
@@ -131,7 +126,7 @@ func runFork(ctx context.Context) error {
 	input := fly.CreateVolumeRequest{
 		Name:                name,
 		MachinesOnly:        machinesOnly,
-		RequireUniqueZone:   requireUniqueZone,
+		RequireUniqueZone:   fly.Pointer(flag.GetBool(ctx, "require-unique-zone")),
 		SourceVolumeID:      &vol.ID,
 		ComputeRequirements: computeRequirements,
 		ComputeImage:        attachedMachineImage,


### PR DESCRIPTION
Checking `flag.IsSpecified` makes its default false.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
