### PR TITLE
Check for cancelled context when updating machines

### DIFF
--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -289,6 +290,11 @@ func (md *machineDeployment) updateMachinesWRecovery(ctx context.Context, oldApp
 			}
 
 			currentState, err := md.appState(ctx, oldAppState)
+			// sort machines by id so we always have the same order when retrying
+			// This is needed for rolling deploys so we can start from the same machine
+			sort.Slice(currentState.Machines, func(i, j int) bool {
+				return currentState.Machines[i].ID < currentState.Machines[j].ID
+			})
 			if err != nil {
 				span.RecordError(updateErr)
 				return fmt.Errorf("failed to get current app state: %w", err)
@@ -328,9 +334,10 @@ func (md *machineDeployment) updateProcessGroup(ctx context.Context, machineTupl
 	ctx, span := tracing.GetTracer().Start(ctx, "update_process_group")
 	defer span.End()
 
-	group := errgroup.Group{}
+	group, gCtx := errgroup.WithContext(ctx)
 	group.SetLimit(poolSize)
 
+	fmt.Println("machineTuples", machineTuples, "poolSize", poolSize)
 	for _, machPair := range machineTuples {
 		machPair := machPair
 		oldMachine := machPair.oldMachine
@@ -352,6 +359,13 @@ func (md *machineDeployment) updateProcessGroup(ctx context.Context, machineTupl
 
 			sl := machineLogger.getLoggerFromID(machineID)
 
+			select {
+			case <-gCtx.Done():
+				sl.LogStatus(statuslogger.StatusFailure, "skipping machine update due to earlier failure")
+				return gCtx.Err()
+			default:
+			}
+
 			checkResult, ok := healthChecksPassed.Load(machineID)
 			// this shouldn't happen, we ensure that the machine is in the map but just in case
 			if !ok {
@@ -362,7 +376,7 @@ func (md *machineDeployment) updateProcessGroup(ctx context.Context, machineTupl
 			}
 			machineCheckResult := checkResult.(*healthcheckResult)
 
-			err := md.updateMachineWChecks(ctx, oldMachine, newMachine, sl, md.io, machineCheckResult)
+			err := md.updateMachineWChecks(gCtx, oldMachine, newMachine, sl, md.io, machineCheckResult)
 			if err != nil {
 				sl.LogStatus(statuslogger.StatusFailure, err.Error())
 				span.RecordError(err)

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -337,7 +337,6 @@ func (md *machineDeployment) updateProcessGroup(ctx context.Context, machineTupl
 	group, gCtx := errgroup.WithContext(ctx)
 	group.SetLimit(poolSize)
 
-	fmt.Println("machineTuples", machineTuples, "poolSize", poolSize)
 	for _, machPair := range machineTuples {
 		machPair := machPair
 		oldMachine := machPair.oldMachine
@@ -359,11 +358,9 @@ func (md *machineDeployment) updateProcessGroup(ctx context.Context, machineTupl
 
 			sl := machineLogger.getLoggerFromID(machineID)
 
-			select {
-			case <-gCtx.Done():
+			if err := gCtx.Err(); err != nil {
 				sl.LogStatus(statuslogger.StatusFailure, "skipping machine update due to earlier failure")
-				return gCtx.Err()
-			default:
+				return err
 			}
 
 			checkResult, ok := healthChecksPassed.Load(machineID)


### PR DESCRIPTION
### Change Summary

What and Why:

Rolling deploys continue on failure because we don't use context with `errGroup` and don't detect an earlier failure.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x ] n/a
