### PR TITLE
Fix name collision when calling DeleteAddOn

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -3001,11 +3001,15 @@ func (v *__CreateTosAgreementInput) GetProviderName() string { return v.Provider
 
 // __DeleteAddOnInput is used internally by genqlient
 type __DeleteAddOnInput struct {
-	Name string `json:"name"`
+	Name     string `json:"name"`
+	Provider string `json:"provider"`
 }
 
 // GetName returns __DeleteAddOnInput.Name, and is useful for accessing the field via an interface.
 func (v *__DeleteAddOnInput) GetName() string { return v.Name }
+
+// GetProvider returns __DeleteAddOnInput.Provider, and is useful for accessing the field via an interface.
+func (v *__DeleteAddOnInput) GetProvider() string { return v.Provider }
 
 // __FlyctlConfigCurrentReleaseInput is used internally by genqlient
 type __FlyctlConfigCurrentReleaseInput struct {
@@ -3509,8 +3513,8 @@ func CreateTosAgreement(
 
 // The mutation executed by DeleteAddOn.
 const DeleteAddOn_Operation = `
-mutation DeleteAddOn ($name: String) {
-	deleteAddOn(input: {name:$name}) {
+mutation DeleteAddOn ($name: String, $provider: String) {
+	deleteAddOn(input: {name:$name,provider:$provider}) {
 		deletedAddOnName
 	}
 }
@@ -3520,12 +3524,14 @@ func DeleteAddOn(
 	ctx_ context.Context,
 	client_ graphql.Client,
 	name string,
+	provider string,
 ) (data_ *DeleteAddOnResponse, err_ error) {
 	req_ := &graphql.Request{
 		OpName: "DeleteAddOn",
 		Query:  DeleteAddOn_Operation,
 		Variables: &__DeleteAddOnInput{
-			Name: name,
+			Name:     name,
+			Provider: provider,
 		},
 	}
 

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -205,8 +205,8 @@ mutation SetNomadVMCount($input: SetVMCountInput!) {
 	}
 }
 
-mutation DeleteAddOn($name: String) {
-	deleteAddOn(input: {name: $name}) {
+mutation DeleteAddOn($name: String, $provider: String) {
+	deleteAddOn(input: {name: $name, provider: $provider}) {
 		deletedAddOnName
 	}
 }

--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -84,7 +84,7 @@ func RunDestroy(ctx context.Context) error {
 		}
 
 		if bucket != nil {
-			_, err = gql.DeleteAddOn(ctx, client.GenqClient(), bucket.Name)
+			_, err = gql.DeleteAddOn(ctx, client.GenqClient(), bucket.Name, string(gql.AddOnTypeTigris))
 			if err != nil {
 				return err
 			}

--- a/internal/command/deploy/statics/addon.go
+++ b/internal/command/deploy/statics/addon.go
@@ -110,7 +110,7 @@ func (deployer *DeployerState) ensureBucketCreated(ctx context.Context) (tokeniz
 		if retErr != nil {
 			client := flyutil.ClientFromContext(ctx).GenqClient()
 			// Using context.Background() here in case the error is that the context is canceled.
-			_, err := gql.DeleteAddOn(context.Background(), client, extName)
+			_, err := gql.DeleteAddOn(context.Background(), client, extName, string(gql.AddOnTypeTigris))
 			if err != nil {
 				fmt.Fprintf(iostreams.FromContext(ctx).ErrOut, "Failed to delete extension: %v\n", err)
 			}

--- a/internal/command/deploy/statics/move.go
+++ b/internal/command/deploy/statics/move.go
@@ -61,7 +61,7 @@ func MoveBucket(
 		return err
 	}
 
-	_, err = gql.DeleteAddOn(ctx, client.GenqClient(), prevBucket.Name)
+	_, err = gql.DeleteAddOn(ctx, client.GenqClient(), prevBucket.Name, string(gql.AddOnTypeTigris))
 	if err != nil {
 		return err
 	}

--- a/internal/command/extensions/arcjet/destroy.go
+++ b/internal/command/extensions/arcjet/destroy.go
@@ -67,7 +67,7 @@ func runDestroy(ctx context.Context) (err error) {
 		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
-	_, err = gql.DeleteAddOn(ctx, client, extension.Name)
+	_, err = gql.DeleteAddOn(ctx, client, extension.Name, string(gql.AddOnTypeArcjet))
 
 	if err != nil {
 		return

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -313,6 +313,12 @@ func WaitForProvision(ctx context.Context, name string, provider string) error {
 			return err
 		}
 
+		// Validate that the returned add-on matches the expected provider type
+		if resp.AddOn.AddOnProvider.Name != provider {
+			return fmt.Errorf("found add-on '%s' with provider '%s', but expected provider '%s'",
+				resp.AddOn.Name, resp.AddOn.AddOnProvider.Name, provider)
+		}
+
 		if resp.AddOn.Status == "error" {
 			if resp.AddOn.ErrorMessage != "" {
 				return errors.New(resp.AddOn.ErrorMessage)
@@ -387,6 +393,12 @@ func OpenDashboard(ctx context.Context, extensionName string, provider gql.AddOn
 		return err
 	}
 
+	// Validate that the returned add-on matches the expected provider type
+	if result.AddOn.AddOnProvider.Name != string(provider) {
+		return fmt.Errorf("found add-on '%s' with provider '%s', but expected provider '%s'",
+			result.AddOn.Name, result.AddOn.AddOnProvider.Name, provider)
+	}
+
 	err = AgreeToProviderTos(ctx, result.AddOn.AddOnProvider.ExtensionProviderData)
 	if err != nil {
 		return err
@@ -406,6 +418,12 @@ func Discover(ctx context.Context, provider gql.AddOnType) (addOn *gql.AddOnData
 		response, err := gql.GetAddOn(ctx, client, flag.FirstArg(ctx), string(provider))
 		if err != nil {
 			return nil, nil, err
+		}
+
+		// Validate that the returned add-on matches the expected provider type
+		if response.AddOn.AddOnProvider.Name != string(provider) {
+			return nil, nil, fmt.Errorf("found add-on '%s' with provider '%s', but expected provider '%s'",
+				response.AddOn.Name, response.AddOn.AddOnProvider.Name, provider)
 		}
 
 		addOn = &response.AddOn.AddOnData

--- a/internal/command/extensions/enveloop/destroy.go
+++ b/internal/command/extensions/enveloop/destroy.go
@@ -61,7 +61,7 @@ func runDestroy(ctx context.Context) (err error) {
 	}
 
 	client := flyutil.ClientFromContext(ctx).GenqClient()
-	if _, err := gql.DeleteAddOn(ctx, client, extension.Name); err != nil {
+	if _, err := gql.DeleteAddOn(ctx, client, extension.Name, string(gql.AddOnTypeEnveloop)); err != nil {
 		return err
 	}
 

--- a/internal/command/extensions/fly_mysql/destroy.go
+++ b/internal/command/extensions/fly_mysql/destroy.go
@@ -67,7 +67,7 @@ func runDestroy(ctx context.Context) (err error) {
 		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
-	_, err = gql.DeleteAddOn(ctx, client, extension.Name)
+	_, err = gql.DeleteAddOn(ctx, client, extension.Name, string(gql.AddOnTypeFlyMysql))
 
 	if err != nil {
 		return

--- a/internal/command/extensions/kubernetes/destroy.go
+++ b/internal/command/extensions/kubernetes/destroy.go
@@ -66,7 +66,7 @@ func runDestroy(ctx context.Context) (err error) {
 		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
-	_, err = gql.DeleteAddOn(ctx, client, extension.Name)
+	_, err = gql.DeleteAddOn(ctx, client, extension.Name, string(gql.AddOnTypeKubernetes))
 
 	if err != nil {
 		return

--- a/internal/command/extensions/sentry/destroy.go
+++ b/internal/command/extensions/sentry/destroy.go
@@ -67,7 +67,7 @@ func runDestroy(ctx context.Context) (err error) {
 		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
-	_, err = gql.DeleteAddOn(ctx, client, extension.Name)
+	_, err = gql.DeleteAddOn(ctx, client, extension.Name, string(gql.AddOnTypeSentry))
 
 	if err != nil {
 		return

--- a/internal/command/extensions/supabase/destroy.go
+++ b/internal/command/extensions/supabase/destroy.go
@@ -67,7 +67,7 @@ func runDestroy(ctx context.Context) (err error) {
 		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
-	_, err = gql.DeleteAddOn(ctx, client, extension.Name)
+	_, err = gql.DeleteAddOn(ctx, client, extension.Name, string(gql.AddOnTypeSupabase))
 
 	if err != nil {
 		return

--- a/internal/command/extensions/tigris/destroy.go
+++ b/internal/command/extensions/tigris/destroy.go
@@ -67,7 +67,7 @@ func runDestroy(ctx context.Context) (err error) {
 		client = flyutil.ClientFromContext(ctx).GenqClient()
 	)
 
-	_, err = gql.DeleteAddOn(ctx, client, extension.Name)
+	_, err = gql.DeleteAddOn(ctx, client, extension.Name, string(gql.AddOnTypeTigris))
 
 	if err != nil {
 		return

--- a/internal/command/extensions/vector/destroy.go
+++ b/internal/command/extensions/vector/destroy.go
@@ -61,7 +61,7 @@ func runDestroy(ctx context.Context) (err error) {
 	}
 
 	client := flyutil.ClientFromContext(ctx).GenqClient()
-	if _, err := gql.DeleteAddOn(ctx, client, extension.Name); err != nil {
+	if _, err := gql.DeleteAddOn(ctx, client, extension.Name, string(gql.AddOnTypeUpstashVector)); err != nil {
 		return err
 	}
 

--- a/internal/command/extensions/wafris/destroy.go
+++ b/internal/command/extensions/wafris/destroy.go
@@ -61,7 +61,7 @@ func runDestroy(ctx context.Context) (err error) {
 	}
 
 	client := flyutil.ClientFromContext(ctx).GenqClient()
-	if _, err := gql.DeleteAddOn(ctx, client, extension.Name); err != nil {
+	if _, err := gql.DeleteAddOn(ctx, client, extension.Name, string(gql.AddOnTypeWafris)); err != nil {
 		return err
 	}
 

--- a/internal/command/redis/destroy.go
+++ b/internal/command/redis/destroy.go
@@ -63,7 +63,7 @@ func runDestroy(ctx context.Context) (err error) {
 
 	name := flag.FirstArg(ctx)
 
-	_, err = gql.DeleteAddOn(ctx, client, name)
+	_, err = gql.DeleteAddOn(ctx, client, name, string(gql.AddOnTypeUpstashRedis))
 
 	if err != nil {
 		return


### PR DESCRIPTION
## Change Summary

### What and Why:
If a user creates multiple add-on resources with the same name (for example, a Tigris bucket named "test-bucket" and a Redis database called "test-bucket"), then tries to delete, say, the Redis database by calling `fly redis delete test-bucket`, **the Tigris bucket will instead be deleted**. This was happening because the `DeleteAddOn` GraphQL mutation was only taking the name of the resource, and not looking at the resource name + provider string together.

I've made changes so that the `DeleteAddOn` mutation now needs a provider string as well as the name, and updated all places where the mutation is called to pass in the provider.

### Related to:
See our internal discussions [here](https://flyio.discourse.team/t/deleting-redis-database-actually-deletes-tigris-bucket-if-they-have-the-same-name/8819), and a customer support ticket reporting the issue [here](https://app.plain.com/workspace/w_01J30S94JDD57QXMT9Q47J928E/thread/th_01JZK5DP8PCTZVNMM70RS7WDXM/).

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
