### PR TITLE
Reenable flyctl docs and fix naming bug

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -27,8 +27,7 @@ jobs:
           DEFAULT_BUMP: "patch"
 
   sync_docs:
-    #if: github.ref == 'refs/heads/master'
-    if: false
+    if: github.ref == 'refs/heads/master'
     needs: release
     runs-on: ubuntu-latest
     steps:

--- a/doc/main.go
+++ b/doc/main.go
@@ -26,6 +26,10 @@ func main() {
 	cmd := cli.NewRootCommand()
 	cmd.DisableAutoGenTag = true
 
+	// Override root command to always be `fly`,
+	// Otherwise it could be `main`, `flyctl` or whatever name is set to the executable
+	cmd.Use = "fly"
+
 	filePrepender := func(filename string) string {
 		return ""
 	}


### PR DESCRIPTION
### Change Summary


```
flyctl on  reenable-docs [$] via 🐹 v1.23.2
✦ ❯ ls out/ -1
fly.md
fly_agent.md
fly_agent_ping.md
fly_agent_restart.md
fly_agent_run.md
fly_agent_start.md
fly_agent_stop.md
fly_apps.md
fly_apps_create.md
fly_apps_destroy.md
fly_apps_errors.md
```

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
