### PR TITLE
ci: upgrade setup-python

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,7 +26,9 @@ jobs:
           check-latest: true
       # pre-commit runs "pip install" which doesn't work under Debian's apt-instaled Python.
       # https://packaging.python.org/en/latest/specifications/externally-managed-environments/#externally-managed-environments
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
       - uses: pre-commit/action@v3.0.1
         with:
           extra_args: --all-files --hook-stage=manual


### PR DESCRIPTION
python-version is recommended to speficy.

https://github.com/actions/setup-python?tab=readme-ov-file#basic-usage
> The default version of Python or PyPy in PATH varies between runners
> and can be changed unexpectedly so we recommend always setting Python
> version explicitly using the python-version or python-version-file
> inputs.

In fact, Dependabot's PR #4001 was failing due to that.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
