### PR TITLE
rails: prefer `Gemfile` over `.ruby-version`

### DIFF
--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -84,22 +84,22 @@ func configureRails(sourceDir string, config *ScannerConfig) (*SourceInfo, error
 
 	var rubyVersion string
 
-	// add ruby version from .ruby-version file
-	versionFile, err := os.ReadFile(".ruby-version")
+	// add ruby version from Gemfile
+	gemfile, err := os.ReadFile("Gemfile")
 	if err == nil {
-		re := regexp.MustCompile(`ruby-(\d+\.\d+\.\d+)`)
-		matches := re.FindStringSubmatch(string(versionFile))
+		re := regexp.MustCompile(`(?m)^ruby\s+["'](\d+\.\d+\.\d+)["']`)
+		matches := re.FindStringSubmatch(string(gemfile))
 		if len(matches) >= 2 {
 			rubyVersion = matches[1]
 		}
 	}
 
 	if rubyVersion == "" {
-		// add ruby version from Gemfile
-		gemfile, err := os.ReadFile("Gemfile")
+		// add ruby version from .ruby-version file
+		versionFile, err := os.ReadFile(".ruby-version")
 		if err == nil {
-			re := regexp.MustCompile(`(?m)^ruby\s+["'](\d+\.\d+\.\d+)["']`)
-			matches := re.FindStringSubmatch(string(gemfile))
+			re := regexp.MustCompile(`ruby-(\d+\.\d+\.\d+)`)
+			matches := re.FindStringSubmatch(string(versionFile))
 			if len(matches) >= 2 {
 				rubyVersion = matches[1]
 			}


### PR DESCRIPTION
### Change Summary

What and Why: Swap the precedence to prefer `Gemfile`'s ruby version over `.ruby-version`. This should prevent mismatched versions from causing deploy failures.

Related to: https://flyio.discourse.team/t/launch-ui-ive-analyzed-our-latest-33-launch-failures-heres-what-ive-learned/7492/3

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
