### PR TITLE
secrets: allow to disable DNS checks for secrets operations

### DIFF
--- a/internal/command/consul/attach.go
+++ b/internal/command/consul/attach.go
@@ -56,6 +56,10 @@ func runAttach(ctx context.Context) error {
 	secretsToSet := map[string]string{
 		secretName: consulPayload.ConsulURL,
 	}
-	err = secrets.SetSecretsAndDeploy(ctx, flapsClient, app, secretsToSet, false, false)
+	err = secrets.SetSecretsAndDeploy(ctx, flapsClient, app, secretsToSet, secrets.DeploymentArgs{
+		Stage:    false,
+		Detach:   false,
+		CheckDNS: true,
+	})
 	return err
 }

--- a/internal/command/consul/detach.go
+++ b/internal/command/consul/detach.go
@@ -44,6 +44,10 @@ func runDetach(ctx context.Context) error {
 		return err
 	}
 	secretsToUnset := []string{secretName}
-	err = secrets.UnsetSecretsAndDeploy(ctx, flapsClient, app, secretsToUnset, false, false)
+	err = secrets.UnsetSecretsAndDeploy(ctx, flapsClient, app, secretsToUnset, secrets.DeploymentArgs{
+		Stage:    false,
+		Detach:   false,
+		CheckDNS: true,
+	})
 	return err
 }

--- a/internal/command/extensions/arcjet/create.go
+++ b/internal/command/extensions/arcjet/create.go
@@ -67,7 +67,11 @@ func runCreate(ctx context.Context) (err error) {
 	}
 
 	if extension.SetsSecrets {
-		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), false, false)
+		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), secrets.DeploymentArgs{
+			Stage:    false,
+			Detach:   false,
+			CheckDNS: true,
+		})
 	}
 
 	return

--- a/internal/command/extensions/fly_mysql/create.go
+++ b/internal/command/extensions/fly_mysql/create.go
@@ -71,7 +71,11 @@ func runCreate(ctx context.Context) (err error) {
 	}
 
 	if extension.SetsSecrets {
-		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), false, false)
+		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), secrets.DeploymentArgs{
+			Stage:    false,
+			Detach:   false,
+			CheckDNS: true,
+		})
 	}
 
 	return

--- a/internal/command/extensions/sentry/create.go
+++ b/internal/command/extensions/sentry/create.go
@@ -36,7 +36,11 @@ func runSentryCreate(ctx context.Context) (err error) {
 		Provider: "sentry",
 	})
 	if extension.SetsSecrets {
-		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), false, false)
+		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), secrets.DeploymentArgs{
+			Stage:    false,
+			Detach:   false,
+			CheckDNS: true,
+		})
 	}
 	return
 }

--- a/internal/command/extensions/tigris/create.go
+++ b/internal/command/extensions/tigris/create.go
@@ -96,7 +96,11 @@ func runCreate(ctx context.Context) (err error) {
 	}
 
 	if extension.SetsSecrets {
-		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), false, false)
+		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), secrets.DeploymentArgs{
+			Stage:    false,
+			Detach:   false,
+			CheckDNS: true,
+		})
 	}
 
 	return err

--- a/internal/command/extensions/vector/create.go
+++ b/internal/command/extensions/vector/create.go
@@ -120,7 +120,11 @@ func runCreate(ctx context.Context) (err error) {
 	}
 
 	if extension.SetsSecrets {
-		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), false, false)
+		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), secrets.DeploymentArgs{
+			Stage:    false,
+			Detach:   false,
+			CheckDNS: true,
+		})
 	}
 
 	return err

--- a/internal/command/extensions/wafris/create.go
+++ b/internal/command/extensions/wafris/create.go
@@ -42,7 +42,11 @@ func runCreate(ctx context.Context) (err error) {
 	})
 
 	if extension.SetsSecrets {
-		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), false, false)
+		err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), secrets.DeploymentArgs{
+			Stage:    false,
+			Detach:   false,
+			CheckDNS: true,
+		})
 	}
 
 	return err

--- a/internal/command/launch/launch_extensions.go
+++ b/internal/command/launch/launch_extensions.go
@@ -19,7 +19,11 @@ func (state *launchState) launchSentry(ctx context.Context, app_name string) err
 		}
 
 		if extension.SetsSecrets {
-			if err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), false, false); err != nil {
+			if err = secrets.DeploySecrets(ctx, gql.ToAppCompact(*extension.App), secrets.DeploymentArgs{
+				Stage:    false,
+				Detach:   false,
+				CheckDNS: true,
+			}); err != nil {
 				return err
 			}
 		}

--- a/internal/command/secrets/deploy.go
+++ b/internal/command/secrets/deploy.go
@@ -24,6 +24,11 @@ func newDeploy() (cmd *cobra.Command) {
 		flag.App(),
 		flag.AppConfig(),
 		flag.Detach(),
+		flag.Bool{
+			Name:        "dns-checks",
+			Description: "Perform DNS checks during deployment",
+			Default:     true,
+		},
 	)
 
 	return cmd
@@ -49,5 +54,9 @@ func runDeploy(ctx context.Context) (err error) {
 		}
 	}
 
-	return DeploySecrets(ctx, app, false, flag.GetBool(ctx, "detach"))
+	return DeploySecrets(ctx, app, DeploymentArgs{
+		Stage:    false,
+		Detach:   flag.GetBool(ctx, "detach"),
+		CheckDNS: flag.GetBool(ctx, "dns-checks"),
+	})
 }

--- a/internal/command/secrets/import.go
+++ b/internal/command/secrets/import.go
@@ -44,5 +44,9 @@ func runImport(ctx context.Context) (err error) {
 		return errors.New("requires at least one SECRET=VALUE pair")
 	}
 
