### PR TITLE
run dockerfile-node if there is a database to be set up

### DIFF
--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -670,4 +670,5 @@ var PlatformMap = map[string]string{
 	"Remix":         "javascript-remix",
 	"Remix/Prisma":  "javascript-remix",
 	"Ruby":          "ruby",
+	"Shopify":       "javascript-shopify",
 }


### PR DESCRIPTION
Skip replacing the dockerfile if it already exists, but perform other functions, like adding [volume] for sqlite3 and [deploy] release_command for postgres.

Also prep for shopify (purely cosmetic)
