### PR TITLE
fix: macos-latest-xl seems unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest-m, macos-latest-xl, windows-latest-l ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest-m, macos-latest-xl, windows-latest-l ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         test:
           - workdir: "."
             target: "test"


### PR DESCRIPTION
Not really sure this is a glitch or not. We probably don't have to be specific about sizes.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