-	return SetSecretsAndDeploy(ctx, flapsClient, app, secrets, flag.GetBool(ctx, "stage"), flag.GetBool(ctx, "detach"))
+	return SetSecretsAndDeploy(ctx, flapsClient, app, secrets, DeploymentArgs{
+		Stage:    flag.GetBool(ctx, "stage"),
+		Detach:   flag.GetBool(ctx, "detach"),
+		CheckDNS: flag.GetBool(ctx, "dns-checks"),
+	})
 }

--- a/internal/command/secrets/secrets.go
+++ b/internal/command/secrets/secrets.go
@@ -23,6 +23,11 @@ var sharedFlags = flag.Set{
 		Name:        "stage",
 		Description: "Set secrets but skip deployment for machine apps",
 	},
+	flag.Bool{
+		Name:        "dns-checks",
+		Description: "Perform DNS checks during deployment",
+		Default:     true,
+	},
 }
 
 func New() *cobra.Command {
@@ -49,11 +54,17 @@ func New() *cobra.Command {
 	return secrets
 }
 
+type DeploymentArgs struct {
+	Stage    bool
+	Detach   bool
+	CheckDNS bool
+}
+
 // DeploySecrets deploys machines with the new secret if this step is not to be skipped.
-func DeploySecrets(ctx context.Context, app *fly.AppCompact, stage bool, detach bool) error {
+func DeploySecrets(ctx context.Context, app *fly.AppCompact, args DeploymentArgs) error {
 	out := iostreams.FromContext(ctx).Out
 
-	if stage {
+	if args.Stage {
 		fmt.Fprint(out, "Secrets have been staged, but not set on VMs. Deploy or update machines in this app for the secrets to take effect.\n")
 		return nil
 	}
@@ -83,7 +94,8 @@ func DeploySecrets(ctx context.Context, app *fly.AppCompact, stage bool, detach 
 	md, err := deploy.NewMachineDeployment(ctx, deploy.MachineDeploymentArgs{
 		AppCompact:       app,
 		RestartOnly:      true,
-		SkipHealthChecks: detach,
+		SkipHealthChecks: args.Detach,
+		SkipDNSChecks:    args.Detach || !args.CheckDNS,
 	})
 	if err != nil {
 		sentry.CaptureExceptionWithAppInfo(ctx, err, "secrets", app)

--- a/internal/command/secrets/set.go
+++ b/internal/command/secrets/set.go
@@ -63,13 +63,17 @@ func runSet(ctx context.Context) (err error) {
 		return errors.New("requires at least one SECRET=VALUE pair")
 	}
 
-	return SetSecretsAndDeploy(ctx, flapsClient, app, secrets, flag.GetBool(ctx, "stage"), flag.GetBool(ctx, "detach"))
+	return SetSecretsAndDeploy(ctx, flapsClient, app, secrets, DeploymentArgs{
+		Stage:    flag.GetBool(ctx, "stage"),
+		Detach:   flag.GetBool(ctx, "detach"),
+		CheckDNS: flag.GetBool(ctx, "dns-checks"),
+	})
 }
 
-func SetSecretsAndDeploy(ctx context.Context, flapsClient flapsutil.FlapsClient, app *fly.AppCompact, secrets map[string]string, stage bool, detach bool) error {
+func SetSecretsAndDeploy(ctx context.Context, flapsClient flapsutil.FlapsClient, app *fly.AppCompact, secrets map[string]string, args DeploymentArgs) error {
 	if err := appsecrets.Update(ctx, flapsClient, app.Name, secrets, nil); err != nil {
 		return fmt.Errorf("update secrets: %w", err)
 	}
 
-	return DeploySecrets(ctx, app, stage, detach)
+	return DeploySecrets(ctx, app, args)
 }

--- a/internal/command/secrets/unset.go
+++ b/internal/command/secrets/unset.go
@@ -38,13 +38,17 @@ func runUnset(ctx context.Context) (err error) {
 		return err
 	}
 
-	return UnsetSecretsAndDeploy(ctx, flapsClient, app, flag.Args(ctx), flag.GetBool(ctx, "stage"), flag.GetBool(ctx, "detach"))
+	return UnsetSecretsAndDeploy(ctx, flapsClient, app, flag.Args(ctx), DeploymentArgs{
+		Stage:    flag.GetBool(ctx, "stage"),
+		Detach:   flag.GetBool(ctx, "detach"),
+		CheckDNS: flag.GetBool(ctx, "dns-checks"),
+	})
 }
 
-func UnsetSecretsAndDeploy(ctx context.Context, flapsClient flapsutil.FlapsClient, app *fly.AppCompact, secrets []string, stage bool, detach bool) error {
+func UnsetSecretsAndDeploy(ctx context.Context, flapsClient flapsutil.FlapsClient, app *fly.AppCompact, secrets []string, args DeploymentArgs) error {
 	if err := appsecrets.Update(ctx, flapsClient, app.Name, nil, secrets); err != nil {
 		return fmt.Errorf("update secrets: %w", err)
 	}
 
-	return DeploySecrets(ctx, app, stage, detach)
+	return DeploySecrets(ctx, app, args)
 }


### PR DESCRIPTION
DNS checks verify that the IP addresses assigned to an app have
propagated to some known public resolver. In some environment the checks
might fail, which adds significant latency to the otherwise fast
operations like 'secrets set'/'secrets unset'.

Allow the checks to be disabled with '--dns-checks=false' flag like
we do for 'flyctl deploy'.

Closes #3992
