### PR TITLE
ci: upgrade GitHub Actions' images

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -70,10 +70,11 @@ jobs:
       max-parallel: 4
       matrix:
         os:
-          - ubuntu-latest
+          # From https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images.
+          - ubuntu-24.04
+          - ubuntu-22.04
           - ubuntu-20.04
-          - macos-latest
-          - macos-12
+          - macos-14
           - macos-13
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
macos-12 is deprecated and ubuntu-24.04 is newly added.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
