### PR TITLE
detect if we're using compatible tokens for MPG commands

### DIFF
--- a/internal/command/mpg/attach.go
+++ b/internal/command/mpg/attach.go
@@ -43,6 +43,11 @@ func newAttach() *cobra.Command {
 }
 
 func runAttach(ctx context.Context) error {
+	// Check token compatibility early
+	if err := validateMPGTokenCompatibility(ctx); err != nil {
+		return err
+	}
+
 	var (
 		clusterId  = flag.FirstArg(ctx)
 		appName    = appconfig.NameFromContext(ctx)

--- a/internal/command/mpg/connect.go
+++ b/internal/command/mpg/connect.go
@@ -33,6 +33,11 @@ func newConnect() (cmd *cobra.Command) {
 }
 
 func runConnect(ctx context.Context) (err error) {
+	// Check token compatibility early
+	if err := validateMPGTokenCompatibility(ctx); err != nil {
+		return err
+	}
+
 	io := iostreams.FromContext(ctx)
 
 	localProxyPort := "16380"

--- a/internal/command/mpg/create.go
+++ b/internal/command/mpg/create.go
@@ -69,6 +69,11 @@ func newCreate() *cobra.Command {
 }
 
 func runCreate(ctx context.Context) error {
+	// Check token compatibility early
+	if err := validateMPGTokenCompatibility(ctx); err != nil {
+		return err
+	}
+
 	var (
 		io      = iostreams.FromContext(ctx)
 		appName = flag.GetString(ctx, "name")

--- a/internal/command/mpg/destroy.go
+++ b/internal/command/mpg/destroy.go
@@ -36,6 +36,11 @@ This action is not reversible.`
 }
 
 func runDestroy(ctx context.Context) error {
+	// Check token compatibility early
+	if err := validateMPGTokenCompatibility(ctx); err != nil {
+		return err
+	}
+
 	var (
 		clusterId  = flag.FirstArg(ctx)
 		uiexClient = uiexutil.ClientFromContext(ctx)

--- a/internal/command/mpg/list.go
+++ b/internal/command/mpg/list.go
@@ -40,6 +40,11 @@ If no organization is specified, the user's personal organization is used.`
 }
 
 func runList(ctx context.Context) error {
+	// Check token compatibility early
+	if err := validateMPGTokenCompatibility(ctx); err != nil {
+		return err
+	}
+
 	cfg := config.FromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
 

--- a/internal/command/mpg/mpg_test.go
+++ b/internal/command/mpg/mpg_test.go
@@ -917,7 +917,7 @@ func TestMPGTokenValidation(t *testing.T) {
 		err := validateMPGTokenCompatibility(ctxWithBearerTokens)
 		assert.Error(t, err, "MPG commands should reject contexts with only bearer tokens")
 		assert.Contains(t, err.Error(), "MPG commands require updated tokens")
-		
+
 		// Create a context with macaroon tokens
 		macaroonTokens := tokens.Parse("fm1r_macaroon_token")
 		configWithMacaroonTokens := &config.Config{

--- a/internal/command/mpg/proxy.go
+++ b/internal/command/mpg/proxy.go
@@ -43,6 +43,11 @@ func newProxy() (cmd *cobra.Command) {
 }
 
 func runProxy(ctx context.Context) (err error) {
+	// Check token compatibility early
+	if err := validateMPGTokenCompatibility(ctx); err != nil {
+		return err
+	}
+
 	localProxyPort := "16380"
 	_, params, _, err := getMpgProxyParams(ctx, localProxyPort)
 	if err != nil {

--- a/internal/command/mpg/status.go
+++ b/internal/command/mpg/status.go
@@ -35,6 +35,11 @@ func newStatus() *cobra.Command {
 }
 
 func runStatus(ctx context.Context) error {
+	// Check token compatibility early
+	if err := validateMPGTokenCompatibility(ctx); err != nil {
+		return err
+	}
+
 	cfg := config.FromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
 	uiexClient := uiexutil.ClientFromContext(ctx)


### PR DESCRIPTION
https://community.fly.io/t/no-postgres-clusters-in-your-organization/25776/3

```
flyctl master*​
❯ flyctl mpg list --org mine
ID                      NAME                    ORG                     REGION  STATUS  PLAN
anid                    aname                   mine                    iad     ready   basic


flyctl master*​
❯ FLY_API_TOKEN="fo1_an_oauth_bearer_token" flyctl mpg list --org mine
Error: MPG commands require updated tokens but found older-style tokens.

Please upgrade your authentication by running:
  flyctl auth logout
  flyctl auth login

```