### PR TITLE
Fix nil pointer dereference in mcp add command

### DIFF
--- a/internal/command/mcp/config.go
+++ b/internal/command/mcp/config.go
@@ -18,8 +18,11 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/prompt"
+	
+	"github.com/superfly/fly-go/flaps"
 )
 
 var McpClients = map[string]string{
@@ -142,6 +145,17 @@ func runAdd(ctx context.Context) error {
 		if appName == "" {
 			return errors.New("app name is required")
 		} else {
+			// Set up flaps client in context before calling FromRemoteApp
+			if flapsutil.ClientFromContext(ctx) == nil {
+				flapsClient, err := flapsutil.NewClientWithOptions(ctx, flaps.NewClientOpts{
+					AppName: appName,
+				})
+				if err != nil {
+					return fmt.Errorf("could not create flaps client: %w", err)
+				}
+				ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
+			}
+			
 			var err error
 			appConfig, err = appconfig.FromRemoteApp(ctx, appName)
 			if err != nil {

--- a/internal/command/mcp/config.go
+++ b/internal/command/mcp/config.go
@@ -21,7 +21,7 @@ import (
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/prompt"
-	
+
 	"github.com/superfly/fly-go/flaps"
 )
 
@@ -155,7 +155,7 @@ func runAdd(ctx context.Context) error {
 				}
 				ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
 			}
-			
+
 			var err error
 			appConfig, err = appconfig.FromRemoteApp(ctx, appName)
 			if err != nil {


### PR DESCRIPTION
## Summary
- Fixed a runtime crash in `flyctl mcp add` command caused by nil pointer dereference
- Added missing flaps client initialization before calling `appconfig.FromRemoteApp()`
- Follows the same pattern used in other commands like deploy and machine commands

## Test plan
- [x] Build completes successfully with `make`
- [ ] Test `flyctl mcp add --url localhost:8080 --claude --app <app-name>` command
- [ ] Verify no nil pointer crashes occur
- [ ] Confirm MCP server configuration is properly added

🤖 Generated with [Claude Code](https://claude.ai/code)