### PR TITLE
buildkit builder

### DIFF
--- a/agent/remote.go
+++ b/agent/remote.go
@@ -1,0 +1,42 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func BringUpAgent(ctx context.Context, client flyutil.Client, app *fly.AppCompact, network string, quiet bool) (*Client, Dialer, error) {
+	io := iostreams.FromContext(ctx)
+
+	agentclient, err := Establish(ctx, client)
+	slug := app.Organization.Slug
+	name := app.Name
+	if err != nil {
+		captureError(ctx, err, "agent-remote", slug, name)
+		return nil, nil, errors.Wrap(err, "can't establish agent")
+	}
+
+	dialer, err := agentclient.Dialer(ctx, slug, network)
+	if err != nil {
+		captureError(ctx, err, "agent-remote", slug, name)
+		return nil, nil, fmt.Errorf("ssh: can't build tunnel for %s: %s\n", slug, err)
+	}
+
+	if !quiet {
+		io.StartProgressIndicatorMsg("Connecting to tunnel")
+	}
+	if err := agentclient.WaitForTunnel(ctx, slug, network); err != nil {
+		captureError(ctx, err, "agent-remote", slug, name)
+		return nil, nil, errors.Wrapf(err, "tunnel unavailable")
+	}
+	if !quiet {
+		io.StopProgressIndicator()
+	}
+
+	return agentclient, dialer, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -158,7 +158,7 @@ require (
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/containerd/console v1.0.4 // indirect
 	github.com/containerd/containerd v1.7.27 // indirect
-	github.com/containerd/containerd/api v1.8.0 // indirect
+	github.com/containerd/containerd/api v1.8.0
 	github.com/containerd/containerd/v2 v2.0.5 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect

--- a/internal/build/imgsrc/buildkit_builder.go
+++ b/internal/build/imgsrc/buildkit_builder.go
@@ -1,0 +1,146 @@
+package imgsrc
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/containerd/containerd/api/services/content/v1"
+	"github.com/moby/buildkit/client"
+	"github.com/superfly/flyctl/agent"
+	"github.com/superfly/flyctl/helpers"
+	"github.com/superfly/flyctl/internal/cmdfmt"
+	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/tracing"
+	"github.com/superfly/flyctl/iostreams"
+	"github.com/superfly/flyctl/terminal"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var _ imageBuilder = (*BuildkitBuilder)(nil)
+
+type BuildkitBuilder struct {
+	addr string
+}
+
+func NewBuildkitBuilder(addr string) *BuildkitBuilder {
+	return &BuildkitBuilder{addr: addr}
+}
+
+func (r *BuildkitBuilder) Name() string { return "Buildkit" }
+
+func (r *BuildkitBuilder) Run(ctx context.Context, _ *dockerClientFactory, streams *iostreams.IOStreams, opts ImageOptions, build *build) (*DeploymentImage, string, error) {
+	ctx, span := tracing.GetTracer().Start(ctx, "buildkit_builder", trace.WithAttributes(opts.ToSpanAttributes()...))
+	defer span.End()
+
+	build.BuildStart()
+	defer build.BuildFinish()
+
+	var dockerfile string
+
+	switch {
+	case opts.DockerfilePath != "" && !helpers.FileExists(opts.DockerfilePath):
+		return nil, "", fmt.Errorf("dockerfile '%s' not found", opts.DockerfilePath)
+	case opts.DockerfilePath != "":
+		dockerfile = opts.DockerfilePath
+	default:
+		dockerfile = ResolveDockerfile(opts.WorkingDir)
+	}
+
+	if dockerfile == "" {
+		terminal.Debug("dockerfile not found, skipping")
+		return nil, "", nil
+	}
+
+	build.ImageBuildStart()
+	defer build.ImageBuildFinish()
+
+	image, err := r.buildWithBuildkit(ctx, streams, opts, dockerfile, build)
+	if err != nil {
+		return nil, "", err
+	}
+	cmdfmt.PrintDone(streams.ErrOut, "Building image done")
+	span.SetAttributes(image.ToSpanAttributes()...)
+	return image, "", nil
+}
+
+func (r *BuildkitBuilder) buildWithBuildkit(ctx context.Context, streams *iostreams.IOStreams, opts ImageOptions, dockerfilePath string, buildState *build) (i *DeploymentImage, err error) {
+	ctx, span := tracing.GetTracer().Start(ctx, "buildkit_build", trace.WithAttributes(opts.ToSpanAttributes()...))
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+		}
+		streams.StopProgressIndicator()
+		span.End()
+	}()
+
+	buildState.BuilderInitStart()
+	defer buildState.BuilderInitFinish()
+	buildState.SetBuilderMetaPart1("buildkit", r.addr, "")
+
+	msg := fmt.Sprintf("Connecting to buildkit daemon at %s...\n", r.addr)
+	if streams.IsInteractive() {
+		streams.StartProgressIndicatorMsg(msg)
+	} else {
+		fmt.Fprintln(streams.ErrOut, msg)
+	}
+
+	buildkitClient, err := client.New(ctx, r.addr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create buildkit client: %w", err)
+	}
+	defer buildkitClient.Close()
+
+	if _, err = buildkitClient.Info(ctx); err != nil {
+		terminal.Debug("Direct connection failed, trying via wireguard...")
+		apiClient := flyutil.ClientFromContext(ctx)
+		app, err := apiClient.GetAppCompact(ctx, opts.AppName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get app info for %s: %w", opts.AppName, err)
+		}
+		_, dialer, err := agent.BringUpAgent(ctx, apiClient, app, app.Network, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed wireguard connection: %w", err)
+		}
+		buildkitClient, err = client.New(ctx, r.addr, client.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "tcp", addr)
+		}))
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect to buildkit daemon at %s via wireguard: %w", r.addr, err)
+		}
+		terminal.Debug("Successfully connected via wireguard")
+	}
+
+	streams.StopProgressIndicator()
+	cmdfmt.PrintDone(streams.ErrOut, fmt.Sprintf("Connected to buildkit daemon at %s", r.addr))
+
+	buildState.BuildAndPushStart()
+	defer buildState.BuildAndPushFinish()
+
+	res, err := buildImage(ctx, buildkitClient, opts, dockerfilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return newDeploymentImage(ctx, buildkitClient, res, opts.Tag)
+}
+
+func readContent(ctx context.Context, contentClient content.ContentClient, desc *Descriptor) (string, error) {
+	readClient, err := contentClient.Read(ctx, &content.ReadContentRequest{Digest: desc.Digest})
+	if err != nil {
+		return "", fmt.Errorf("failed to create read stream: %w", err)
+	}
+	var data []byte
+	for {
+		resp, err := readClient.Recv()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return "", fmt.Errorf("failed to read from stream: %w", err)
+		}
+		data = append(data, resp.Data...)
+	}
+	return string(data), nil
+}

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -246,7 +246,9 @@ func (r *Resolver) BuildImage(ctx context.Context, streams *iostreams.IOStreams,
 
 	}
 
