### PR TITLE
resolve compute for group for "console"

### DIFF
--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"slices"
 
 	"github.com/google/shlex"
 	"github.com/samber/lo"
@@ -401,18 +400,8 @@ func makeEphemeralConsoleMachine(ctx context.Context, app *fly.AppCompact, appCo
 func determineEphemeralConsoleMachineGuest(ctx context.Context, appConfig *appconfig.Config) (*fly.MachineGuest, error) {
 	var guest *fly.MachineGuest
 
-	haveConsoleVMSection := 0 <= slices.IndexFunc(
-		appConfig.Compute,
-		func(c *appconfig.Compute) bool {
-			return slices.Index(c.Processes, "console") >= 0
-		},
-	)
-	if haveConsoleVMSection {
-		groupConfig, err := appConfig.ToMachineConfig("console", nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check Machine configuration for the 'console' group: %w", err)
-		}
-		guest = groupConfig.Guest
+	if compute := appConfig.ComputeForGroup("console"); compute != nil {
+		guest = compute.MachineGuest
 	}
 
 	guest, err := flag.GetMachineGuest(ctx, guest)


### PR DESCRIPTION
replace logic that only looks for a specific console override with one that uses the standard function for finding the most specific vm compute requirements for group console.

https://github.com/superfly/flyctl/blob/7467ca0c3e46d0b5e28e367dc290eb52f57b0fc4/internal/appconfig/processgroups.go#L188-L193

See: https://community.fly.io/t/fly-console-crashes-by-default-for-rails-apps/22436