### PR TITLE
Update Deno version and Alpine base image

### DIFF
--- a/scanner/templates/deno/Dockerfile
+++ b/scanner/templates/deno/Dockerfile
@@ -1,10 +1,10 @@
 # Based on https://github.com/denoland/deno_docker/blob/main/alpine.dockerfile
 
-ARG DENO_VERSION=1.14.0
+ARG DENO_VERSION=2.4.5
 ARG BIN_IMAGE=denoland/deno:bin-${DENO_VERSION}
 FROM ${BIN_IMAGE} AS bin
 
-FROM frolvlad/alpine-glibc:alpine-3.13
+FROM frolvlad/alpine-glibc:alpine-3.22
 
 RUN apk --no-cache add ca-certificates
 


### PR DESCRIPTION
### Change Summary

What and Why:
The deno version in the templates flyctl pulls from was a major version behind. I noticed it when I set up a new project with deno and it crashed on launch.
How:

Related to:
scanner/templates
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
