### PR TITLE
half the default max concurrent value to 8

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-var defaultMaxConcurrent = 16
+var defaultMaxConcurrent = 8
 
 var CommonFlags = flag.Set{
 	flag.Image(),


### PR DESCRIPTION
### Change Summary

What and Why:
The system now enforces rate limits on machine creates which can cause rate limit issue for apps with lots of machines in one region. 

How:
For now, adjusting down to 8 as a default should result in less rate limit being hit.

Related to:

https://community.fly.io/t/bluegreen-deployment-with-15-machines-error-failed-to-launch-vm-resource-exhausted-rate-limit-exceeded/21940