### PR TITLE
removed stale docs about building via docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,5 @@ app: banana
 
 There is a simple Powershell script, `winbuild.ps1`, which will run the code generation for the help files, format them, and run a full build, leaving a new binary in the bin directory.
 
-## Running from branches on your local machine
-
-Run `scripts/build-dfly` to build a Docker image from the current branch. Then, use `scripts/dfly` to run it. This assumes you are already
-authenticated to Fly in your local environment.
-
-
 ## Contributing guide
 See [CONTRIBUTING.md](./CONTRIBUTING.md)


### PR DESCRIPTION
These docs are stale, out of date and keep catching me out - 

> ~~Run scripts/build-dfly to build a Docker image from the current branch. Then, use scripts/dfly to run it. This assumes you are already authenticated to Fly in your local environment.~~

Actual up to date docs are already in CONTRIBUTING.md which is linked to from README.md -

> To build flyctl, all you need to do is to run make build from the root directory. This will build a binary in the bin/ directory. Alternatively, you can run go build -o <EXE_NAME> .
