### PR TITLE
Drop Ubuntu 20.04 from CI install tests

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -19,7 +19,6 @@ jobs:
         image:
           # Only test LTS versions.
           - "ubuntu:24.04"
-          - "ubuntu:20.04"
           - "ubuntu:22.04"
 
           - "debian:oldstable-slim"
@@ -75,7 +74,6 @@ jobs:
           # From https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images.
           - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
           - macos-14
           - macos-13
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
No longer supported (and will be canceled/failed) by GitHub:

https://github.com/actions/runner-images/issues/11101