### PR TITLE
Use cli not api for tagging new versions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -26,3 +26,4 @@ jobs:
           WITH_V: true
           VERBOSE: true
           DEFAULT_BUMP: "patch"
+          GIT_API_TAGGING: false


### PR DESCRIPTION
### Change Summary

Add `GIT_API_TAGGING: false` to use the cli not the api when bumping the version to tag commits for a release. 

What and Why:

See https://github.com/anothrNick/github-tag-action/issues/350 for reference. 

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
