### PR TITLE
Fix hanging on launch/deploy by adding timeout to tracing shutdown

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -248,8 +248,7 @@ func (cmd *Command) run(ctx context.Context) (err error) {
 	}
 
 	defer func() {
-		// Use a short timeout for shutdown to prevent hanging
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		defer cancel()
 		tp.Shutdown(shutdownCtx)
 	}()

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -247,7 +247,12 @@ func (cmd *Command) run(ctx context.Context) (err error) {
 		return err
 	}
 
-	defer tp.Shutdown(ctx)
+	defer func() {
+		// Use a short timeout for shutdown to prevent hanging
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		tp.Shutdown(shutdownCtx)
+	}()
 
 	ctx, span := tracing.CMDSpan(ctx, "cmd.deploy")
 	defer span.End()

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -285,7 +285,12 @@ func run(ctx context.Context) (err error) {
 		return err
 	}
 
-	defer tp.Shutdown(ctx)
+	defer func() {
+		// Use a short timeout for shutdown to prevent hanging
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		tp.Shutdown(shutdownCtx)
+	}()
 
 	ctx, span := tracing.CMDSpan(ctx, "cmd.launch")
 	defer span.End()

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -286,8 +286,7 @@ func run(ctx context.Context) (err error) {
 	}
 
 	defer func() {
-		// Use a short timeout for shutdown to prevent hanging
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		defer cancel()
 		tp.Shutdown(shutdownCtx)
 	}()


### PR DESCRIPTION
## Summary
- Fix hanging issue when launch and deploy commands encounter errors
- Add 2-second timeout to tracing provider shutdown to cancel slow/stuck requests
- Ensures error messages are displayed immediately instead of being delayed by up to a minute

## Problem
When `flyctl launch` or `flyctl deploy` commands encounter errors, they would hang for up to a minute before displaying the error. This happened because `tp.Shutdown(ctx)` was blocking indefinitely while trying to flush telemetry data to the remote collector, especially when the collector was unreachable or slow to respond.

## Solution
Added a 2-second timeout to the tracing provider shutdown using `context.WithTimeout`. This cancels the telemetry flush request after 2 seconds, ensuring that even if the telemetry collector is unreachable or slow, the command fails fast and shows the error immediately.

## Test plan
- [x] Test with docker-compose file that has validation errors
- [x] Verify error message appears immediately (within 2 seconds)
- [x] Verify no hanging behavior
- [x] Verify normal launch and deploy flows still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)