### PR TITLE
Macaroon update fixes

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -604,11 +604,14 @@ func RequireSession(ctx context.Context) (context.Context, error) {
 }
 
 func tryOpenUserURL(ctx context.Context, url string) error {
+	io := iostreams.FromContext(ctx)
+
+	if !io.IsInteractive() || env.IsCI() {
+		return errors.New("failed opening browser")
+	}
+
 	if err := open.Run(url); err != nil {
-		fmt.Fprintf(iostreams.FromContext(ctx).ErrOut,
-			"failed opening browser. Copy the url (%s) into a browser and continue\n",
-			url,
-		)
+		fmt.Fprintf(io.ErrOut, "failed opening browser. Copy the url (%s) into a browser and continue\n", url)
 	}
 
 	return nil

--- a/internal/config/tokens.go
+++ b/internal/config/tokens.go
@@ -47,7 +47,7 @@ func MonitorTokens(monitorCtx context.Context, t *tokens.Tokens, uucb UserURLCal
 		log.Debugf("failed to update discharge tokens: %s", err)
 	}
 
-	if file != "" && updated1 || updated2 {
+	if file != "" && (updated1 || updated2) {
 		if err := SetAccessToken(file, t.All()); err != nil {
 			log.Debugf("failed to persist updated tokens: %s", err)
 		}
@@ -198,6 +198,11 @@ func refreshDischargeTokens(ctx context.Context, t *tokens.Tokens, uucb UserURLC
 //
 // Don't call this when other goroutines might also be accessing t.
 func fetchOrgTokens(ctx context.Context, t *tokens.Tokens) (bool, error) {
+	// don't fetch missing org tokens if tokens came from environment var
+	if t.FromFile() == "" {
+		return false, nil
+	}
+
 	return doFetchOrgTokens(ctx, t, defaultOrgFetcher, defaultTokenMinter)
 }
 


### PR DESCRIPTION
- d8752b2ef19639e8e2521e9d94aff2e6cd101d4d - In CI/non-interactive settings, we were trying to open auth.fly.io URLs. When that failed, we printed a message for the user to open the URL and waited for them to do that. Instead, we should fail the 3p discharge attempt. The print-url-and-wait strategy only makes sense in non-local interactive settings (e.g. SSH).
- f90145f33b88927e3eae44e544b1a01e104b8fd8 - When flyctl has some macaroons and an OAuth token, it checks whether it's missing macaroons for any orgs in order to accommodate for the user being added to new orgs. This behavior makes less sense when flyctl's tokens came from an environment variable instead of from the config file. So, we disable it in that case.