### PR TITLE
ci: upgrade golangci-lint and enable misspell linter

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,6 +41,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64
+          version: v2.4.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - staticcheck
     - unconvert
     - unused
+    - misspell
   settings:
     errcheck:
       exclude-functions:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,96 +1,70 @@
-issues:
-  # List of regexps of issue texts to exclude, empty list by default.
-  # But independently from this option we use default exclude patterns,
-  # it can be disabled by `exclude-use-default: false`. To list all
-  # excluded by default patterns execute `golangci-lint run --help`
-
-  exclude-rules:
-    # Exclude gosimple bool check
-    - linters:
-        - gosimple
-      text: "S(1002|1008|1021)"
-    # Exclude failing staticchecks for now
-    - linters:
-        - staticcheck
-      text: "SA(1006|1019|4006|4010|4017|5007|6005|9004):"
-    # Exclude lll issues for long lines with go:generate
-    - linters:
-        - lll
-      source: "^//go:generate "
-
-  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
-  max-issues-per-linter: 0
-
-  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
-  max-same-issues: 0
-
+version: "2"
+run:
+  concurrency: 4
+  go: "1.21"
+  issues-exit-code: 1
+  tests: true
 linters:
-  disable-all: true
+  default: none
   enable:
-    - gofmt
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unconvert
     - unused
-
-# options for analysis running
-run:
-  go: "1.21"
-
-  # default concurrency is a available CPU number
-  concurrency: 4
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 10m
-
-  # exit code when at least one issue was found, default is 1
-  issues-exit-code: 1
-
-  # include test files or not, default is true
-  tests: true
-
-  # list of build tags, all linters use it. Default is empty list.
-  #build-tags:
-  #  - mytag
-  #  - lib/bad.go
-
-  # by default isn't set. If set we pass it to "go list -mod={option}". From "go help modules":
-  # If invoked with -mod=readonly, the go command is disallowed from the implicit
-  # automatic updating of go.mod described above. Instead, it fails when any changes
-  # to go.mod are needed. This setting is most useful to check that go.mod does
-  # not need updates, such as in a continuous integration and testing system.
-  # If invoked with -mod=vendor, the go command assumes that the vendor
-  # directory holds the correct copies of dependencies and ignores
-  # the dependency descriptions in go.mod.
-  # modules-download-mode: vendor
-
-# output configuration options
-output:
-  # print lines of code with issue, default is true
-  print-issued-lines: true
-
-  # print linter name in the end of issue text, default is true
-  print-linter-name: true
-
-
-  sort-results: true
-
-# all available settings of specific linters
-linters-settings:
-  errcheck:
-    exclude-functions:
-      - fmt.*
-      - io.Close
-  govet:
-    settings:
-      printf:
-        funcs:
-          - github.com/superfly/flyctl/terminal.Debugf
-          - github.com/superfly/flyctl/terminal.Infof
-          - github.com/superfly/flyctl/terminal.Warnf
-          - github.com/superfly/flyctl/terminal.Errorf
-          - github.com/superfly/flyctl/render.Printf
-          - github.com/superfly/flyctl/render.Detailf
-          - github.com/superfly/flyctl/render.Donef
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.*
+        - io.Close
+    govet:
+      settings:
+        printf:
+          funcs:
+            - github.com/superfly/flyctl/terminal.Debugf
+            - github.com/superfly/flyctl/terminal.Infof
+            - github.com/superfly/flyctl/terminal.Warnf
+            - github.com/superfly/flyctl/terminal.Errorf
+            - github.com/superfly/flyctl/render.Printf
+            - github.com/superfly/flyctl/render.Detailf
+            - github.com/superfly/flyctl/render.Donef
+    staticcheck:
+      checks:
+        - all
+        - -SA1019 # ... is deprecated
+        - -ST1003 # struct field ... should be ... (mostly acronyms such as Http -> HTTP)
+        - -ST1005 # error strings should not be capitalized
+        - -ST1008 # error should be returned as the last argument
+        - -ST1012 # error var ... should have name of the form Err...
+        - -QF1001 # could apply De Morgan's law
+        - -QF1002 # could use tagged switch
+        - -QF1003 # could use tagged switch on app
+        - -QF1008 # could remove embedded field ... from selector
+        - -QF1012 # Use fmt.Fprintf(...) instead of WriteString(fmt.Sprintf(...))
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - lll
+        source: '^//go:generate '
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
 # because goalngci-lint github action is much more useful than the pre-commit action.
 # The trick is to run github action only for "manual" hook stage
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v1.54.2
+    rev: v1.24.0
     hooks:
     -   id: golangci-lint
         stages: [pre-commit]

