### PR TITLE
let user know when `fly mpg connect` fails due to cluster not being in ready state

### DIFF
--- a/internal/command/mpg/connect.go
+++ b/internal/command/mpg/connect.go
@@ -42,6 +42,10 @@ func runConnect(ctx context.Context) (err error) {
 		return err
 	}
 
+	if cluster.Status != "ready" {
+		return fmt.Errorf("cluster is not in ready state, currently: %s", cluster.Status)
+	}
+
 	psqlPath, err := exec.LookPath("psql")
 	if err != nil {
 		fmt.Fprintf(io.Out, "Could not find psql in your $PATH. Install it or point your psql at: %s", "someurl")


### PR DESCRIPTION


### Change Summary

What and Why:

Prior to change, `psql` would fail with an unfriendly error that might trip up less experienced users.

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
