### PR TITLE
fix: remove ubuntu:23.04

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -17,9 +17,11 @@ jobs:
       max-parallel: 4
       matrix:
         image:
+          # Only test LTS versions.
+          - "ubuntu:24.04"
           - "ubuntu:20.04"
           - "ubuntu:22.04"
-          - "ubuntu:23.04"
+
           - "debian:oldstable-slim"
           - "debian:stable-slim"
           - "alpine:latest"


### PR DESCRIPTION
It is EOL. `apt-get update` no longer works.

https://wiki.ubuntu.com/Releases

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
