### PR TITLE
retrieve user and db from credentials (to support more flexible naming)

### DIFF
--- a/internal/command/mpg/connect.go
+++ b/internal/command/mpg/connect.go
@@ -37,7 +37,7 @@ func runConnect(ctx context.Context) (err error) {
 
 	localProxyPort := "16380"
 
-	cluster, params, password, err := getMpgProxyParams(ctx, localProxyPort)
+	cluster, params, credentials, err := getMpgProxyParams(ctx, localProxyPort)
 	if err != nil {
 		return err
 	}
@@ -57,8 +57,11 @@ func runConnect(ctx context.Context) (err error) {
 		return err
 	}
 
-	name := fmt.Sprintf("pgdb-%s", cluster.Id)
-	connectUrl := fmt.Sprintf("postgres://%s:%s@localhost:%s/%s", name, password, localProxyPort, name)
+	user := credentials.User
+	password := credentials.Password
+	db := credentials.DBName
+
+	connectUrl := fmt.Sprintf("postgres://%s:%s@localhost:%s/%s", user, password, localProxyPort, db)
 	cmd := exec.CommandContext(ctx, psqlPath, connectUrl)
 	cmd.Stdout = io.Out
 	cmd.Stderr = io.ErrOut

--- a/internal/command/mpg/proxy.go
+++ b/internal/command/mpg/proxy.go
@@ -45,19 +45,20 @@ func newProxy() (cmd *cobra.Command) {
 
 func runProxy(ctx context.Context) (err error) {
 	localProxyPort := "16380"
-	cluster, params, password, err := getMpgProxyParams(ctx, localProxyPort)
+	_, params, credentials, err := getMpgProxyParams(ctx, localProxyPort)
 	if err != nil {
 		return err
 	}
 
-	name := fmt.Sprintf("pgdb-%s", cluster.Id)
+	user := credentials.User
+	password := credentials.Password
 
-	terminal.Infof("Proxying postgres to port \"%s\" with user \"%s\" password \"%s\"", localProxyPort, name, password)
+	terminal.Infof("Proxying postgres to port \"%s\" with user \"%s\" password \"%s\"", localProxyPort, user, password)
 
 	return proxy.Connect(ctx, params)
 }
 
-func getMpgProxyParams(ctx context.Context, localProxyPort string) (*uiex.ManagedCluster, *proxy.ConnectParams, string, error) {
+func getMpgProxyParams(ctx context.Context, localProxyPort string) (*uiex.ManagedCluster, *proxy.ConnectParams, *uiex.GetManagedClusterCredentialsResponse, error) {
 	client := flyutil.ClientFromContext(ctx)
 	uiexClient := uiexutil.ClientFromContext(ctx)
 
@@ -72,7 +73,7 @@ func getMpgProxyParams(ctx context.Context, localProxyPort string) (*uiex.Manage
 		// If cluster ID is provided, get cluster details directly and extract org info from it
 		response, err := uiexClient.GetManagedClusterById(ctx, clusterID)
 		if err != nil {
-			return nil, nil, "", fmt.Errorf("failed retrieving cluster %s: %w", clusterID, err)
+			return nil, nil, nil, fmt.Errorf("failed retrieving cluster %s: %w", clusterID, err)
 		}
 		cluster = &response.Data
 		orgSlug = cluster.Organization.Slug
@@ -80,20 +81,20 @@ func getMpgProxyParams(ctx context.Context, localProxyPort string) (*uiex.Manage
 		// If no cluster ID is provided, let user select org first, then cluster
 		org, err := orgs.OrgFromFlagOrSelect(ctx)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, nil, err
 		}
 
 		// For ui-ex requests we need the real org slug (resolve aliases like "personal")
 		genqClient := client.GenqClient()
 		var fullOrg *gql.GetOrganizationResponse
 		if fullOrg, err = gql.GetOrganization(ctx, genqClient, org.Slug); err != nil {
-			return nil, nil, "", fmt.Errorf("failed fetching org: %w", err)
+			return nil, nil, nil, fmt.Errorf("failed fetching org: %w", err)
 		}
 
 		// Now let user select a cluster from this organization
 		selectedCluster, err := ClusterFromFlagOrSelect(ctx, fullOrg.Organization.RawSlug)
 		if err != nil {
-			return nil, nil, "", err
+			return nil, nil, nil, err
 		}
 
 		cluster = selectedCluster
@@ -104,36 +105,36 @@ func getMpgProxyParams(ctx context.Context, localProxyPort string) (*uiex.Manage
 	// Get credentials for the cluster
 	response, err := uiexClient.GetManagedClusterById(ctx, cluster.Id)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("failed retrieving cluster credentials %s: %w", cluster.Id, err)
+		return nil, nil, nil, fmt.Errorf("failed retrieving cluster credentials %s: %w", cluster.Id, err)
 	}
 
 	// Resolve organization slug to handle aliases
 	resolvedOrgSlug, err := ResolveOrganizationSlug(ctx, orgSlug)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("failed to resolve organization slug: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to resolve organization slug: %w", err)
 	}
 
 	if response.Credentials.Status == "initializing" {
-		return nil, nil, "", fmt.Errorf("cluster is still initializing, wait a bit more")
+		return nil, nil, nil, fmt.Errorf("cluster is still initializing, wait a bit more")
 	}
 
 	if response.Credentials.Status == "error" || response.Credentials.Password == "" {
-		return nil, nil, "", fmt.Errorf("error getting cluster password")
+		return nil, nil, nil, fmt.Errorf("error getting cluster password")
 	}
 
 	if cluster.IpAssignments.Direct == "" {
-		return nil, nil, "", fmt.Errorf("error getting cluster IP")
+		return nil, nil, nil, fmt.Errorf("error getting cluster IP")
 	}
 
 	agentclient, err := agent.Establish(ctx, client)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, nil, err
 	}
 
 	// Use the resolved organization slug for wireguard tunnel
 	dialer, err := agentclient.ConnectToTunnel(ctx, resolvedOrgSlug, "", false)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, nil, err
 	}
 
 	return cluster, &proxy.ConnectParams{
@@ -142,5 +143,5 @@ func getMpgProxyParams(ctx context.Context, localProxyPort string) (*uiex.Manage
 		Dialer:           dialer,
 		BindAddr:         flag.GetBindAddr(ctx),
 		RemoteHost:       cluster.IpAssignments.Direct,
-	}, response.Credentials.Password, nil
+	}, &response.Credentials, nil
 }

--- a/internal/uiex/managed_postgres.go
+++ b/internal/uiex/managed_postgres.go
@@ -43,7 +43,9 @@ type ListManagedClustersResponse struct {
 
 type GetManagedClusterCredentialsResponse struct {
 	Status        string `json:"status"`
+	User          string `json:"user"`
 	Password      string `json:"password"`
+	DBName        string `json:"dbname"`
 	ConnectionUri string `json:"pgbouncer_uri"`
 }
 


### PR DESCRIPTION
Related: https://github.com/superfly/ui-ex/pull/3755
Note: This PR (flyctl) is backward/forward compatible (we read user/dbname from cluster credentials).
This PR can be merged before ui-ex changes are deployed.

----

Existing behaviour is to assume the following naming convention for MPG clusters - 
* `dbname: pgdb-<hashid>`
* `user: pgdb-<hashid>`

MPG is changing its internal naming conventions.
The proxy params currently includes credentials (currently used to retrieve `password`).
We now retrieve the associated `dbname` and `user` from credentials.

Testing against MPG cluster that uses existing internal naming conventions - 

```
./bin/flyctl mpg connect
[...]
Proxying local port 16380 to remote [fdaa:18:6608:0:1::21]:5432
psql (16.2, server 16.8 - Percona Distribution)
Type "help" for help.

pgdb-gjpkdon3qdryln46=> \c
psql (16.2, server 16.8 - Percona Distribution)
You are now connected to database "pgdb-gjpkdon3qdryln46" as user "pgdb-gjpkdon3qdryln46".
```

```
./bin/flyctl mpg proxy
[...]
INFO Proxying postgres to port "16380" with user "pgdb-gjpkdon3qdryln46" password "<REDACTED>"
Proxying local port 16380 to remote [fdaa:18:6608:0:1::21]:5432
```

Testing against an MPG cluster that uses the new simplified internal naming conventions - 

```
./bin/flyctl mpg connect
[...]
Proxying local port 16380 to remote [fdaa:18:6608:0:1::3f]:5432
psql (16.2, server 16.8 - Percona Distribution)
Type "help" for help.

db=> \c
psql (16.2, server 16.8 - Percona Distribution)
You are now connected to database "db" as user "user".
```

```
./bin/flyctl mpg proxy
[...]
INFO Proxying postgres to port "16380" with user "user" password "<REDACTED>"
Proxying local port 16380 to remote [fdaa:18:6608:0:1::3f]:5432
```