### PR TITLE
fix: fix slice init length

### DIFF
--- a/internal/command/postgres/db.go
+++ b/internal/command/postgres/db.go
@@ -131,7 +131,7 @@ func listDBs(ctx context.Context, leaderIP string) error {
 		return render.JSON(io.Out, databases)
 	}
 
-	rows := make([][]string, len(databases))
+	rows := make([][]string, 0, len(databases))
 	for _, db := range databases {
 		var users string
 		for index, name := range db.Users {

--- a/internal/command/postgres/users.go
+++ b/internal/command/postgres/users.go
@@ -131,7 +131,7 @@ func renderUsers(ctx context.Context, leaderIP string) error {
 		return render.JSON(io.Out, users)
 	}
 
-	rows := make([][]string, len(users))
+	rows := make([][]string, 0, len(users))
 
 	for _, user := range users {
 		var databases string


### PR DESCRIPTION
### Change Summary

What and Why:

The intention here should be to initialize a slice with a capacity of length rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW



How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
