### PR TITLE
Handle org flag for storage list

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -2664,92 +2664,101 @@ func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) __premarshalJSON() (*__prema
 	return &retval, nil
 }
 
-// ListAddOnsForOrganizationOrganization includes the requested fields of the GraphQL type Organization.
-type ListAddOnsForOrganizationOrganization struct {
-	// List third party integrations associated with an organization
-	AddOns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnection `json:"addOns"`
+// ListAddOnsResponse is returned by ListAddOns on success.
+type ListAddOnsResponse struct {
+	// List add-ons associated with an organization
+	AddOns ListAddOnsAddOnsAddOnConnection `json:"addOns"`
 }
 
-// GetAddOns returns ListAddOnsForOrganizationOrganization.AddOns, and is useful for accessing the field via an interface.
-func (v *ListAddOnsForOrganizationOrganization) GetAddOns() ListAddOnsForOrganizationOrganizationAddOnsAddOnConnection {
+// GetAddOns returns ListAddOnsResponse.AddOns, and is useful for accessing the field via an interface.
+func (v *ListAddOnsResponse) GetAddOns() ListAddOnsAddOnsAddOnConnection { return v.AddOns }
+
+// ListOrganizationAddOnsOrganization includes the requested fields of the GraphQL type Organization.
+type ListOrganizationAddOnsOrganization struct {
+	// List third party integrations associated with an organization
+	AddOns ListOrganizationAddOnsOrganizationAddOnsAddOnConnection `json:"addOns"`
+}
+
+// GetAddOns returns ListOrganizationAddOnsOrganization.AddOns, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganization) GetAddOns() ListOrganizationAddOnsOrganizationAddOnsAddOnConnection {
 	return v.AddOns
 }
 
-// ListAddOnsForOrganizationOrganizationAddOnsAddOnConnection includes the requested fields of the GraphQL type AddOnConnection.
+// ListOrganizationAddOnsOrganizationAddOnsAddOnConnection includes the requested fields of the GraphQL type AddOnConnection.
 // The GraphQL type's documentation follows.
 //
 // The connection type for AddOn.
-type ListAddOnsForOrganizationOrganizationAddOnsAddOnConnection struct {
+type ListOrganizationAddOnsOrganizationAddOnsAddOnConnection struct {
 	// A list of nodes.
-	Nodes []ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn `json:"nodes"`
+	Nodes []ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn `json:"nodes"`
 }
 
-// GetNodes returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnection.Nodes, and is useful for accessing the field via an interface.
-func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnection) GetNodes() []ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn {
+// GetNodes returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnection) GetNodes() []ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn {
 	return v.Nodes
 }
 
-// ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn includes the requested fields of the GraphQL type AddOn.
-type ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn struct {
+// ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn includes the requested fields of the GraphQL type AddOn.
+type ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn struct {
 	ListAddOnData `json:"-"`
 }
 
-// GetId returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.Id, and is useful for accessing the field via an interface.
-func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetId() string {
+// GetId returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Id, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetId() string {
 	return v.ListAddOnData.Id
 }
 
-// GetName returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.Name, and is useful for accessing the field via an interface.
-func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetName() string {
+// GetName returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Name, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetName() string {
 	return v.ListAddOnData.Name
 }
 
-// GetAddOnPlan returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.AddOnPlan, and is useful for accessing the field via an interface.
-func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetAddOnPlan() ListAddOnDataAddOnPlan {
+// GetAddOnPlan returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.AddOnPlan, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetAddOnPlan() ListAddOnDataAddOnPlan {
 	return v.ListAddOnData.AddOnPlan
 }
 
-// GetPrivateIp returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.PrivateIp, and is useful for accessing the field via an interface.
-func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetPrivateIp() string {
+// GetPrivateIp returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.PrivateIp, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetPrivateIp() string {
 	return v.ListAddOnData.PrivateIp
 }
 
-// GetPrimaryRegion returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.PrimaryRegion, and is useful for accessing the field via an interface.
-func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetPrimaryRegion() string {
+// GetPrimaryRegion returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.PrimaryRegion, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetPrimaryRegion() string {
 	return v.ListAddOnData.PrimaryRegion
 }
 
-// GetReadRegions returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.ReadRegions, and is useful for accessing the field via an interface.
-func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetReadRegions() []string {
+// GetReadRegions returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.ReadRegions, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetReadRegions() []string {
 	return v.ListAddOnData.ReadRegions
 }
 
-// GetOptions returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.Options, and is useful for accessing the field via an interface.
-func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetOptions() interface{} {
+// GetOptions returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Options, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetOptions() interface{} {
 	return v.ListAddOnData.Options
 }
 
-// GetMetadata returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.Metadata, and is useful for accessing the field via an interface.
-func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetMetadata() interface{} {
+// GetMetadata returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Metadata, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetMetadata() interface{} {
 	return v.ListAddOnData.Metadata
 }
 
-// GetOrganization returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.Organization, and is useful for accessing the field via an interface.
-func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetOrganization() ListAddOnDataOrganization {
+// GetOrganization returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Organization, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetOrganization() ListAddOnDataOrganization {
 	return v.ListAddOnData.Organization
 }
 
-func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) UnmarshalJSON(b []byte) error {
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
 		return nil
 	}
 
 	var firstPass struct {
-		*ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn
+		*ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn
 		graphql.NoUnmarshalJSON
 	}
-	firstPass.ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn = v
+	firstPass.ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn = v
 
 	err := json.Unmarshal(b, &firstPass)
 	if err != nil {
@@ -2764,7 +2773,7 @@ func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) U
 	return nil
 }
 
