### PR TITLE
Allow overriding 'sleep inf' with fly machine run --shell

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -716,13 +716,11 @@ func determineMachineConfig(
 		// Called from `run`. Command is specified by arguments.
 		args := flag.Args(ctx)
 
-		if len(args) != 0 {
+		if len(args) > 1 {
 			machineConf.Init.Cmd = args[1:]
+		} else if input.interact {
+			machineConf.Init.Exec = []string{"/bin/sleep", "inf"}
 		}
-	}
-
-	if input.interact {
-		machineConf.Init.Exec = []string{"/bin/sleep", "inf"}
 	}
 
 	if flag.IsSpecified(ctx, "skip-dns-registration") {


### PR DESCRIPTION
### Change Summary

What and Why: Allow `fly machine run --shell ubuntu sleep 10` for an ephemeral machine that auto-destroys after 10 seconds.

How: Only set `Init.Exec = []string{"/bin/sleep", "inf"}` if `Init.Cmd` isn't set, so the user can override the default `/bin/sleep inf` when `--shell` is passed

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
