### PR TITLE
Update `PlatformMap` so Sentry extensions for Shopify apps work correctly

### DIFF
--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -670,5 +670,5 @@ var PlatformMap = map[string]string{
 	"Remix":         "javascript-remix",
 	"Remix/Prisma":  "javascript-remix",
 	"Ruby":          "ruby",
-	"Shopify":       "javascript-shopify",
+	"Shopify":       "javascript",
 }


### PR DESCRIPTION
### Change Summary

What and Why:
- Updated the Shopify property in `PlatformMap` to point to `javascript` rather than `javascript-shopify`, because `javascript-shopify` isn't a valid Sentry Platform.

Related to:
- See user ticket [here](https://app.plain.com/workspace/w_01J30S94JDD57QXMT9Q47J928E/thread/th_01JW89PCKA0ZH0V9SPH2PWGCXG/?q=sentry).
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
