### PR TITLE
Error on unexpected args rather than silently ignoring

### DIFF
--- a/internal/command/apps/list.go
+++ b/internal/command/apps/list.go
@@ -41,6 +41,7 @@ the name, owner (org), status, and date/time of latest deploy for each app.
 	})
 
 	cmd.Aliases = []string{"ls"}
+	cmd.Args = cobra.NoArgs
 	return cmd
 }
 

--- a/internal/command/auth/login.go
+++ b/internal/command/auth/login.go
@@ -23,6 +23,7 @@ browser-based authentication.
 	)
 
 	cmd := command.New("login", short, long, runLogin)
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(cmd,
 		flag.Bool{

--- a/internal/command/auth/token.go
+++ b/internal/command/auth/token.go
@@ -40,6 +40,7 @@ instead, to create narrowly-scoped tokens with a custom expiry.`
 	)
 
 	cmd.Hidden = true
+	cmd.Args = cobra.NoArgs
 
 	return cmd
 }

--- a/internal/command/auth/whoami.go
+++ b/internal/command/auth/whoami.go
@@ -25,6 +25,7 @@ authenticated and in use.
 
 	cmd := command.New("whoami", long, short, runWhoAmI,
 		command.RequireSession)
+	cmd.Args = cobra.NoArgs
 	flag.Add(cmd, flag.JSONOutput())
 	return cmd
 }

--- a/internal/command/info/info.go
+++ b/internal/command/info/info.go
@@ -16,6 +16,7 @@ func New() *cobra.Command {
 	cmd := command.New("info", short, long, nil)
 	cmd.Hidden = true
 	cmd.Deprecated = "Replaced by 'status', 'ips list', and 'services list'"
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(cmd,
 		flag.App(),

--- a/internal/command/ips/allocate.go
+++ b/internal/command/ips/allocate.go
@@ -23,6 +23,7 @@ func newAllocatev4() *cobra.Command {
 		command.RequireSession,
 		command.RequireAppName,
 	)
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(cmd,
 		flag.Bool{

--- a/internal/command/ips/list.go
+++ b/internal/command/ips/list.go
@@ -26,6 +26,7 @@ func newList() *cobra.Command {
 	)
 
 	cmd.Aliases = []string{"ls"}
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(cmd,
 		flag.App(),

--- a/internal/command/ips/private.go
+++ b/internal/command/ips/private.go
@@ -21,6 +21,7 @@ func newPrivate() *cobra.Command {
 		command.RequireSession,
 		command.RequireAppName,
 	)
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(cmd,
 		flag.App(),

--- a/internal/command/machine/proxy.go
+++ b/internal/command/machine/proxy.go
@@ -21,6 +21,7 @@ func newProxy() *cobra.Command {
 	)
 
 	cmd := command.New(usage, short, long, runMachineProxy, command.RequireSession)
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(cmd,
 		flag.Org(),

--- a/internal/command/orgs/list.go
+++ b/internal/command/orgs/list.go
@@ -28,6 +28,7 @@ func newList() *cobra.Command {
 
 	flag.Add(cmd, flag.JSONOutput())
 	cmd.Aliases = []string{"ls"}
+	cmd.Args = cobra.NoArgs
 	return cmd
 }
 

--- a/internal/command/postgres/add_flycast.go
+++ b/internal/command/postgres/add_flycast.go
@@ -35,6 +35,7 @@ func newAddFlycast() *cobra.Command {
 	)
 
 	cmd.Hidden = true
+	cmd.Args = cobra.NoArgs
 
 	return cmd
 }

--- a/internal/command/postgres/connect.go
+++ b/internal/command/postgres/connect.go
@@ -31,6 +31,7 @@ func newConnect() *cobra.Command {
 		command.RequireSession,
 		command.RequireAppName,
 	)
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(cmd,
 		flag.App(),

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -29,6 +29,7 @@ func newCreate() *cobra.Command {
 	cmd := command.New("create", short, long, run,
 		command.RequireSession,
 	)
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(
 		cmd,

--- a/internal/command/postgres/failover.go
+++ b/internal/command/postgres/failover.go
@@ -37,6 +37,7 @@ func newFailover() *cobra.Command {
 		command.RequireSession,
 		command.RequireAppName,
 	)
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(
 		cmd,

--- a/internal/command/postgres/list.go
+++ b/internal/command/postgres/list.go
@@ -27,6 +27,7 @@ func newList() *cobra.Command {
 
 	flag.Add(cmd, flag.JSONOutput())
 	cmd.Aliases = []string{"ls"}
+	cmd.Args = cobra.NoArgs
 	return cmd
 }
 

--- a/internal/command/postgres/renew_certs.go
+++ b/internal/command/postgres/renew_certs.go
@@ -28,6 +28,7 @@ func newRenewSSHCerts() *cobra.Command {
 		command.RequireSession,
 		command.RequireAppName,
 	)
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(cmd,
 		flag.App(),

--- a/internal/command/postgres/restart.go
+++ b/internal/command/postgres/restart.go
@@ -28,6 +28,7 @@ func newRestart() *cobra.Command {
 		command.RequireSession,
 		command.RequireAppName,
 	)
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(cmd,
 		flag.App(),

--- a/internal/command/services/list.go
+++ b/internal/command/services/list.go
@@ -27,6 +27,7 @@ func newList() *cobra.Command {
 
 	cmd := command.New("list", short, long, runList, command.RequireSession, command.RequireAppName)
 	cmd.Aliases = []string{"ls"}
+	cmd.Args = cobra.NoArgs
 	flag.Add(cmd,
 		flag.App(),
 		flag.AppConfig(),

--- a/internal/command/ssh/log.go
+++ b/internal/command/ssh/log.go
@@ -24,6 +24,7 @@ func newLog() *cobra.Command {
 	)
 
 	cmd := command.New(usage, short, long, runLog, command.RequireSession)
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(cmd,
 		flag.JSONOutput(),

--- a/internal/command/tokens/attenuate.go
+++ b/internal/command/tokens/attenuate.go
@@ -27,6 +27,7 @@ func newAttenuate() *cobra.Command {
 	)
 
 	cmd := command.New(usage, short, long, runAttenuate)
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(cmd,
 		flag.String{

--- a/internal/command/tokens/debug.go
+++ b/internal/command/tokens/debug.go
@@ -24,6 +24,7 @@ func newDebug() *cobra.Command {
 	)
 
 	cmd := command.New(usage, short, long, runDebug)
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(cmd,
 		flag.String{

--- a/internal/command/tokens/list.go
+++ b/internal/command/tokens/list.go
@@ -40,6 +40,7 @@ func newList() *cobra.Command {
 	)
 
 	cmd.Aliases = []string{"ls"}
+	cmd.Args = cobra.NoArgs
 
 	return cmd
 }

--- a/internal/command/version/save_install.go
+++ b/internal/command/version/save_install.go
@@ -36,6 +36,7 @@ func newSaveInstall() *cobra.Command {
 	)
 
 	cmd.Hidden = true
+	cmd.Args = cobra.NoArgs
 
 	return cmd
 }

--- a/internal/command/volumes/list.go
+++ b/internal/command/volumes/list.go
@@ -30,6 +30,7 @@ func newList() *cobra.Command {
 	)
 
 	cmd.Aliases = []string{"ls"}
+	cmd.Args = cobra.NoArgs
 
 	flag.Add(cmd,
 		flag.App(),


### PR DESCRIPTION
- Fixes #2924

Makes it easier to identify errors in running commands where `-` has been missed for example. Rather than silently ignoring the argument, an error message is reported. Applies only to commands where there are no subcommands.