### PR TITLE
Support config argument on apps restart

### DIFF
--- a/internal/command/apps/restart.go
+++ b/internal/command/apps/restart.go
@@ -32,6 +32,7 @@ func newRestart() *cobra.Command {
 
 	// Note -
 	flag.Add(cmd,
+		flag.AppConfig(),
 		flag.Bool{
 			Name:        "force-stop",
 			Description: "Performs a force stop against the target Machine",


### PR DESCRIPTION
Fix #4279

```diff
 Restart an application. Perform a rolling restart against all running Machines.
 
 Usage:
   fly apps restart <app name> [flags]
 
 Flags:
+  -c, --config string        Path to application configuration file
       --force-stop           Performs a force stop against the target Machine
   -h, --help                 help for restart
       --skip-health-checks   Restarts app without waiting for health checks
```