### PR TITLE
add `registry files` command for file listing

### DIFF
--- a/internal/command/registry/command.go
+++ b/internal/command/registry/command.go
@@ -17,6 +17,7 @@ func New() *cobra.Command {
 	cmd.Hidden = true
 
 	cmd.AddCommand(
+		newFiles(),
 		newSbom(),
 		newVulns(),
 		newVulnSummary(),

--- a/internal/command/registry/files.go
+++ b/internal/command/registry/files.go
@@ -13,15 +13,15 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 )
 
-func newSbom() *cobra.Command {
+func newFiles() *cobra.Command {
 	const (
-		usage = "sbom"
-		short = "Generate an SBOM for a registry image [experimental]"
-		long  = "Genearte an SBOM for a registry image.\n" +
+		usage = "files"
+		short = "Generate a file listing for a registry image [experimental]"
+		long  = "Genearte a file listing for a registry iamge.\n" +
 			"The image is selected by name, or the image of the app's first machine\n" +
 			"is used unless interactive machine selection or machine ID is specified."
 	)
-	cmd := command.New(usage, short, long, runSbom,
+	cmd := command.New(usage, short, long, runFiles,
 		command.RequireSession,
 		command.RequireAppName,
 	)
@@ -50,7 +50,7 @@ func newSbom() *cobra.Command {
 	return cmd
 }
 
-func runSbom(ctx context.Context) error {
+func runFiles(ctx context.Context) error {
 	imgPath, orgId, err := argsGetImgPath(ctx)
 	if err != nil {
 		return err
@@ -61,19 +61,19 @@ func runSbom(ctx context.Context) error {
 		return err
 	}
 
-	res, err := scantronSbomReq(ctx, imgPath, token)
+	res, err := scantronFilesReq(ctx, imgPath, token)
 	if err != nil {
 		return err
 	}
 	defer res.Body.Close() // skipcq: GO-S2307
 
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed fetching SBOM (status code %d)", res.StatusCode)
+		return fmt.Errorf("failed fetching file listing (status code %d)", res.StatusCode)
 	}
 
 	ios := iostreams.FromContext(ctx)
 	if _, err := io.Copy(ios.Out, res.Body); err != nil {
-		return fmt.Errorf("failed to read SBOM: %w", err)
+		return fmt.Errorf("failed to read file listing: %w", err)
 	}
 	return nil
 }

--- a/internal/command/registry/scantron.go
+++ b/internal/command/registry/scantron.go
@@ -62,6 +62,10 @@ func scantronVulnscanReq(ctx context.Context, imgPath, token string) (*http.Resp
 	return scantronReq(ctx, imgPath, token, "application/json")
 }
 
+func scantronFilesReq(ctx context.Context, imgPath, token string) (*http.Response, error) {
+	return scantronReq(ctx, imgPath+"?files=1", token, "application/json")
+}
+
 type Scan struct {
 	SchemaVersion int
 	CreatedAt     string


### PR DESCRIPTION
### Change Summary

What and Why: Add support for pulling a file listing from scantron.

How: Requests data from scantron using the file listing endpoint which was recentlya dded.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
