### PR TITLE
Adding extras support to python dependencies parsing

### DIFF
--- a/scanner/python.go
+++ b/scanner/python.go
@@ -100,6 +100,7 @@ func parsePyDep(dep string) string {
 	dep = strings.ToLower(dep)
 	dep = strings.Split(dep, ";")[0]
 	dep = strings.Split(dep, " ")[0]
+	dep = strings.Split(dep, "[")[0]
 	dep = strings.Split(dep, "==")[0]
 	dep = strings.Split(dep, ">")[0]
 	dep = strings.Split(dep, "<")[0]


### PR DESCRIPTION
### Change Summary

Fixes #4078 

Python dependencies parsing doesn't support [extras](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#extras) which can lead to a failed parsing. For example, [FastAPI docs](fastapi.tiangolo.com/#installation) suggests installing it with `[standard]` extra, in this case the app won't be detected as FastAPI app.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
