### PR TITLE
Restore preflight cleanup workflow schedule

### DIFF
--- a/.github/workflows/preflight_cleanup.yml
+++ b/.github/workflows/preflight_cleanup.yml
@@ -2,7 +2,7 @@ name: Preflight Tests Cleanup
 
 on:
   schedule:
-    - cron: "*/20 * * * *"
+    - cron: "*/30 * * * *"
   workflow_dispatch:
     inputs:
       reason:


### PR DESCRIPTION
### Change Summary

What and Why:

My hypothesis in https://github.com/superfly/flyctl/pull/4038 was correct and we're no longer seeing the phantom workflows. We can restore the schedule to the Preflight Cleanup workflow. 

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
