### PR TITLE
build: upgrade Go to 1.24.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as build
+FROM golang:1.24.5-alpine as build
 RUN apk --no-cache add ca-certificates
 
 RUN mkdir /newtmp && chown 1777 /newtmp

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:alpine as build
+FROM golang:1.24.5-alpine as build
 RUN apk --no-cache add ca-certificates
 
 WORKDIR /build

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/superfly/flyctl
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.5
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/internal/command/certificates/root.go
+++ b/internal/command/certificates/root.go
@@ -522,9 +522,9 @@ func printDNSSetupOptions(opts DNSSetupFlags) error {
 	}
 
 	if opts.Certificate.IsWildcard {
-		fmt.Fprintf(io.Out, colorize.Yellow("Required: DNS Challenge\n\n"))
+		fmt.Fprint(io.Out, colorize.Yellow("Required: DNS Challenge\n\n"))
 	} else {
-		fmt.Fprintf(io.Out, colorize.Yellow("Optional: DNS Challenge\n\n"))
+		fmt.Fprint(io.Out, colorize.Yellow("Optional: DNS Challenge\n\n"))
 	}
 	fmt.Fprintf(io.Out, "   %s → %s\n\n", opts.Certificate.DNSValidationHostname, opts.Certificate.DNSValidationTarget)
 	fmt.Fprintln(io.Out, "   Additional to one of the DNS setups.")

--- a/internal/uiex/managed_postgres.go
+++ b/internal/uiex/managed_postgres.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -289,7 +290,7 @@ func (c *Client) CreateCluster(ctx context.Context, input CreateClusterInput) (C
 	case http.StatusForbidden:
 		if err = json.Unmarshal(body, &response); err == nil {
 			if response.Errors.Detail != "" {
-				return response, fmt.Errorf(response.Errors.Detail)
+				return response, errors.New(response.Errors.Detail)
 			}
 		}
 


### PR DESCRIPTION
There are small tweaks since 1.24 is more strict about fmt.Printf and its family.

https://tip.golang.org/doc/go1.24#vet
> The existing printf analyzer now reports a diagnostic for calls of
> the form fmt.Printf(s), where s is a non-constant format string,
> with no other arguments.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
