### PR TITLE
test: test "fly console --dockerfile"

### DIFF
--- a/test/preflight/fly_console_test.go
+++ b/test/preflight/fly_console_test.go
@@ -4,6 +4,8 @@
 package preflight
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -17,12 +19,13 @@ func TestFlyConsole(t *testing.T) {
 	appName := f.CreateRandomAppMachines()
 	targetOutput := "console test in " + appName
 
+	// The image is based on Debian bookworm.
 	f.WriteFlyToml(`
 app = "%s"
 console_command = "/bin/echo '%s'"
 
 [build]
-  image = "nginx"
+  image = "nginx:1.29-bookworm"
 
 [processes]
   app = "/bin/sleep inf"
@@ -32,13 +35,30 @@ console_command = "/bin/echo '%s'"
 
 	f.Fly("deploy --ha=false")
 
-	result := f.Fly("console")
-	output := result.StdOutString()
-	require.Contains(f, output, targetOutput)
+	t.Run("console_command", func(t *testing.T) {
+		result := f.Fly("console")
+		output := result.StdOutString()
+		require.Contains(f, output, targetOutput)
+	})
 
-	// Give time for the machine to be destroyed.
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
 		ml := f.MachinesList(appName)
-		assert.Equal(c, 1, len(ml))
-	}, 10*time.Second, 1*time.Second)
+		assert.Equal(t, 1, len(ml))
+	}, 10*time.Second, 1*time.Second, "machine is ephemeral and eventually gone")
+
+	t.Run("dockerfile", func(t *testing.T) {
+		dockerfile := filepath.Join(t.TempDir(), "dockerfile")
+		err := os.WriteFile(dockerfile, []byte(`
+FROM alpine:latest
+CMD ["/bin/sleep", "inf"]
+`), 0644)
+		require.NoError(t, err)
+
+		result := f.Fly("console -a %s --dockerfile %s", appName, dockerfile)
+		assert.Contains(f, result.StdOutString(), targetOutput, "console_command is still used")
+
+		// Because of the dockerfile, the image here is Alpine.
+		result = f.Fly("console -a %s --dockerfile %s --command 'cat /etc/os-release'", appName, dockerfile)
+		assert.Contains(f, result.StdOutString(), "ID=alpine")
+	})
 }


### PR DESCRIPTION
This change is a follow-up for #4551.
The --dockerfile flag was not tested and we broke that.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