-	if r.dockerFactory.mode.UseNixpacks() {
+	if buildkitAddr := flag.GetBuildkitAddr(ctx); buildkitAddr != "" {
+		strategies = append(strategies, NewBuildkitBuilder(buildkitAddr))
+	} else if r.dockerFactory.mode.UseNixpacks() {
 		strategies = append(strategies, &nixpacksBuilder{})
 	} else if (r.dockerFactory.mode.UseDepot() && !r.dockerFactory.mode.UseManagedBuilder()) && len(opts.Buildpacks) == 0 && opts.Builder == "" && opts.BuiltIn == "" {
 		strategies = append(strategies, &DepotBuilder{Scope: builderScope})

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/shlex"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/agent"
 
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
@@ -214,7 +215,7 @@ func runConsole(ctx context.Context) error {
 		defer cleanup()
 	}
 
-	_, dialer, err := ssh.BringUpAgent(ctx, apiClient, app, *network, false)
+	_, dialer, err := agent.BringUpAgent(ctx, apiClient, app, *network, false)
 	if err != nil {
 		return err
 	}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -53,6 +53,7 @@ var CommonFlags = flag.Set{
 	flag.Depot(),
 	flag.DepotScope(),
 	flag.Nixpacks(),
+	flag.BuildkitAddr(),
 	flag.BuildOnly(),
 	flag.BpDockerHost(),
 	flag.BpVolume(),

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/command"
@@ -462,7 +463,7 @@ func runMachineRun(ctx context.Context) error {
 	}
 
 	if interact {
-		_, dialer, err := ssh.BringUpAgent(ctx, client, app, *network, false)
+		_, dialer, err := agent.BringUpAgent(ctx, client, app, *network, false)
 		if err != nil {
 			return err
 		}

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -66,6 +66,7 @@ func newUpdate() *cobra.Command {
 			Description: "Container to update with the new image, files, etc; defaults to \"app\" or the first container in the config.",
 			Hidden:      false,
 		},
+		flag.BuildkitAddr(),
 	)
 
 	cmd.Args = cobra.RangeArgs(0, 1)

--- a/internal/command/postgres/barman.go
+++ b/internal/command/postgres/barman.go
@@ -468,7 +468,7 @@ func runConsole(ctx context.Context, cmd string) error {
 		return fmt.Errorf("get app: %w", err)
 	}
 
-	agentclient, dialer, err := ssh.BringUpAgent(ctx, client, app, "", false)
+	agentclient, dialer, err := agent.BringUpAgent(ctx, client, app, "", false)
 	if err != nil {
 		return err
 	}

--- a/internal/command/ssh/connect.go
+++ b/internal/command/ssh/connect.go
@@ -14,41 +14,11 @@ import (
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/flyutil"
-	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/ssh"
 	"github.com/superfly/flyctl/terminal"
 )
 
 const DefaultSshUsername = "root"
-
-func BringUpAgent(ctx context.Context, client flyutil.Client, app *fly.AppCompact, network string, quiet bool) (*agent.Client, agent.Dialer, error) {
-	io := iostreams.FromContext(ctx)
-
-	agentclient, err := agent.Establish(ctx, client)
-	if err != nil {
-		captureError(ctx, err, app)
-		return nil, nil, errors.Wrap(err, "can't establish agent")
-	}
-
-	dialer, err := agentclient.Dialer(ctx, app.Organization.Slug, network)
-	if err != nil {
-		captureError(ctx, err, app)
-		return nil, nil, fmt.Errorf("ssh: can't build tunnel for %s: %s\n", app.Organization.Slug, err)
-	}
-
-	if !quiet {
-		io.StartProgressIndicatorMsg("Connecting to tunnel")
-	}
-	if err := agentclient.WaitForTunnel(ctx, app.Organization.Slug, network); err != nil {
-		captureError(ctx, err, app)
-		return nil, nil, errors.Wrapf(err, "tunnel unavailable")
-	}
-	if !quiet {
-		io.StopProgressIndicator()
-	}
-
-	return agentclient, dialer, nil
-}
 
 type ConnectParams struct {
 	Ctx            context.Context

--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -172,7 +172,7 @@ func runConsole(ctx context.Context) error {
 		return fmt.Errorf("get app network: %w", err)
 	}
 
-	agentclient, dialer, err := BringUpAgent(ctx, client, app, *network, quiet(ctx))
+	agentclient, dialer, err := agent.BringUpAgent(ctx, client, app, *network, quiet(ctx))
 	if err != nil {
 		return err
 	}

--- a/internal/command/ssh/sftp.go
+++ b/internal/command/ssh/sftp.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/pkg/sftp"
 	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
@@ -100,7 +101,7 @@ func newSFTPConnection(ctx context.Context) (*sftp.Client, error) {
 		return nil, fmt.Errorf("get app network: %w", err)
 	}
 
-	agentclient, dialer, err := BringUpAgent(ctx, client, app, *network, quiet(ctx))
+	agentclient, dialer, err := agent.BringUpAgent(ctx, client, app, *network, quiet(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/flag/context.go
+++ b/internal/flag/context.go
@@ -196,3 +196,11 @@ func GetFlagsName(ctx context.Context, ignoreFlags []string) []string {
 func GetProcessGroup(ctx context.Context) string {
 	return GetString(ctx, flagnames.ProcessGroup)
 }
+
+func GetBuildkitAddr(ctx context.Context) string {
+	addr := GetString(ctx, "buildkit-addr")
+	if addr == "" {
+		addr = env.First("BUILDKIT_ADDR")
+	}
+	return addr
+}

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -584,6 +584,14 @@ func Nixpacks() Bool {
 	}
 }
 
+func BuildkitAddr() String {
+	return String{
+		Name:        "buildkit-addr",
+		Description: "Address of remote buildkit daemon (e.g. tcp://127.0.0.1:1234 or unix:///path/to/socket)",
+		EnvName:     "BUILDKIT_ADDR",
+	}
+}
+
 func Strategy() String {
 	return String{
 		Name:        "strategy",


### PR DESCRIPTION
### Change Summary

This PR adds a 'buildkit' build strategy, selected when the `--buildkit-addr` flag (or `BUILDKIT_ADDR` env) is set.
If a direct connection fails, the strategy attempts to connect through the target app's private network using a Wireguard agent.

What and Why:

Supports building images using a standard `buildkit` daemon, which may run separately from the Docker daemon.

The main use-case is to build images on a stock `moby/buildkit` image, running in an app with a private IPv6 address connecting over Flycast. See [`wjordan/buildkit`](https://github.com/wjordan/fly-buildkit) for a simple, fully-functional template in about 10 lines of config.

How:

Since the Depot build strategy mostly uses a Buildkit client already, a lot of the existing code was able to be reused along with some boilerplate to fit the existing build strategy interfaces.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
