### PR TITLE
`fly app restart` only restarts started machines

### DIFF
--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -105,6 +105,12 @@ func runMachinesRestart(ctx context.Context, app *fly.AppCompact) error {
 	}
 
 	for _, m := range machines {
+		// Restart only if started
+		// If you change this condition ensure standby machines aren't started when not running
+		if m.State != fly.MachineStateStarted {
+			continue
+		}
+
 		if err := machine.Restart(ctx, m, input, m.LeaseNonce); err != nil {
 			return err
 		}

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -62,7 +62,7 @@ func (md *machineDeployment) launchInputForLaunch(processGroup string, guest *fl
 	return &fly.LaunchMachineInput{
 		Region:     region,
 		Config:     mConfig,
-		SkipLaunch: len(standbyFor) > 0,
+		SkipLaunch: skipLaunch(nil, mConfig),
 	}, nil
 }
 
@@ -223,12 +223,18 @@ func (md *machineDeployment) setMachineReleaseData(mConfig *fly.MachineConfig) {
 // * any services use autoscaling (autostop or autostart).
 // * it is a standby machine
 func skipLaunch(origMachineRaw *fly.Machine, mConfig *fly.MachineConfig) bool {
+	state := "<not-set>"
+	if origMachineRaw != nil {
+		state = origMachineRaw.State
+	}
+
 	switch {
-	case origMachineRaw.State == fly.MachineStateStarted:
+	case state == fly.MachineStateStarted:
 		return false
 	case len(mConfig.Standbys) > 0:
 		return true
-	case origMachineRaw.State == fly.MachineStateStopped || origMachineRaw.State == fly.MachineStateSuspended:
+	case state == fly.MachineStateStopped,
+		state == fly.MachineStateSuspended:
 		for _, s := range mConfig.Services {
 			if (s.Autostop != nil && *s.Autostop != fly.MachineAutostopOff) || (s.Autostart != nil && *s.Autostart) {
 				return true

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -233,8 +233,7 @@ func skipLaunch(origMachineRaw *fly.Machine, mConfig *fly.MachineConfig) bool {
 		return false
 	case len(mConfig.Standbys) > 0:
 		return true
-	case state == fly.MachineStateStopped,
-		state == fly.MachineStateSuspended:
+	case state == fly.MachineStateStopped, state == fly.MachineStateSuspended:
 		for _, s := range mConfig.Services {
 			if (s.Autostop != nil && *s.Autostop != fly.MachineAutostopOff) || (s.Autostart != nil && *s.Autostart) {
 				return true


### PR DESCRIPTION
### Change Summary

What and Why: `fly app restart` is starting stopped machines like standbys

How: Fix by only restarting started machines

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
