### PR TITLE
Update fly scale vm flag

### DIFF
--- a/internal/command/scale/vm.go
+++ b/internal/command/scale/vm.go
@@ -17,10 +17,11 @@ func newScaleVm() *cobra.Command {
 		short = "Change an app's VM to a named size (eg. shared-cpu-1x, performance-1x, performance-2x...)"
 		long  = `Change an application's VM size to one of the named VM sizes.
 
-For a full list of supported sizes use the command 'flyctl platform vm-sizes'
+For a full list of supported sizes use the command ` + "`flyctl platform vm-sizes`" + `.
 
-Memory size can be set with --memory=number-of-MB
-e.g. flyctl scale vm shared-cpu-1x --memory=2048
+Memory size can be set with the ` + "`--vm-memory`" + ` flag followed by the number of MB.
+
+For example: ` + "`flyctl scale vm shared-cpu-1x --vm-memory=2048`" + `.
 
 For pricing, see https://fly.io/docs/about/pricing/`
 	)


### PR DESCRIPTION
### Change Summary
Changed out the incorrect flag usage of the `fly scale vm` command from -memory to --vm-memory. Wraps --vm-memory in backticks so the double dashes render correctly instead of being converted by markdown. Makes it more readable with clearer phrasing and formatting as well.

[PR](https://github.com/superfly/docs/pull/2114) from docs for the same change

### Documentation
https://fly.io/docs/flyctl/scale-vm/

- [ ] Fresh Produce
- [x ] In superfly/docs, or asked for help from docs team
- [ ] n/a
