### PR TITLE
test: trace preflight

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install gotesplit, set FLY_PREFLIGHT_TEST_APP_PREFIX
         run: |
           curl -sfL https://raw.githubusercontent.com/Songmu/gotesplit/v0.2.1/install.sh | sh -s
-          echo "FLY_PREFLIGHT_TEST_APP_PREFIX=pf-gha-$(openssl rand -hex 4)" >> "$GITHUB_ENV"
+          echo "FLY_PREFLIGHT_TEST_APP_PREFIX=gha-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" >> "$GITHUB_ENV"
       # If this workflow is triggered by code changes (eg PRs), download the binary to save time.
       - uses: actions/download-artifact@v4
         with:

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -39,11 +39,6 @@ func getCollectorUrl() string {
 	if url != "" {
 		return url
 	}
-
-	if buildinfo.IsDev() {
-		return "fly-otel-collector-dev.fly.dev"
-	}
-
 	return "fly-otel-collector-prod.fly.dev"
 }
 


### PR DESCRIPTION
Preflight test's flyctl is IsDev == true, but the traces are better to go to the production endpoint, to connect them with server-side production traces.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
