### PR TITLE
feat: --buildkit flag and buildkit-builder improvements

### DIFF
--- a/internal/build/imgsrc/buildkit_builder.go
+++ b/internal/build/imgsrc/buildkit_builder.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/containerd/containerd/api/services/content/v1"
 	"github.com/moby/buildkit/client"
+	"github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/helpers"
+	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/cmdfmt"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flyutil"
@@ -81,6 +83,7 @@ func (r *BuildkitBuilder) Run(ctx context.Context, _ *dockerClientFactory, strea
 
 func (r *BuildkitBuilder) buildWithBuildkit(ctx context.Context, streams *iostreams.IOStreams, opts ImageOptions, dockerfilePath string, buildState *build) (i *DeploymentImage, err error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "buildkit_build", trace.WithAttributes(opts.ToSpanAttributes()...))
+	ctx = appconfig.WithName(ctx, opts.AppName)
 	defer func() {
 		if err != nil {
 			span.RecordError(err)
@@ -89,56 +92,24 @@ func (r *BuildkitBuilder) buildWithBuildkit(ctx context.Context, streams *iostre
 		span.End()
 	}()
 
-	buildkitAddr := r.addr
-	if buildkitAddr == "" {
-		_, app, err := r.provisioner.EnsureBuilder(
-			ctx, os.Getenv("FLY_REMOTE_BUILDER_REGION"), flag.GetRecreateBuilder(ctx),
-		)
-		if err != nil {
-			return nil, err
-		}
-		buildkitAddr = fmt.Sprintf("%s.flycast:%d", app.Name, buildkitGRPCPort)
+	app := r.provisioner.org.RemoteBuilderApp
+	if r.addr == "" && app != nil {
+		r.addr = fmt.Sprintf("%s.flycast:%d", app.Name, buildkitGRPCPort)
 	}
 
 	buildState.BuilderInitStart()
 	defer buildState.BuilderInitFinish()
-	buildState.SetBuilderMetaPart1("buildkit", buildkitAddr, "")
+	buildState.SetBuilderMetaPart1("buildkit", r.addr, "")
 
-	msg := fmt.Sprintf("Connecting to buildkit daemon at %s...\n", buildkitAddr)
-	if streams.IsInteractive() {
-		streams.StartProgressIndicatorMsg(msg)
-	} else {
-		fmt.Fprintln(streams.ErrOut, msg)
-	}
+	streams.StartProgressIndicator()
 
-	buildkitClient, err := client.New(ctx, buildkitAddr)
+	buildkitClient, err := r.connectClient(ctx, appToAppCompact(app))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create buildkit client: %w", err)
 	}
-	defer buildkitClient.Close()
-
-	if _, err = buildkitClient.Info(ctx); err != nil {
-		terminal.Debug("Direct connection failed, trying via wireguard...")
-		apiClient := flyutil.ClientFromContext(ctx)
-		app, err := apiClient.GetAppCompact(ctx, opts.AppName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get app info for %s: %w", opts.AppName, err)
-		}
-		_, dialer, err := agent.BringUpAgent(ctx, apiClient, app, app.Network, true)
-		if err != nil {
-			return nil, fmt.Errorf("failed wireguard connection: %w", err)
-		}
-		buildkitClient, err = client.New(ctx, buildkitAddr, client.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
-			return dialer.DialContext(ctx, "tcp", addr)
-		}))
-		if err != nil {
-			return nil, fmt.Errorf("failed to connect to buildkit daemon at %s via wireguard: %w", buildkitAddr, err)
-		}
-		terminal.Debug("Successfully connected via wireguard")
-	}
 
 	streams.StopProgressIndicator()
-	cmdfmt.PrintDone(streams.ErrOut, fmt.Sprintf("Connected to buildkit daemon at %s", buildkitAddr))
+	cmdfmt.PrintDone(streams.ErrOut, fmt.Sprintf("Connected to buildkit daemon at %s", r.addr))
 
 	buildState.BuildAndPushStart()
 	defer buildState.BuildAndPushFinish()
@@ -149,6 +120,62 @@ func (r *BuildkitBuilder) buildWithBuildkit(ctx context.Context, streams *iostre
 	}
 
 	return newDeploymentImage(ctx, buildkitClient, res, opts.Tag)
+}
+
+func (r *BuildkitBuilder) connectClient(ctx context.Context, app *fly.AppCompact) (*client.Client, error) {
+	recreateBuilder := flag.GetRecreateBuilder(ctx)
+	ensureBuilder := false
+	if r.addr == "" || recreateBuilder {
+		_, builderApp, err := r.provisioner.EnsureBuilder(
+			ctx, os.Getenv("FLY_REMOTE_BUILDER_REGION"), recreateBuilder,
+		)
+		if err != nil {
+			return nil, err
+		}
+		app = appToAppCompact(builderApp)
+		r.addr = fmt.Sprintf("%s.flycast:%d", app.Name, buildkitGRPCPort)
+		ensureBuilder = true
+	}
+	var opts []client.ClientOpt
+	apiClient := flyutil.ClientFromContext(ctx)
+	if app != nil {
+		_, dialer, err := agent.BringUpAgent(ctx, apiClient, app, app.Network, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed wireguard connection: %w", err)
+		}
+		opts = append(opts, client.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "tcp", addr)
+		}))
+	}
+
+	streams := iostreams.FromContext(ctx)
+	msg := fmt.Sprintf("Connecting to buildkit daemon at %s...\n", r.addr)
+	if streams.IsInteractive() {
+		streams.ChangeProgressIndicatorMsg(msg)
+	} else {
+		fmt.Fprintln(streams.ErrOut, msg)
+	}
+
+	buildkitClient, err := client.New(ctx, r.addr, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create buildkit client: %w", err)
+	}
+	_, err = buildkitClient.Info(ctx)
+	if err != nil {
+		if app == nil { // Retry with Wireguard connection
+			app, err = apiClient.GetAppCompact(ctx, appconfig.NameFromContext(ctx))
+			if err != nil {
+				return nil, fmt.Errorf("failed to get app: %w", err)
+			}
+			return r.connectClient(ctx, app)
+		} else if !ensureBuilder && r.provisioner.buildkitImage != "" { // Retry with ensureBuilder
+			r.addr = ""
+			return r.connectClient(ctx, nil)
+		} else {
+			return nil, fmt.Errorf("failed to connect to buildkit: %w", err)
+		}
+	}
+	return buildkitClient, nil
 }
 
 func readContent(ctx context.Context, contentClient content.ContentClient, desc *Descriptor) (string, error) {

--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -46,6 +46,7 @@ func (p *Provisioner) UseBuildkit() bool {
 }
 
 const defaultImage = "docker-hub-mirror.fly.io/flyio/rchab:sha-9346699"
+const DefaultBuildkitImage = "docker-hub-mirror.fly.io/flyio/buildkit@sha256:0fe49e6f506f0961cb2fc45d56171df0e852229facf352f834090345658b7e1c"
 
 func (p *Provisioner) image() string {
 	if p.buildkitImage != "" {
@@ -58,6 +59,9 @@ func (p *Provisioner) image() string {
 }
 
 func appToAppCompact(app *fly.App) *fly.AppCompact {
+	if app == nil {
+		return nil
+	}
 	return &fly.AppCompact{
 		ID:       app.ID,
 		Name:     app.Name,

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -55,6 +55,7 @@ var CommonFlags = flag.Set{
 	flag.Nixpacks(),
 	flag.BuildkitAddr(),
 	flag.BuildkitImage(),
+	flag.Buildkit(),
 	flag.BuildOnly(),
 	flag.BpDockerHost(),
 	flag.BpVolume(),
@@ -185,6 +186,7 @@ var CommonFlags = flag.Set{
 		Default:     "auto",
 		NoOptDefVal: "true",
 		Description: "Experimental: Use pooled builder from Fly.io",
+		Hidden:      true,
 	},
 }
 

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -109,6 +109,9 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config, useWG, rec
 	var provisioner *imgsrc.Provisioner
 	buildkitAddr := flag.GetBuildkitAddr(ctx)
 	buildkitImage := flag.GetBuildkitImage(ctx)
+	if flag.GetBool(ctx, "buildkit") && buildkitImage == "" && buildkitAddr == "" {
+		buildkitImage = imgsrc.DefaultBuildkitImage
+	}
 	if buildkitAddr != "" || buildkitImage != "" {
 		provisioner = imgsrc.NewBuildkitProvisioner(org, buildkitAddr, buildkitImage)
 	} else {

--- a/internal/command/machine/update.go
+++ b/internal/command/machine/update.go
@@ -68,6 +68,7 @@ func newUpdate() *cobra.Command {
 		},
 		flag.BuildkitAddr(),
 		flag.BuildkitImage(),
+		flag.Buildkit(),
 	)
 
 	cmd.Args = cobra.RangeArgs(0, 1)

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -589,6 +589,7 @@ func BuildkitAddr() String {
 		Name:        "buildkit-addr",
 		Description: "Address of remote buildkit daemon (e.g. tcp://127.0.0.1:1234 or unix:///path/to/socket)",
 		EnvName:     "BUILDKIT_ADDR",
+		Hidden:      true,
 	}
 }
 
@@ -597,6 +598,14 @@ func BuildkitImage() String {
 		Name:        "buildkit-image",
 		Description: "Image to use for remote buildkit daemon",
 		EnvName:     "BUILDKIT_IMAGE",
+		Hidden:      true,
+	}
+}
+
+func Buildkit() Bool {
+	return Bool{
+		Name:        "buildkit",
+		Description: "Deploy using buildkit-based remote builder",
 	}
 }
 


### PR DESCRIPTION
Followup PR for the buildkit builder with a few more UX and performance tweaks:

* run `ensureBuilder` only after connection failure, to minimize happy-path latency (eliminates extra API-call round-trips before making initial connection attempt over Flycast)
* add `--buildkit` boolean flag which uses the default buildkit image for the builder app
* mark, `--buildkit-addr`, `--buildkit-image`, `--builder-pool` flags hidden (they are for advanced/experimental usage, and don't need to be displayed on the main help page)

Related to:

#4489, #4526

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
