### PR TITLE
feat: happiness both on fly.io and in docker compose

### DIFF
--- a/scanner/phoenix.go
+++ b/scanner/phoenix.go
@@ -143,17 +143,23 @@ a Postgres database.
 func PhoenixCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan, flags []string) error {
 	envEExPath := "rel/env.sh.eex"
 	envEExContents := `
-# configure node for distributed erlang with IPV6 support
-export ERL_AFLAGS="-proto_dist inet6_tcp"
-export ECTO_IPV6="true"
-export DNS_CLUSTER_QUERY="${FLY_APP_NAME}.internal"
+if [ -n "$FLY_APP_NAME" ]; then
+  export DNS_CLUSTER_QUERY="${FLY_APP_NAME}.internal"
+  export RELEASE_NODE="${FLY_APP_NAME}-${FLY_IMAGE_REF##*-}@${FLY_PRIVATE_IP}"
+  # configure node for distributed erlang with IPV6 support
+  export ERL_AFLAGS="-proto_dist inet6_tcp"
+  export ECTO_IPV6="true"
+fi
+
 export RELEASE_DISTRIBUTION="name"
-export RELEASE_NODE="${FLY_APP_NAME}-${FLY_IMAGE_REF##*-}@${FLY_PRIVATE_IP}"
 
 # Uncomment to send crash dumps to stderr
 # This can be useful for debugging, but may log sensitive information
 # export ERL_CRASH_DUMP=/dev/stderr
 # export ERL_CRASH_DUMP_BYTES=4096
+
+# when not running on fly.io, use a sensible default
+export RELEASE_NODE=${RELEASE_NODE:-<%= @release.name %>@$(hostname)}
 `
 	_, err := os.Stat(envEExPath)
 	if os.IsNotExist(err) {


### PR DESCRIPTION
### Change Summary

What and Why:

**Problem**: 

- when launching a fresh phoenix app that wasn't yet deployed in docker, sensible default files are generated
- the defaults are valid for fly.io but e.g. not for local docker compose set up, where there's no `ipv6`
- trying to get (auto-)clustering right might frustrate users with phoenix and elixir. Since developer happiness is writ large, this frustration might be averted
- I've fixed this before but forgot I did &rarr; re-work, same debugging session

How:

- generate a sensible `env.sh.eex` that will work both with `libcluster` in `docker compose` and on fly.io

Related to:

- there are some defaults generated by phx.new that could be improved (will gladly follow up with the worked out patterns)

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
