### PR TITLE
ci: remove windows-2019 and include macos-15

### DIFF
--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -1,3 +1,6 @@
+# Check https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images for
+# existing OS images.
+
 name: Test Installation
 
 on:
@@ -71,11 +74,10 @@ jobs:
       max-parallel: 4
       matrix:
         os:
-          # From https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images.
           - ubuntu-24.04
           - ubuntu-22.04
+          - macos-15
           - macos-14
-          - macos-13
     runs-on: ${{ matrix.os }}
     steps:
     - name: checkout
@@ -99,8 +101,8 @@ jobs:
       max-parallel: 4
       matrix:
         os:
-          - windows-latest
-          - windows-2019
+          - windows-2025
+          - windows-2022
     runs-on: ${{ matrix.os }}
     env:
       FLYCTL_INSTALL: "C:\\flyctl"


### PR DESCRIPTION
windows-2019 is deprecated. macos-15 is not yet tagged "macos-latest", but Apple's latest version.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
