### PR TITLE
Support machine configuration directly in fly.toml

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	Checks           map[string]*ToplevelCheck `toml:"checks,omitempty" json:"checks,omitempty"`
 	Files            []File                    `toml:"files,omitempty" json:"files,omitempty"`
 	HostDedicationID string                    `toml:"host_dedication_id,omitempty" json:"host_dedication_id,omitempty"`
+	MachineConfigs   []*MachineConfig          `toml:"machine_config,omitempty" json:"machine_config,omitempty"`
 
 	MachineChecks []*ServiceMachineCheck `toml:"machine_checks,omitempty" json:"machine_checks,omitempty"`
 
@@ -162,6 +163,12 @@ type Experimental struct {
 	EnableEtcd     bool     `toml:"enable_etcd,omitempty" json:"enable_etcd,omitempty"`
 	LazyLoadImages bool     `toml:"lazy_load_images,omitempty" json:"lazy_load_images,omitempty"`
 	Attached       Attached `toml:"attached,omitempty" json:"attached,omitempty"`
+}
+
+type MachineConfig struct {
+	FromFile  string             `toml:"from_file,omitempty" json:"from_file,omitempty"`
+	Config    *fly.MachineConfig `toml:"config,omitempty" json:"config,omitempty"`
+	Processes []string           `toml:"processes,omitempty" json:"processes,omitempty"`
 }
 
 type Attached struct {

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -57,7 +57,6 @@ type Config struct {
 	Checks           map[string]*ToplevelCheck `toml:"checks,omitempty" json:"checks,omitempty"`
 	Files            []File                    `toml:"files,omitempty" json:"files,omitempty"`
 	HostDedicationID string                    `toml:"host_dedication_id,omitempty" json:"host_dedication_id,omitempty"`
-	MachineConfigs   []*MachineConfig          `toml:"machine_config,omitempty" json:"machine_config,omitempty"`
 
 	MachineChecks []*ServiceMachineCheck `toml:"machine_checks,omitempty" json:"machine_checks,omitempty"`
 
@@ -163,12 +162,7 @@ type Experimental struct {
 	EnableEtcd     bool     `toml:"enable_etcd,omitempty" json:"enable_etcd,omitempty"`
 	LazyLoadImages bool     `toml:"lazy_load_images,omitempty" json:"lazy_load_images,omitempty"`
 	Attached       Attached `toml:"attached,omitempty" json:"attached,omitempty"`
-}
-
-type MachineConfig struct {
-	FromFile  string             `toml:"from_file,omitempty" json:"from_file,omitempty"`
-	Config    *fly.MachineConfig `toml:"config,omitempty" json:"config,omitempty"`
-	Processes []string           `toml:"processes,omitempty" json:"processes,omitempty"`
+	MachineConfig  string   `toml:"machine_config,omitempty" json:"machine_config,omitempty"`
 }
 
 type Attached struct {

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -1,7 +1,10 @@
 package appconfig
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/docker/go-units"
 	"github.com/google/shlex"
@@ -233,6 +236,26 @@ func (c *Config) updateMachineConfig(src *fly.MachineConfig) (*fly.MachineConfig
 	mConfig := &fly.MachineConfig{}
 	if src != nil {
 		mConfig = helpers.Clone(src)
+	}
+
+	if len(c.MachineConfigs) > 0 {
+		mc0 := c.MachineConfigs[0]
+		switch {
+		case mc0.Config != nil:
+			mConfig = helpers.Clone(mc0.Config)
+		case mc0.FromFile != "":
+			file, err := os.Open(mc0.FromFile)
+			if err != nil {
+				return nil, err
+			}
+			buf, err := io.ReadAll(file)
+			if err != nil {
+				return nil, err
+			}
+			if err := json.Unmarshal(buf, mConfig); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// Metrics

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -261,7 +261,7 @@ func (c *Config) updateMachineConfig(src *fly.MachineConfig) (*fly.MachineConfig
 		}
 
 		if err := json.Unmarshal(buf, mConfig); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid machine config %q: %w", emc, err)
 		}
 	}
 

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -53,6 +53,7 @@ func TestToMachineConfig(t *testing.T) {
 		Restart: &fly.MachineRestart{
 			Policy: fly.MachineRestartPolicyAlways,
 		},
+		DNS: &fly.DNSConfig{Nameservers: []string{"1.2.3.4"}},
 	}
 
 	got, err := cfg.ToMachineConfig("", nil)
@@ -79,7 +80,7 @@ func TestToMachineConfig(t *testing.T) {
 	assert.Equal(t, "24/7", got.Schedule)
 	assert.Equal(t, true, got.AutoDestroy)
 	assert.Equal(t, &fly.MachineRestart{Policy: "always"}, got.Restart)
-	assert.Equal(t, &fly.DNSConfig{SkipRegistration: true}, got.DNS)
+	assert.Equal(t, &fly.DNSConfig{SkipRegistration: true, Nameservers: []string{"1.2.3.4"}}, got.DNS)
 	assert.Equal(t, "propagated", got.Metadata["retain"])
 	assert.Empty(t, got.Init.Cmd)
 }
@@ -460,7 +461,7 @@ func TestToTestMachineConfigWTestMachine(t *testing.T) {
 	}
 	got, err := cfg.ToTestMachineConfig(check, machine)
 	assert.NoError(t, err)
-	assert.Equal(t, got, want)
+	assert.Equal(t, want, got)
 }
 
 func TestToConsoleMachineConfig(t *testing.T) {

--- a/internal/appconfig/processgroups.go
+++ b/internal/appconfig/processgroups.go
@@ -170,14 +170,6 @@ func (c *Config) Flatten(groupName string) (*Config, error) {
 		dst.Restart[i].Processes = []string{groupName}
 	}
 
-	// [[machine_config]]
-	dst.MachineConfigs = lo.Filter(dst.MachineConfigs, func(x *MachineConfig, _ int) bool {
-		return matchesGroups(x.Processes)
-	})
-	for i := range dst.MachineConfigs {
-		dst.MachineConfigs[i].Processes = []string{groupName}
-	}
-
 	// [[vm]]
 	compute := dst.ComputeForGroup(groupName)
 

--- a/internal/appconfig/processgroups.go
+++ b/internal/appconfig/processgroups.go
@@ -162,11 +162,20 @@ func (c *Config) Flatten(groupName string) (*Config, error) {
 		dst.Metrics[i].Processes = []string{groupName}
 	}
 
+	// [[restart]]
 	dst.Restart = lo.Filter(dst.Restart, func(x Restart, _ int) bool {
 		return matchesGroups(x.Processes)
 	})
 	for i := range dst.Restart {
 		dst.Restart[i].Processes = []string{groupName}
+	}
+
+	// [[machine_config]]
+	dst.MachineConfigs = lo.Filter(dst.MachineConfigs, func(x *MachineConfig, _ int) bool {
+		return matchesGroups(x.Processes)
+	})
+	for i := range dst.MachineConfigs {
+		dst.MachineConfigs[i].Processes = []string{groupName}
 	}
 
 	// [[vm]]

--- a/internal/appconfig/testdata/tomachine.toml
+++ b/internal/appconfig/testdata/tomachine.toml
@@ -46,3 +46,6 @@ guest_path = "/guest/path"
 url_prefix = "/url/prefix"
 tigris_bucket = "example-bucket"
 index_document = "index.html"
+
+[experimental]
+machine_config = '{"dns": {"nameservers": ["1.2.3.4"]}}'


### PR DESCRIPTION
### Change Summary

What and Why: There are options is machine config (i.e.: dns config) which are not directly controllable from fly.toml.  This change adds an experimental `machine_config` directive to load machine config values from a json string or file.

How:

```toml
[experimental]
machine_config = '{"dns": {"nameservers": ["1.2.3.4", "5.6.7.8"]}}'
```

or 
```toml
[experimental]
machine_config = 'machine-config.json'
```

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
