### PR TITLE
Ensure the machine is launched on the same region used for the volume

### DIFF
--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -179,7 +179,6 @@ func validateBuilder(ctx context.Context, app *fly.App) (*fly.Machine, error) {
 	}
 
 	return machine, nil
-
 }
 
 func validateBuilderVolumes(ctx context.Context, flapsClient flapsutil.FlapsClient) (*fly.Volume, error) {
@@ -324,6 +323,7 @@ func createBuilder(ctx context.Context, org *fly.Organization, region, builderNa
 			Region:              region,
 		})
 		if retErr == nil {
+			region = volume.Region
 			break
 		}
 


### PR DESCRIPTION
### Change Summary

What and Why: When creating a builtin builder, the region field is sempty,  by default the volume will be created in `iad` while the machine will attempt to be created in the closest region failing for clients whose closest region isn't `iad`.

How: Ensure the machine is created on the same region than the volume

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
