### PR TITLE
fix: don't hardcode fly.toml in the warning message

### DIFF
--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -42,7 +42,7 @@ func multipleDockerfile(ctx context.Context, appConfig *appconfig.Config) error 
 	}
 
 	if found != config {
-		return fmt.Errorf("Ignoring %s, and using %s (from fly.toml).", found, config)
+		return fmt.Errorf("ignoring %s, and using %s (from %s)", found, config, appConfig.ConfigFilePath())
 	}
 	return nil
 }
@@ -78,7 +78,7 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config, useWG, rec
 
 	if err := multipleDockerfile(ctx, appConfig); err != nil {
 		span.AddEvent("found multiple dockerfiles")
-		terminal.Warnf("%s\n", err.Error())
+		terminal.Warnf("%s", err.Error())
 	}
 
 	resolver := imgsrc.NewResolver(daemonType, client, appConfig.AppName, io, useWG, recreateBuilder)

--- a/internal/command/deploy/deploy_build_test.go
+++ b/internal/command/deploy/deploy_build_test.go
@@ -2,33 +2,38 @@ package deploy
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/state"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 func TestMultipleDockerfile(t *testing.T) {
 	dir := t.TempDir()
 
-	f, err := os.Create(filepath.Join(dir, "Dockerfile"))
+	dockerfile, err := os.Create(filepath.Join(dir, "Dockerfile"))
 	require.NoError(t, err)
-	defer f.Close() // skipcq: GO-S2307
+	defer dockerfile.Close() // skipcq: GO-S2307
+
+	flyToml, err := os.Create(filepath.Join(dir, "fly.production.toml"))
+	require.NoError(t, err)
+	defer flyToml.Close() // skipcq: GO-S2307
+
+	cfg, err := appconfig.LoadConfig(flyToml.Name())
+	require.NoError(t, err)
+	cfg.Build = &appconfig.Build{
+		Dockerfile: "Dockerfile.from-fly-toml",
+	}
 
 	ctx := state.WithWorkingDirectory(context.Background(), dir)
 	err = multipleDockerfile(ctx, &appconfig.Config{})
+
 	assert.NoError(t, err)
 
-	err = multipleDockerfile(
-		ctx,
-		&appconfig.Config{
-			Build: &appconfig.Build{
-				Dockerfile: "Dockerfile.from-fly-toml",
-			},
-		},
-	)
-	assert.Error(t, err)
+	err = multipleDockerfile(ctx, cfg)
+	assert.ErrorContains(t, err, "fly.production.toml")
 }


### PR DESCRIPTION
Fixes #4136.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
