### PR TITLE
Validate, default, and allow container to be selected

### DIFF
--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -53,7 +53,7 @@ func New() *cobra.Command {
 		flag.Bool{
 			Name:        "select",
 			Shorthand:   "s",
-			Description: "Select the machine on which to execute the console from a list.",
+			Description: "Select the machine and container on which to execute the console from a list.",
 			Default:     false,
 		},
 		flag.String{

--- a/internal/command/ssh/sftp.go
+++ b/internal/command/ssh/sftp.go
@@ -105,7 +105,7 @@ func newSFTPConnection(ctx context.Context) (*sftp.Client, error) {
 		return nil, err
 	}
 
-	addr, err := lookupAddress(ctx, agentclient, dialer, app, false)
+	addr, container, err := lookupAddressAndContainer(ctx, agentclient, dialer, app, false)
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +116,7 @@ func newSFTPConnection(ctx context.Context) (*sftp.Client, error) {
 		Dialer:         dialer,
 		Username:       DefaultSshUsername,
 		DisableSpinner: true,
+		Container:      container,
 		AppNames:       []string{app.Name},
 	}
 


### PR DESCRIPTION
if `--container` is specified
*  validate that the selected machine is running containers, and has the container you specified

if `--container` is not specified and the selected machine is running containers
*  default to the first container (this matches previous behavior on selecting machines)
*  if `--selected` is specified and there is more than one, prompt for selection

Notes:
*  `--select` now applies to *both* machines and containers
*  `--select` now is ignored if there is only one possible selection
*  `fly ssh sftp` now will respect the container selected