### PR TITLE
ci: skip "make" correctly

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -35,12 +35,14 @@ jobs:
           echo "FLY_PREFLIGHT_TEST_APP_PREFIX=gha-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" >> "$GITHUB_ENV"
       # If this workflow is triggered by code changes (eg PRs), download the binary to save time.
       - uses: actions/download-artifact@v4
+        id: download-flyctl
         with:
           name: flyctl
           path: master-build
         continue-on-error: true
       # But if this is a manual run, build the binary first.
       - run: make
+        if: steps.download-flyctl.outcome == 'failure'
       - name: Run preflight tests
         id: preflight
         env:


### PR DESCRIPTION
It has been broken since #4013. Building flyctl takes 1.5 minutes nowadays. So skipping the step will shorten the feedback cycle.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
