### PR TITLE
Shift mpg proxy to only listen on localhost

### DIFF
--- a/internal/command/mpg/proxy.go
+++ b/internal/command/mpg/proxy.go
@@ -107,6 +107,7 @@ func getMpgProxyParams(ctx context.Context, localProxyPort string) (*uiex.Manage
 		Ports:            []string{localProxyPort, "5432"},
 		OrganizationSlug: org.Slug,
 		Dialer:           dialer,
+		BindAddr:         "localhost",
 		RemoteHost:       cluster.IpAssignments.Direct,
 	}, response.Credentials.Password, nil
 }


### PR DESCRIPTION
### Change Summary

What and Why: Specify that `mpg connect` should only bind to loopback interface vs. all interfaces

How: Specify`BindAddr` in the proxy.ConnectParams 

Related to: Infosec recommendation (sev:low)

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
