### PR TITLE
add experimental feature to enable zstd for depot builds

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -163,6 +163,7 @@ type Experimental struct {
 	LazyLoadImages bool     `toml:"lazy_load_images,omitempty" json:"lazy_load_images,omitempty"`
 	Attached       Attached `toml:"attached,omitempty" json:"attached,omitempty"`
 	MachineConfig  string   `toml:"machine_config,omitempty" json:"machine_config,omitempty"`
+	UseZstd        bool     `toml:"use_zstd,omitempty" json:"use_zstd,omitempty"`
 }
 
 type Attached struct {

--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -258,6 +258,8 @@ func buildImage(ctx context.Context, buildkitClient *client.Client, opts ImageOp
 
 	if opts.UseZstd {
 		exportEntry.Attrs["compression"] = "zstd"
+		exportEntry.Attrs["compression-level"] = "3"
+		exportEntry.Attrs["force-compression"] = "true"
 	}
 
 	ch := make(chan *client.SolveStatus)

--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -256,6 +256,10 @@ func buildImage(ctx context.Context, buildkitClient *client.Client, opts ImageOp
 		exportEntry.Attrs["push"] = "true"
 	}
 
+	if opts.UseZstd {
+		exportEntry.Attrs["compression"] = "zstd"
+	}
+
 	ch := make(chan *client.SolveStatus)
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -54,6 +54,7 @@ type ImageOptions struct {
 	BuildpacksDockerHost string
 	BuildpacksVolumes    []string
 	UseOverlaybd         bool
+	UseZstd              bool
 }
 
 func (io ImageOptions) ToSpanAttributes() []attribute.KeyValue {
@@ -72,6 +73,7 @@ func (io ImageOptions) ToSpanAttributes() []attribute.KeyValue {
 		attribute.String("imageoptions.buildpacks_docker_host", io.BuildpacksDockerHost),
 		attribute.StringSlice("imageoptions.buildpacks", io.Buildpacks),
 		attribute.StringSlice("imageoptions.buildpacks_volumes", io.BuildpacksVolumes),
+		attribute.Bool("imageoptions.use_zstd", io.UseZstd),
 	}
 
 	if io.BuildArgs != nil {

--- a/internal/command/command_run.go
+++ b/internal/command/command_run.go
@@ -73,6 +73,14 @@ func DetermineImage(ctx context.Context, appName string, imageOrPath string) (im
 		}
 		opts.BuildArgs = extraArgs
 
+		if cfg != nil && cfg.Experimental != nil {
+			opts.UseZstd = cfg.Experimental.UseZstd
+		}
+		// use-zstd passed through flags takes precedence over the one set in config
+		if useZstd := flag.GetBool(ctx, "use-zstd"); useZstd {
+			opts.UseZstd = useZstd
+		}
+
 		img, err = resolver.BuildImage(ctx, io, opts)
 		if err != nil {
 			return nil, err

--- a/internal/command/command_run.go
+++ b/internal/command/command_run.go
@@ -76,9 +76,10 @@ func DetermineImage(ctx context.Context, appName string, imageOrPath string) (im
 		if cfg != nil && cfg.Experimental != nil {
 			opts.UseZstd = cfg.Experimental.UseZstd
 		}
+
 		// use-zstd passed through flags takes precedence over the one set in config
-		if useZstd := flag.GetBool(ctx, "use-zstd"); useZstd {
-			opts.UseZstd = useZstd
+		if flag.IsSpecified(ctx, "use-zstd") {
+			opts.UseZstd = flag.GetBool(ctx, "use-zstd")
 		}
 
 		img, err = resolver.BuildImage(ctx, io, opts)

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -134,6 +134,8 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config, useWG, rec
 
 	if appConfig.Experimental != nil {
 		opts.UseOverlaybd = appConfig.Experimental.LazyLoadImages
+
+		opts.UseZstd = appConfig.Experimental.UseZstd
 	}
 
 	// flyctl supports key=value form while Docker supports id=key,src=/path/to/secret form.

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -180,6 +180,10 @@ var runOrCreateFlags = flag.Set{
 		Description: "Enable LSVD for this machine",
 		Hidden:      true,
 	},
+	flag.Bool{
+		Name:        "use-zstd",
+		Description: "Enable zstd compression for the image",
+	},
 }
 
 func soManyErrors(args ...interface{}) error {


### PR DESCRIPTION
### Change Summary

What and Why:

For most Apps, enabling `zstd` will improve machine create times due to faster image pulls. With Fly's built-in builder, it was never able to make it possible to enable `zstd` builds and left the user having to manage the image build process on their own. However, now that we default to depot builders, it's possible to enable the feature with an additional argument, https://depot.dev/blog/building-images-gzip-vs-zstd.

How:

To start, we'll allow enabling `zstd` builds to be done with the `experimental` section of `fly.toml` or as a flag passed to `fly machine run`.

Related to:

https://community.fly.io/t/try-out-faster-machine-creation-with-zstd/18354
https://community.fly.io/t/why-machines-take-a-lot-of-time-to-be-created-sometimes/22647/2

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
