### PR TITLE
ci: fix pre-commit/action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,10 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Install Go since pre-commit below runs "go mod tidy".
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
           check-latest: true
+      # pre-commit runs "pip install" which doesn't work under Debian's apt-instaled Python.
+      # https://packaging.python.org/en/latest/specifications/externally-managed-environments/#externally-managed-environments
+      - uses: actions/setup-python@v3
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files --hook-stage=manual


### PR DESCRIPTION
Installing pre-commit under Debian's python caused the following;

```
Run python -m pip install pre-commit
  python -m pip install pre-commit
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
