### PR TITLE
Add deploy.release_command_vm directive to set release machine size

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -87,11 +87,12 @@ type Metrics struct {
 }
 
 type Deploy struct {
-	ReleaseCommand        string        `toml:"release_command,omitempty" json:"release_command,omitempty"`
-	ReleaseCommandTimeout *fly.Duration `toml:"release_command_timeout,omitempty" json:"release_command_timeout,omitempty"`
 	Strategy              string        `toml:"strategy,omitempty" json:"strategy,omitempty"`
 	MaxUnavailable        *float64      `toml:"max_unavailable,omitempty" json:"max_unavailable,omitempty"`
 	WaitTimeout           *fly.Duration `toml:"wait_timeout,omitempty" json:"wait_timeout,omitempty"`
+	ReleaseCommand        string        `toml:"release_command,omitempty" json:"release_command,omitempty"`
+	ReleaseCommandTimeout *fly.Duration `toml:"release_command_timeout,omitempty" json:"release_command_timeout,omitempty"`
+	ReleaseCommandCompute *Compute      `toml:"release_command_vm,omitempty" json:"release_command_vm,omitempty"`
 }
 
 type File struct {

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -261,7 +261,10 @@ func TestToDefinition(t *testing.T) {
 			"max_unavailable":         0.2,
 			"release_command":         "release command",
 			"release_command_timeout": "3m0s",
-			"release_command_vm":      map[string]any{"size": "performance-2x"},
+			"release_command_vm": map[string]any{
+				"size":   "performance-2x",
+				"memory": "8g",
+			},
 		},
 		"env": map[string]any{
 			"FOO": "BAR",

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -257,9 +257,11 @@ func TestToDefinition(t *testing.T) {
 		},
 
 		"deploy": map[string]any{
-			"release_command": "release command",
-			"strategy":        "rolling-eyes",
-			"max_unavailable": 0.2,
+			"strategy":                "rolling-eyes",
+			"max_unavailable":         0.2,
+			"release_command":         "release command",
+			"release_command_timeout": "3m0s",
+			"release_command_vm":      map[string]any{"size": "performance-2x"},
 		},
 		"env": map[string]any{
 			"FOO": "BAR",

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -63,6 +63,15 @@ func (c *Config) ToReleaseMachineConfig() (*fly.MachineConfig, error) {
 	mConfig.Files = nil
 	fly.MergeFiles(mConfig, c.MergedFiles)
 
+	// Guest
+	if v := c.Deploy.ReleaseCommandCompute; v != nil {
+		guest, err := c.computeToGuest(v)
+		if err != nil {
+			return nil, err
+		}
+		mConfig.Guest = guest
+	}
+
 	return mConfig, nil
 }
 
@@ -406,8 +415,10 @@ func (c *Config) toMachineGuest() (*fly.MachineGuest, error) {
 	}
 
 	// At most one compute after group flattening
-	compute := c.Compute[0]
+	return c.computeToGuest(c.Compute[0])
+}
 
+func (c *Config) computeToGuest(compute *Compute) (*fly.MachineGuest, error) {
 	size := fly.DefaultVMSize
 	switch {
 	case compute.Size != "":

--- a/internal/appconfig/machines_test.go
+++ b/internal/appconfig/machines_test.go
@@ -168,6 +168,11 @@ func TestToReleaseMachineConfig(t *testing.T) {
 			Timeout: fly.MustParseDuration("10s"),
 			Signal:  fly.Pointer("SIGTERM"),
 		},
+		Guest: &fly.MachineGuest{
+			CPUKind:  "performance",
+			CPUs:     2,
+			MemoryMB: 4096,
+		},
 	}
 
 	got, err := cfg.ToReleaseMachineConfig()

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -392,7 +392,10 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 			MaxUnavailable:        fly.Pointer(0.2),
 			ReleaseCommand:        "release command",
 			ReleaseCommandTimeout: fly.MustParseDuration("3m"),
-			ReleaseCommandCompute: &Compute{Size: "performance-2x"},
+			ReleaseCommandCompute: &Compute{
+				Size:   "performance-2x",
+				Memory: "8g",
+			},
 		},
 
 		Env: map[string]string{

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -388,9 +388,11 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 		},
 
 		Deploy: &Deploy{
-			ReleaseCommand: "release command",
-			Strategy:       "rolling-eyes",
-			MaxUnavailable: fly.Pointer(0.2),
+			Strategy:              "rolling-eyes",
+			MaxUnavailable:        fly.Pointer(0.2),
+			ReleaseCommand:        "release command",
+			ReleaseCommandTimeout: fly.MustParseDuration("3m"),
+			ReleaseCommandCompute: &Compute{Size: "performance-2x"},
 		},
 
 		Env: map[string]string{

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -34,6 +34,8 @@ host_dedication_id = "06031957"
 
 [deploy]
   release_command = "release command"
+  release_command_timeout = "3m"
+  release_command_vm.size = "performance-2x"
   strategy = "rolling-eyes"
   max_unavailable = 0.2
 

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -36,6 +36,7 @@ host_dedication_id = "06031957"
   release_command = "release command"
   release_command_timeout = "3m"
   release_command_vm.size = "performance-2x"
+  release_command_vm.memory = "8g"
   strategy = "rolling-eyes"
   max_unavailable = 0.2
 

--- a/internal/appconfig/testdata/tomachine.toml
+++ b/internal/appconfig/testdata/tomachine.toml
@@ -6,6 +6,10 @@ swap_size_mb = 512
 
 [deploy]
   release_command = "migrate-db"
+  release_command_timeout = "3m"
+  [deploy.release_command_vm]
+    size = "performance-2x"
+    memory = "4G"
 
 [[restart]]
   policy = "always"

--- a/internal/command/deploy/machines_releasecommand.go
+++ b/internal/command/deploy/machines_releasecommand.go
@@ -185,8 +185,10 @@ func (md *machineDeployment) launchInputForReleaseCommand(origMachineRaw *fly.Ma
 	// We can ignore the error because ToReleaseMachineConfig fails only
 	// if it can't split the command and we test that at initialization
 	mConfig, _ := md.appConfig.ToReleaseMachineConfig()
-	mConfig.Guest = md.inferReleaseCommandGuest()
 	mConfig.Image = md.img
+	if mConfig.Guest == nil {
+		mConfig.Guest = md.inferReleaseCommandGuest()
+	}
 	md.setMachineReleaseData(mConfig)
 
 	if hdid := md.appConfig.HostDedicationID; hdid != "" {


### PR DESCRIPTION
### Change Summary

What and Why: There is no way to explicitly set the release command machine size

How: Add `[deploy.release_command_vm]` directive similar to `[[vm]]` 

```
[deploy]
  release_command = "run something for me"
  [deploy.release_command_vm]
    size = "performance-1x"
    memory = "8gb"
```

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
