### PR TITLE
fix: nil pointer reference setMachineReleaseData

### DIFF
--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/samber/lo"
 	fly "github.com/superfly/fly-go"
+
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/containerconfig"
 	"github.com/superfly/flyctl/internal/machine"
@@ -240,6 +241,15 @@ func hasContainerFiles(mConfig *fly.MachineConfig) bool {
 }
 
 func (md *machineDeployment) setMachineReleaseData(mConfig *fly.MachineConfig) {
+	if mConfig == nil {
+		return
+	}
+
+	// Set the release metadata if not already set
+	if mConfig.Metadata == nil {
+		mConfig.Metadata = make(map[string]string)
+	}
+
 	mConfig.Metadata = lo.Assign(mConfig.Metadata, map[string]string{
 		fly.MachineConfigMetadataKeyFlyReleaseId:      md.releaseId,
 		fly.MachineConfigMetadataKeyFlyReleaseVersion: strconv.Itoa(md.releaseVersion),


### PR DESCRIPTION
### Change Summary

What and Why:
Fix a potential nil panic when accessing app.Role in the setMachineReleaseData function.
In some cases, md.app could be nil, leading to a runtime panic during deploys or restarts.

How:
Added a nil check, nothing else

Related to: https://github.com/superfly/flyctl/issues/4190 
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
