### PR TITLE
rewrite `fly mpg attach` to merely grab the pgbouncer connection URI …

### DIFF
--- a/internal/command/mpg/attach.go
+++ b/internal/command/mpg/attach.go
@@ -3,35 +3,22 @@ package mpg
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flyutil"
-	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 )
-
-type AttachParams struct {
-	DbName       string
-	AppName      string
-	ClusterId    string
-	DbUser       string
-	VariableName string
-}
 
 func newAttach() *cobra.Command {
 	const (
 		short = "Attach a managed Postgres cluster to an app"
 		long  = short + ". " +
-			`This command will grant the specified database user access to the
- specified database on the managed Postgres cluster. It will also
- add a secret to the app containing the connection string for the
- database. If either of the database or user do not exist, they will
- be created.`
+			`This command will add a secret to the specified app
+ containing the connection string for the database.`
 		usage = "attach <CLUSTER ID>"
 	)
 
@@ -46,19 +33,10 @@ func newAttach() *cobra.Command {
 		flag.App(),
 		flag.AppConfig(),
 		flag.String{
-			Name:        "database-name",
-			Description: "The designated database name for this consuming app.",
-		},
-		flag.String{
-			Name:        "database-user",
-			Description: "The database user to create. By default, we will use the name of the consuming app.",
-		},
-		flag.String{
 			Name:        "variable-name",
 			Default:     "DATABASE_URL",
-			Description: "The environment variable name that will be added to the consuming app. ",
+			Description: "The name of the environment variable that will be added to the attached app",
 		},
-		flag.Yes(),
 	)
 
 	return cmd
@@ -70,82 +48,35 @@ func runAttach(ctx context.Context) error {
 		appName    = appconfig.NameFromContext(ctx)
 		client     = flyutil.ClientFromContext(ctx)
 		uiexClient = uiexutil.ClientFromContext(ctx)
+		io         = iostreams.FromContext(ctx)
 	)
 
 	response, err := uiexClient.GetManagedClusterById(ctx, clusterId)
-
 	if err != nil {
 		return fmt.Errorf("failed retrieving cluster %s: %w", clusterId, err)
 	}
-	cluster := response.Data
 
 	app, err := client.GetAppCompact(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("failed retrieving app %s: %w", appName, err)
 	}
 
-	params := AttachParams{
-		AppName:      app.Name,
-		ClusterId:    cluster.Id,
-		DbName:       flag.GetString(ctx, "database-name"),
-		DbUser:       flag.GetString(ctx, "database-user"),
-		VariableName: flag.GetString(ctx, "variable-name"),
-	}
+	variableName := flag.GetString(ctx, "variable-name")
 
-	return runAttachCluster(ctx, params)
-}
-
-func runAttachCluster(ctx context.Context, params AttachParams) error {
-	var (
-		client     = flyutil.ClientFromContext(ctx)
-		uiexClient = uiexutil.ClientFromContext(ctx)
-		io         = iostreams.FromContext(ctx)
-
-		appName   = params.AppName
-		clusterId = params.ClusterId
-		dbName    = params.DbName
-		dbUser    = params.DbUser
-		varName   = params.VariableName
-	)
-
-	if dbName == "" {
-		dbName = appName
-	}
-
-	if dbUser == "" {
-		dbUser = appName
-	}
-
-	dbUser = strings.ToLower(strings.ReplaceAll(dbUser, "_", "-"))
-
-	if varName == "" {
-		varName = "DATABASE_URL"
-	}
-
-	dbName = strings.ToLower(strings.ReplaceAll(dbName, "_", "-"))
-
-	input := uiex.CreateUserInput{
-		DbName:   dbName,
-		UserName: dbUser,
-	}
-
-	fmt.Println("Creating user... This might take a while")
-
-	response, err := uiexClient.CreateUser(ctx, clusterId, input)
-	if err != nil {
-		return err
+	if variableName == "" {
+		variableName = "DATABASE_URL"
 	}
 
 	s := map[string]string{}
-	s[varName] = response.ConnectionUri
+	s[variableName] = response.Credentials.ConnectionUri
 
-	_, err = client.SetSecrets(ctx, appName, s)
+	_, err = client.SetSecrets(ctx, app.Name, s)
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintf(io.Out, "\nPostgres cluster %s is being attached to %s\n", clusterId, appName)
-	fmt.Fprintf(io.Out, "The following secret was added to %s:\n  %s=%s\n", appName, varName, response.ConnectionUri)
+	fmt.Fprintf(io.Out, "The following secret was added to %s:\n  %s=%s\n", appName, variableName, response.Credentials.ConnectionUri)
 
 	return nil
 }

--- a/internal/command/mpg/proxy.go
+++ b/internal/command/mpg/proxy.go
@@ -81,11 +81,11 @@ func getMpgProxyParams(ctx context.Context, localProxyPort string) (*uiex.Manage
 	}
 	cluster := response.Data
 
-	if response.Password.Status == "initializing" {
+	if response.Credentials.Status == "initializing" {
 		return nil, nil, "", fmt.Errorf("Cluster is still initializing, wait a bit more")
 	}
 
-	if response.Password.Status == "error" {
+	if response.Credentials.Status == "error" {
 		return nil, nil, "", fmt.Errorf("Error getting cluster password")
 	}
 
@@ -104,5 +104,5 @@ func getMpgProxyParams(ctx context.Context, localProxyPort string) (*uiex.Manage
 		OrganizationSlug: org.Slug,
 		Dialer:           dialer,
 		RemoteHost:       cluster.IpAssignments.Direct,
-	}, response.Password.Value, nil
+	}, response.Credentials.Password, nil
 }

--- a/internal/uiex/managed_postgres.go
+++ b/internal/uiex/managed_postgres.go
@@ -31,14 +31,15 @@ type ListManagedClustersResponse struct {
 	Data []ManagedCluster `json:"data"`
 }
 
-type GetManagedClusterPasswordResponse struct {
-	Status string `json:"status"`
-	Value  string `json:"value"`
+type GetManagedClusterCredentialsResponse struct {
+	Status        string `json:"status"`
+	Password      string `json:"password"`
+	ConnectionUri string `json:"pgbouncer_uri"`
 }
 
 type GetManagedClusterResponse struct {
-	Data     ManagedCluster                    `json:"data"`
-	Password GetManagedClusterPasswordResponse `json:"password"`
+	Data        ManagedCluster                       `json:"data"`
+	Credentials GetManagedClusterCredentialsResponse `json:"credentials"`
 }
 
 func (c *Client) ListManagedClusters(ctx context.Context, orgSlug string) (ListManagedClustersResponse, error) {


### PR DESCRIPTION
…and write it to a secret in the app; we are holding off the whole "create a new user and database" thing for now, waiting until Percona Operator v2.7.0 is released with `grantPublicSchemaAccess` (or else until we merge some code to allow executing arbitrary SQL, so we can run `GRANT`s ourselves)

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
