### PR TITLE
add registry auth for internal mirror

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -37,6 +37,7 @@ import (
 	"github.com/superfly/flyctl/internal/tracing"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/terminal"
+	"github.com/superfly/macaroon/flyio/machinesapi"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -670,10 +671,12 @@ func registryAuth(token string) registry.AuthConfig {
 
 func authConfigs(token string) map[string]registry.AuthConfig {
 	targetRegistry := viper.GetString(flyctl.ConfigRegistryHost)
+	mirrorRegistry := net.JoinHostPort(machinesapi.InternalURL.Hostname(), "5000")
 
 	authConfigs := map[string]registry.AuthConfig{}
 
 	authConfigs[targetRegistry] = registryAuth(token)
+	authConfigs[mirrorRegistry] = registryAuth(token)
 
 	dockerhubUsername := os.Getenv("DOCKER_HUB_USERNAME")
 	dockerhubPassword := os.Getenv("DOCKER_HUB_PASSWORD")


### PR DESCRIPTION
### Change Summary

What and Why:

Adds the internal Machines API endpoint to Docker auth configs, so credentials are passed through to a local registry mirror.

How:

adds an extra entry to the `authConfigs` map in `imgsrc.authConfigs(token)`.

Related to:

#4489, #4526 

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
