### PR TITLE
feat: honor BUILDKIT_PROGRESS as like Docker

### DIFF
--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -15,7 +15,6 @@ import (
 	depotmachine "github.com/depot/depot-go/machine"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/session/secrets/secretsprovider"
-	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/pkg/errors"
 	"github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/helpers"
@@ -301,16 +300,7 @@ func buildImage(ctx context.Context, buildkitClient *client.Client, opts ImageOp
 		res, err = buildkitClient.Solve(ctx, nil, solverOptions, ch)
 		return err
 	})
-
-	eg.Go(func() error {
-		display, err := progressui.NewDisplay(os.Stderr, progressui.AutoMode)
-		if err != nil {
-			return err
-		}
-
-		_, err = display.UpdateFrom(context.Background(), ch)
-		return err
-	})
+	eg.Go(newDisplay(ch))
 
 	if err := eg.Wait(); err != nil {
 		span.RecordError(err)

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -24,7 +24,6 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/session/secrets/secretsprovider"
-	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/buildinfo"
@@ -492,19 +491,7 @@ func runBuildKitBuild(ctx context.Context, docker *dockerclient.Client, opts Ima
 	// Build the image.
 	statusCh := make(chan *client.SolveStatus)
 	eg, ctx := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		var err error
-
-		display, err := progressui.NewDisplay(os.Stderr, "auto")
-		if err != nil {
-			return err
-		}
-		// Don't use `ctx` here.
-		// Cancelling the context kills the reader of statusCh which blocks bc.Solve below.
-		// bc.Solve closes statusCh at the end and UpdateFrom returns by reading the closed channel.
-		_, err = display.UpdateFrom(context.Background(), statusCh)
-		return err
-	})
+	eg.Go(newDisplay(statusCh))
 	var res *client.SolveResponse
 	eg.Go(func() error {
 		options := solveOptFromImageOptions(opts, dockerfilePath, buildArgs)


### PR DESCRIPTION
BUILDKIT_PROGRESS=plain is especially useful for debugging. Before this change, it only works when DOCKER_BUILDKIT=false.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
