### PR TITLE
Replace INCOMING_WEBHOOK with incoming-webhook

### DIFF
--- a/.github/workflows/preflight_cleanup.yml
+++ b/.github/workflows/preflight_cleanup.yml
@@ -36,7 +36,7 @@ jobs:
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.PREFLIGHT_SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_WEBHOOK_TYPE: incoming-webhook
         with:
           payload: |
             {


### PR DESCRIPTION
### Change Summary

What and Why:

Preflight test failures in GitHub Actions aren't being posted to Slack. Evidently the webhook type changed and we never noticed until now. 

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
