### PR TITLE
improve error messages when comppose files aren't parseable

### DIFF
--- a/internal/containerconfig/compose.go
+++ b/internal/containerconfig/compose.go
@@ -78,7 +78,12 @@ func parseComposeFile(composePath string) (*ComposeFile, error) {
 
 	var compose ComposeFile
 	if err := yaml.Unmarshal(data, &compose); err != nil {
-		return nil, fmt.Errorf("failed to parse compose file: %w", err)
+		// Try to extract more detailed error information from yaml.TypeError
+		if typeErr, ok := err.(*yaml.TypeError); ok && len(typeErr.Errors) > 0 {
+			return nil, fmt.Errorf("YAML syntax error in compose file %s: %s", composePath, typeErr.Errors[0])
+		}
+		// Provide the file path and line/column info if available in the error message
+		return nil, fmt.Errorf("YAML syntax error in compose file %s: %w", composePath, err)
 	}
 
 	return &compose, nil

--- a/internal/containerconfig/parse.go
+++ b/internal/containerconfig/parse.go
@@ -20,7 +20,8 @@ func ParseContainerConfig(mConfig *fly.MachineConfig, composePath, machineConfig
 			composePath = filepath.Join(configDir, composePath)
 		}
 		if err := ParseComposeFileWithPath(mConfig, composePath); err != nil {
-			return err
+			// Add more context to compose file errors
+			return fmt.Errorf("failed to load compose file '%s': %w", composePath, err)
 		}
 	} else if machineConfigStr != "" {
 		// Fall back to machine config if specified


### PR DESCRIPTION
See https://community.fly.io/t/docker-compose-compatibility-the-journey-begins/25285/22?u=rubys