### PR TITLE
Add --cluster flag to `fly mpg connect` and `fly mpg proxy`.

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -51,7 +51,10 @@ func Establish(ctx context.Context, apiClient wireguard.WebClient) (*Client, err
 		return nil, err
 	}
 
-	if buildinfo.Version().Equal(resVer) {
+	// Seems like the flyctl agent version is set when the agent is started,
+	// so, in development, it can't ever be equal to the flyctl version,
+	// which seems to be set at build time.
+	if buildinfo.Version().Equal(resVer) || (buildinfo.Version().Channel == "dev" && buildinfo.Version().Newer(resVer)) {
 		return c, nil
 	}
 

--- a/internal/command/mpg/connect.go
+++ b/internal/command/mpg/connect.go
@@ -26,6 +26,7 @@ func newConnect() (cmd *cobra.Command) {
 
 	flag.Add(cmd,
 		flag.Org(),
+		flag.MPGCluster(),
 	)
 
 	return cmd

--- a/internal/command/mpg/mpg.go
+++ b/internal/command/mpg/mpg.go
@@ -1,8 +1,15 @@
 package mpg
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/internal/uiexutil"
 )
 
 func New() *cobra.Command {
@@ -23,4 +30,43 @@ func New() *cobra.Command {
 	)
 
 	return cmd
+}
+
+// ClusterFromFlagOrSelect retrieves the cluster ID from the --cluster flag.
+// If the flag is not set, it prompts the user to select a cluster from the available ones for the given organization.
+func ClusterFromFlagOrSelect(ctx context.Context, orgSlug string) (*uiex.ManagedCluster, error) {
+	clusterID := flag.GetMPGClusterID(ctx)
+	uiexClient := uiexutil.ClientFromContext(ctx)
+
+	clustersResponse, err := uiexClient.ListManagedClusters(ctx, orgSlug)
+	if err != nil {
+		return nil, fmt.Errorf("failed retrieving postgres clusters: %w", err)
+	}
+
+	if len(clustersResponse.Data) == 0 {
+		return nil, fmt.Errorf("no managed postgres clusters found in organization %s", orgSlug)
+	}
+
+	if clusterID != "" {
+		// If a cluster ID is provided via flag, find it
+		for i := range clustersResponse.Data {
+			if clustersResponse.Data[i].Id == clusterID {
+				return &clustersResponse.Data[i], nil
+			}
+		}
+		return nil, fmt.Errorf("managed postgres cluster %q not found in organization %s", clusterID, orgSlug)
+	} else {
+		// Otherwise, prompt the user to select a cluster
+		var options []string
+		for _, cluster := range clustersResponse.Data {
+			options = append(options, fmt.Sprintf("%s (%s)", cluster.Name, cluster.Region))
+		}
+
+		var index int
+		selectErr := prompt.Select(ctx, &index, "Select a Postgres cluster", "", options...)
+		if selectErr != nil {
+			return nil, selectErr
+		}
+		return &clustersResponse.Data[index], nil
+	}
 }

--- a/internal/flag/context.go
+++ b/internal/flag/context.go
@@ -142,6 +142,11 @@ func GetOrg(ctx context.Context) string {
 	return org
 }
 
+// GetMPGClusterID is shorthand for GetString(ctx, "cluster").
+func GetMPGClusterID(ctx context.Context) string {
+	return GetString(ctx, flagnames.MPGClusterID)
+}
+
 // GetRegion is shorthand for GetString(ctx, Region).
 func GetRegion(ctx context.Context) string {
 	return GetString(ctx, flagnames.Region)

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -320,6 +320,13 @@ func Org() String {
 	}
 }
 
+func MPGCluster() String {
+	return String{
+		Name:        "cluster",
+		Description: "The target cluster ID",
+	}
+}
+
 // Region returns a region string flag.
 func Region() String {
 	return String{

--- a/internal/flag/flagnames/constants.go
+++ b/internal/flag/flagnames/constants.go
@@ -51,4 +51,7 @@ const (
 
 	// ProcessGroup denotes the name of the process group flag.
 	ProcessGroup = "process-group"
+
+	// MPGClusterID denotes the name of the MPG cluster ID flag.
+	MPGClusterID = "cluster"
 )


### PR DESCRIPTION
### Change Summary

What and Why:

Add `--cluster` flag to `flyctl mpg connect` and `flyctl mpg proxy` commands. Both for quality of life and to enable use of these commands in scripts.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
