### PR TITLE
Add capacity info to `fly platform regions`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
-	github.com/superfly/fly-go v0.1.44
+	github.com/superfly/fly-go v0.1.45
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.44 h1:060lpfJr/7KmlItCpTNpGNgOVAsI8/81SFHinJxpRqA=
-github.com/superfly/fly-go v0.1.44/go.mod h1:YcVyr0bQm6cdydoMsqIHDPZDQqbmErwCSIuJI4pNwZM=
+github.com/superfly/fly-go v0.1.45 h1:mLcl2N9Y/+4OXMHXXFzrlmkfm0WHncOjhgEuRt/gIVQ=
+github.com/superfly/fly-go v0.1.45/go.mod h1:YcVyr0bQm6cdydoMsqIHDPZDQqbmErwCSIuJI4pNwZM=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/command/mcp/server/platform.go
+++ b/internal/command/mcp/server/platform.go
@@ -1,9 +1,11 @@
 package mcpServer
 
+import "github.com/superfly/flyctl/internal/command/platform"
+
 var PlatformCommands = []FlyCommand{
 	{
 		ToolName:        "fly-platform-regions",
-		ToolDescription: "Get a list of regions where Fly has edges and/or datacenters",
+		ToolDescription: platform.RegionsCommandDesc,
 		ToolArgs:        map[string]FlyArg{},
 
 		Builder: func(args map[string]string) ([]string, error) {

--- a/internal/command/mpg/connect.go
+++ b/internal/command/mpg/connect.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/iostreams"
@@ -43,7 +44,7 @@ func runConnect(ctx context.Context) (err error) {
 	}
 
 	if cluster.Status != "ready" {
-		return fmt.Errorf("cluster is not in ready state, currently: %s", cluster.Status)
+		fmt.Fprintf(io.ErrOut, "%s Cluster is not in ready state, currently: %s\n", aurora.Yellow("WARN"), cluster.Status)
 	}
 
 	psqlPath, err := exec.LookPath("psql")

--- a/internal/command/mpg/proxy.go
+++ b/internal/command/mpg/proxy.go
@@ -85,8 +85,12 @@ func getMpgProxyParams(ctx context.Context, localProxyPort string) (*uiex.Manage
 		return nil, nil, "", fmt.Errorf("Cluster is still initializing, wait a bit more")
 	}
 
-	if response.Credentials.Status == "error" {
+	if response.Credentials.Status == "error" || response.Credentials.Password == "" {
 		return nil, nil, "", fmt.Errorf("Error getting cluster password")
+	}
+
+	if cluster.IpAssignments.Direct == "" {
+		return nil, nil, "", fmt.Errorf("Error getting cluster IP")
 	}
 
 	agentclient, err := agent.Establish(ctx, client)

--- a/internal/command/platform/regions.go
+++ b/internal/command/platform/regions.go
@@ -32,7 +32,7 @@ func newRegions() (cmd *cobra.Command) {
 		short = "List regions"
 	)
 
-	cmd = command.New("regions", short, RegionsCommandDesc+"\n", runRegions,
+	cmd = command.New("regions", short, RegionsCommandDesc, runRegions,
 		command.RequireSession,
 	)
 

--- a/internal/command/platform/regions.go
+++ b/internal/command/platform/regions.go
@@ -67,7 +67,7 @@ func runRegions(ctx context.Context) error {
 	for _, key := range keys {
 		regionGroup := regionGroups[key]
 		rows = append(rows, []string{""})
-		rows = append(rows, []string{key.String() + ":"})
+		rows = append(rows, []string{io.ColorScheme().Underline(key.String())})
 		for _, region := range regionGroup {
 			gateway := ""
 			if region.GatewayAvailable {

--- a/internal/command/platform/regions.go
+++ b/internal/command/platform/regions.go
@@ -1,35 +1,38 @@
 package platform
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
+	"github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
-	"github.com/superfly/flyctl/internal/flapsutil"
-	"golang.org/x/exp/slices"
-
-	"github.com/superfly/flyctl/iostreams"
-
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/render"
+	"github.com/superfly/flyctl/iostreams"
 )
 
 // Hardcoded list of regions with GPUs
 // TODO: fetch this list from the graphql endpoint once it is there
 var gpuRegions = []string{"iad", "sjc", "syd", "ams"}
 
+const RegionsCommandDesc = `View a list of regions where Fly has datacenters.
+'Capacity' shows how many performance-1x VMs can currently be launched in each region.
+`
+
 func newRegions() (cmd *cobra.Command) {
 	const (
-		long = `View a list of regions where Fly has edges and/or datacenters
-`
 		short = "List regions"
 	)
 
-	cmd = command.New("regions", short, long, runRegions,
+	cmd = command.New("regions", short, RegionsCommandDesc+"\n", runRegions,
 		command.RequireSession,
 	)
 
@@ -43,7 +46,7 @@ func runRegions(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	regions, err := flapsClient.GetRegions(ctx, "performance-1x")
+	regions, err := flapsClient.GetRegions(ctx, "")
 	if err != nil {
 		return fmt.Errorf("failed retrieving regions: %w", err)
 	}
@@ -58,31 +61,39 @@ func runRegions(ctx context.Context) error {
 	}
 
 	var rows [][]string
-	for _, region := range regions {
-		gateway := ""
-		if region.GatewayAvailable {
-			gateway = "✓"
-		}
-		paidPlan := ""
-		if region.RequiresPaidPlan {
-			paidPlan = "✓"
-		}
-		gpuAvailable := ""
-		if slices.Contains(gpuRegions, region.Code) {
-			gpuAvailable = "✓"
-		}
+	regionGroups := lo.GroupBy(regions, func(item fly.Region) fly.GeoRegion { return item.GeoRegion })
+	keys := lo.Keys(regionGroups)
+	slices.SortFunc(keys, func(a, b fly.GeoRegion) int { return cmp.Compare(a, b) })
+	for _, key := range keys {
+		regionGroup := regionGroups[key]
+		rows = append(rows, []string{""})
+		rows = append(rows, []string{key.String() + ":"})
+		for _, region := range regionGroup {
+			gateway := ""
+			if region.GatewayAvailable {
+				gateway = "✓"
+			}
+			paidPlan := ""
+			if region.RequiresPaidPlan {
+				paidPlan = "✓"
+			}
+			gpuAvailable := ""
+			if slices.Contains(gpuRegions, region.Code) {
+				gpuAvailable = "✓"
+			}
 
-		capacity := fmt.Sprint(region.Capacity)
-		capacity = io.ColorScheme().RedGreenGradient(capacity, float64(region.Capacity)/1000)
+			capacity := fmt.Sprint(region.Capacity)
+			capacity = io.ColorScheme().RedGreenGradient(capacity, float64(region.Capacity)/1000)
 
-		rows = append(rows, []string{
-			region.Name,
-			region.Code,
-			gateway,
-			gpuAvailable,
-			capacity,
-			paidPlan,
-		})
+			rows = append(rows, []string{
+				region.Name,
+				region.Code,
+				gateway,
+				gpuAvailable,
+				capacity,
+				paidPlan,
+			})
+		}
 	}
 
 	return render.Table(out, "", rows, "Name", "Code", "Gateway", "GPUs", "Capacity", "Launch Plan+")


### PR DESCRIPTION
### Change Summary

Adds a 'capacity' field to `fly platform regions` output, along with with a colorized column in the printed output.

### What and Why:

Give customers better insight into platform capacity across regions to inform when a region has limited capacity, and for planning regions for new machine creation.

### How:

- added a new `/platform/regions` API endpoint (superfly/nomad-firecracker#3304- internal), along with an an update in superfly/fly-go#153 to expose this endpoint to the Flaps client.
- Update `fly platform regions` to use the new API to replace the old graphql API query.
- Add a `RedGreenGradient` function to colorize the output of the column on a red-green gradient.

The query will use `performance-1x` as a machine-size unit, and the color display will be normalized to 1000 (so any region over 1000 capacity will be full-green, scaling down to full-red at 0.)

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
