### PR TITLE
fix(scale): Ignore volumes on troubled hosts

### DIFF
--- a/internal/command/scale/machine_defaults.go
+++ b/internal/command/scale/machine_defaults.go
@@ -68,7 +68,7 @@ func newDefaults(appConfig *appconfig.Config, latest fly.Release, machines []*fl
 		defaults.existingVolumes = lo.MapValues(
 			lo.GroupBy(
 				lo.FilterMap(volumes, func(v fly.Volume, _ int) (*fly.Volume, bool) {
-					return &v, !v.IsAttached()
+					return &v, !v.IsAttached() && v.HostStatus == "ok"
 				}),
 				func(v *fly.Volume) string { return v.Name },
 			),


### PR DESCRIPTION
### Change Summary

What and Why: `fly scale` is considering volumes in unreachable hosts as available 

How: Ignore volumes if its `HostStatus` is not `ok`.  Same as we do for `fly deploy` at https://github.com/superfly/flyctl/blob/master/internal/command/deploy/machines.go#L445-L447

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