--- a/agent/client.go
+++ b/agent/client.go
@@ -59,7 +59,7 @@ func Establish(ctx context.Context, apiClient wireguard.WebClient) (*Client, err
 		return c, nil
 	}
 
-	// TOOD: log this instead
+	// TODO: log this instead
 	msg := fmt.Sprintf("The running flyctl agent (v%s) is older than the current flyctl (v%s).", res.Version, buildinfo.Version())
 
 	logger := logger.MaybeFromContext(ctx)

--- a/doc/main.go
+++ b/doc/main.go
@@ -110,7 +110,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			}
 			cname := name + " " + child.Name()
 			link := cname + ".md"
-			link = strings.Replace(link, " ", "_", -1)
+			link = strings.ReplaceAll(link, " ", "_")
 			buf.WriteString(fmt.Sprintf("* [%s](%s)\t - %s\n", child.Name(), linkHandler(link), child.Short))
 		}
 		buf.WriteString("\n")
@@ -130,7 +130,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 			parent := cmd.Parent()
 			pname := parent.CommandPath()
 			link := pname + ".md"
-			link = strings.Replace(link, " ", "_", -1)
+			link = strings.ReplaceAll(link, " ", "_")
 			buf.WriteString(fmt.Sprintf("* [%s](%s)\t - %s\n", pname, linkHandler(link), parent.Short))
 			cmd.VisitParents(func(c *cobra.Command) {
 				if c.DisableAutoGenTag {
@@ -172,7 +172,7 @@ func GenMarkdownTreeCustom(cmd *cobra.Command, dir string, filePrepender, linkHa
 		}
 	}
 
-	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".md"
+	basename := strings.ReplaceAll(cmd.CommandPath(), " ", "_") + ".md"
 	filename := filepath.Join(dir, basename)
 	f, err := os.Create(filename)
 	if err != nil {

--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -298,48 +298,48 @@ func (c *Config) InternalPort() int {
 	return 0
 }
 
-func (cfg *Config) BuildStrategies() []string {
+func (c *Config) BuildStrategies() []string {
 	strategies := []string{}
 
-	if cfg == nil || cfg.Build == nil {
+	if c == nil || c.Build == nil {
 		return strategies
 	}
 
-	if cfg.Build.Image != "" {
-		strategies = append(strategies, fmt.Sprintf("the \"%s\" docker image", cfg.Build.Image))
+	if c.Build.Image != "" {
+		strategies = append(strategies, fmt.Sprintf("the \"%s\" docker image", c.Build.Image))
 	}
-	if cfg.Build.Builder != "" || len(cfg.Build.Buildpacks) > 0 {
+	if c.Build.Builder != "" || len(c.Build.Buildpacks) > 0 {
 		strategies = append(strategies, "a buildpack")
 	}
-	if cfg.Build.Dockerfile != "" || cfg.Build.DockerBuildTarget != "" {
-		if cfg.Build.Dockerfile != "" {
-			strategies = append(strategies, fmt.Sprintf("the \"%s\" dockerfile", cfg.Build.Dockerfile))
+	if c.Build.Dockerfile != "" || c.Build.DockerBuildTarget != "" {
+		if c.Build.Dockerfile != "" {
+			strategies = append(strategies, fmt.Sprintf("the \"%s\" dockerfile", c.Build.Dockerfile))
 		} else {
 			strategies = append(strategies, "a dockerfile")
 		}
 	}
-	if cfg.Build.Builtin != "" {
-		strategies = append(strategies, fmt.Sprintf("the \"%s\" builtin image", cfg.Build.Builtin))
+	if c.Build.Builtin != "" {
+		strategies = append(strategies, fmt.Sprintf("the \"%s\" builtin image", c.Build.Builtin))
 	}
 
 	return strategies
 }
 
-func (cfg *Config) URL() *url.URL {
+func (c *Config) URL() *url.URL {
 	u := &url.URL{
 		Scheme: "https",
-		Host:   cfg.AppName + ".fly.dev",
+		Host:   c.AppName + ".fly.dev",
 		Path:   "/",
 	}
 
 	// HTTPService always listen on https, even if ForceHTTPS is false
-	if cfg.HTTPService != nil && cfg.HTTPService.InternalPort > 0 {
+	if c.HTTPService != nil && c.HTTPService.InternalPort > 0 {
 		return u
 	}
 
 	var httpPorts []int
 	var httpsPorts []int
-	for _, service := range cfg.Services {
+	for _, service := range c.Services {
 		for _, port := range service.Ports {
 			if port.Port == nil || !slices.Contains(port.Handlers, "http") {
 				continue
@@ -374,10 +374,10 @@ func (cfg *Config) URL() *url.URL {
 
 // MergeFiles merges the provided files with the files in the config wherein the provided files
 // take precedence.
-func (cfg *Config) MergeFiles(files []*fly.File) error {
+func (c *Config) MergeFiles(files []*fly.File) error {
 	// First convert the Config files to Machine files.
-	cfgFiles := make([]*fly.File, 0, len(cfg.Files))
-	for _, f := range cfg.Files {
+	cfgFiles := make([]*fly.File, 0, len(c.Files))
+	for _, f := range c.Files {
 		machineFile, err := f.toMachineFile()
 		if err != nil {
 			return err
@@ -392,29 +392,29 @@ func (cfg *Config) MergeFiles(files []*fly.File) error {
 	fly.MergeFiles(mConfig, files)
 
 	// Persist the merged files back to the config to be used later for deploying.
-	cfg.MergedFiles = mConfig.Files
+	c.MergedFiles = mConfig.Files
 
 	return nil
 }
 
-func (cfg *Config) DeployStrategy() string {
-	if cfg.Deploy == nil {
+func (c *Config) DeployStrategy() string {
+	if c.Deploy == nil {
 		return ""
 	}
-	return cfg.Deploy.Strategy
+	return c.Deploy.Strategy
 }
 
 // DetectComposeFile returns Build.Compose.File if set, otherwise looks for
 // well-known compose filenames in the directory containing the config file.
 // Returns the first found filename or empty string.
-func (cfg *Config) DetectComposeFile() string {
+func (c *Config) DetectComposeFile() string {
 	// If compose file is explicitly set, return it
-	if cfg.Build != nil && cfg.Build.Compose != nil && cfg.Build.Compose.File != "" {
-		return cfg.Build.Compose.File
+	if c.Build != nil && c.Build.Compose != nil && c.Build.Compose.File != "" {
+		return c.Build.Compose.File
 	}
 
 	// Otherwise, detect well-known filenames
-	configDir := filepath.Dir(cfg.configFilePath)
+	configDir := filepath.Dir(c.configFilePath)
 
 	for _, filename := range WellKnownComposeFilenames {
 		path := filepath.Join(configDir, filename)

--- a/internal/appconfig/machines.go
+++ b/internal/appconfig/machines.go
@@ -239,7 +239,7 @@ func (c *Config) ToConsoleMachineConfig() (*fly.MachineConfig, error) {
 
 // updateMachineConfig applies configuration options from the optional MachineConfig passed in, then the base config, into a new MachineConfig
 func (c *Config) updateMachineConfig(src *fly.MachineConfig) (*fly.MachineConfig, error) {
-	// For flattened app configs there is only one proces name and it is the group it was flattened for
+	// For flattened app configs there is only one process name and it is the group it was flattened for
 	processGroup := c.DefaultProcessName()
 
 	mConfig := &fly.MachineConfig{}

--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -182,7 +182,7 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 }
 
 // initBuilder returns a Depot machine to build a container image.
-// Note that the caller is reponsible for passing a context with a resonable timeout.
+// Note that the caller is responsible for passing a context with a resonable timeout.
 // Otherwise, the function cloud block indefinitely.
 func initBuilder(ctx context.Context, buildState *build, appName string, streams *iostreams.IOStreams, builderScope depotBuilderScope) (m *depotmachine.Machine, b *depotbuild.Build, retErr error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "init_depot_build")

--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -205,7 +205,7 @@ const (
 	buildkitGRPCPort = 1234
 )
 
-// validateBuilder returns a machine if it is availabe for building images.
+// validateBuilder returns a machine if it is available for building images.
 func (p *Provisioner) validateBuilder(ctx context.Context, app *fly.App) (*fly.Machine, error) {
 	machine, err := p.validateBuilderMachine(ctx, app)
 	if err != nil {

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -665,7 +665,7 @@ func (r *Resolver) StartHeartbeat(ctx context.Context) (*StopSignal, error) {
 	defer span.End()
 
 	if !r.dockerFactory.remote || r.dockerFactory.mode.UseDepot() || r.provisioner.UseBuildkit() {
-		span.AddEvent("won't check heartbeart of non-remote build")
+		span.AddEvent("won't check heartbeat of non-remote build")
 		return nil, nil
 	}
 

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -127,14 +127,14 @@ type DeploymentImage struct {
 	Labels    map[string]string
 }
 
-func (image *DeploymentImage) String() string {
-	if image.Digest == "" {
-		return image.Tag
+func (di *DeploymentImage) String() string {
+	if di.Digest == "" {
+		return di.Tag
 	}
-	return fmt.Sprintf("%s@%s", image.Tag, image.Digest)
+	return fmt.Sprintf("%s@%s", di.Tag, di.Digest)
 }
 
-func (di DeploymentImage) ToSpanAttributes() []attribute.KeyValue {
+func (di *DeploymentImage) ToSpanAttributes() []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attribute.String("image.id", di.ID),
 		attribute.String("image.tag", di.Tag),

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -116,8 +116,8 @@ func BuildTime() time.Time {
 
 func Commit() string {
 	info, _ := debug.ReadBuildInfo()
-	var rev string = "<none>"
-	var dirty string = ""
+	var rev = "<none>"
+	var dirty = ""
 	for _, v := range info.Settings {
 		if v.Key == "vcs.revision" {
 			rev = v.Value

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -132,7 +132,7 @@ func ApplyAliases(ctx context.Context) (context.Context, error) {
 			errorMessages = append(errorMessages, fmt.Sprintf("flags '%v' have different types", invalidTypes))
 		}
 		if len(errorMessages) > 1 {
-			err = fmt.Errorf("multiple errors occured:\n > %s\n", strings.Join(errorMessages, "\n > "))
+			err = fmt.Errorf("multiple errors occurred:\n > %s\n", strings.Join(errorMessages, "\n > "))
 		} else if len(errorMessages) == 1 {
 			err = fmt.Errorf("%s", errorMessages[0])
 		}

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -558,7 +558,7 @@ func deployToMachines(
 		deployRetries = int(retries)
 
 	default:
-		var invalidRetriesErr error = fmt.Errorf("--deploy-retries must be set to a positive integer, 0, or 'auto'")
+		var invalidRetriesErr = fmt.Errorf("--deploy-retries must be set to a positive integer, 0, or 'auto'")
 		retries, err := strconv.Atoi(retriesFlag)
 		if err != nil {
 			return invalidRetriesErr

--- a/internal/command/deploy/machinebasedtest.go
+++ b/internal/command/deploy/machinebasedtest.go
@@ -2,6 +2,7 @@ package deploy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -147,7 +148,7 @@ func (md *machineDeployment) runTestMachines(ctx context.Context, machineToTest 
 	return nil
 }
 
-const ErrNoLogsFound = "no logs found"
+var errNoLogsFound = errors.New("no logs found")
 
 func (md *machineDeployment) waitForLogs(ctx context.Context, mach *fly.Machine, timeout time.Duration) error {
 	b := backoff.NewExponentialBackOff()
@@ -160,7 +161,7 @@ func (md *machineDeployment) waitForLogs(ctx context.Context, mach *fly.Machine,
 			return nil, err
 		}
 		if len(logs) == 0 {
-			return nil, errors.New(ErrNoLogsFound)
+			return nil, errNoLogsFound
 		}
 
 		return logs, nil

--- a/internal/command/deploy/machinebasedtest.go
+++ b/internal/command/deploy/machinebasedtest.go
@@ -160,7 +160,7 @@ func (md *machineDeployment) waitForLogs(ctx context.Context, mach *fly.Machine,
 			return nil, err
 		}
 		if len(logs) == 0 {
-			return nil, fmt.Errorf(ErrNoLogsFound)
+			return nil, errors.New(ErrNoLogsFound)
 		}
 
 		return logs, nil

--- a/internal/command/deploy/statics/addon.go
+++ b/internal/command/deploy/statics/addon.go
@@ -128,6 +128,9 @@ func (deployer *DeployerState) ensureBucketCreated(ctx context.Context) (tokeniz
 
 	// TODO(allison): I'd really like ProvisionExtension to return the extension's ID, but for now we can just refetch it
 	extFull, err := gql.GetAddOn(ctx, client.GenqClient(), extName, string(gql.AddOnTypeTigris))
+	if err != nil {
+		return "", err
+	}
 
 	// Update the addon with the tokenized key and the name of the app
 	_, err = gql.UpdateAddOn(ctx, client.GenqClient(), extFull.AddOn.Id, extFull.AddOn.AddOnPlan.Id, []string{}, extFull.AddOn.Options, map[string]interface{}{

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -449,9 +449,9 @@ func Discover(ctx context.Context, provider gql.AddOnType) (addOn *gql.AddOnData
 
 func setSecretsFromExtension(ctx context.Context, app *gql.AppData, extension *Extension, overrideSecretKeyNamesMap map[string]string) (err error) {
 	var (
-		io              = iostreams.FromContext(ctx)
-		client          = flyutil.ClientFromContext(ctx).GenqClient()
-		setSecrets bool = true
+		io         = iostreams.FromContext(ctx)
+		client     = flyutil.ClientFromContext(ctx).GenqClient()
+		setSecrets = true
 	)
 
 	environment := extension.Data.Environment
@@ -556,7 +556,7 @@ func Status(ctx context.Context, provider gql.AddOnType) (err error) {
 		},
 	}
 
-	var cols []string = []string{"Name", "Primary Region", "Status"}
+	var cols = []string{"Name", "Primary Region", "Status"}
 
 	if app != nil {
 		obj[0] = append(obj[0], app.Name)

--- a/internal/command/extensions/enveloop/status.go
+++ b/internal/command/extensions/enveloop/status.go
@@ -51,7 +51,7 @@ func runStatus(ctx context.Context) (err error) {
 		},
 	}
 
-	var cols []string = []string{"Name", "Status", "Region"}
+	var cols = []string{"Name", "Status", "Region"}
 
 	if app != nil {
 		obj[0] = append(obj[0], app.Name)

--- a/internal/command/extensions/tigris/status.go
+++ b/internal/command/extensions/tigris/status.go
@@ -52,7 +52,7 @@ func runStatus(ctx context.Context) (err error) {
 		},
 	}
 
-	var cols []string = []string{"Name", "Status"}
+	var cols = []string{"Name", "Status"}
 
 	optionKeys := []string{"public", "shadow_bucket.write_through", "shadow_bucket.name", "shadow_bucket.endpoint"}
 
@@ -86,7 +86,7 @@ func runStatus(ctx context.Context) (err error) {
 			}
 		}
 		obj[0] = append(obj[0], value)
-		colName := strings.Title(strings.Replace(strings.Join(keys, " "), "_", " ", -1))
+		colName := strings.Title(strings.ReplaceAll(strings.Join(keys, " "), "_", " "))
 		cols = append(cols, colName)
 	}
 

--- a/internal/command/extensions/vector/create.go
+++ b/internal/command/extensions/vector/create.go
@@ -97,7 +97,7 @@ func runCreate(ctx context.Context) (err error) {
 		return err
 	}
 
-	var defaultDimensionCount int = 128
+	var defaultDimensionCount = 128
 
 	var options = gql.AddOnOptions{
 		"similarity_function": function.Identifier,

--- a/internal/command/extensions/vector/status.go
+++ b/internal/command/extensions/vector/status.go
@@ -51,7 +51,7 @@ func runStatus(ctx context.Context) (err error) {
 		},
 	}
 
-	var cols []string = []string{"Name", "Status", "Region"}
+	var cols = []string{"Name", "Status", "Region"}
 
 	if app != nil {
 		obj[0] = append(obj[0], app.Name)

--- a/internal/command/image/update.go
+++ b/internal/command/image/update.go
@@ -38,7 +38,7 @@ The update will perform a rolling restart against each Machine, which may result
 		},
 		flag.Bool{
 			Name:        "skip-health-checks",
-			Description: "Skip waiting for health checks inbetween VM updates.",
+			Description: "Skip waiting for health checks between VM updates.",
 			Default:     false,
 		},
 	)

--- a/internal/command/launch/deploy.go
+++ b/internal/command/launch/deploy.go
@@ -29,11 +29,7 @@ func (state *launchState) firstDeploy(ctx context.Context) error {
 	// TODO(Allison): Do we want to make the executive decision to just *always* deploy?
 	// Feedback(Sam): scanners need the abiiity to abort the deploy if they detect a problem
 
-	deployNow := true
-
-	if state.sourceInfo.SkipDeploy || flag.GetBool(ctx, "no-deploy") {
-		deployNow = false
-	}
+	deployNow := !(state.sourceInfo.SkipDeploy || flag.GetBool(ctx, "no-deploy"))
 
 	if flag.GetBool(ctx, "now") {
 		deployNow = true

--- a/internal/command/launch/sourceinfo.go
+++ b/internal/command/launch/sourceinfo.go
@@ -119,7 +119,7 @@ func determineSourceInfo(ctx context.Context, appConfig *appconfig.Config, copyC
 }
 
 func articleFor(w string) string {
-	var article string = "a"
+	var article = "a"
 	if matched, _ := regexp.MatchString(`^[aeiou]`, strings.ToLower(w)); matched {
 		article += "n"
 	}

--- a/internal/command/machine/select.go
+++ b/internal/command/machine/select.go
@@ -18,7 +18,7 @@ import (
 )
 
 // We now prompt for a machine automatically when no machine IDs are
-// provided. This flag is retained for backward compatability.
+// provided. This flag is retained for backward compatibility.
 var selectFlag = flag.Bool{
 	Name:        "select",
 	Description: "Select from a list of machines",

--- a/internal/command/machine/status.go
+++ b/internal/command/machine/status.go
@@ -121,7 +121,7 @@ func runMachineStatus(ctx context.Context) (err error) {
 		},
 	}
 
-	var cols []string = []string{"ID", "Instance ID", "State", "Image", "Name", "Private IP", "Region", "Process Group", "CPU Kind", "vCPUs", "Memory", "Created", "Updated", "Entrypoint", "Command"}
+	var cols = []string{"ID", "Instance ID", "State", "Image", "Name", "Private IP", "Region", "Process Group", "CPU Kind", "vCPUs", "Memory", "Created", "Updated", "Entrypoint", "Command"}
 
 	if len(mConfig.Mounts) > 0 {
 		cols = append(cols, "Volume")

--- a/internal/command/mcp/proxy.go
+++ b/internal/command/mcp/proxy.go
@@ -178,7 +178,7 @@ func runInspect(ctx context.Context) error {
 			proxyInfo.Password, _ = mcpConfig["password"].(string)
 		}
 	} else if len(configPaths) > 1 {
-		return fmt.Errorf("multiple MCP client configuration files specifed. Please specify at most one")
+		return fmt.Errorf("multiple MCP client configuration files specified. Please specify at most one")
 	}
 
 	return runProxyOrInspect(ctx, proxyInfo, true)

--- a/internal/command/orgs/create.go
+++ b/internal/command/orgs/create.go
@@ -51,9 +51,7 @@ func runCreate(ctx context.Context) error {
 		return err
 	}
 
-	var name string
-
-	name = flag.FirstArg(ctx)
+	var name string = flag.FirstArg(ctx)
 
 	if user.EnablePaidHobby {
 		fmt.Fprintf(io.Out, "New organizations start on the Pay As You Go plan.\n\n")

--- a/internal/command/orgs/create.go
+++ b/internal/command/orgs/create.go
@@ -51,7 +51,7 @@ func runCreate(ctx context.Context) error {
 		return err
 	}
 
-	var name string = flag.FirstArg(ctx)
+	var name = flag.FirstArg(ctx)
 
 	if user.EnablePaidHobby {
 		fmt.Fprintf(io.Out, "New organizations start on the Pay As You Go plan.\n\n")

--- a/internal/command/postgres/add_flycast.go
+++ b/internal/command/postgres/add_flycast.go
@@ -72,8 +72,8 @@ func doAddFlycast(ctx context.Context) error {
 		return fmt.Errorf("machines could not be retrieved %w", err)
 	}
 
-	var bouncerPort int = 5432
-	var pgPort int = 5433
+	var bouncerPort = 5432
+	var pgPort = 5433
 	for _, machine := range machines {
 		for _, service := range machine.Config.Services {
 			if service.InternalPort == 5432 || service.InternalPort == 5433 {

--- a/internal/command/postgres/config_update.go
+++ b/internal/command/postgres/config_update.go
@@ -328,7 +328,7 @@ func resolveConfigChanges(ctx context.Context, app *fly.AppCompact, manager stri
 }
 
 func resolveChangeLog(ctx context.Context, changes map[string]string, settings *flypg.PGSettings) (diff.Changelog, error) {
-	// Verify that input values are within acceptible ranges.
+	// Verify that input values are within acceptable ranges.
 	// Stolon does not verify this, so we need to do it here.
 	for k, v := range changes {
 		for _, setting := range settings.Settings {

--- a/internal/command/postgres/failover.go
+++ b/internal/command/postgres/failover.go
@@ -356,7 +356,7 @@ func handleFlexFailoverFail(ctx context.Context, machines []*fly.Machine) (err e
 		return fmt.Errorf("old leader %s could not be started: %s", leader.ID, mach.Message)
 	}
 
-	fmt.Println("Old leader started succesfully")
+	fmt.Println("Old leader started successfully")
 
 	return nil
 }

--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -94,7 +94,7 @@ func runCreate(ctx context.Context) (err error) {
 		return err
 	}
 
-	var enableEviction bool = false
+	var enableEviction = false
 
 	if flag.GetBool(ctx, "enable-eviction") {
 		enableEviction = true

--- a/internal/command/redis/status.go
+++ b/internal/command/redis/status.go
@@ -46,7 +46,7 @@ func runStatus(ctx context.Context) (err error) {
 
 	addOn := response.AddOn
 
-	var readRegions string = "None"
+	var readRegions = "None"
 
 	if len(addOn.ReadRegions) > 0 {
 		readRegions = strings.Join(addOn.ReadRegions, ",")
@@ -76,7 +76,7 @@ func runStatus(ctx context.Context) (err error) {
 		},
 	}
 
-	var cols []string = []string{"ID", "Name", "Plan", "Primary Region", "Read Regions", "Eviction", "Private URL"}
+	var cols = []string{"ID", "Name", "Plan", "Primary Region", "Read Regions", "Eviction", "Private URL"}
 
 	if err = render.VerticalTable(io.Out, "Redis", obj, cols...); err != nil {
 		return

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -36,7 +36,7 @@ func makeAlias[T any](template T, name string) T {
 	useAliasShortHandField := reflect.ValueOf(template).FieldByName("UseAliasShortHand")
 	if useAliasShortHandField.IsValid() {
 		useAliasShortHand := useAliasShortHandField.Interface().(bool)
-		if useAliasShortHand == true {
+		if useAliasShortHand {
 			value.FieldByName("Shorthand").SetString(string(name[0]))
 		}
 	}

--- a/internal/inmem/client.go
+++ b/internal/inmem/client.go
@@ -296,7 +296,7 @@ func (m *Client) GetIPAddresses(ctx context.Context, appName string) ([]fly.IPAd
 	return nil, nil // TODO
 }
 
-func (c *Client) GetEgressIPAddresses(ctx context.Context, appName string) (map[string][]fly.EgressIPAddress, error) {
+func (m *Client) GetEgressIPAddresses(ctx context.Context, appName string) (map[string][]fly.EgressIPAddress, error) {
 	panic("TODO")
 }
 

--- a/internal/machine/update.go
+++ b/internal/machine/update.go
@@ -151,7 +151,7 @@ func (e InvalidConfigErr) Suggestion() string {
 		validNumCpus := cpusPerKind[e.guest.CPUKind]
 		return fmt.Sprintf("Valid numbers are %v", validNumCpus)
 	case invalidMemorySize:
-		var incrementSize int = 1024
+		var incrementSize = 1024
 		switch e.guest.CPUKind {
 		case "shared":
 			incrementSize = 256

--- a/internal/metrics/synthetics/agent.go
+++ b/internal/metrics/synthetics/agent.go
@@ -78,7 +78,7 @@ type ProbeMessage struct {
 
 func processProbe(ctx context.Context, probeMessageJSON []byte, ws *SyntheticsWs) error {
 	logger := logger.FromContext(ctx)
-	logger.Debug("proccessing probes")
+	logger.Debug("processing probes")
 
 	probeMessage := ProbeMessage{}
 	err := json.Unmarshal(probeMessageJSON, &probeMessage)

--- a/scanner/jsFramework.go
+++ b/scanner/jsFramework.go
@@ -183,7 +183,7 @@ func configureJsFramework(sourceDir string, config *ScannerConfig) (*SourceInfo,
 		srcInfo.ObjectStorageDesired = true
 	}
 
-	// if prisma is used, provider is definative
+	// if prisma is used, provider is definitive
 	if checksPass(sourceDir+"/prisma", dirContains("*.prisma", "provider")) {
 		if checksPass(sourceDir+"/prisma", dirContains("*.prisma", "postgresql")) {
 			srcInfo.DatabaseDesired = DatabaseKindPostgres

--- a/scanner/laravel.go
+++ b/scanner/laravel.go
@@ -267,7 +267,7 @@ var redisRegStr = "^[^#]*redis"
 
 // extractConnections detects the database connection of a laravel fly app
 // by checking the .env file in the project's base directory for connection keywords.
-// This ignores commented out lines and prioritizes the first connection occurance over others.
+// This ignores commented out lines and prioritizes the first connection occurrence over others.
 //
 // Returns three variables:
 //

--- a/scanner/node.go
+++ b/scanner/node.go
@@ -49,12 +49,12 @@ func configureNode(sourceDir string, config *ScannerConfig) (*SourceInfo, error)
 
 	vars := make(map[string]interface{})
 
-	var yarnVersion string = "latest"
+	var yarnVersion = "latest"
 
 	// node-build requires a version, so either use the same version as install locally,
 	// or default to an LTS version
-	var nodeLtsVersion string = "18.16.0"
-	var nodeVersion string = nodeLtsVersion
+	var nodeLtsVersion = "18.16.0"
+	var nodeVersion = nodeLtsVersion
 
 	out, err := exec.Command("node", "-v").Output()
 

--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -373,7 +373,7 @@ func RailsCallback(appName string, srcInfo *SourceInfo, plan *plan.LaunchPlan, f
 	}
 
 	// ensure fly.toml exists.  If present, the rails dockerfile generator will
-	// add volumes, processes, release command and potentailly other configuration.
+	// add volumes, processes, release command and potentially other configuration.
 	flyToml := "fly.toml"
 	_, err = os.Stat(flyToml)
 	if os.IsNotExist(err) {

--- a/tools/distribute/bundle/meta.go
+++ b/tools/distribute/bundle/meta.go
@@ -52,7 +52,7 @@ func (m Meta) Validate() error {
 	}
 
 	if m.Release.Version == nil {
-		return errors.New("missing version number. make sure there's a verison in release.json")
+		return errors.New("missing version number. make sure there's a version in release.json")
 	}
 
 	if len(m.Assets) == 0 {


### PR DESCRIPTION
### Change Summary

What and Why: I couldn't spell [provisioner](https://github.com/superfly/flyctl/pull/4526)!

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
