### PR TITLE
Restore automatically pushing new releases to Docker Hub

### DIFF
--- a/.goreleaser.2.yml
+++ b/.goreleaser.2.yml
@@ -94,5 +94,15 @@ archives:
     wrap_in_directory: false
     format: zip
 
+dockers:
+  - goos: linux
+    goarch: amd64
+    image_templates:
+      - "flyio/flyctl:latest"
+      - "flyio/flyctl:v{{ .Version }}"
+      - "ghcr.io/superfly/flyctl:latest"
+      - "ghcr.io/superfly/flyctl:v{{ .Version }}"
+    skip_push: auto
+
 release:
   disable: false


### PR DESCRIPTION
### Change Summary

What and Why:

The flyctl Docker image on Docker Hub is outdated. We stopped pushing new Docker images when we automated new releases here. 

This PR restores pushing new images to Docker Hub. 

Related to:

Resolves https://github.com/superfly/flyctl/issues/3924

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
