### PR TITLE
Pass the fly_version into GetLatestImageDetails

### DIFF
--- a/internal/command/image/show.go
+++ b/internal/command/image/show.go
@@ -152,7 +152,7 @@ func showMachineImage(ctx context.Context, app *fly.AppCompact) error {
 	for _, machine := range machines {
 		image := fmt.Sprintf("%s:%s", machine.ImageRef.Repository, machine.ImageRef.Tag)
 
-		latestImage, err := client.GetLatestImageDetails(ctx, image)
+		latestImage, err := client.GetLatestImageDetails(ctx, image, machine.ImageVersion())
 
 		if err != nil && strings.Contains(err.Error(), "Unknown repository") {
 			continue

--- a/internal/command/image/update_machines.go
+++ b/internal/command/image/update_machines.go
@@ -263,7 +263,7 @@ func resolveImage(ctx context.Context, machine fly.Machine) (string, error) {
 
 	if image == "" {
 		ref := fmt.Sprintf("%s:%s", machine.ImageRef.Repository, machine.ImageRef.Tag)
-		latestImage, err := client.GetLatestImageDetails(ctx, ref)
+		latestImage, err := client.GetLatestImageDetails(ctx, ref, machine.ImageVersion())
 		if err != nil && !strings.Contains(err.Error(), "Unknown repository") {
 			return "", err
 		}

--- a/internal/command/status/machines.go
+++ b/internal/command/status/machines.go
@@ -116,7 +116,7 @@ func RenderMachineStatus(ctx context.Context, app *fly.AppCompact, out io.Writer
 			continue
 		}
 
-		latestImage, err := client.GetLatestImageDetails(ctx, image)
+		latestImage, err := client.GetLatestImageDetails(ctx, image, machine.ImageVersion())
 		if err != nil {
 			if strings.Contains(err.Error(), "Unknown repository") {
 				unknownRepos[image] = true
@@ -304,7 +304,7 @@ func renderPGStatus(ctx context.Context, app *fly.AppCompact, machines []*fly.Ma
 	for _, machine := range machines {
 		image := fmt.Sprintf("%s:%s", machine.ImageRef.Repository, machine.ImageRef.Tag)
 
-		latestImage, err := client.GetLatestImageDetails(ctx, image)
+		latestImage, err := client.GetLatestImageDetails(ctx, image, machine.ImageVersion())
 
 		if err != nil && strings.Contains(err.Error(), "Unknown repository") {
 			continue

--- a/internal/flyutil/client.go
+++ b/internal/flyutil/client.go
@@ -70,7 +70,7 @@ type Client interface {
 	GetDomains(ctx context.Context, organizationSlug string) ([]*fly.Domain, error)
 	GetIPAddresses(ctx context.Context, appName string) ([]fly.IPAddress, error)
 	GetEgressIPAddresses(ctx context.Context, appName string) (map[string][]fly.EgressIPAddress, error)
-	GetLatestImageDetails(ctx context.Context, image string) (*fly.ImageVersion, error)
+	GetLatestImageDetails(ctx context.Context, image string, flyVersion string) (*fly.ImageVersion, error)
 	GetLatestImageTag(ctx context.Context, repository string, snapshotId *string) (string, error)
 	GetLoggedCertificates(ctx context.Context, slug string) ([]fly.LoggedCertificate, error)
 	GetMachine(ctx context.Context, machineId string) (*fly.GqlMachine, error)

--- a/internal/inmem/client.go
+++ b/internal/inmem/client.go
@@ -296,7 +296,7 @@ func (c *Client) GetEgressIPAddresses(ctx context.Context, appName string) (map[
 	panic("TODO")
 }
 
-func (m *Client) GetLatestImageDetails(ctx context.Context, image string) (*fly.ImageVersion, error) {
+func (m *Client) GetLatestImageDetails(ctx context.Context, image string, flyVersion string) (*fly.ImageVersion, error) {
 	panic("TODO")
 }
 

--- a/internal/mock/client.go
+++ b/internal/mock/client.go
@@ -71,7 +71,7 @@ type Client struct {
 	GetDomainsFunc                         func(ctx context.Context, organizationSlug string) ([]*fly.Domain, error)
 	GetIPAddressesFunc                     func(ctx context.Context, appName string) ([]fly.IPAddress, error)
 	GetEgressIPAddressesFunc               func(ctx context.Context, appName string) (map[string][]fly.EgressIPAddress, error)
-	GetLatestImageDetailsFunc              func(ctx context.Context, image string) (*fly.ImageVersion, error)
+	GetLatestImageDetailsFunc              func(ctx context.Context, image string, flyVersion string) (*fly.ImageVersion, error)
 	GetLatestImageTagFunc                  func(ctx context.Context, repository string, snapshotId *string) (string, error)
 	GetLoggedCertificatesFunc              func(ctx context.Context, slug string) ([]fly.LoggedCertificate, error)
 	GetMachineFunc                         func(ctx context.Context, machineId string) (*fly.GqlMachine, error)
@@ -335,8 +335,8 @@ func (m *Client) GetEgressIPAddresses(ctx context.Context, appName string) (map[
 	return m.GetEgressIPAddressesFunc(ctx, appName)
 }
 
-func (m *Client) GetLatestImageDetails(ctx context.Context, image string) (*fly.ImageVersion, error) {
-	return m.GetLatestImageDetailsFunc(ctx, image)
+func (m *Client) GetLatestImageDetails(ctx context.Context, image string, flyVersion string) (*fly.ImageVersion, error) {
+	return m.GetLatestImageDetailsFunc(ctx, image, flyVersion)
 }
 
 func (m *Client) GetLatestImageTag(ctx context.Context, repository string, snapshotId *string) (string, error) {


### PR DESCRIPTION
### Change Summary

What and Why:

In order to consider the proper upgrade path for Postgres Flex, we need to send the image version "fly version" along with the image string.  A non-compatible upgrade path was introduced a while back and we need to ensure users running older versions cannot upgrade past a certain point through the upgrade tooling.  

Related to:
Postgres image upgrades. 
