### PR TITLE
Fix `fly launch` failing in pnpm workspace while adding `@flydotio/dockerfile` dependency

### DIFF
--- a/scanner/jsFramework.go
+++ b/scanner/jsFramework.go
@@ -298,7 +298,13 @@ func JsFrameworkCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchP
 
 			_, err = os.Stat("pnpm-lock.yaml")
 			if !errors.Is(err, fs.ErrNotExist) {
-				args = []string{"pnpm", "add", "-D", "@flydotio/dockerfile@latest"}
+
+				_, err = os.Stat("pnpm-workspace.yaml")
+				if errors.Is(err, fs.ErrNotExist) {
+					args = []string{"pnpm", "add", "-D", "@flydotio/dockerfile@latest"}
+				} else {
+					args = []string{"pnpm", "add", "-w", "-D", "@flydotio/dockerfile@latest"}
+				}
 			}
 
 			_, err = os.Stat("bun.lockb")


### PR DESCRIPTION
### Change Summary

What and Why: `fly launch` was throwing an error at the step where it runs `pnpm add -D @flydotio/dockerfile@latest` because of an error from `pnpm`.

```sh
Postgres cluster my-database is now attached to my-app
The following secret was added to my-app:
DATABASE_URL=postgres://my_app:foo
Postgres cluster my-database is now attached to my-app
installing: pnpm add -D @flydotio/dockerfile@latest

ERR_PNPM_ADDING_TO_ROOT Running this command will add the dependency to the workspace root, which might not be what you want - if you really meant it, make it explicit by running this command again with the -w flag (or --workspace-root). If you don't want to see this warning anymore, you may set the ignore-workspace-root-check setting to true.
Error: failed to install @flydotio/dockerfile: exit status 1
```

How:

We detect if the file _pnpm-workspace.yaml_ is present since it is a requirement for pnpm according to the documentation (https://pnpm.io/workspaces).

> A workspace must have a [pnpm-workspace.yaml](https://pnpm.io/pnpm-workspace_yaml) file in its root.

If the file is present, it runs `pnpm add -w -D @flydotio/dockerfile@latest`, if not, it runs `pnpm add -D @flydotio/dockerfile@latest`. This is to avoid the following error on non-workspace repository ` ERROR  --workspace-root may only be used inside a workspace`.

Related to:

https://community.fly.io/t/fly-launch-fails-with-pnpm-workspace/22362

### Documentation

**⚠️ I'm not a Go developer. I made the PR because the change is very straightforward and I hope to see the fix shipped sooner. Nevertheless, I would need help to add test/documentation if you think it's needed.**

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
