### PR TITLE
Disable docs sync

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -26,6 +26,7 @@ jobs:
           DEFAULT_BUMP: "patch"
 
   sync_docs:
+    if: false
     needs: release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Docs sync is causing all docs pages to be deleted, so we disable it for now.