### PR TITLE
Support https metrics endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
-	github.com/superfly/fly-go v0.1.33
+	github.com/superfly/fly-go v0.1.34
 	github.com/superfly/graphql v0.2.4
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.14-0.20240819201738-61a02aa53648

--- a/go.sum
+++ b/go.sum
@@ -642,8 +642,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.33 h1:CRMZ/w/g9RE3R2KElIOoi2YPxpOYf+AIhXI2cSkKiXU=
-github.com/superfly/fly-go v0.1.33/go.mod h1:FfFgQk88G60rZWnpcCqgufk5CZoCjZznLws699gswWU=
+github.com/superfly/fly-go v0.1.34 h1:h6tL+z8VqMH4yHM+YwbC8fib3PquUB3IrGu+0cxuFNw=
+github.com/superfly/fly-go v0.1.34/go.mod h1:ZLXEOA1TpJz89A3tUBpzW3/foX+HGLaVtudSeUymj/w=
 github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
 github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=


### PR DESCRIPTION
This PR ads support for HTTP-based metrics endpoints in `fly.toml`. 