### PR TITLE
fix: add builder ID to Depot image build metadata

### DIFF
--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -109,7 +109,7 @@ func (d *DepotBuilder) Run(ctx context.Context, _ *dockerClientFactory, streams 
 		tracing.RecordError(span, err, "failed to build image")
 		return nil, "", errors.Wrap(err, "error building")
 	}
-
+	build.BuilderMeta.RemoteMachineId = image.BuilderID
 	build.ImageBuildFinish()
 	build.BuildFinish()
 	cmdfmt.PrintDone(streams.ErrOut, "Building image done")


### PR DESCRIPTION
Since #4533, we set the build metadata's remote builder ID from the buildkit worker's hostname label for buildkit-based builds, this simple followup fix sets the same metadata for Depot-based remote builder builds.