### PR TITLE
Allow enabling Postgis via mpg create command

### DIFF
--- a/internal/command/mpg/create.go
+++ b/internal/command/mpg/create.go
@@ -27,6 +27,7 @@ type CreateClusterParams struct {
 	Plan            string
 	VolumeSizeGB    int
 	PGVectorEnabled bool
+	PostGISEnabled  bool
 }
 
 // PlanDetails holds the details for each managed postgres plan.
@@ -90,6 +91,11 @@ func newCreate() *cobra.Command {
 		flag.Bool{
 			Name:        "pgvector",
 			Description: "Enable PGVector for the Postgres cluster",
+			Default:     false,
+		},
+		flag.Bool{
+			Name:        "postgis",
+			Description: "Enable PostGIS for the Postgres cluster",
 			Default:     false,
 		},
 	)
@@ -222,6 +228,7 @@ func runCreate(ctx context.Context) error {
 		Plan:            plan,
 		VolumeSizeGB:    flag.GetInt(ctx, "volume-size"),
 		PGVectorEnabled: flag.GetBool(ctx, "pgvector"),
+		PostGISEnabled:  flag.GetBool(ctx, "postgis"),
 	}
 
 	uiexClient := uiexutil.ClientFromContext(ctx)
@@ -233,6 +240,7 @@ func runCreate(ctx context.Context) error {
 		OrgSlug:         params.OrgSlug,
 		Disk:            params.VolumeSizeGB,
 		PGVectorEnabled: params.PGVectorEnabled,
+		PostGISEnabled:  params.PostGISEnabled,
 	}
 
 	response, err := uiexClient.CreateCluster(ctx, input)
@@ -289,6 +297,7 @@ func runCreate(ctx context.Context) error {
 	fmt.Fprintf(io.Out, "  Plan: %s\n", params.Plan)
 	fmt.Fprintf(io.Out, "  Disk: %dGB\n", response.Data.Disk)
 	fmt.Fprintf(io.Out, "  PGVector: %t\n", response.Data.PGVectorEnabled)
+	fmt.Fprintf(io.Out, "  PostGIS: %t\n", response.Data.PostGISEnabled)
 	fmt.Fprintf(io.Out, "  Connection string: %s\n", connectionURI)
 
 	return nil

--- a/internal/command/mpg/mpg_test.go
+++ b/internal/command/mpg/mpg_test.go
@@ -584,6 +584,7 @@ func TestCreateCommand_Logic(t *testing.T) {
 					Disk            int                              `json:"disk"`
 					IpAssignments   uiex.ManagedClusterIpAssignments `json:"ip_assignments"`
 					PGVectorEnabled bool                             `json:"pgvector_enabled"`
+					PostGISEnabled  bool                             `json:"postgis_enabled"`
 				}{
 					Id:              expectedCluster.Id,
 					Name:            expectedCluster.Name,
@@ -591,6 +592,7 @@ func TestCreateCommand_Logic(t *testing.T) {
 					Plan:            expectedCluster.Plan,
 					Organization:    expectedCluster.Organization,
 					PGVectorEnabled: false,
+					PostGISEnabled:  false,
 				},
 			}, nil
 		},

--- a/internal/uiex/managed_postgres.go
+++ b/internal/uiex/managed_postgres.go
@@ -228,6 +228,7 @@ type CreateClusterInput struct {
 	OrgSlug         string `json:"org_slug"`
 	Disk            int    `json:"disk"`
 	PGVectorEnabled bool   `json:"pgvector_enabled"`
+	PostGISEnabled  bool   `json:"postgis_enabled"`
 }
 
 type CreateClusterResponse struct {
@@ -245,6 +246,7 @@ type CreateClusterResponse struct {
 		Disk            int                         `json:"disk"`
 		IpAssignments   ManagedClusterIpAssignments `json:"ip_assignments"`
 		PGVectorEnabled bool                        `json:"pgvector_enabled"`
+		PostGISEnabled  bool                        `json:"postgis_enabled"`
 	} `json:"data"`
 }
 


### PR DESCRIPTION
### Change Summary

What and Why:
This adds a `--postgis` flag to the `mpg create` command, letting users enable Postgis without using the dashboard.

How:
Adds the flag + call to UIEX to enable postgis, same as what the dashboard uses. Tested locally and confirmed that all permutations work:
- Creating a cluster with PostGIS 
- Creating a cluster with both PostGIS + PGVector
- Creating a cluster with PGVector
- Creating a cluster without any extensions

Related to:

---

### Documentation

- [ ] Fresh Produce
- [X ] In superfly/docs, or asked for help from docs team
- [ ] n/a
