### PR TITLE
Check if oldMachine is nil when updating process group

### DIFF
--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -362,7 +362,6 @@ func (md *machineDeployment) updateProcessGroup(ctx context.Context, machineTupl
 			}
 			machineCheckResult := checkResult.(*healthcheckResult)
 
-			
 			err := md.updateMachineWChecks(ctx, oldMachine, newMachine, sl, md.io, machineCheckResult)
 			if err != nil {
 				sl.LogStatus(statuslogger.StatusFailure, err.Error())


### PR DESCRIPTION
### Change Summary

Sometimes, the oldMachine field in the MachineTuple during deploys is nil and we don't check for this when loading from the healthCheckPassed sync map. 
https://github.com/superfly/flyctl/blob/26a778ec23ba74394cc0112a009b5b2cb7e09352/internal/command/deploy/plan.go#L151.
			

What and Why:
This fixes a panic that users occasionally encounter during deploy

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
