### PR TITLE
Check for app health checks and volume mounts before `bluegreen` build

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -412,3 +412,8 @@ func (cfg *Config) HasHealthChecks() bool {
 
 	return false
 }
+
+// HasMounts returns true if the configuration defines any mounts.
+func (cfg *Config) HasMounts() bool {
+	return len(cfg.Mounts) > 0
+}

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -389,3 +389,26 @@ func (cfg *Config) DeployStrategy() string {
 	}
 	return cfg.Deploy.Strategy
 }
+
+// HasHealthChecks returns true if there is at least one health check defined in
+// the configuration. It inspects top-level checks as well as checks defined for
+// any service or the http_service.
+func (cfg *Config) HasHealthChecks() bool {
+	if len(cfg.Checks) > 0 {
+		return true
+	}
+
+	if cfg.HTTPService != nil {
+		if len(cfg.HTTPService.HTTPChecks) > 0 || len(cfg.HTTPService.TCPChecks) > 0 {
+			return true
+		}
+	}
+
+	for _, svc := range cfg.Services {
+		if len(svc.HTTPChecks) > 0 || len(svc.TCPChecks) > 0 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -394,18 +394,18 @@ func (cfg *Config) DeployStrategy() string {
 // the configuration. It inspects top-level checks as well as checks defined for
 // any service or the http_service.
 func (cfg *Config) HasHealthChecks() bool {
-	if len(cfg.Checks) > 0 {
+	if len(cfg.Checks) > 0 || len(cfg.MachineChecks) > 0 {
 		return true
 	}
 
 	if cfg.HTTPService != nil {
-		if len(cfg.HTTPService.HTTPChecks) > 0 || len(cfg.HTTPService.TCPChecks) > 0 {
+		if len(cfg.HTTPService.HTTPChecks) > 0 || len(cfg.HTTPService.MachineChecks) > 0 {
 			return true
 		}
 	}
 
 	for _, svc := range cfg.Services {
-		if len(svc.HTTPChecks) > 0 || len(svc.TCPChecks) > 0 {
+		if len(svc.HTTPChecks) > 0 || len(svc.TCPChecks) > 0 || len(svc.MachineChecks) > 0 {
 			return true
 		}
 	}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -352,6 +352,15 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, userID i
 		}
 	}
 
+	strategy := flag.GetString(ctx, "strategy")
+	if strategy == "" {
+		strategy = appConfig.DeployStrategy()
+	}
+	if strategy == "bluegreen" && !appConfig.HasHealthChecks() {
+		fmt.Fprint(io.ErrOut, healthChecksRequirementMsg)
+		return ErrValidationError
+	}
+
 	httpFailover := flag.GetHTTPSFailover(ctx)
 	usingWireguard := flag.GetWireguard(ctx)
 	recreateBuilder := flag.GetRecreateBuilder(ctx)

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -356,9 +356,15 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, userID i
 	if strategy == "" {
 		strategy = appConfig.DeployStrategy()
 	}
-	if strategy == "bluegreen" && !appConfig.HasHealthChecks() {
-		fmt.Fprint(io.ErrOut, healthChecksRequirementMsg)
-		return ErrValidationError
+	if strategy == "bluegreen" {
+		if appConfig.HasMounts() {
+			fmt.Fprint(io.ErrOut, volumesRequirementMsg)
+			return ErrValidationError
+		}
+		if !appConfig.HasHealthChecks() {
+			fmt.Fprint(io.ErrOut, healthChecksRequirementMsg)
+			return ErrValidationError
+		}
 	}
 
 	httpFailover := flag.GetHTTPSFailover(ctx)

--- a/internal/command/deploy/strategy_bluegreen_test.go
+++ b/internal/command/deploy/strategy_bluegreen_test.go
@@ -39,11 +39,18 @@ func newBlueGreenStrategy(client flapsutil.FlapsClient, numberOfExistingMachines
 		apiClient:     &mockWebClient{},
 		flaps:         client,
 		maxConcurrent: 10,
-		appConfig:     &appconfig.Config{},
-		io:            ios,
-		colorize:      ios.ColorScheme(),
-		timeout:       1 * time.Second,
-		blueMachines:  machines,
+		appConfig: &appconfig.Config{
+			Checks: map[string]*appconfig.ToplevelCheck{
+				"alive": {
+					Type: fly.Pointer("tcp"),
+					Port: fly.Pointer(8080),
+				},
+			},
+		},
+		io:           ios,
+		colorize:     ios.ColorScheme(),
+		timeout:      1 * time.Second,
+		blueMachines: machines,
 	}
 	strategy.initialize()
 


### PR DESCRIPTION
## Summary

`bluegreen` deployment strategy will trigger a full build before it fails with a message that at least one health check needs to be configured and before an app with volumes cannot be used with `bluegreen`.

This PR:
- adds `HasHealthChecks()` helper on `appconfig.Config`
- fail `fly deploy` early for bluegreen strategy if no health checks are defined and an app has volume mounts