### PR TITLE
Update fly-go to split MachineCheck/MachineServiceCheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
-	github.com/superfly/fly-go v0.1.43
+	github.com/superfly/fly-go v0.1.44
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.43 h1:oH3H0OEqMKSytUMQ+QhHldFqdJP2ei0LJkTwhXJ1vD0=
-github.com/superfly/fly-go v0.1.43/go.mod h1:YcVyr0bQm6cdydoMsqIHDPZDQqbmErwCSIuJI4pNwZM=
+github.com/superfly/fly-go v0.1.44 h1:060lpfJr/7KmlItCpTNpGNgOVAsI8/81SFHinJxpRqA=
+github.com/superfly/fly-go v0.1.44/go.mod h1:YcVyr0bQm6cdydoMsqIHDPZDQqbmErwCSIuJI4pNwZM=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -271,15 +271,13 @@ func TestToDefinition(t *testing.T) {
 		},
 		"metrics": []any{
 			map[string]any{
-				"port":  int64(9999),
-				"path":  "/metrics",
-				"https": false,
+				"port": int64(9999),
+				"path": "/metrics",
 			},
 			map[string]any{
 				"port":      int64(9998),
 				"path":      "/metrics",
 				"processes": []any{"web"},
-				"https":     false,
 			},
 		},
 		"statics": []any{

--- a/internal/appconfig/service.go
+++ b/internal/appconfig/service.go
@@ -121,8 +121,8 @@ func (svc *Service) toMachineService() *fly.MachineService {
 	return s
 }
 
-func (chk *ServiceHTTPCheck) toMachineCheck() *fly.MachineCheck {
-	return &fly.MachineCheck{
+func (chk *ServiceHTTPCheck) toMachineCheck() *fly.MachineServiceCheck {
+	return &fly.MachineServiceCheck{
 		Type:              fly.Pointer("http"),
 		Interval:          chk.Interval,
 		Timeout:           chk.Timeout,
@@ -143,8 +143,8 @@ func (chk *ServiceHTTPCheck) String(port int) string {
 	return fmt.Sprintf("http-%d-%v", port, chk.HTTPMethod)
 }
 
-func (chk *ServiceTCPCheck) toMachineCheck() *fly.MachineCheck {
-	return &fly.MachineCheck{
+func (chk *ServiceTCPCheck) toMachineCheck() *fly.MachineServiceCheck {
+	return &fly.MachineServiceCheck{
 		Type:        fly.Pointer("tcp"),
 		Interval:    chk.Interval,
 		Timeout:     chk.Timeout,
@@ -185,7 +185,7 @@ func serviceFromMachineService(ctx context.Context, ms fly.MachineService, proce
 	}
 }
 
-func tcpCheckFromMachineCheck(mc fly.MachineCheck) *ServiceTCPCheck {
+func tcpCheckFromMachineCheck(mc fly.MachineServiceCheck) *ServiceTCPCheck {
 	return &ServiceTCPCheck{
 		Interval:    mc.Interval,
 		Timeout:     mc.Timeout,
@@ -193,7 +193,7 @@ func tcpCheckFromMachineCheck(mc fly.MachineCheck) *ServiceTCPCheck {
 	}
 }
 
-func httpCheckFromMachineCheck(ctx context.Context, mc fly.MachineCheck) *ServiceHTTPCheck {
+func httpCheckFromMachineCheck(ctx context.Context, mc fly.MachineServiceCheck) *ServiceHTTPCheck {
 	headers := make(map[string]string)
 	for _, h := range mc.HTTPHeaders {
 		if len(h.Values) > 0 {


### PR DESCRIPTION
### Change Summary

What and Why: Update `fly-go`

Not all of the `MachineCheck` fields are supported for service checks. To fix our api.machines.dev docs, we need to split them into separate structs. This makes the necessary changes in `flyctl`.

How:

Related to: https://github.com/superfly/fly-go/pull/152

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
