### PR TITLE
fix: refresh buildkit credentials

### DIFF
--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -288,7 +288,9 @@ func buildImage(ctx context.Context, buildkitClient *client.Client, opts ImageOp
 		}
 		solverOptions.Session = append(
 			solverOptions.Session,
-			newBuildkitAuthProvider(config.Tokens(ctx).Docker()),
+			newBuildkitAuthProvider(func() string {
+				return config.Tokens(ctx).Docker()
+			}),
 			secretsprovider.FromMap(secrets),
 		)
 

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -503,7 +503,9 @@ func runBuildKitBuild(ctx context.Context, docker *dockerclient.Client, opts Ima
 			options.Session,
 			// To pull images from local Docker Engine with Fly's access token,
 			// we need to pass the provider. Remote builders don't need that.
-			newBuildkitAuthProvider(config.Tokens(ctx).Docker()),
+			newBuildkitAuthProvider(func() string {
+				return config.Tokens(ctx).Docker()
+			}),
 			secretsprovider.FromMap(secrets),
 		)
 


### PR DESCRIPTION
fixes #4556, returns refreshed auth token to buildkit client on each credentials request.