-type __premarshalListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn struct {
+type __premarshalListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn struct {
 	Id string `json:"id"`
 
 	Name string `json:"name"`
@@ -2784,7 +2793,7 @@ type __premarshalListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodes
 	Organization ListAddOnDataOrganization `json:"organization"`
 }
 
-func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) MarshalJSON() ([]byte, error) {
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) MarshalJSON() ([]byte, error) {
 	premarshaled, err := v.__premarshalJSON()
 	if err != nil {
 		return nil, err
@@ -2792,8 +2801,8 @@ func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) M
 	return json.Marshal(premarshaled)
 }
 
-func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) __premarshalJSON() (*__premarshalListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn, error) {
-	var retval __premarshalListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) __premarshalJSON() (*__premarshalListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn, error) {
+	var retval __premarshalListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn
 
 	retval.Id = v.ListAddOnData.Id
 	retval.Name = v.ListAddOnData.Name
@@ -2807,25 +2816,16 @@ func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) _
 	return &retval, nil
 }
 
-// ListAddOnsForOrganizationResponse is returned by ListAddOnsForOrganization on success.
-type ListAddOnsForOrganizationResponse struct {
+// ListOrganizationAddOnsResponse is returned by ListOrganizationAddOns on success.
+type ListOrganizationAddOnsResponse struct {
 	// Find an organization by ID
-	Organization ListAddOnsForOrganizationOrganization `json:"organization"`
+	Organization ListOrganizationAddOnsOrganization `json:"organization"`
 }
 
-// GetOrganization returns ListAddOnsForOrganizationResponse.Organization, and is useful for accessing the field via an interface.
-func (v *ListAddOnsForOrganizationResponse) GetOrganization() ListAddOnsForOrganizationOrganization {
+// GetOrganization returns ListOrganizationAddOnsResponse.Organization, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsResponse) GetOrganization() ListOrganizationAddOnsOrganization {
 	return v.Organization
 }
-
-// ListAddOnsResponse is returned by ListAddOns on success.
-type ListAddOnsResponse struct {
-	// List add-ons associated with an organization
-	AddOns ListAddOnsAddOnsAddOnConnection `json:"addOns"`
-}
-
-// GetAddOns returns ListAddOnsResponse.AddOns, and is useful for accessing the field via an interface.
-func (v *ListAddOnsResponse) GetAddOns() ListAddOnsAddOnsAddOnConnection { return v.AddOns }
 
 // LogOutLogOutLogOutPayload includes the requested fields of the GraphQL type LogOutPayload.
 // The GraphQL type's documentation follows.
@@ -3355,18 +3355,6 @@ type __ListAddOnPlansInput struct {
 // GetAddOnType returns __ListAddOnPlansInput.AddOnType, and is useful for accessing the field via an interface.
 func (v *__ListAddOnPlansInput) GetAddOnType() AddOnType { return v.AddOnType }
 
-// __ListAddOnsForOrganizationInput is used internally by genqlient
-type __ListAddOnsForOrganizationInput struct {
-	AddOnType      AddOnType `json:"addOnType"`
-	OrganizationId string    `json:"organizationId"`
-}
-
-// GetAddOnType returns __ListAddOnsForOrganizationInput.AddOnType, and is useful for accessing the field via an interface.
-func (v *__ListAddOnsForOrganizationInput) GetAddOnType() AddOnType { return v.AddOnType }
-
-// GetOrganizationId returns __ListAddOnsForOrganizationInput.OrganizationId, and is useful for accessing the field via an interface.
-func (v *__ListAddOnsForOrganizationInput) GetOrganizationId() string { return v.OrganizationId }
-
 // __ListAddOnsInput is used internally by genqlient
 type __ListAddOnsInput struct {
 	AddOnType AddOnType `json:"addOnType"`
@@ -3374,6 +3362,18 @@ type __ListAddOnsInput struct {
 
 // GetAddOnType returns __ListAddOnsInput.AddOnType, and is useful for accessing the field via an interface.
 func (v *__ListAddOnsInput) GetAddOnType() AddOnType { return v.AddOnType }
+
+// __ListOrganizationAddOnsInput is used internally by genqlient
+type __ListOrganizationAddOnsInput struct {
+	OrganizationId string    `json:"organizationId"`
+	AddOnType      AddOnType `json:"addOnType"`
+}
+
+// GetOrganizationId returns __ListOrganizationAddOnsInput.OrganizationId, and is useful for accessing the field via an interface.
+func (v *__ListOrganizationAddOnsInput) GetOrganizationId() string { return v.OrganizationId }
+
+// GetAddOnType returns __ListOrganizationAddOnsInput.AddOnType, and is useful for accessing the field via an interface.
+func (v *__ListOrganizationAddOnsInput) GetAddOnType() AddOnType { return v.AddOnType }
 
 // __ResetAddOnPasswordInput is used internally by genqlient
 type __ResetAddOnPasswordInput struct {
@@ -4400,9 +4400,9 @@ func ListAddOns(
 	return data_, err_
 }
 
-// The query executed by ListAddOnsForOrganization.
-const ListAddOnsForOrganization_Operation = `
-query ListAddOnsForOrganization ($addOnType: AddOnType, $organizationId: ID!) {
+// The query executed by ListOrganizationAddOns.
+const ListOrganizationAddOns_Operation = `
+query ListOrganizationAddOns ($organizationId: ID!, $addOnType: AddOnType) {
 	organization(id: $organizationId) {
 		addOns(type: $addOnType) {
 			nodes {
@@ -4430,22 +4430,22 @@ fragment ListAddOnData on AddOn {
 }
 `
 
-func ListAddOnsForOrganization(
+func ListOrganizationAddOns(
 	ctx_ context.Context,
 	client_ graphql.Client,
-	addOnType AddOnType,
 	organizationId string,
-) (data_ *ListAddOnsForOrganizationResponse, err_ error) {
+	addOnType AddOnType,
+) (data_ *ListOrganizationAddOnsResponse, err_ error) {
 	req_ := &graphql.Request{
-		OpName: "ListAddOnsForOrganization",
-		Query:  ListAddOnsForOrganization_Operation,
-		Variables: &__ListAddOnsForOrganizationInput{
-			AddOnType:      addOnType,
+		OpName: "ListOrganizationAddOns",
+		Query:  ListOrganizationAddOns_Operation,
+		Variables: &__ListOrganizationAddOnsInput{
 			OrganizationId: organizationId,
+			AddOnType:      addOnType,
 		},
 	}
 
-	data_ = &ListAddOnsForOrganizationResponse{}
+	data_ = &ListOrganizationAddOnsResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/gql/generated.go
+++ b/gql/generated.go
@@ -2406,6 +2406,79 @@ func (v *GetOrganizationResponse) GetOrganization() GetOrganizationOrganization 
 	return v.Organization
 }
 
+// ListAddOnData includes the GraphQL fields of AddOn requested by the fragment ListAddOnData.
+type ListAddOnData struct {
+	Id string `json:"id"`
+	// The service name according to the provider
+	Name string `json:"name"`
+	// The add-on plan
+	AddOnPlan ListAddOnDataAddOnPlan `json:"addOnPlan"`
+	// Private flycast IP address of the add-on
+	PrivateIp string `json:"privateIp"`
+	// Region where the primary instance is deployed
+	PrimaryRegion string `json:"primaryRegion"`
+	// Regions where replica instances are deployed
+	ReadRegions []string `json:"readRegions"`
+	// Add-on options
+	Options interface{} `json:"options"`
+	// Add-on metadata
+	Metadata interface{} `json:"metadata"`
+	// Organization that owns this service
+	Organization ListAddOnDataOrganization `json:"organization"`
+}
+
+// GetId returns ListAddOnData.Id, and is useful for accessing the field via an interface.
+func (v *ListAddOnData) GetId() string { return v.Id }
+
+// GetName returns ListAddOnData.Name, and is useful for accessing the field via an interface.
+func (v *ListAddOnData) GetName() string { return v.Name }
+
+// GetAddOnPlan returns ListAddOnData.AddOnPlan, and is useful for accessing the field via an interface.
+func (v *ListAddOnData) GetAddOnPlan() ListAddOnDataAddOnPlan { return v.AddOnPlan }
+
+// GetPrivateIp returns ListAddOnData.PrivateIp, and is useful for accessing the field via an interface.
+func (v *ListAddOnData) GetPrivateIp() string { return v.PrivateIp }
+
+// GetPrimaryRegion returns ListAddOnData.PrimaryRegion, and is useful for accessing the field via an interface.
+func (v *ListAddOnData) GetPrimaryRegion() string { return v.PrimaryRegion }
+
+// GetReadRegions returns ListAddOnData.ReadRegions, and is useful for accessing the field via an interface.
+func (v *ListAddOnData) GetReadRegions() []string { return v.ReadRegions }
+
+// GetOptions returns ListAddOnData.Options, and is useful for accessing the field via an interface.
+func (v *ListAddOnData) GetOptions() interface{} { return v.Options }
+
+// GetMetadata returns ListAddOnData.Metadata, and is useful for accessing the field via an interface.
+func (v *ListAddOnData) GetMetadata() interface{} { return v.Metadata }
+
+// GetOrganization returns ListAddOnData.Organization, and is useful for accessing the field via an interface.
+func (v *ListAddOnData) GetOrganization() ListAddOnDataOrganization { return v.Organization }
+
+// ListAddOnDataAddOnPlan includes the requested fields of the GraphQL type AddOnPlan.
+type ListAddOnDataAddOnPlan struct {
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+}
+
+// GetDisplayName returns ListAddOnDataAddOnPlan.DisplayName, and is useful for accessing the field via an interface.
+func (v *ListAddOnDataAddOnPlan) GetDisplayName() string { return v.DisplayName }
+
+// GetDescription returns ListAddOnDataAddOnPlan.Description, and is useful for accessing the field via an interface.
+func (v *ListAddOnDataAddOnPlan) GetDescription() string { return v.Description }
+
+// ListAddOnDataOrganization includes the requested fields of the GraphQL type Organization.
+type ListAddOnDataOrganization struct {
+	Id string `json:"id"`
+	// Unique organization slug
+	Slug string `json:"slug"`
+}
+
+// GetId returns ListAddOnDataOrganization.Id, and is useful for accessing the field via an interface.
+func (v *ListAddOnDataOrganization) GetId() string { return v.Id }
+
+// GetSlug returns ListAddOnDataOrganization.Slug, and is useful for accessing the field via an interface.
+func (v *ListAddOnDataOrganization) GetSlug() string { return v.Slug }
+
 // ListAddOnPlansAddOnPlansAddOnPlanConnection includes the requested fields of the GraphQL type AddOnPlanConnection.
 // The GraphQL type's documentation follows.
 //
@@ -2479,84 +2552,271 @@ func (v *ListAddOnsAddOnsAddOnConnection) GetNodes() []ListAddOnsAddOnsAddOnConn
 
 // ListAddOnsAddOnsAddOnConnectionNodesAddOn includes the requested fields of the GraphQL type AddOn.
 type ListAddOnsAddOnsAddOnConnectionNodesAddOn struct {
-	Id string `json:"id"`
-	// The service name according to the provider
-	Name string `json:"name"`
-	// The add-on plan
-	AddOnPlan ListAddOnsAddOnsAddOnConnectionNodesAddOnAddOnPlan `json:"addOnPlan"`
-	// Private flycast IP address of the add-on
-	PrivateIp string `json:"privateIp"`
-	// Region where the primary instance is deployed
-	PrimaryRegion string `json:"primaryRegion"`
-	// Regions where replica instances are deployed
-	ReadRegions []string `json:"readRegions"`
-	// Add-on options
-	Options interface{} `json:"options"`
-	// Add-on metadata
-	Metadata interface{} `json:"metadata"`
-	// Organization that owns this service
-	Organization ListAddOnsAddOnsAddOnConnectionNodesAddOnOrganization `json:"organization"`
+	ListAddOnData `json:"-"`
 }
 
 // GetId returns ListAddOnsAddOnsAddOnConnectionNodesAddOn.Id, and is useful for accessing the field via an interface.
-func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetId() string { return v.Id }
+func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetId() string { return v.ListAddOnData.Id }
 
 // GetName returns ListAddOnsAddOnsAddOnConnectionNodesAddOn.Name, and is useful for accessing the field via an interface.
-func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetName() string { return v.Name }
+func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetName() string { return v.ListAddOnData.Name }
 
 // GetAddOnPlan returns ListAddOnsAddOnsAddOnConnectionNodesAddOn.AddOnPlan, and is useful for accessing the field via an interface.
-func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetAddOnPlan() ListAddOnsAddOnsAddOnConnectionNodesAddOnAddOnPlan {
-	return v.AddOnPlan
+func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetAddOnPlan() ListAddOnDataAddOnPlan {
+	return v.ListAddOnData.AddOnPlan
 }
 
 // GetPrivateIp returns ListAddOnsAddOnsAddOnConnectionNodesAddOn.PrivateIp, and is useful for accessing the field via an interface.
-func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetPrivateIp() string { return v.PrivateIp }
+func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetPrivateIp() string {
+	return v.ListAddOnData.PrivateIp
+}
 
 // GetPrimaryRegion returns ListAddOnsAddOnsAddOnConnectionNodesAddOn.PrimaryRegion, and is useful for accessing the field via an interface.
-func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetPrimaryRegion() string { return v.PrimaryRegion }
+func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetPrimaryRegion() string {
+	return v.ListAddOnData.PrimaryRegion
+}
 
 // GetReadRegions returns ListAddOnsAddOnsAddOnConnectionNodesAddOn.ReadRegions, and is useful for accessing the field via an interface.
-func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetReadRegions() []string { return v.ReadRegions }
+func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetReadRegions() []string {
+	return v.ListAddOnData.ReadRegions
+}
 
 // GetOptions returns ListAddOnsAddOnsAddOnConnectionNodesAddOn.Options, and is useful for accessing the field via an interface.
-func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetOptions() interface{} { return v.Options }
+func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetOptions() interface{} {
+	return v.ListAddOnData.Options
+}
 
 // GetMetadata returns ListAddOnsAddOnsAddOnConnectionNodesAddOn.Metadata, and is useful for accessing the field via an interface.
-func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetMetadata() interface{} { return v.Metadata }
+func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetMetadata() interface{} {
+	return v.ListAddOnData.Metadata
+}
 
 // GetOrganization returns ListAddOnsAddOnsAddOnConnectionNodesAddOn.Organization, and is useful for accessing the field via an interface.
-func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetOrganization() ListAddOnsAddOnsAddOnConnectionNodesAddOnOrganization {
+func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) GetOrganization() ListAddOnDataOrganization {
+	return v.ListAddOnData.Organization
+}
+
+func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*ListAddOnsAddOnsAddOnConnectionNodesAddOn
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.ListAddOnsAddOnsAddOnConnectionNodesAddOn = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.ListAddOnData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalListAddOnsAddOnsAddOnConnectionNodesAddOn struct {
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	AddOnPlan ListAddOnDataAddOnPlan `json:"addOnPlan"`
+
+	PrivateIp string `json:"privateIp"`
+
+	PrimaryRegion string `json:"primaryRegion"`
+
+	ReadRegions []string `json:"readRegions"`
+
+	Options interface{} `json:"options"`
+
+	Metadata interface{} `json:"metadata"`
+
+	Organization ListAddOnDataOrganization `json:"organization"`
+}
+
+func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOn) __premarshalJSON() (*__premarshalListAddOnsAddOnsAddOnConnectionNodesAddOn, error) {
+	var retval __premarshalListAddOnsAddOnsAddOnConnectionNodesAddOn
+
+	retval.Id = v.ListAddOnData.Id
+	retval.Name = v.ListAddOnData.Name
+	retval.AddOnPlan = v.ListAddOnData.AddOnPlan
+	retval.PrivateIp = v.ListAddOnData.PrivateIp
+	retval.PrimaryRegion = v.ListAddOnData.PrimaryRegion
+	retval.ReadRegions = v.ListAddOnData.ReadRegions
+	retval.Options = v.ListAddOnData.Options
+	retval.Metadata = v.ListAddOnData.Metadata
+	retval.Organization = v.ListAddOnData.Organization
+	return &retval, nil
+}
+
+// ListAddOnsForOrganizationOrganization includes the requested fields of the GraphQL type Organization.
+type ListAddOnsForOrganizationOrganization struct {
+	// List third party integrations associated with an organization
+	AddOns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnection `json:"addOns"`
+}
+
+// GetAddOns returns ListAddOnsForOrganizationOrganization.AddOns, and is useful for accessing the field via an interface.
+func (v *ListAddOnsForOrganizationOrganization) GetAddOns() ListAddOnsForOrganizationOrganizationAddOnsAddOnConnection {
+	return v.AddOns
+}
+
+// ListAddOnsForOrganizationOrganizationAddOnsAddOnConnection includes the requested fields of the GraphQL type AddOnConnection.
+// The GraphQL type's documentation follows.
+//
+// The connection type for AddOn.
+type ListAddOnsForOrganizationOrganizationAddOnsAddOnConnection struct {
+	// A list of nodes.
+	Nodes []ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn `json:"nodes"`
+}
+
+// GetNodes returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnection) GetNodes() []ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn {
+	return v.Nodes
+}
+
+// ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn includes the requested fields of the GraphQL type AddOn.
+type ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn struct {
+	ListAddOnData `json:"-"`
+}
+
+// GetId returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.Id, and is useful for accessing the field via an interface.
+func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetId() string {
+	return v.ListAddOnData.Id
+}
+
+// GetName returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.Name, and is useful for accessing the field via an interface.
+func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetName() string {
+	return v.ListAddOnData.Name
+}
+
+// GetAddOnPlan returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.AddOnPlan, and is useful for accessing the field via an interface.
+func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetAddOnPlan() ListAddOnDataAddOnPlan {
+	return v.ListAddOnData.AddOnPlan
+}
+
+// GetPrivateIp returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.PrivateIp, and is useful for accessing the field via an interface.
+func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetPrivateIp() string {
+	return v.ListAddOnData.PrivateIp
+}
+
+// GetPrimaryRegion returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.PrimaryRegion, and is useful for accessing the field via an interface.
+func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetPrimaryRegion() string {
+	return v.ListAddOnData.PrimaryRegion
+}
+
+// GetReadRegions returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.ReadRegions, and is useful for accessing the field via an interface.
+func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetReadRegions() []string {
+	return v.ListAddOnData.ReadRegions
+}
+
+// GetOptions returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.Options, and is useful for accessing the field via an interface.
+func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetOptions() interface{} {
+	return v.ListAddOnData.Options
+}
+
+// GetMetadata returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.Metadata, and is useful for accessing the field via an interface.
+func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetMetadata() interface{} {
+	return v.ListAddOnData.Metadata
+}
+
+// GetOrganization returns ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn.Organization, and is useful for accessing the field via an interface.
+func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) GetOrganization() ListAddOnDataOrganization {
+	return v.ListAddOnData.Organization
+}
+
+func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.ListAddOnData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn struct {
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	AddOnPlan ListAddOnDataAddOnPlan `json:"addOnPlan"`
+
+	PrivateIp string `json:"privateIp"`
+
+	PrimaryRegion string `json:"primaryRegion"`
+
+	ReadRegions []string `json:"readRegions"`
+
+	Options interface{} `json:"options"`
+
+	Metadata interface{} `json:"metadata"`
+
+	Organization ListAddOnDataOrganization `json:"organization"`
+}
+
+func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *ListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn) __premarshalJSON() (*__premarshalListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn, error) {
+	var retval __premarshalListAddOnsForOrganizationOrganizationAddOnsAddOnConnectionNodesAddOn
+
+	retval.Id = v.ListAddOnData.Id
+	retval.Name = v.ListAddOnData.Name
+	retval.AddOnPlan = v.ListAddOnData.AddOnPlan
+	retval.PrivateIp = v.ListAddOnData.PrivateIp
+	retval.PrimaryRegion = v.ListAddOnData.PrimaryRegion
+	retval.ReadRegions = v.ListAddOnData.ReadRegions
+	retval.Options = v.ListAddOnData.Options
+	retval.Metadata = v.ListAddOnData.Metadata
+	retval.Organization = v.ListAddOnData.Organization
+	return &retval, nil
+}
+
+// ListAddOnsForOrganizationResponse is returned by ListAddOnsForOrganization on success.
+type ListAddOnsForOrganizationResponse struct {
+	// Find an organization by ID
+	Organization ListAddOnsForOrganizationOrganization `json:"organization"`
+}
+
+// GetOrganization returns ListAddOnsForOrganizationResponse.Organization, and is useful for accessing the field via an interface.
+func (v *ListAddOnsForOrganizationResponse) GetOrganization() ListAddOnsForOrganizationOrganization {
 	return v.Organization
 }
-
-// ListAddOnsAddOnsAddOnConnectionNodesAddOnAddOnPlan includes the requested fields of the GraphQL type AddOnPlan.
-type ListAddOnsAddOnsAddOnConnectionNodesAddOnAddOnPlan struct {
-	DisplayName string `json:"displayName"`
-	Description string `json:"description"`
-}
-
-// GetDisplayName returns ListAddOnsAddOnsAddOnConnectionNodesAddOnAddOnPlan.DisplayName, and is useful for accessing the field via an interface.
-func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOnAddOnPlan) GetDisplayName() string {
-	return v.DisplayName
-}
-
-// GetDescription returns ListAddOnsAddOnsAddOnConnectionNodesAddOnAddOnPlan.Description, and is useful for accessing the field via an interface.
-func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOnAddOnPlan) GetDescription() string {
-	return v.Description
-}
-
-// ListAddOnsAddOnsAddOnConnectionNodesAddOnOrganization includes the requested fields of the GraphQL type Organization.
-type ListAddOnsAddOnsAddOnConnectionNodesAddOnOrganization struct {
-	Id string `json:"id"`
-	// Unique organization slug
-	Slug string `json:"slug"`
-}
-
-// GetId returns ListAddOnsAddOnsAddOnConnectionNodesAddOnOrganization.Id, and is useful for accessing the field via an interface.
-func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOnOrganization) GetId() string { return v.Id }
-
-// GetSlug returns ListAddOnsAddOnsAddOnConnectionNodesAddOnOrganization.Slug, and is useful for accessing the field via an interface.
-func (v *ListAddOnsAddOnsAddOnConnectionNodesAddOnOrganization) GetSlug() string { return v.Slug }
 
 // ListAddOnsResponse is returned by ListAddOns on success.
 type ListAddOnsResponse struct {
@@ -3094,6 +3354,18 @@ type __ListAddOnPlansInput struct {
 
 // GetAddOnType returns __ListAddOnPlansInput.AddOnType, and is useful for accessing the field via an interface.
 func (v *__ListAddOnPlansInput) GetAddOnType() AddOnType { return v.AddOnType }
+
+// __ListAddOnsForOrganizationInput is used internally by genqlient
+type __ListAddOnsForOrganizationInput struct {
+	AddOnType      AddOnType `json:"addOnType"`
+	OrganizationId string    `json:"organizationId"`
+}
+
+// GetAddOnType returns __ListAddOnsForOrganizationInput.AddOnType, and is useful for accessing the field via an interface.
+func (v *__ListAddOnsForOrganizationInput) GetAddOnType() AddOnType { return v.AddOnType }
+
+// GetOrganizationId returns __ListAddOnsForOrganizationInput.OrganizationId, and is useful for accessing the field via an interface.
+func (v *__ListAddOnsForOrganizationInput) GetOrganizationId() string { return v.OrganizationId }
 
 // __ListAddOnsInput is used internally by genqlient
 type __ListAddOnsInput struct {
@@ -4080,22 +4352,25 @@ const ListAddOns_Operation = `
 query ListAddOns ($addOnType: AddOnType) {
 	addOns(type: $addOnType) {
 		nodes {
-			id
-			name
-			addOnPlan {
-				displayName
-				description
-			}
-			privateIp
-			primaryRegion
-			readRegions
-			options
-			metadata
-			organization {
-				id
-				slug
-			}
+			... ListAddOnData
 		}
+	}
+}
+fragment ListAddOnData on AddOn {
+	id
+	name
+	addOnPlan {
+		displayName
+		description
+	}
+	privateIp
+	primaryRegion
+	readRegions
+	options
+	metadata
+	organization {
+		id
+		slug
 	}
 }
 `
@@ -4114,6 +4389,63 @@ func ListAddOns(
 	}
 
 	data_ = &ListAddOnsResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by ListAddOnsForOrganization.
+const ListAddOnsForOrganization_Operation = `
+query ListAddOnsForOrganization ($addOnType: AddOnType, $organizationId: ID!) {
+	organization(id: $organizationId) {
+		addOns(type: $addOnType) {
+			nodes {
+				... ListAddOnData
+			}
+		}
+	}
+}
+fragment ListAddOnData on AddOn {
+	id
+	name
+	addOnPlan {
+		displayName
+		description
+	}
+	privateIp
+	primaryRegion
+	readRegions
+	options
+	metadata
+	organization {
+		id
+		slug
+	}
+}
+`
+
+func ListAddOnsForOrganization(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	addOnType AddOnType,
+	organizationId string,
+) (data_ *ListAddOnsForOrganizationResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "ListAddOnsForOrganization",
+		Query:  ListAddOnsForOrganization_Operation,
+		Variables: &__ListAddOnsForOrganizationInput{
+			AddOnType:      addOnType,
+			OrganizationId: organizationId,
+		},
+	}
+
+	data_ = &ListAddOnsForOrganizationResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -264,7 +264,7 @@ query ListAddOns($addOnType: AddOnType) {
 	}
 }
 
-query ListAddOnsForOrganization($addOnType: AddOnType, $organizationId: ID!) {
+query ListOrganizationAddOns($organizationId: ID!, $addOnType: AddOnType) {
 	organization(id: $organizationId) {
 		addOns(type: $addOnType) {
 			nodes {

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -238,10 +238,8 @@ query GetAddOnProvider($name: String!) {
 	}
 }
 
-query ListAddOns($addOnType: AddOnType) {
-	addOns(type: $addOnType) {
-		nodes {
-			id
+fragment ListAddOnData on AddOn {
+	id
 			name
 			addOnPlan {
 				displayName
@@ -255,6 +253,22 @@ query ListAddOns($addOnType: AddOnType) {
 			organization {
 				id
 				slug
+			}
+}
+
+query ListAddOns($addOnType: AddOnType) {
+	addOns(type: $addOnType) {
+		nodes {
+			...ListAddOnData
+		}
+	}
+}
+
+query ListAddOnsForOrganization($addOnType: AddOnType, $organizationId: ID!) {
+	organization(id: $organizationId) {
+		addOns(type: $addOnType) {
+			nodes {
+				...ListAddOnData
 			}
 		}
 	}

--- a/internal/command/apps/list.go
+++ b/internal/command/apps/list.go
@@ -48,7 +48,7 @@ func runList(ctx context.Context) (err error) {
 	client := flyutil.ClientFromContext(ctx)
 	silence := flag.GetBool(ctx, "quiet")
 	cfg := config.FromContext(ctx)
-	org, err := getOrg(ctx)
+	org, err := flyutil.OrgFromContextBySlug(ctx, flag.GetOrg(ctx))
 	if err != nil {
 		return fmt.Errorf("error getting organization: %w", err)
 	}
@@ -102,16 +102,4 @@ func runList(ctx context.Context) (err error) {
 	_ = render.Table(out, "", rows, "Name", "Owner", "Status", "Latest Deploy")
 
 	return
-}
-
-func getOrg(ctx context.Context) (*fly.Organization, error) {
-	client := flyutil.ClientFromContext(ctx)
-
-	orgName := flag.GetOrg(ctx)
-
-	if orgName == "" {
-		return nil, nil
-	}
-
-	return client.GetOrganizationBySlug(ctx, orgName)
 }

--- a/internal/command/extensions/tigris/list.go
+++ b/internal/command/extensions/tigris/list.go
@@ -48,7 +48,7 @@ func runList(ctx context.Context) (err error) {
 
 	var nodes []*gql.ListAddOnData
 	if org != nil {
-		response, err := gql.ListAddOnsForOrganization(ctx, client, "tigris", org.ID)
+		response, err := gql.ListOrganizationAddOns(ctx, client, org.ID, "tigris")
 		if err != nil {
 			return fmt.Errorf("error listing add-ons for organization: %w", err)
 		}

--- a/internal/command/extensions/tigris/list.go
+++ b/internal/command/extensions/tigris/list.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/iostreams"
 
@@ -42,7 +41,7 @@ func runList(ctx context.Context) (err error) {
 		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
-	org, err := getOrg(ctx)
+	org, err := flyutil.OrgFromContextBySlug(ctx, flag.GetOrg(ctx))
 	if err != nil {
 		return fmt.Errorf("error getting organization: %w", err)
 	}
@@ -78,16 +77,4 @@ func runList(ctx context.Context) (err error) {
 	_ = render.Table(out, "", rows, "Name", "Org")
 
 	return
-}
-
-func getOrg(ctx context.Context) (*fly.Organization, error) {
-	client := flyutil.ClientFromContext(ctx)
-
-	orgName := flag.GetOrg(ctx)
-
-	if orgName == "" {
-		return nil, nil
-	}
-
-	return client.GetOrganizationBySlug(ctx, orgName)
 }

--- a/internal/flyutil/client.go
+++ b/internal/flyutil/client.go
@@ -119,3 +119,13 @@ func ClientFromContext(ctx context.Context) Client {
 	c, _ := ctx.Value(contextKeyClient).(Client)
 	return c
 }
+
+// OrgFromContextBySlug returns the organization by slug, or nil if slug is empty, using the client from ctx.
+func OrgFromContextBySlug(ctx context.Context, orgSlug string) (*fly.Organization, error) {
+	if orgSlug == "" {
+		return nil, nil
+	}
+
+	client := ClientFromContext(ctx)
+	return client.GetOrganizationBySlug(ctx, orgSlug)
+}


### PR DESCRIPTION
### Change Summary

What and Why:

When you are a user of multiple organizations and try to see configured storage for one particular one running `fly storage list --org personal` will return results for all your organizations. When one of your organizations has too many storages configured you might not be able to see the ones you are looking for since we return 250 first ones.

`--org` flag was declared among supported for `fly storage list` command but was never taken into consideration within the handler. This change fixes this issue and makes behavior consisted with `fly apps list` command.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
