### PR TITLE
phx: less brittle node naming for dns_cluster

### DIFF
--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -141,9 +141,9 @@ export ERL_AFLAGS="-proto_dist inet6_tcp"
 export ECTO_IPV6="true"
 export DNS_CLUSTER_QUERY="${FLY_APP_NAME}.internal"
 export RELEASE_DISTRIBUTION="name"
-image_label="${FLY_IMAGE_REF##*:}"
+image_tag="${FLY_IMAGE_REF##*:}"
 # trim the non-unique part of the default Fly.io label for the node name
-export RELEASE_NODE="${FLY_APP_NAME}-${image_label#deployment-}@${FLY_PRIVATE_IP}"
+export RELEASE_NODE="${FLY_APP_NAME}-${image_tag#deployment-}@${FLY_PRIVATE_IP}"
 
 # Uncomment to send crash dumps to stderr
 # This can be useful for debugging, but may log sensitive information

--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -141,7 +141,9 @@ export ERL_AFLAGS="-proto_dist inet6_tcp"
 export ECTO_IPV6="true"
 export DNS_CLUSTER_QUERY="${FLY_APP_NAME}.internal"
 export RELEASE_DISTRIBUTION="name"
-export RELEASE_NODE="${FLY_APP_NAME}-${FLY_IMAGE_REF##*-}@${FLY_PRIVATE_IP}"
+image_label="${FLY_IMAGE_REF##*:}"
+# trim the non-unique part of the default Fly.io label for the node name
+export RELEASE_NODE="${FLY_APP_NAME}-${image_label#deployment-}@${FLY_PRIVATE_IP}"
 
 # Uncomment to send crash dumps to stderr
 # This can be useful for debugging, but may log sensitive information


### PR DESCRIPTION
### Change Summary

What and Why:
The node naming in `env.sh.eex` as generated by the Phoenix scanner works great if it gets a default tag of the form "deployment-<id>", but broke with an invalid Erlang node name when I deployed using the `--image-label` flag to get a custom tag containing no hyphen.

How:
As described in #2554, the launch callback as-is creates a node name that uses the unique part of the default image tag when it's of the expected form. This PR suggests a way to strip `deployment-` if present, and otherwise just use the tag to identify the image version.

Build of app `garbage` with default tagging by `fly deploy`:

```
iex(garbage-01J9ST7EVHM23NPVE448VR2RW7@fdaa:0:3b99:a7b:ef:7c89:2bca:2)1> 
```

and on a different build using `fly deploy --image-label test` (`FLY_IMAGE_REF=registry.fly.io/garbage:test`):

```
iex(garbage-test@fdaa:0:3b99:a7b:ef:7c89:2bca:2)1> 
```

And with three nodes running:

```
iex(garbage-test@fdaa:0:3b99:a7b:174:d855:55b8:2)1> Node.list()
[:"garbage-test@fdaa:0:3b99:a7b:ef:7c89:2bca:2",
 :"garbage-test@fdaa:0:3b99:a7b:1d4:7a95:987b:2"]
```

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
