### PR TITLE
set fly_builder_id metadata from remote builder

### DIFF
--- a/internal/build/imgsrc/buildkit_builder.go
+++ b/internal/build/imgsrc/buildkit_builder.go
@@ -60,6 +60,7 @@ func (r *BuildkitBuilder) Run(ctx context.Context, _ *dockerClientFactory, strea
 	if err != nil {
 		return nil, "", err
 	}
+	build.BuilderMeta.RemoteMachineId = image.BuilderID
 	cmdfmt.PrintDone(streams.ErrOut, "Building image done")
 	span.SetAttributes(image.ToSpanAttributes()...)
 	return image, "", nil

--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -14,6 +14,7 @@ import (
 	depotmachine "github.com/depot/depot-go/machine"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/session/secrets/secretsprovider"
+	"github.com/moby/buildkit/worker/label"
 	"github.com/pkg/errors"
 	"github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/helpers"
@@ -326,10 +327,19 @@ func newDeploymentImage(ctx context.Context, c *client.Client, res *client.Solve
 		}
 	}
 
+	var builderHostname string
+	workers, err := c.ListWorkers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, w := range workers {
+		builderHostname = w.Labels[label.Hostname]
+	}
 	image := &DeploymentImage{
-		ID:   id,
-		Tag:  tag,
-		Size: descriptor.Bytes(),
+		ID:        id,
+		Tag:       tag,
+		Size:      descriptor.Bytes(),
+		BuilderID: builderHostname,
 	}
 
 	return image, nil

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -118,12 +118,13 @@ func (ro RefOptions) ToSpanAttributes() []attribute.KeyValue {
 }
 
 type DeploymentImage struct {
-	ID      string
-	Tag     string
-	Digest  string
-	Size    int64
-	BuildID string
-	Labels  map[string]string
+	ID        string
+	Tag       string
+	Digest    string
+	Size      int64
+	BuildID   string
+	BuilderID string
+	Labels    map[string]string
 }
 
 func (image *DeploymentImage) String() string {
@@ -292,6 +293,7 @@ func (r *Resolver) BuildImage(ctx context.Context, streams *iostreams.IOStreams,
 				// we should only set the image's buildID if we push the build info to web
 				img.BuildID = buildResult.BuildId
 			}
+			img.BuilderID = bld.BuilderMeta.RemoteMachineId
 
 			return img, nil
 		}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -607,6 +607,7 @@ func deployToMachines(
 		ProcessGroups:         processGroups,
 		DeployRetries:         deployRetries,
 		BuildID:               img.BuildID,
+		BuilderID:             img.BuilderID,
 	}
 
 	var path = flag.GetString(ctx, "export-manifest")

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -76,6 +76,7 @@ type MachineDeploymentArgs struct {
 	RestartMaxRetries     int
 	DeployRetries         int
 	BuildID               string
+	BuilderID             string
 }
 
 func argsFromManifest(manifest *DeployManifest, app *fly.AppCompact) MachineDeploymentArgs {
@@ -155,6 +156,7 @@ type machineDeployment struct {
 	tigrisStatics         *statics.DeployerState
 	deployRetries         int
 	buildID               string
+	builderID             string
 }
 
 func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (_ MachineDeployment, err error) {
@@ -282,6 +284,7 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (_ Ma
 		processGroups:         args.ProcessGroups,
 		deployRetries:         args.DeployRetries,
 		buildID:               args.BuildID,
+		builderID:             args.BuilderID,
 	}
 	if err := md.setStrategy(); err != nil {
 		tracing.RecordError(span, err, "failed to set strategy")
@@ -419,6 +422,9 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 			m.Config.Metadata[fly.MachineConfigMetadataKeyFlyctlVersion] = buildinfo.Version().String()
 			if m.Config.Metadata[fly.MachineConfigMetadataKeyFlyProcessGroup] == "" {
 				m.Config.Metadata[fly.MachineConfigMetadataKeyFlyProcessGroup] = md.appConfig.DefaultProcessName()
+			}
+			if md.builderID != "" {
+				m.Config.Metadata["fly_builder_id"] = md.builderID
 			}
 		}
 	}

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -263,6 +263,10 @@ func (md *machineDeployment) setMachineReleaseData(mConfig *fly.MachineConfig) {
 	} else {
 		delete(mConfig.Metadata, fly.MachineConfigMetadataKeyFlyManagedPostgres)
 	}
+
+	if md.builderID != "" {
+		mConfig.Metadata["fly_builder_id"] = md.builderID
+	}
 }
 
 // Skip launching currently-stopped or suspended machines if:


### PR DESCRIPTION
Sets a new `fly_builder_id` Machine metadata field from the remote builder ID, when a remote builder is used to create+push the image used to deploy Machines.

Also sets the remote builder ID derived from the buildkit worker's hostname label for buildkit-based builds.

Related to:

#4489

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
