### PR TITLE
Detect when interface cast fails and return an error instead of panic.

### DIFF
--- a/internal/command/extensions/kubernetes/kubeconfig.go
+++ b/internal/command/extensions/kubernetes/kubeconfig.go
@@ -42,7 +42,10 @@ func runSaveKubeconfig(ctx context.Context) error {
 	}
 
 	metadata := resp.AddOn.Metadata.(map[string]interface{})
-	kubeconfig := metadata["kubeconfig"].(string)
+	kubeconfig, ok := metadata["kubeconfig"].(string)
+	if !ok {
+		return fmt.Errorf("failed to fetch kubeconfig")
+	}
 
 	outFilename := flag.GetString(ctx, "output")
 	if outFilename == "" {

--- a/internal/command/extensions/kubernetes/kubeconfig.go
+++ b/internal/command/extensions/kubernetes/kubeconfig.go
@@ -44,7 +44,7 @@ func runSaveKubeconfig(ctx context.Context) error {
 	metadata := resp.AddOn.Metadata.(map[string]interface{})
 	kubeconfig, ok := metadata["kubeconfig"].(string)
 	if !ok {
-		return fmt.Errorf("failed to fetch kubeconfig")
+		return fmt.Errorf("Failed to fetch kubeconfig. If provisioning your cluster failed you may have to delete it and reprovision it.")
 	}
 
 	outFilename := flag.GetString(ctx, "output")


### PR DESCRIPTION
### Change Summary

What and Why: Fix a panic

```
% flyctl ext k8s save-kubeconfig fks-tim-newsham-fks-sake
Oops, something went wrong! Could you try that again?

interface conversion: interface {} is nil, not string
goroutine 1 [running]:
runtime/debug.Stack()
    runtime/debug/stack.go:26 +0x64
github.com/superfly/flyctl/internal/sentry.printError({0x104f91b20, 0x140006646f0})
    github.com/superfly/flyctl/internal/sentry/sentry.go:190 +0x168
github.com/superfly/flyctl/internal/sentry.Recover({0x104f91b20, 0x140006646f0})
    github.com/superfly/flyctl/internal/sentry/sentry.go:180 +0xb8
main.run.func1()
    github.com/superfly/flyctl/main.go:40 +0x34
panic({0x104f91b20?, 0x140006646f0?})
    runtime/panic.go:785 +0x124
github.com/superfly/flyctl/internal/command/extensions/kubernetes.runSaveKubeconfig({0x105322348, 0x1400054d410})
    github.com/superfly/flyctl/internal/command/extensions/kubernetes/kubeconfig.go:45 +0x2d8
github.com/superfly/flyctl/internal/command/extensions/kubernetes.saveKubeconfig.New.newRunE.func2(0x140006c8008, {0x1400005aa00?, 0x4?, 0x1047e1859?})
    github.com/superfly/flyctl/internal/command/command.go:140 +0x188
```
probably related to a failure provisioning the cluster:
```
% flyctl ext k8s create -o personal -n fks-sake
Fly Kubernetes is in beta, it is not recommended for critical production use cases. For help or feedback, email us at beta@fly.io
Some regions require a Launch plan or higher (bom).
See https://fly.io/plans to set up a plan.

? Choose the primary region (can't be changed later) [staff] Ashburn, Virginia (US) (qmx)
Error: failed to create etcd cluster - Failed to create volume: Status 500, Trace ID: b273d47d095c8504f7f14e76c573850d, Body: {"error"=>"internal: failed to get app: sql: no rows in result set"}
```

How: by detecting when an interface cast fails and returning an error instead of crashing.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
