### PR TITLE
Support JSON output of machine VM sizes

### DIFF
--- a/internal/command/platform/vmsizes.go
+++ b/internal/command/platform/vmsizes.go
@@ -3,6 +3,8 @@ package platform
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 
 	"github.com/samber/lo"
@@ -10,6 +12,7 @@ import (
 
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/iostreams"
@@ -34,6 +37,10 @@ func newVMSizes() (cmd *cobra.Command) {
 
 func runMachineVMSizes(ctx context.Context) error {
 	out := iostreams.FromContext(ctx).Out
+
+	if config.FromContext(ctx).JSONOutput {
+		return render.JSON(out, slices.Collect(maps.Values(fly.MachinePresets)))
+	}
 
 	type preset struct {
 		guest   *fly.MachineGuest


### PR DESCRIPTION
- Fixes #4146

Regressed in bd6d9663b489a1fc0ee259d3c6ef1caf7f4a842f according to bisect.

Previously the JSON output format included `priceMonth` and `priceSecond` as it was a dump of [fly.VMSize](https://pkg.go.dev/github.com/superfly/fly-go#VMSize) returned from the API, but the function which returned this information (`client.PlatformVMSizes`) has also been removed in a different change. Since the non-JSON format doesn't include this information, that's probably a future enhancement to add it to both tabular output and JSON output, and apparently the exact format of the JSON is not important per the linked issue as it is not documented.