### PR TITLE
test: upgrade Ruby's bundler to make it work with modern Rubies

### DIFF
--- a/test/preflight/fixtures/example-buildpack/Gemfile.lock
+++ b/test/preflight/fixtures/example-buildpack/Gemfile.lock
@@ -26,4 +26,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   2.0.2
+   2.6.1


### PR DESCRIPTION
bundler 2.0.2 is too old for Ruby 3.2.3, due to its untaint usage.

https://github.com/rubygems/bundler/pull/7385
https://github.com/actions/runner-images/blob/ubuntu24/20241215.1/images/ubuntu/Ubuntu2404-Readme.md#language-and-runtime

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
