### PR TITLE
Add region back to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,4 +38,6 @@ jobs:
   preflight:
     needs: test_build
     uses: ./.github/workflows/preflight.yml
+    with:
+      region: ord
     secrets: inherit


### PR DESCRIPTION
Fix failing mount tests

### Change Summary

What and Why: FLY_PREFLIGHT_TEST_FLY_REGIONS default to iad but region defaults to ord

How: Add back region

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
