### PR TITLE
Change launch http service checks to be service checks (was top level)

### DIFF
--- a/internal/appconfig/setters_test.go
+++ b/internal/appconfig/setters_test.go
@@ -52,11 +52,7 @@ func TestSettersWithHTTPService(t *testing.T) {
 			HardLimit: 34,
 			SoftLimit: 12,
 		},
-	})
-	assert.Equal(t, cfg.Checks, map[string]*ToplevelCheck{
-		"status": {
-			Port:              fly.Pointer(1234),
-			Type:              fly.Pointer("http"),
+		HTTPChecks: []*ServiceHTTPCheck{{
 			Interval:          fly.MustParseDuration("10s"),
 			Timeout:           fly.MustParseDuration("2s"),
 			GracePeriod:       fly.MustParseDuration("5s"),
@@ -64,7 +60,7 @@ func TestSettersWithHTTPService(t *testing.T) {
 			HTTPPath:          fly.Pointer("/status"),
 			HTTPProtocol:      fly.Pointer("http"),
 			HTTPTLSSkipVerify: fly.Pointer(false),
-		},
+		}},
 	})
 }
 


### PR DESCRIPTION
This will (eventually) enable auto start to wait until the service is ready before the proxy starts routing requests to the machine.