### PR TITLE
Support path indices in GraphQLError.Path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,8 +75,8 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0
-	github.com/superfly/fly-go v0.1.36
-	github.com/superfly/graphql v0.2.4
+	github.com/superfly/fly-go v0.1.37
+	github.com/superfly/graphql v0.2.5
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.2.14-0.20240819201738-61a02aa53648
 	github.com/superfly/tokenizer v0.0.3-0.20240826174224-a17a2e0a9dc0

--- a/go.sum
+++ b/go.sum
@@ -631,10 +631,10 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.36 h1:0UeBJyAfjUB4a+Bbt+EyTJJnJBJ+fwit5H0Brh81/LE=
-github.com/superfly/fly-go v0.1.36/go.mod h1:aPrmbN+GqUM3w8Y2pXMIqr9MPbF4ZiUnG82EAoXcvAY=
-github.com/superfly/graphql v0.2.4 h1:Av8hSk4x8WvKJ6MTnEwrLknSVSGPc7DWpgT3z/kt3PU=
-github.com/superfly/graphql v0.2.4/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
+github.com/superfly/fly-go v0.1.37 h1:VqlLrbCDwo+wdE9l5WP1HAoLf09yLj29nTD8ux1NbM8=
+github.com/superfly/fly-go v0.1.37/go.mod h1:lad5/CIMPpYvuAYQSwT8C154xuZPgBmhbkLwgau5V+o=
+github.com/superfly/graphql v0.2.5 h1:61TUt5MrWxlOpdipfYNl9TsG0dXnvb3tkkn/Dre2GcA=
+github.com/superfly/graphql v0.2.5/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=
 github.com/superfly/lfsc-go v0.1.1/go.mod h1:zVb0VENz/Il8Nmvvd4XAsX2bWhQ+sr0nK8vv9PeezcE=
 github.com/superfly/ltx v0.3.12 h1:Z7z1sc4g34/jUi3XO84+zBlIsbaoh2RJ3b4zTQpBK/M=


### PR DESCRIPTION
### Change Summary

What and Why:

Fixes the following error in `flyctl`:

```
Error: decoding response: json: cannot unmarshal number into Go struct field GraphQLError.Errors.Path of type string
```

How:

Update dependencies to pull in bugfixes from https://github.com/superfly/graphql/pull/7 and https://github.com/superfly/fly-go/pull/128

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
