### PR TITLE
Rename command to 'mpg' and remove alias

### DIFF
--- a/internal/command/mpg/mpg.go
+++ b/internal/command/mpg/mpg.go
@@ -61,9 +61,7 @@ func New() *cobra.Command {
 		long = short + "\n"
 	)
 
-	cmd := command.New("managed-postgres", short, long, nil)
-
-	cmd.Aliases = []string{"mpg"}
+	cmd := command.New("mpg", short, long, nil)
 
 	flag.Add(cmd,
 		flag.Org(),


### PR DESCRIPTION
### Change Summary

What and Why:

Changed the command name from `managed-postgres` to `mpg` and removed the alias for simplification.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
