### PR TITLE
fix: cancel acquiring a Depot machine if it takes > 5 minutes

### DIFF
--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/cenkalti/backoff/v5"
 	depotbuild "github.com/depot/depot-go/build"
 	depotmachine "github.com/depot/depot-go/machine"
 	"github.com/moby/buildkit/client"
@@ -118,9 +117,15 @@ func (d *DepotBuilder) Run(ctx context.Context, _ *dockerClientFactory, streams 
 	return image, "", nil
 }
 
-func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOptions, dockerfilePath string, buildState *build, scope depotBuilderScope) (*DeploymentImage, error) {
+func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOptions, dockerfilePath string, buildState *build, scope depotBuilderScope) (i *DeploymentImage, retErr error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "depot_build", trace.WithAttributes(opts.ToSpanAttributes()...))
-	defer span.End()
+	defer func() {
+		if retErr != nil {
+			streams.StopProgressIndicator()
+			span.RecordError(retErr)
+		}
+		span.End()
+	}()
 
 	buildState.BuilderInitStart()
 	buildState.SetBuilderMetaPart1(depotBuilderType, "", "")
@@ -134,10 +139,13 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 		}
 	}
 
-	buildkit, build, buildErr := initBuilder(ctx, buildState, opts.AppName, streams, scope)
+	// Building a container image may take multiple minutes.
+	// So we can only have the provisoning part in this context.
+	provisionCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	buildkit, build, buildErr := initBuilder(provisionCtx, buildState, opts.AppName, streams, scope)
 	if buildErr != nil {
-		streams.StopProgressIndicator()
-		span.RecordError(buildErr)
 		return nil, buildErr
 	}
 	defer func() {
@@ -145,15 +153,10 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 		build.Finish(buildErr)
 	}()
 
-	connectCtx, cancelConnect := context.WithTimeout(ctx, 5*time.Minute)
-	defer cancelConnect()
-
 	span.AddEvent("connecting to buildkit")
 	var buildkitClient *client.Client
-	buildkitClient, buildErr = buildkit.Connect(connectCtx)
+	buildkitClient, buildErr = buildkit.Connect(provisionCtx)
 	if buildErr != nil {
-		streams.StopProgressIndicator()
-		span.RecordError(buildErr)
 		return nil, buildErr
 	}
 
@@ -167,7 +170,6 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 	res, buildErr := buildImage(ctx, buildkitClient, opts, dockerfilePath)
 	if buildErr != nil {
 		buildState.BuildAndPushFinish()
-		span.RecordError(buildErr)
 		return nil, buildErr
 	}
 	buildState.BuildAndPushFinish()
@@ -178,11 +180,20 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 	return newDeploymentImage(res, opts.Tag)
 }
 
-func initBuilder(ctx context.Context, buildState *build, appName string, streams *iostreams.IOStreams, builderScope depotBuilderScope) (*depotmachine.Machine, *depotbuild.Build, error) {
+// initBuilder returns a Depot machine to build a container image.
+// Note that the caller is reponsible for passing a context with a resonable timeout.
+// Otherwise, the function cloud block indefinitely.
+func initBuilder(ctx context.Context, buildState *build, appName string, streams *iostreams.IOStreams, builderScope depotBuilderScope) (m *depotmachine.Machine, b *depotbuild.Build, retErr error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "init_depot_build")
-	defer span.End()
 
-	defer buildState.BuilderInitFinish()
+	defer func() {
+		if retErr != nil {
+			streams.StopProgressIndicator()
+			span.RecordError(retErr)
+		}
+		buildState.BuilderInitFinish()
+		span.End()
+	}()
 
 	apiClient := flyutil.ClientFromContext(ctx)
 	region := os.Getenv("FLY_REMOTE_BUILDER_REGION")
@@ -197,7 +208,6 @@ func initBuilder(ctx context.Context, buildState *build, appName string, streams
 		BuilderScope: fly.StringPointer(builderScope.String()),
 	})
 	if err != nil {
-		streams.StopProgressIndicator()
 		return nil, nil, err
 	}
 
@@ -206,30 +216,14 @@ func initBuilder(ctx context.Context, buildState *build, appName string, streams
 		return nil, nil, err
 	}
 
-	// Set the buildErr to any error that represents the build failing.
-	var finalBuildErr error
-
 	span.AddEvent("Acquiring Depot machine")
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, 25*time.Second)
-	defer cancel()
-
-	buildkit, finalBuildErr := backoff.Retry(timeoutCtx, func() (*depotmachine.Machine, error) {
-		machine, err := depotmachine.Acquire(ctx, build.ID, build.Token, "amd64")
-		if err != nil {
-			span.RecordError(err)
-			return nil, err
-		}
-
-		return machine, nil
-	}, backoff.WithMaxTries(2))
-
-	if finalBuildErr != nil {
-		streams.StopProgressIndicator()
-		return nil, nil, finalBuildErr
+	machine, err := depotmachine.Acquire(ctx, build.ID, build.Token, "amd64")
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return buildkit, &build, err
+	return machine, &build, nil
 }
 
 func buildImage(ctx context.Context, buildkitClient *client.Client, opts ImageOptions, dockerfilePath string) (*client.SolveResponse, error) {

--- a/internal/build/imgsrc/depot_test.go
+++ b/internal/build/imgsrc/depot_test.go
@@ -1,0 +1,22 @@
+package imgsrc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func TestInitBuilder(t *testing.T) {
+	ctx := context.Background()
+	ctx = flyutil.NewContextWithClient(ctx, flyutil.NewClientFromOptions(ctx, fly.ClientOptions{BaseURL: "invalid://localhost"}))
+	ios, _, _, _ := iostreams.Test()
+	build := newBuild("build1", false)
+
+	// The invocation below doesn't test things much, but it may be better than nothing.
+	_, _, err := initBuilder(ctx, build, "app1", ios, DepotBuilderScopeOrganization)
+	require.ErrorContains(t, err, `unsupported protocol scheme "invalid"`)
+}


### PR DESCRIPTION
Before this change, depotmachine.Acquire() was blocking indefinitely because we are not passing timeoutCtx.

Instead of doing so, this change simplifies the flow by moving the timeout one above (at depotBuild).

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
