### PR TITLE
32, 64 and 128 are valid cpu values under certain conditions

### DIFF
--- a/internal/machine/update.go
+++ b/internal/machine/update.go
@@ -15,7 +15,7 @@ import (
 
 var cpusPerKind = map[string][]int{
 	"shared":      {1, 2, 4, 6, 8},
-	"performance": {1, 2, 4, 6, 8, 10, 12, 14, 16},
+	"performance": {1, 2, 4, 6, 8, 10, 12, 14, 16, 32, 64, 128},
 }
 
 func Update(ctx context.Context, m *fly.Machine, input *fly.LaunchMachineInput) error {


### PR DESCRIPTION
### Change Summary

What and Why: `fly m update` validates cpu number client side but It is possible to allocate 16 cpus per attached GPU card. 

How: add 32, 64 and 128 to the list.