### PR TITLE
Add list and destroy commands for sentry projects

### DIFF
--- a/internal/command/extensions/sentry/destroy.go
+++ b/internal/command/extensions/sentry/destroy.go
@@ -1,0 +1,79 @@
+package sentry_ext
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/superfly/flyctl/gql"
+	"github.com/superfly/flyctl/iostreams"
+
+	"github.com/superfly/flyctl/internal/command"
+	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/prompt"
+)
+
+func destroy() (cmd *cobra.Command) {
+	const (
+		long = `Permanently destroy a Sentry project`
+
+		short = long
+		usage = "destroy [project-name]"
+	)
+
+	cmd = command.New(usage, short, long, runDestroy, command.RequireSession, command.LoadAppNameIfPresent)
+
+	cmd.Args = cobra.MaximumNArgs(1)
+
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+		extensions_core.SharedFlags,
+	)
+
+	return cmd
+}
+
+func runDestroy(ctx context.Context) (err error) {
+	io := iostreams.FromContext(ctx)
+	colorize := io.ColorScheme()
+
+	extension, _, err := extensions_core.Discover(ctx, gql.AddOnTypeSentry)
+	if err != nil {
+		return err
+	}
+
+	if !flag.GetYes(ctx) {
+		const msg = "Destroying a Sentry project will remove it from Fly's records, but will not delete the project from your Sentry account."
+		fmt.Fprintln(io.ErrOut, colorize.Red(msg))
+
+		switch confirmed, err := prompt.Confirmf(ctx, "Do you want to destroy the project named %s?", extension.Name); {
+		case err == nil:
+			if !confirmed {
+				return nil
+			}
+		case prompt.IsNonInteractive(err):
+			return prompt.NonInteractiveError("yes flag must be specified when not running interactively")
+		default:
+			return err
+		}
+	}
+
+	var (
+		out    = iostreams.FromContext(ctx).Out
+		client = flyutil.ClientFromContext(ctx).GenqClient()
+	)
+
+	_, err = gql.DeleteAddOn(ctx, client, extension.Name)
+
+	if err != nil {
+		return
+	}
+
+	fmt.Fprintf(out, "Your Sentry project %s was destroyed\n", extension.Name)
+
+	return
+}

--- a/internal/command/extensions/sentry/list.go
+++ b/internal/command/extensions/sentry/list.go
@@ -1,0 +1,57 @@
+package sentry_ext
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/superfly/flyctl/gql"
+	"github.com/superfly/flyctl/iostreams"
+
+	"github.com/superfly/flyctl/internal/command"
+	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/render"
+)
+
+func list() (cmd *cobra.Command) {
+	const (
+		long  = `List your Sentry projects`
+		short = long
+		usage = "list"
+	)
+
+	cmd = command.New(usage, short, long, runList, command.RequireSession)
+
+	cmd.Aliases = []string{"ls"}
+
+	flag.Add(cmd,
+		flag.Org(),
+		extensions_core.SharedFlags,
+	)
+
+	return cmd
+}
+
+func runList(ctx context.Context) (err error) {
+	var (
+		out    = iostreams.FromContext(ctx).Out
+		client = flyutil.ClientFromContext(ctx).GenqClient()
+	)
+
+	response, err := gql.ListAddOns(ctx, client, "sentry")
+
+	var rows [][]string
+
+	for _, extension := range response.AddOns.Nodes {
+		rows = append(rows, []string{
+			extension.Name,
+			extension.Organization.Slug,
+		})
+	}
+
+	_ = render.Table(out, "", rows, "Name", "Org")
+
+	return
+}

--- a/internal/command/extensions/sentry/sentry.go
+++ b/internal/command/extensions/sentry/sentry.go
@@ -13,7 +13,7 @@ func New() (cmd *cobra.Command) {
 	)
 
 	cmd = command.New("sentry", short, long, nil)
-	cmd.AddCommand(create(), Dashboard())
+	cmd.AddCommand(create(), Dashboard(), destroy(), list())
 
 	return cmd
 }


### PR DESCRIPTION
This PR allows removing Sentry projects from Fly, so new projects can be added with the same name. Also, `fly ext sentry list` works.