### PR TITLE
:sparkles: add --redis-database flag to redis connect and proxy commands

### DIFF
--- a/internal/command/redis/connect.go
+++ b/internal/command/redis/connect.go
@@ -27,6 +27,7 @@ func newConnect() (cmd *cobra.Command) {
 	flag.Add(cmd,
 		flag.Org(),
 		flag.Region(),
+		flag.RedisDatabase(),
 	)
 
 	return cmd

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -671,3 +671,15 @@ func Env() StringArray {
 		Description: "Set of environment variables in the form of NAME=VALUE pairs. Can be specified multiple times.",
 	}
 }
+
+func RedisDatabase() String {
+	return String{
+		Name:        "redis-database",
+		Shorthand:   "d",
+		Description: "The Redis name of the redis database instance to use",
+	}
+}
+
+func GetRedisDatabase(ctx context.Context) string {
+	return GetString(ctx, "redis-database")
+}


### PR DESCRIPTION
currently these commands require user input to select which database instance by ame they want to connect to. This adds a flag to support using this in contexts where user input is either not possible or not desired
