### PR TITLE
limit shell app names to 63 chars

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -530,12 +530,13 @@ func getOrCreateEphemeralShellApp(ctx context.Context, client flyutil.Client) (*
 	}
 
 	if appc == nil {
+		shellAppName := fmt.Sprintf("flyctl-interactive-shells-%s-%d", strings.ToLower(org.ID), rand.Intn(1_000_000))
+		shellAppName = strings.TrimRight(shellAppName[:min(len(shellAppName), 63)], "-")
 		appc, err = client.CreateApp(ctx, fly.CreateAppInput{
 			OrganizationID: org.ID,
-			// i'll never find love again like the kind you give like the kind you send
-			Name: fmt.Sprintf("flyctl-interactive-shells-%s-%d", strings.ToLower(org.ID), rand.Intn(1_000_000)),
+			// I'll never find love again like the kind you give like the kind you send
+			Name: shellAppName,
 		})
-
 		if err != nil {
 			return nil, fmt.Errorf("create interactive shell app: %w", err)
 		}


### PR DESCRIPTION
Fix for https://github.com/superfly/flyctl/issues/4292

The app created for interactive shells adds 26 chars plus a string generated from organization id whose length depends on its internal numerical value, that plus the random integer appended to the end can generate a longer than 63 chars string.
