### PR TITLE
remove unreachable return

### DIFF
--- a/ssh/terminal_windows.go
+++ b/ssh/terminal_windows.go
@@ -65,8 +65,6 @@ func watchWindowSize(ctx context.Context, fd windows.Handle, sess *ssh.Session, 
 			return err
 		}
 	}
-
-	return nil
 }
 
 func getConsoleSize(fd windows.Handle) (int, int, error) {


### PR DESCRIPTION
### Change Summary

What and Why:

Remove Unreachable `return` statement

How:

By deleting the line
