### PR TITLE
Increase scanner buffer size to support MCP responses up to 10MB

### DIFF
--- a/internal/command/mcp/wrap.go
+++ b/internal/command/mcp/wrap.go
@@ -219,6 +219,11 @@ func (s *Server) ReadFromProgram() {
 	}()
 
 	scanner := bufio.NewScanner(s.stdout)
+	const (
+		defaultBufSize  = bufio.MaxScanTokenSize // 64KiB
+		maxResponseSize = 10 * 1024 * 1024       // 10MiB
+	)
+	scanner.Buffer(make([]byte, 0, defaultBufSize), maxResponseSize)
 	for scanner.Scan() {
 		line := scanner.Text() + "\n"
 


### PR DESCRIPTION
### Change Summary

What and Why:

I've been getting errors such as this when making calls to a server created by `mcp wrap`:

```
2025/05/28 17:17:45 Error reading from program: bufio.Scanner: token too long
```

Scanner buffer's default limit is only 64KiB, which is way too little for many MCP responses.

How:

Increase the buffer size to 10MiB by calling `scanner.Buffer` and setting the limit.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a (bug fix)
