### PR TITLE
Return the original deploy error when it also fails to fetch logs

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -1263,7 +1263,7 @@ type smokeChecksError struct {
 }
 
 func (s smokeChecksError) Error() string {
-	return fmt.Sprintf("smoke checks for %s failed: %w", s.machineID, s.err)
+	return fmt.Sprintf("smoke checks for %s failed: %s", s.machineID, s.err)
 }
 
 func (s smokeChecksError) Unwrap() error {


### PR DESCRIPTION
### Change Summary

What and Why: Failed deploys are reporting the wrong error when it also fails to download the failed machine logs 

```
failed to update machine 1857xxxxx348: Unrecoverable error: error getting logs for machine 1857xxxxx348: 422 Unprocessable Entity
```

How: Always return the original error and show a warning saying logs couldn't be retrieved   

Additionally, do not fetch logs if we don't plan to show them.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
