### PR TITLE
add support for [deploy] seed_command

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -93,6 +93,7 @@ type Deploy struct {
 	ReleaseCommand        string        `toml:"release_command,omitempty" json:"release_command,omitempty"`
 	ReleaseCommandTimeout *fly.Duration `toml:"release_command_timeout,omitempty" json:"release_command_timeout,omitempty"`
 	ReleaseCommandCompute *Compute      `toml:"release_command_vm,omitempty" json:"release_command_vm,omitempty"`
+	SeedCommand           string        `toml:"seed_command,omitempty" json:"seed_command,omitempty"`
 }
 
 type File struct {

--- a/internal/appconfig/context.go
+++ b/internal/appconfig/context.go
@@ -10,6 +10,7 @@ const (
 	_ contextKeyType = iota
 	configContextKey
 	nameContextKey
+	seedContextKey
 )
 
 // WithConfig derives a context that carries cfg from ctx.
@@ -35,6 +36,20 @@ func WithName(ctx context.Context, name string) context.Context {
 func NameFromContext(ctx context.Context) string {
 	if name, ok := ctx.Value(nameContextKey).(string); ok {
 		return name
+	}
+
+	return ""
+}
+
+// WithSeed derives a context that carries the given seed from ctx.
+func WithSeedCommand(ctx context.Context, seedCommand string) context.Context {
+	return context.WithValue(ctx, seedContextKey, seedCommand)
+}
+
+// SeedFromContext returns the seed ctx carries or an empty string.
+func SeedCommandFromContext(ctx context.Context) string {
+	if seed, ok := ctx.Value(seedContextKey).(string); ok {
+		return seed
 	}
 
 	return ""

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -425,7 +425,7 @@ func (md *machineDeployment) deployMachinesApp(ctx context.Context) error {
 	defer span.End()
 
 	if !md.skipReleaseCommand {
-		if err := md.runReleaseCommand(ctx); err != nil {
+		if err := md.runReleaseCommands(ctx); err != nil {
 			return fmt.Errorf("release command failed - aborting deployment. %w", err)
 		}
 	}

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -129,6 +129,10 @@ func (state *launchState) Launch(ctx context.Context) error {
 	}
 
 	if state.sourceInfo != nil {
+		if state.appConfig.Deploy != nil && state.appConfig.Deploy.SeedCommand != "" {
+			ctx = appconfig.WithSeedCommand(ctx, state.appConfig.Deploy.SeedCommand)
+		}
+
 		if err := state.firstDeploy(ctx); err != nil {
 			return err
 		}

--- a/internal/command/launch/launch_frameworks.go
+++ b/internal/command/launch/launch_frameworks.go
@@ -197,6 +197,10 @@ func (state *launchState) scannerRunCallback(ctx context.Context) error {
 					state.sourceInfo.ReleaseCmd = cfg.Deploy.ReleaseCommand
 				}
 
+				if state.sourceInfo.SeedCmd == "" && cfg.Deploy != nil {
+					state.sourceInfo.SeedCmd = cfg.Deploy.SeedCommand
+				}
+
 				if len(cfg.Env) > 0 {
 					if len(state.sourceInfo.Env) == 0 {
 						state.sourceInfo.Env = cfg.Env
@@ -324,6 +328,11 @@ func (state *launchState) scannerSetAppconfig(ctx context.Context) error {
 
 	if srcInfo.ReleaseCmd != "" {
 		appConfig.SetReleaseCommand(srcInfo.ReleaseCmd)
+	}
+
+	if srcInfo.SeedCmd != "" {
+		// no V1 compatibility for this feature so bypass setters
+		appConfig.Deploy.SeedCommand = srcInfo.SeedCmd
 	}
 
 	if srcInfo.DockerCommand != "" {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -51,6 +51,7 @@ type SourceInfo struct {
 	BuildArgs        map[string]string
 	Builder          string
 	ReleaseCmd       string
+	SeedCmd          string
 	DockerCommand    string
 	DockerEntrypoint string
 	KillSignal       string


### PR DESCRIPTION
The motivation here is to support fly launch (from either the CLI or web UI) getting an application completely up and running.  In general, this not only involves creating of databases and running of migrations, but also seeding the database.

The timing of the run of the seed command is after the first migration is run, and before any prerendering/SSG or deploy.  This is awkward/impossible with the current flow.

Seed support has been available in Rails for quite some time, and for the popular prisma ORM, the seed command can be determined from the `package.json` file:

https://github.com/prisma/prisma-examples/blob/7a74fc64c82037f15b23e189a241bc643023f957/orm/nextjs-trpc/package.json#L36-L38

This implementation add [deploy] seed_command to fly.toml.  Launch will insert that value (if present) into the ctx. . Deploy will only run that command if it is found in the context.  The guarantees that the seed command is only run when deploy is called by Launch.

At the moment, this is accomplished by launching new ephemeral machines for each command.  Perhaps that could be optimized to reuse a single machine.  Also perhaps, that could be generalized to support a series of post-build, pre-deploy commands.

This depends on an unreleased change to dockerfile_node:

https://github.com/fly-apps/dockerfile-node/commit/eebcf1e528ccc7cca0c4dd8729c3383024806b07

If is possible to test this change against dockerfile-node from github, using a Prisma ORM Fullstack example:

https://github.com/prisma/prisma-examples?tab=readme-ov-file#prisma-orm

This involves downloading the example, installing dockerfile-node, modifying the example to use PostgreSQL as the database, creating migrations, and finally, launching.

```
npx try-prisma@latest --template orm/sveltekit
cd orm_sveltekit
npm install --save-dev fly-apps/dockerfile-node
sed -i.bak 's/sqlite/postgresql/;s/"file:.\/dev.db"/env("DATABASE_URL")/' prisma/schema.prisma
psql -c "DROP DATABASE IF EXISTS testdb"
export DATABASE_URL=postgres://$USER@localhost/testdb
npx prisma migrate dev --name init
~/path/flyctl/bin/flyctl launch
```