### PR TITLE
Fix panic determining console machine guest type

### DIFF
--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -410,7 +410,9 @@ func determineEphemeralConsoleMachineGuest(ctx context.Context, appConfig *appco
 			if err != nil {
 				return nil, fmt.Errorf("invalid memory size: %w", err)
 			}
-
+			if guest == nil {
+				guest = &fly.MachineGuest{}
+			}
 			guest.MemoryMB = mb
 		}
 	}


### PR DESCRIPTION
### Change Summary

What and Why: Compute type embeds MachineGuest which can be null if none of its fields are present causing a panic setting the memory_mb field. 

How: Instantiate MachineGuest if nil 

Closes https://github.com/superfly/flyctl/issues/4107
