### PR TITLE
fix acquireMachineLease timeout seconds calculation

### DIFF
--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -746,7 +746,7 @@ func waitForMachineState(ctx context.Context, lm mach.LeasableMachine, possibleS
 }
 
 func (md *machineDeployment) acquireMachineLease(ctx context.Context, machID string) (*fly.MachineLease, error) {
-	leaseTimeout := int(md.leaseTimeout)
+	leaseTimeout := int(md.leaseTimeout.Seconds())
 	lease, err := md.flapsClient.AcquireLease(ctx, machID, &leaseTimeout)
 	if err != nil {
 		// TODO: tell users how to manually clear the lease


### PR DESCRIPTION
fixes a small unit-conversion bug that was causing machines to acquire longer than expected leases (e.g., 13 billion seconds instead of 13 seconds).