### PR TITLE
Add MPG 'starter' plan

### DIFF
--- a/internal/command/mpg/plans.go
+++ b/internal/command/mpg/plans.go
@@ -15,6 +15,12 @@ var MPGPlans = map[string]PlanDetails{
 		Memory:     "1 GB",
 		PricePerMo: 38,
 	},
+	"starter": {
+		Name:       "Starter",
+		CPU:        "Shared x 2",
+		Memory:     "2 GB",
+		PricePerMo: 72,
+	},
 	"launch": {
 		Name:       "Launch",
 		CPU:        "Performance x 2",


### PR DESCRIPTION
### Change Summary

What and Why:

Introduces a new 'starter' plan for MPG with 2 shared CPUs, 2 GB memory, and a monthly price of $72.00