### PR TITLE
Fix expectations of env parsing for secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/haileys/go-harlog v0.0.0-20230517070437-0f99204b5a57
+	github.com/hashicorp/go-envparse v0.1.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.7.0
 	github.com/inancgumus/screen v0.0.0-20190314163918-06e984b86ed3

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,8 @@ github.com/haileys/go-harlog v0.0.0-20230517070437-0f99204b5a57/go.mod h1:feJwxr
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-envparse v0.1.0 h1:bE++6bhIsNCPLvgDZkYqo3nA+/PFI51pkrHdmPSDFPY=
+github.com/hashicorp/go-envparse v0.1.0/go.mod h1:OHheN1GoygLlAkTlXLXvAdnXdZxy8JUweQ1rAXx1xnc=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=

--- a/internal/command/secrets/parser.go
+++ b/internal/command/secrets/parser.go
@@ -1,66 +1,11 @@
 package secrets
 
 import (
-	"bufio"
-	"fmt"
 	"io"
-	"strings"
-)
 
-const (
-	parserStateSingleline = iota
-	parserStateMultiline  = iota
+	"github.com/hashicorp/go-envparse"
 )
 
 func parseSecrets(reader io.Reader) (map[string]string, error) {
-	secrets := map[string]string{}
-	scanner := bufio.NewScanner(reader)
-	parserState := parserStateSingleline
-	parsedKey := ""
-	parsedVal := strings.Builder{}
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		switch parserState {
-		case parserStateSingleline:
-			// Skip comments and empty lines
-			if strings.HasPrefix(line, "#") || strings.TrimSpace(line) == "" {
-				continue
-			}
-
-			parts := strings.SplitN(line, "=", 2)
-			if len(parts) != 2 {
-				return nil, fmt.Errorf("Secrets must be provided as NAME=VALUE pairs (%s is invalid)", line)
-			}
-
-			if strings.HasPrefix(parts[1], `"""`) {
-				// Switch to multiline
-				parserState = parserStateMultiline
-				parsedKey = parts[0]
-				parsedVal.WriteString(strings.TrimPrefix(parts[1], `"""`))
-				parsedVal.WriteString("\n")
-			} else {
-				value := parts[1]
-				if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
-					// Remove double quotes
-					value = value[1 : len(value)-1]
-				}
-				secrets[parts[0]] = value
-			}
-		case parserStateMultiline:
-			if strings.HasSuffix(line, `"""`) {
-				// End of multiline
-				parsedVal.WriteString(strings.TrimSuffix(line, `"""`))
-				secrets[parsedKey] = parsedVal.String()
-				parsedVal.Reset()
-				parserState = parserStateSingleline
-				parsedKey = ""
-			} else {
-				parsedVal.WriteString(line + "\n")
-			}
-
-		}
-	}
-
-	return secrets, nil
+	return envparse.Parse(reader)
 }

--- a/internal/command/secrets/parser_test.go
+++ b/internal/command/secrets/parser_test.go
@@ -90,3 +90,33 @@ func Test_parse_with_double_quotes(t *testing.T) {
 		"FOO": "BAR BAZ",
 	}, secrets)
 }
+
+// https://github.com/superfly/flyctl/issues/4291
+func Test_parse_with_comment(t *testing.T) {
+	reader := strings.NewReader(`FOO="BAR BAZ" # comment`)
+	secrets, err := parseSecrets(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"FOO": "BAR BAZ",
+	}, secrets)
+}
+
+// https://github.com/superfly/flyctl/issues/589
+func Test_parse_with_quotes(t *testing.T) {
+	reader := strings.NewReader(`FOO="BAR\nBAZ\n"`)
+	secrets, err := parseSecrets(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"FOO": "BAR\nBAZ\n",
+	}, secrets)
+}
+
+// https://github.com/superfly/flyctl/issues/3002
+func Test_parse_with_spaces(t *testing.T) {
+	reader := strings.NewReader(`FOO = BAR`)
+	secrets, err := parseSecrets(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"FOO": "BAR",
+	}, secrets)
+}


### PR DESCRIPTION
Use [hashicorp/go-envparse#Parse](https://pkg.go.dev/github.com/hashicorp/go-envparse#Parse) to parse env vars which supports comments on end of line (fixes #4291), spaces around the equals (fixes #3002), and escaping of \n (fixes #589). Added tests for existing issues that fail with the previous implementation.

I'm not affiliated with hashicorp, there exists other hashicorp dependencies already, and this package has no dependencies itself. Let me know if you'd rather I fix the existing parser though if you want to continue to maintain your own!