### PR TITLE
fix: --json should not show human steps

### DIFF
--- a/internal/command/certificates/root.go
+++ b/internal/command/certificates/root.go
@@ -164,7 +164,11 @@ func runCertificatesShow(ctx context.Context) error {
 		return nil
 	}
 
-	return reportNextStepCert(ctx, hostname, cert, hostcheck)
+	if config.FromContext(ctx).JSONOutput {
+		return nil
+	}
+	
+	return reportNextStepCert(ctx, hostname, cert, hostcheck)	
 }
 
 func runCertificatesCheck(ctx context.Context) error {
@@ -183,6 +187,9 @@ func runCertificatesCheck(ctx context.Context) error {
 		return nil
 	}
 
+	if config.FromContext(ctx).JSONOutput {
+		return nil
+	}
 	return reportNextStepCert(ctx, hostname, cert, hostcheck)
 }
 
@@ -196,6 +203,9 @@ func runCertificatesAdd(ctx context.Context) error {
 		return err
 	}
 
+	if config.FromContext(ctx).JSONOutput {
+		return nil
+	}
 	return reportNextStepCert(ctx, hostname, cert, hostcheck)
 }
 


### PR DESCRIPTION
As a human, yes I want human readable steps.
But If I'm asking for --json, I really don't expect those steps to break my json.

# Current behaviour

```
flyctl certs show yourdomain.be --app $NAME --json                            
{
    "ID": "cert_1235ln",
    "AcmeDNSConfigured": false,
    "AcmeALPNConfigured": false,
    "Configured": false,
    "CertificateAuthority": "lets_encrypt",
    "CreatedAt": "2025-03-14T11:11:23Z",
    "DNSProvider": "cloudflare",
...
    "Hostname": "yourdomain.be",
    "Source": "fly",
    "ClientStatus": "Awaiting configuration",
    "IsApex": false,
    "IsWildcard": false,
    "Issued": {
        "Nodes": []
    }
}

You are creating a certificate for yourdomain.be
We are using Let's Encrypt for this certificate.

You can configure your DNS for yourdomain.be by:

1: Adding an CNAME record to your DNS service which reads:

    CNAME test. yourdomain-test.fly.dev
```

Notice the human readable 'next steps' that should not be there when using --json


# after this change

```
flyctl certs show yourdomain.be --app $NAME --json                            
{
    "ID": "cert_1235ln",
    "AcmeDNSConfigured": false,
    "AcmeALPNConfigured": false,
    "Configured": false,
    "CertificateAuthority": "lets_encrypt",
    "CreatedAt": "2025-03-14T11:11:23Z",
    "DNSProvider": "cloudflare",
...
    "Hostname": "yourdomain.be",
    "Source": "fly",
    "ClientStatus": "Awaiting configuration",
    "IsApex": false,
    "IsWildcard": false,
    "Issued": {
        "Nodes": []
    }
}
```