### PR TITLE
fix: make lease functions less chatty

### DIFF
--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -175,7 +175,7 @@ func (bg *blueGreen) CreateGreenMachines(ctx context.Context) error {
 			}
 
 			greenMachine := machine.NewLeasableMachine(bg.flaps, bg.io, newMachineRaw, true)
-			defer greenMachine.ReleaseLease(ctx)
+			defer releaseLease(ctx, greenMachine)
 
 			lock.Lock()
 			defer lock.Unlock()

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -60,8 +60,10 @@ type leasableMachine struct {
 	leaseNonce string
 }
 
-// TODO: make sure the other functions handle showLogs correctly
+// NewLeasableMachine creates a wrapper for the given machine.
+// A lease must be held before calling this function.
 func NewLeasableMachine(flapsClient flapsutil.FlapsClient, io *iostreams.IOStreams, machine *fly.Machine, showLogs bool) LeasableMachine {
+	// TODO: make sure the other functions handle showLogs correctly
 	return &leasableMachine{
 		flapsClient: flapsClient,
 		io:          io,

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -516,6 +516,7 @@ func (lm *leasableMachine) refreshLeaseUntilCanceled(ctx context.Context, durati
 	}
 }
 
+// ReleaseLease releases the lease on this machine.
 func (lm *leasableMachine) ReleaseLease(ctx context.Context) error {
 	lm.mu.Lock()
 	defer lm.mu.Unlock()
@@ -536,13 +537,7 @@ func (lm *leasableMachine) ReleaseLease(ctx context.Context) error {
 		defer cancel()
 	}
 
-	err := lm.flapsClient.ReleaseLease(ctx, lm.machine.ID, nonce)
-	contextTimedOutOrCanceled := errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
-	if err != nil && (!contextWasAlreadyCanceled || !contextTimedOutOrCanceled) {
-		terminal.Warnf("failed to release lease for machine %s: %v\n", lm.machine.ID, err)
-		return err
-	}
-	return nil
+	return lm.flapsClient.ReleaseLease(ctx, lm.machine.ID, nonce)
 }
 
 func (lm *leasableMachine) resetLease() {


### PR DESCRIPTION
Without this change, the console would be filled with "failed to release lease: lease not found" even if flyctl couldn't acquire one lease.

```
Updating existing machines in '...' with bluegreen strategy
WARN failed to acquire lease: failed to get lease on VM e7843075ad2408: request returned non-2xx status: 408:

WARN failed to release lease for machine 178122df9672d8: lease not found

WARN failed to release lease: lease not found

WARN failed to release lease for machine 7811772a5d7698: lease not found

WARN failed to release lease: lease not found

WARN failed to release lease for machine e286076f933508: lease not found

WARN failed to release lease: lease not found
...
```

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
