### PR TITLE
MCP wrap/proxy refactor and improvements

### DIFF
--- a/internal/command/mcp/proxy/passthru.go
+++ b/internal/command/mcp/proxy/passthru.go
@@ -1,0 +1,215 @@
+package mcpProxy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+func Passthru(ctx context.Context, proxyInfo ProxyInfo) error {
+	err := waitForServer(proxyInfo)
+	if err != nil {
+		return fmt.Errorf("error waiting for server: %w", err)
+	}
+
+	// Store whether the SSE connection is ready
+	// This may become unready if the connection is closed
+	ready := false
+	readyMutex := sync.Mutex{}
+	readyCond := sync.NewCond(&readyMutex)
+
+	// Start the HTTP client
+	go func() {
+		start := time.Now()
+		for {
+			getFromServer(proxyInfo, &ready, readyCond)
+
+			// Ready should be set to false when the connection is closed
+			readyCond.L.Lock()
+			ready = false
+			readyCond.Broadcast()
+			readyCond.L.Unlock()
+
+			// Wait a minimum of 10 seconds before the next request
+			elapsed := time.Since(start)
+			if elapsed < 10*time.Second {
+				time.Sleep(10*time.Second - elapsed)
+			}
+			start = time.Now()
+		}
+	}()
+
+	// Start processing stdin
+	if err := processStdin(proxyInfo, &ready, readyCond); err != nil {
+		return fmt.Errorf("error processing stdin: %w", err)
+	}
+
+	return nil
+}
+
+// waitForServer waits for the server to be up and running
+func waitForServer(proxyInfo ProxyInfo) error {
+	// Continue to post nothing until the server is up
+	delay := 100 * time.Millisecond
+	var err error
+	for delay < 60*time.Second {
+		err = sendToServer("", proxyInfo)
+
+		if err == nil {
+			break
+		} else if !strings.Contains(err.Error(), "connection refused") {
+			log.Printf("Error sending message to server: %v", err)
+			break
+		}
+
+		time.Sleep(delay)
+		delay *= 2
+	}
+
+	return err
+}
+
+// ProcessStdin reads messages from stdin and forwards them to the server
+func processStdin(proxyInfo ProxyInfo, ready *bool, readyCond *sync.Cond) error {
+	stp := make(chan os.Signal, 1)
+	signal.Notify(stp, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-stp
+		os.Exit(0)
+	}()
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Text() + "\n"
+
+		// Skip empty lines
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		// Wait for the server to be ready
+		readyCond.L.Lock()
+		for !*ready {
+			readyCond.Wait()
+		}
+		readyCond.L.Unlock()
+
+		// Forward raw message to server
+		err := sendToServer(line, proxyInfo)
+		if err != nil {
+			// Log error but continue processing
+			log.Printf("Error sending message to server: %v", err)
+			// We could format an error message here, but since we're operating at the raw string level,
+			// we'll return a generic error JSON
+			errMsg := fmt.Sprintf(`{"type":"error","content":"Failed to send to server: %v"}`, err)
+			fmt.Fprintln(os.Stdout, errMsg)
+			continue
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading from stdin: %w", err)
+	}
+
+	return nil
+}
+
+// getFromServer sends a GET request to the server and streams the response to stdout
+func getFromServer(proxyInfo ProxyInfo, ready *bool, readyCond *sync.Cond) error {
+	// Create HTTP request
+	req, err := http.NewRequest("GET", proxyInfo.Url, nil)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("User-Agent", "mcp-bridge-client")
+	req.Header.Set("Accept", "application/json")
+
+	// Set basic authentication if bearer token or user is provided
+	if proxyInfo.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+proxyInfo.BearerToken)
+	} else if proxyInfo.User != "" {
+		req.SetBasicAuth(proxyInfo.User, proxyInfo.Password)
+	}
+
+	// Send request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("server returned error: %s (status %d)", resp.Status, resp.StatusCode)
+	}
+
+	// We're now ready to receive messages
+	readyCond.L.Lock()
+	*ready = true
+	readyCond.Broadcast()
+	readyCond.L.Unlock()
+
+	// Stream response body to stdout
+	if _, err := io.Copy(os.Stdout, resp.Body); err != nil {
+		return fmt.Errorf("error streaming response to stdout: %w", err)
+	}
+
+	return nil
+}
+
+// SendToServer sends a raw message to the server and returns the raw response
+func sendToServer(message string, proxyInfo ProxyInfo) error {
+	// Create HTTP request with raw message
+	req, err := http.NewRequest("POST", proxyInfo.Url, bytes.NewBufferString(message))
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "mcp-bridge-client")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	// Set basic authentication if bearer token or user is provided
+	if proxyInfo.BearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+proxyInfo.BearerToken)
+	} else if proxyInfo.User != "" {
+		req.SetBasicAuth(proxyInfo.User, proxyInfo.Password)
+	}
+
+	// If requesting a specific instance, set the header
+	if proxyInfo.Instance != "" {
+		req.Header.Set("Fly-Force-Instance-Id", proxyInfo.Instance)
+	}
+
+	// Send request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode != http.StatusAccepted {
+		// Read response body
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("error reading response: %w", err)
+		}
+
+		return fmt.Errorf("server returned error: %s (status %d)", body, resp.StatusCode)
+	}
+
+	// Request was accepted
+	return nil
+}

