### PR TITLE
Jphenow/forcibly prevent extensions at launch for automation

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -114,6 +114,21 @@ func New() (cmd *cobra.Command) {
 			Hidden:      true,
 		},
 		flag.Bool{
+			Name:        "no-db",
+			Description: "Skip automatically provisioning a database",
+			Default:     false,
+		},
+		flag.Bool{
+			Name:        "no-redis",
+			Description: "Skip automatically provisioning a Redis instance",
+			Default:     false,
+		},
+		flag.Bool{
+			Name:        "no-object-storage",
+			Description: "Skip automatically provisioning an object storage bucket",
+			Default:     false,
+		},
+		flag.Bool{
 			Name:        "json",
 			Description: "Generate configuration in JSON format",
 		},

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -226,20 +226,22 @@ func buildManifest(ctx context.Context, parentConfig *appconfig.Config, recovera
 	if srcInfo != nil {
 		lp.ScannerFamily = srcInfo.Family
 		const scannerSource = "determined from app source"
-		switch srcInfo.DatabaseDesired {
-		case scanner.DatabaseKindPostgres:
-			lp.Postgres = plan.DefaultPostgres(lp)
-			planSource.postgresSource = scannerSource
-		case scanner.DatabaseKindMySQL:
-			// TODO
-		case scanner.DatabaseKindSqlite:
-			// TODO
+		if !flag.GetBool(ctx, "no-db") {
+			switch srcInfo.DatabaseDesired {
+			case scanner.DatabaseKindPostgres:
+				lp.Postgres = plan.DefaultPostgres(lp)
+				planSource.postgresSource = scannerSource
+			case scanner.DatabaseKindMySQL:
+				// TODO
+			case scanner.DatabaseKindSqlite:
+				// TODO
+			}
 		}
-		if srcInfo.RedisDesired {
+		if !flag.GetBool(ctx, "no-redis") && srcInfo.RedisDesired {
 			lp.Redis = plan.DefaultRedis(lp)
 			planSource.redisSource = scannerSource
 		}
-		if srcInfo.ObjectStorageDesired {
+		if !flag.GetBool(ctx, "no-object-storage") && srcInfo.ObjectStorageDesired {
 			lp.ObjectStorage = plan.DefaultObjectStorage(lp)
 			planSource.tigrisSource = scannerSource
 		}


### PR DESCRIPTION
### Change Summary

What and Why:

Allows skipping source info so things like GitHub PR review app actions can prevent a new database due to scanner findings.

How:

`fly launch --no-db --no-redis --no-object-storage`

---

### Documentation

- [X] flyctl help
- [ ] https://github.com/superfly/fly-pr-review-apps
- [ ] Fresh Produce
