### PR TITLE
Honor --yes flag for `fly storage update` command!

### DIFF
--- a/internal/command/extensions/tigris/update.go
+++ b/internal/command/extensions/tigris/update.go
@@ -124,10 +124,15 @@ func runUpdate(ctx context.Context) (err error) {
 			return fmt.Errorf("You cannot specify both --custom-domain and --clear-custom-domain")
 		}
 
-		fmt.Fprintf(io.Out, "Before continuing, set a DNS CNAME record to enable your custom domain: %s -> %s\n\n", domain, addOn.Name+".fly.storage.tigris.dev")
-
-		confirm, err := prompt.Confirm(ctx, "Continue with the update?")
-
+		confirm := false
+		if !flag.GetYes(ctx) {
+			fmt.Fprintf(io.Out, "Before continuing, set a DNS CNAME record to enable your custom domain: %s -> %s\n\n", domain, addOn.Name+".fly.storage.tigris.dev")
+			confirm, err = prompt.Confirm(ctx, "Continue with the update?")
+		}else{
+			fmt.Fprintf(io.Out, "By specifying the --yes flag you have agreed to set a DNS CNAME record to enable your custom domain: %s -> %s\n\n", domain, addOn.Name+".fly.storage.tigris.dev")
+			confirm = true
+		}
+		
 		if err != nil || !confirm {
 			return err
 		}


### PR DESCRIPTION
### Change Summary

What and Why:
This change updates the  `fly storage update` [command(https://fly.io/docs/flyctl/storage-update/#main-content-start) command to properly remove the confirmation prompt in the case when the --yes flag is passed. 

The reason for this change is because:
- This command has a workflow that prompts user's confirmation for adding DNS CNAME if they pass the --custom-domain flag.
- This command also accepts the --yes flag
- However, even with the yes flag passed, the user is still prompted for the confirmation
- It reasons that since the command accepts the --yes flag, the user should be able to use it to assume that all confirmation prompts are given the true value/ a yes 

How:
- Add a condition block that proceeds with the confirmation only if the yes flag is present 

Related to:
- Discourse post: https://flyio.discourse.team/t/fly-storage-update-does-not-consider-yes-flag-in-its-workflow/9205
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