--- a/internal/command/mcp/proxy/types.go
+++ b/internal/command/mcp/proxy/types.go
@@ -1,0 +1,9 @@
+package mcpProxy
+
+type ProxyInfo struct {
+	Url         string
+	BearerToken string
+	User        string
+	Password    string
+	Instance    string
+}

--- a/internal/command/mcp/wrap.go
+++ b/internal/command/mcp/wrap.go
@@ -286,6 +286,20 @@ func (s *Server) HandleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// Create channel for response
+		responseCh := make(chan string, 1)
+		s.mutex.Lock()
+		if s.client == nil {
+			s.client = responseCh
+		}
+		s.mutex.Unlock()
+
+		if s.client != responseCh {
+			// If we already have a client, return an error
+			http.Error(w, "Another client is already connected", http.StatusConflict)
+			return
+		}
+
 		// Set headers for SSE
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")
@@ -293,12 +307,6 @@ func (s *Server) HandleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 
 		w.(http.Flusher).Flush() // Flush headers to the client
-
-		// Create channel for response
-		responseCh := make(chan string, 1)
-		s.mutex.Lock()
-		s.client = responseCh
-		s.mutex.Unlock()
 
 		// Stream responses to the client
 		for {
@@ -316,15 +324,43 @@ func (s *Server) HandleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 		}
 
 	} else if r.Method == http.MethodPost {
-		// Stream request body to program's stdin
-		if _, err := io.Copy(s.stdin, r.Body); err != nil {
-			log.Printf("Error writing to program: %v", err)
-			http.Error(w, fmt.Sprintf("Error writing to program: %v", err), http.StatusInternalServerError)
-		} else {
-			// Successfully wrote to program
-			w.WriteHeader(http.StatusAccepted)
+		// Stream request body to program's stdin, but inspect the last byte
+		var lastByte byte
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Body.Read(buf)
+			if n > 0 {
+				lastByte = buf[n-1]
+				if _, werr := s.stdin.Write(buf[:n]); werr != nil {
+					log.Printf("Error writing to program: %v", werr)
+					http.Error(w, fmt.Sprintf("Error writing to program: %v", werr), http.StatusInternalServerError)
+					return
+				}
+			}
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				log.Printf("Error reading request body: %v", err)
+				http.Error(w, fmt.Sprintf("Error reading request body: %v", err), http.StatusBadRequest)
+				return
+			}
 		}
-		defer r.Body.Close()
+
+		// Ensure the last byte is a newline
+		if lastByte != '\n' {
+			s.stdin.Write([]byte{'\n'})
+		}
+
+		if f, ok := s.stdin.(interface{ Flush() error }); ok {
+			if err := f.Flush(); err != nil {
+				log.Printf("Error flushing stdin: %v", err)
+			}
+		}
+
+		// Successfully wrote to program
+		w.WriteHeader(http.StatusAccepted)
+		r.Body.Close()
 
 	} else {
 		// Method not allowed


### PR DESCRIPTION
Proxy:
  - support --instance to specify target machine
  - if url resolves, don't create a wireguard proxy
  - move passthru support to a separate file (prep for supporting replay)

Wrap:
  - produce an error when there is an attempt to connect a second get
  - ensure last byte is a newline on POST