### PR TITLE
cleanup output for flyctl mpg proxy

### DIFF
--- a/internal/command/mpg/proxy.go
+++ b/internal/command/mpg/proxy.go
@@ -15,7 +15,6 @@ import (
 	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/proxy"
-	"github.com/superfly/flyctl/terminal"
 )
 
 func newProxy() (cmd *cobra.Command) {
@@ -45,15 +44,10 @@ func newProxy() (cmd *cobra.Command) {
 
 func runProxy(ctx context.Context) (err error) {
 	localProxyPort := "16380"
-	_, params, credentials, err := getMpgProxyParams(ctx, localProxyPort)
+	_, params, _, err := getMpgProxyParams(ctx, localProxyPort)
 	if err != nil {
 		return err
 	}
-
-	user := credentials.User
-	password := credentials.Password
-
-	terminal.Infof("Proxying postgres to port \"%s\" with user \"%s\" password \"%s\"", localProxyPort, user, password)
 
 	return proxy.Connect(ctx, params)
 }

--- a/proxy/connect.go
+++ b/proxy/connect.go
@@ -125,7 +125,7 @@ func NewServer(ctx context.Context, p *ConnectParams) (*Server, error) {
 		}
 	}
 
-	fmt.Fprintf(io.Out, "Proxying local port %s to remote %s\n", localPort, remoteAddr)
+	fmt.Fprintf(io.Out, "Proxying localhost:%s to remote %s\n", localPort, remoteAddr)
 
 	return &Server{
 		Addr:     remoteAddr,


### PR DESCRIPTION
flyctl mpg proxy currentyl displays the username/password for the database uri being proxied.
But these credentials are effectively unused - the appropriate credentials must be explicitly specified when _connecting_ via the proxy.

Proposed:

```
./bin/flyctl mpg proxy --cluster <ID>
Proxying localhost:16380 to remote [fdaa:18:6608:0:1::57]:5432
```

Existing behaviour:

```
flyctl mpg proxy --cluster <ID>
INFO Proxying postgres to port "16380" with user "fly-user" password "<REDACTED>"
Proxying local port 16380 to remote [fdaa:18:6608:0:1::57]:5432
```