### PR TITLE
Retry Depot builder initialization after 25 seconds

### DIFF
--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -673,7 +673,7 @@ func (r *Resolver) StartHeartbeat(ctx context.Context) (*StopSignal, error) {
 	terminal.Debugf("Sending remote builder heartbeat pulse to %s...\n", heartbeatUrl)
 
 	span.AddEvent("sending first heartbeat")
-	err = retry.Retry(func() error {
+	err = retry.Retry(ctx, func() error {
 		return r.heartbeatFn(ctx, dockerClient, heartbeatReq)
 	}, 3)
 	if err != nil {

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,30 +1,49 @@
 package retry
 
 import (
+	"context"
 	"time"
 
 	"github.com/jpillora/backoff"
 )
 
-func Retry(fn func() error, attempts uint) (err error) {
+// Retry attempts to execute the provided function up to 'attempts' times,
+// respecting the context for cancellation and timeout
+func Retry(ctx context.Context, fn func() error, attempts uint) (err error) {
 	for i := attempts; i > 0; i-- {
+
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		err = fn()
 		if err == nil {
-			break
+			return nil
 		}
 	}
 
-	return
+	return err
 }
 
-func RetryBackoff(fn func() error, attempts uint, backoff *backoff.Backoff) (err error) {
+// Retry attempts to execute the provided function up to 'attempts' times with an
+// exponential backoff strategy, respecting the context for cancellation and timeout
+func RetryBackoff(ctx context.Context, fn func() error, attempts uint, backoffStrategy *backoff.Backoff) (err error) {
 	for i := attempts; i > 0; i-- {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		err = fn()
 		if err == nil {
-			break
+			return nil
 		}
-		time.Sleep(backoff.Duration())
+
+		select {
+		case <-time.After(backoffStrategy.Duration()):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
-	return
+	return err
 }

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,9 +1,12 @@
 package retry
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/jpillora/backoff"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,6 +18,8 @@ func TestRetry(t *testing.T) {
 	t.Run("testFail1", testFail1)
 	t.Run("testFail2", testFail2)
 	t.Run("testFailAll", testFailAll)
+	t.Run("testContextTimeout", testContextTimeout)           // Added test
+	t.Run("testRetryBackoffContextTimeout", testRetryBackoff) // Test for RetryBackoff
 }
 
 func testSuccess(t *testing.T) {
@@ -25,7 +30,7 @@ func testSuccess(t *testing.T) {
 		return nil
 	}
 
-	err := Retry(fn, 3)
+	err := Retry(context.Background(), fn, 3)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, count)
 }
@@ -41,7 +46,7 @@ func testFail1(t *testing.T) {
 		return nil
 	}
 
-	err := Retry(fn, 3)
+	err := Retry(context.Background(), fn, 3)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, count)
 }
@@ -57,7 +62,7 @@ func testFail2(t *testing.T) {
 		return nil
 	}
 
-	err := Retry(fn, 3)
+	err := Retry(context.Background(), fn, 3)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, count)
 }
@@ -70,7 +75,64 @@ func testFailAll(t *testing.T) {
 		return errFail
 	}
 
-	err := Retry(fn, 3)
+	err := Retry(context.Background(), fn, 3)
 	assert.ErrorIs(t, err, errFail)
 	assert.Equal(t, 3, count)
+}
+
+func testContextTimeout(t *testing.T) {
+	var count int
+
+	fn := func() error {
+		count++
+		time.Sleep(50 * time.Millisecond)
+		return errFail
+	}
+
+	timeoutDuration := 100 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
+	defer cancel()
+
+	startTime := time.Now()
+
+	err := Retry(ctx, fn, 10)
+	elapsed := time.Since(startTime)
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.LessOrEqual(t, count, 3)
+	assert.GreaterOrEqual(t, elapsed, timeoutDuration)
+}
+
+func testRetryBackoff(t *testing.T) {
+	var count int
+
+	fn := func() error {
+		count++
+		time.Sleep(50 * time.Millisecond)
+		return errFail
+	}
+
+	timeoutDuration := 200 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
+	defer cancel()
+
+	b := &backoff.Backoff{
+		Min:    10 * time.Millisecond,
+		Max:    50 * time.Millisecond,
+		Factor: 2,
+	}
+
+	startTime := time.Now()
+
+	err := RetryBackoff(ctx, fn, 10, b)
+
+	elapsed := time.Since(startTime)
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded, "expected context deadline exceeded error")
+
+	assert.LessOrEqual(t, count, 4, "count should not exceed the number of attempts before timeout")
+
+	assert.GreaterOrEqual(t, elapsed, timeoutDuration, "elapsed time should be at least the timeout duration")
+
+	t.Logf("RetryBackoff - Attempts made: %d, Elapsed time: %v", count, elapsed)
 }


### PR DESCRIPTION
This addresses cases, especially for first-time deployers, where a builder can take longer to boot due to slow volume init, image pulls, etc. 