### PR TITLE
Remove Docker Hub image templates

### DIFF
--- a/.goreleaser.2.yml
+++ b/.goreleaser.2.yml
@@ -98,8 +98,6 @@ dockers:
   - goos: linux
     goarch: amd64
     image_templates:
-      - "flyio/flyctl:latest"
-      - "flyio/flyctl:v{{ .Version }}"
       - "ghcr.io/superfly/flyctl:latest"
       - "ghcr.io/superfly/flyctl:v{{ .Version }}"
     skip_push: auto


### PR DESCRIPTION
### Change Summary

What and Why:

We have an auth issue we need to get sorted out, but the GitHub images shouldn't be an issue. 

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
