### PR TITLE
Allow TIGRIS_ACCESS_KEY_ID as non-secret env var

### DIFF
--- a/internal/command/deploy/common_secrets.go
+++ b/internal/command/deploy/common_secrets.go
@@ -8,7 +8,7 @@ var commonSecretSubstrings = []string{"KEY", "PRIVATE", "DATABASE_URL", "PASSWOR
 func containsCommonSecretSubstring(s string) bool {
 	// Allowlist for strings which contain a substring but are not secrets.
 	switch s {
-	case "AWS_ACCESS_KEY_ID":
+	case "AWS_ACCESS_KEY_ID", "TIGRIS_ACCESS_KEY_ID":
 		return false
 	}
 


### PR DESCRIPTION
### Change Summary

What and Why: Storing Tigris access key ID in `TIGRIS_ACCESS_KEY_ID` causes `flyctl` to complain about a possibly sensitive environment variables.

How: Add to allow-list with `AWS_ACCESS_KEY_ID`

---

### Documentation

- [x] n/a
