### PR TITLE
Debug phantom workflow events

### DIFF
--- a/.github/workflows/preflight_cleanup.yml
+++ b/.github/workflows/preflight_cleanup.yml
@@ -2,7 +2,7 @@ name: Preflight Tests Cleanup
 
 on:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: "*/20 * * * *"
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
### Change Summary

The Preflight Cleanup workflow hasn't run on its schedule for the past two weeks. Mysteriously, 2 weeks ago we also started seeing "(Unknown event) (Unnamed workflow)" events approximately every 30 minutes. They fail with the error, "Please verify your email address to run GitHub Actions workflows."

I think the problem is that the email for the user last associated with this workflow no longer exists. This commit will change the association to me.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
