### PR TITLE
fix: clear machine lease nonce in releaseLeases

### DIFF
--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -482,6 +482,7 @@ func (md *machineDeployment) releaseLeases(ctx context.Context, machineTuples []
 				sl.LogStatus(statuslogger.StatusFailure, fmt.Sprintf("Failed to clear lease for %s: %v", machine.ID, err))
 				return err
 			}
+			machine.LeaseNonce = ""
 
 			sl.LogStatus(statuslogger.StatusSuccess, fmt.Sprintf("Cleared lease for %s", machine.ID))
 			return nil

--- a/internal/command/deploy/plan_test.go
+++ b/internal/command/deploy/plan_test.go
@@ -227,6 +227,9 @@ func TestUpdateMachines(t *testing.T) {
 			}, nil
 		},
 		ReleaseLeaseFunc: func(ctx context.Context, machineID, nonce string) error {
+			if _, loaded := acquiredLeases.LoadAndDelete(machineID); !loaded {
+				t.Error("Release lease not found for machine:", machineID)
+			}
 			return nil
 		},
 		UpdateFunc: func(ctx context.Context, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error) {
@@ -288,10 +291,11 @@ func TestUpdateMachines(t *testing.T) {
 		app: &fly.AppCompact{
 			Name: "myapp",
 		},
-		appConfig:      &appconfig.Config{AppName: "myapp"},
-		waitTimeout:    10 * time.Second,
-		deployRetries:  5,
-		maxUnavailable: 3,
+		appConfig:       &appconfig.Config{AppName: "myapp"},
+		waitTimeout:     10 * time.Second,
+		deployRetries:   5,
+		maxUnavailable:  3,
+		skipSmokeChecks: true,
 	}
 
 	oldAppState := &AppState{
@@ -303,7 +307,7 @@ func TestUpdateMachines(t *testing.T) {
 	settings := updateMachineSettings{
 		pushForward:          true,
 		skipHealthChecks:     false,
-		skipSmokeChecks:      false,
+		skipSmokeChecks:      true,
 		skipLeaseAcquisition: false,
 	}
 


### PR DESCRIPTION
In the edge-case where a `fly.Machine` is updated twice in a single deploy (which currently happens with a single machine in 'canary' deployments), the lease won't get acquired during the second deploy if a nonce still exists on the Machine struct, so we need to explicitly clear this field in `machineDeployment.releaseLeases`.

Fixes `lease not found` error on cleanup for canary deploys, including an update to an existing test to demonstrate the failure (and ensure the fix in this PR works).