### PR TITLE
support clearing machine's command by passing an empty string

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -699,12 +699,18 @@ func determineMachineConfig(
 
 	if input.updating {
 		// Called from `update`. Command is specified by flag.
-		if command := flag.GetString(ctx, "command"); command != "" {
-			split, err := shlex.Split(command)
-			if err != nil {
-				return machineConf, errors.Wrap(err, "invalid command")
+		if flag.IsSpecified(ctx, "command") {
+			command := strings.TrimSpace(flag.GetString(ctx, "command"))
+			switch command {
+			case "":
+				machineConf.Init.Cmd = nil
+			default:
+				split, err := shlex.Split(command)
+				if err != nil {
+					return machineConf, errors.Wrap(err, "invalid command")
+				}
+				machineConf.Init.Cmd = split
 			}
-			machineConf.Init.Cmd = split
 		}
 	} else {
 		// Called from `run`. Command is specified by arguments.


### PR DESCRIPTION
### Change Summary

passing an empty string to allows removing the machine's init command.

```
✦ ❯ fly m update --command "" 328xxxxxxx24e28
Configuration changes to be applied to machine: 328xxxxxxx24e28 (rough-flower-xxxx)

        ... // 3 identical lines
            "PRIMARY_REGION": "scl"
          },
-         "init": {
-           "cmd": [
-             "sleep",
-             "inf"
-           ]
-         },
+         "init": {},
          "guest": {
            "cpu_kind": "shared",
        ... // 65 identical lines
  
? Apply changes? Yes
Updating machine 328xxxxxxx24e28
Machine 328xxxxxxx24e28 updated successfully!
```
