### PR TITLE
Fix panic in case Cargo.toml has no dependencies

### DIFF
--- a/scanner/rust.go
+++ b/scanner/rust.go
@@ -1,5 +1,7 @@
 package scanner
 
+import "fmt"
+
 func configureRust(sourceDir string, _ *ScannerConfig) (*SourceInfo, error) {
 	if !checksPass(sourceDir, fileExists("Cargo.toml", "Cargo.lock")) {
 		return nil, nil
@@ -10,7 +12,8 @@ func configureRust(sourceDir string, _ *ScannerConfig) (*SourceInfo, error) {
 		return nil, err
 	}
 
-	deps := cargoData["dependencies"].(map[string]interface{})
+	// Cargo.toml may not contain a "dependencies" section, so we don't return an error if it's missing.
+	deps, _ := cargoData["dependencies"].(map[string]interface{})
 	family := "Rust"
 	env := map[string]string{
 		"PORT": "8080",
@@ -30,8 +33,16 @@ func configureRust(sourceDir string, _ *ScannerConfig) (*SourceInfo, error) {
 		family = "Poem"
 	}
 
+	pkg, ok := cargoData["package"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("file Cargo.toml does not contain a valid package section")
+	}
+
 	vars := make(map[string]interface{})
-	vars["appName"] = cargoData["package"].(map[string]interface{})["name"].(string)
+	vars["appName"], ok = pkg["name"].(string)
+	if !ok {
+		return nil, fmt.Errorf("file Cargo.toml does not contain a valid package name")
+	}
 
 	s := &SourceInfo{
 		Files:        templatesExecute("templates/rust", vars),


### PR DESCRIPTION
### Change Summary

Fixes #4338

As mentioned in #4338 `flyctl` panics in case the dependencies section is missing in Cargo.toml. This PR fixes it by adding some checks.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
