### PR TITLE
Fix `fly launch --yes` so that it overwrites the deploy file without a prompt

### DIFF
--- a/internal/command/launch/launch_frameworks.go
+++ b/internal/command/launch/launch_frameworks.go
@@ -115,9 +115,13 @@ func (state *launchState) scannerCreateFiles(ctx context.Context) error {
 				fmt.Fprintf(io.Out, "You specified --now, so not overwriting %s\n", path)
 				continue
 			}
-			confirm, err := prompt.ConfirmOverwrite(ctx, path)
-			if !confirm || err != nil {
-				continue
+			if !flag.GetBool(ctx, "yes") {
+				confirm, err := prompt.ConfirmOverwrite(ctx, path)
+				if !confirm || err != nil {
+					continue
+				}
+			} else {
+				fmt.Fprintf(io.Out, "You specified --yes, overwriting %s\n", path)
 			}
 		}
 


### PR DESCRIPTION
### Change Summary

What and Why:
- Even with the `--yes` flag specified, the user would still get prompted whether they wanted to overwrite their GitHub Actions Fly deploy workflow. With `--yes`, `fly launch` should just go ahead and overwrite this file without user input.

Related to:
- See the customer support ticket [here](https://app.plain.com/workspace/w_01J30S94JDD57QXMT9Q47J928E/thread/th_01JSM7TN0V3WH6HM5AMPXP0VV4/).

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
