### PR TITLE
Run `release` and `sync_docs` jobs on master branch only

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master branch
@@ -27,7 +27,7 @@ jobs:
           DEFAULT_BUMP: "patch"
 
   sync_docs:
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: github.ref == 'refs/heads/master'
     needs: release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   release:
+    if: ${{ github.ref == 'refs/heads/master' }} && false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master branch
@@ -26,7 +27,7 @@ jobs:
           DEFAULT_BUMP: "patch"
 
   sync_docs:
-    if: false
+    if: ${{ github.ref == 'refs/heads/master' }} && false
     needs: release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    if: ${{ github.ref == 'refs/heads/master' }} && false
+    if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout master branch
@@ -27,7 +27,7 @@ jobs:
           DEFAULT_BUMP: "patch"
 
   sync_docs:
-    if: ${{ github.ref == 'refs/heads/master' }} && false
+    if: ${{ github.ref == 'refs/heads/master' }}
     needs: release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Change Summary

What and Why:

If the `auto-release` workflow is run from a branch other than `master`, that can result in deleting docs. This PR limits execution of the two jobs in `auto-release` to the `master` branch. 

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
