### PR TITLE
fix: remove feature flag check from launch --db flag

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -23,7 +23,6 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/internal/flyutil"
-	"github.com/superfly/flyctl/internal/launchdarkly"
 	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/state"
@@ -166,20 +165,11 @@ func New() (cmd *cobra.Command) {
 		},
 	}
 
-	ldClient, err := launchdarkly.NewServiceClient()
-	if err != nil {
-		return nil
-	}
-
-	managedPostgresEnabled := ldClient.ManagedPostgresEnabled()
-	if managedPostgresEnabled {
-		flags = append(flags, flag.Bool{
-			Name:        "db",
-			Description: "Force provisioning a managed Postgres database",
-			Default:     false,
-		})
-	}
-
+	flags = append(flags, flag.Bool{
+		Name:        "db",
+		Description: "Force provisioning a Postgres database",
+		Default:     false,
+	})
 	flag.Add(cmd, flags...)
 
 	cmd.AddCommand(NewPlan())


### PR DESCRIPTION
Fixes a performance regression introduced in #4371.
Flags are defined in `command.New()` invoked on every single command run, adding round-trip request latency (up to 10s when the API server times out or rate-limits requests) to the start of every flyctl command (even `--help`).
I don't think this `--db` flag needs to be conditionally displayed anyway, so this PR removes the feature flag check to restore original flyctl performance.