### PR TITLE
support fly deploy --regions when no machines exist (first deploy)

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -559,7 +559,7 @@ func deployToMachines(
 	// If exactly one region is specified, use that as the primary region
 	region := cfg.PrimaryRegion
 	if len(onlyRegions) == 1 {
-		for r, _ := range onlyRegions {
+		for r := range onlyRegions {
 			region = r
 		}
 	}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -124,6 +124,10 @@ var CommonFlags = flag.Set{
 		Name:        "file-secret",
 		Description: "Set of secrets in the form of /path/inside/machine=SECRET pairs where SECRET is the name of the secret. Can be specified multiple times.",
 	},
+	flag.String{
+		Name:        "primary-region",
+		Description: "Override primary region in fly.toml configuration.",
+	},
 	flag.StringSlice{
 		Name:        "regions",
 		Aliases:     []string{"only-regions"},
@@ -518,10 +522,15 @@ func deployToMachines(
 	status.AppName = app.Name
 	status.OrgSlug = app.Organization.Slug
 	status.Image = img.Tag
-	status.PrimaryRegion = cfg.PrimaryRegion
 	status.Strategy = cfg.DeployStrategy()
 	if flag.GetString(ctx, "strategy") != "" {
 		status.Strategy = flag.GetString(ctx, "strategy")
+	}
+
+	if flag.IsSpecified(ctx, "primary-region") {
+		status.PrimaryRegion = flag.GetString(ctx, "primary-region")
+	} else {
+		status.PrimaryRegion = cfg.PrimaryRegion
 	}
 
 	status.FlyctlVersion = buildinfo.Info().Version.String()
@@ -556,20 +565,12 @@ func deployToMachines(
 		ip = "none"
 	}
 
-	// If exactly one region is specified, use that as the primary region
-	region := cfg.PrimaryRegion
-	if len(onlyRegions) == 1 {
-		for r := range onlyRegions {
-			region = r
-		}
-	}
-
 	args := MachineDeploymentArgs{
 		AppCompact:            app,
 		DeploymentImage:       img.Tag,
 		Strategy:              flag.GetString(ctx, "strategy"),
 		EnvFromFlags:          flag.GetStringArray(ctx, "env"),
-		PrimaryRegionFlag:     region,
+		PrimaryRegionFlag:     status.PrimaryRegion,
 		SkipSmokeChecks:       flag.GetDetach(ctx) || !flag.GetBool(ctx, "smoke-checks"),
 		SkipHealthChecks:      flag.GetDetach(ctx),
 		SkipDNSChecks:         flag.GetDetach(ctx) || !flag.GetBool(ctx, "dns-checks"),

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -556,12 +556,20 @@ func deployToMachines(
 		ip = "none"
 	}
 
+	// If exactly one region is specified, use that as the primary region
+	region := cfg.PrimaryRegion
+	if len(onlyRegions) == 1 {
+		for r, _ := range onlyRegions {
+			region = r
+		}
+	}
+
 	args := MachineDeploymentArgs{
 		AppCompact:            app,
 		DeploymentImage:       img.Tag,
 		Strategy:              flag.GetString(ctx, "strategy"),
 		EnvFromFlags:          flag.GetStringArray(ctx, "env"),
-		PrimaryRegionFlag:     cfg.PrimaryRegion,
+		PrimaryRegionFlag:     region,
 		SkipSmokeChecks:       flag.GetDetach(ctx) || !flag.GetBool(ctx, "smoke-checks"),
 		SkipHealthChecks:      flag.GetDetach(ctx),
 		SkipDNSChecks:         flag.GetDetach(ctx) || !flag.GetBool(ctx, "dns-checks"),


### PR DESCRIPTION
Default to cfg.PrimaryRegion, but override that if exactly one region is specified.

See: https://community.fly.io/t/regions-flag-is-not-picked-up-on-fly-deploy/23882