### PR TITLE
WIP: Roll out zstd image compression with LaunchDarkly

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -188,7 +188,14 @@ type Experimental struct {
 	LazyLoadImages bool     `toml:"lazy_load_images,omitempty" json:"lazy_load_images,omitempty"`
 	Attached       Attached `toml:"attached,omitempty" json:"attached,omitempty"`
 	MachineConfig  string   `toml:"machine_config,omitempty" json:"machine_config,omitempty"`
-	UseZstd        bool     `toml:"use_zstd,omitempty" json:"use_zstd,omitempty"`
+	Compression    string   `toml:"compression,omitempty" json:"compression,omitempty"`
+}
+
+func ValidateCompression(compression string) error {
+	if compression != "" && compression != "zstd" && compression != "gzip" {
+		return fmt.Errorf("invalid compression algorithm '%s'. Must be 'zstd' or 'gzip'", compression)
+	}
+	return nil
 }
 
 type Attached struct {

--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -248,11 +248,9 @@ func buildImage(ctx context.Context, buildkitClient *client.Client, opts ImageOp
 		exportEntry.Attrs["push"] = "true"
 	}
 
-	if opts.UseZstd {
-		exportEntry.Attrs["compression"] = "zstd"
-		exportEntry.Attrs["compression-level"] = "3"
-		exportEntry.Attrs["force-compression"] = "true"
-	}
+	exportEntry.Attrs["compression"] = opts.Compression
+	exportEntry.Attrs["compression-level"] = "3"
+	exportEntry.Attrs["force-compression"] = "true"
 
 	ch := make(chan *client.SolveStatus)
 	eg, ctx := errgroup.WithContext(ctx)

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -54,7 +54,7 @@ type ImageOptions struct {
 	BuildpacksDockerHost string
 	BuildpacksVolumes    []string
 	UseOverlaybd         bool
-	UseZstd              bool
+	Compression          string
 }
 
 func (io ImageOptions) ToSpanAttributes() []attribute.KeyValue {
@@ -73,7 +73,7 @@ func (io ImageOptions) ToSpanAttributes() []attribute.KeyValue {
 		attribute.String("imageoptions.buildpacks_docker_host", io.BuildpacksDockerHost),
 		attribute.StringSlice("imageoptions.buildpacks", io.Buildpacks),
 		attribute.StringSlice("imageoptions.buildpacks_volumes", io.BuildpacksVolumes),
-		attribute.Bool("imageoptions.use_zstd", io.UseZstd),
+		attribute.String("imageoptions.compression", io.Compression),
 	}
 
 	if io.BuildArgs != nil {

--- a/internal/command/command_run.go
+++ b/internal/command/command_run.go
@@ -101,13 +101,26 @@ func DetermineImage(ctx context.Context, appName string, imageOrPath string) (im
 		}
 		opts.BuildArgs = extraArgs
 
-		if cfg != nil && cfg.Experimental != nil {
-			opts.UseZstd = cfg.Experimental.UseZstd
+		// Determine compression based on CLI flags, then app config, then LaunchDarkly, then default to gzip
+		opts.Compression = "gzip"
+
+		if ldClient.UseZstdEnabled() {
+			opts.Compression = "zstd"
 		}
 
-		// use-zstd passed through flags takes precedence over the one set in config
-		if flag.IsSpecified(ctx, "use-zstd") {
-			opts.UseZstd = flag.GetBool(ctx, "use-zstd")
+		if cfg != nil && cfg.Experimental != nil && cfg.Experimental.Compression != "" {
+			if err := cfg.ValidateCompression(cfg.Experimental.Compression); err != nil {
+				return nil, err
+			}
+			opts.Compression = cfg.Experimental.Compression
+		}
+
+		if flag.IsSpecified(ctx, "compression") {
+			cliCompression := flag.GetString(ctx, "compression")
+			if err := appconfig.ValidateCompression(cliCompression); err != nil {
+				return nil, err
+			}
+			opts.Compression = cliCompression
 		}
 
 		img, err = resolver.BuildImage(ctx, io, opts)

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -609,6 +609,14 @@ func Buildkit() Bool {
 	}
 }
 
+func Compression() String {
+	return String{
+		Name:        "compression",
+		Description: `Compression algorithm to use for the image. Options are "zstd" or "gzip". Defaults to "gzip".`,
+		Default:     "gzip",
+	}
+}
+
 func Strategy() String {
 	return String{
 		Name:        "strategy",

--- a/internal/launchdarkly/launchdarkly.go
+++ b/internal/launchdarkly/launchdarkly.go
@@ -215,3 +215,7 @@ func (ldClient *Client) getManagedBuilderEnabled() bool {
 func (ldClient *Client) ManagedBuilderEnabled() bool {
 	return ldClient.getManagedBuilderEnabled()
 }
+
+func (ldClient *Client) UseZstdEnabled() bool {
+	return ldClient.GetFeatureFlagValue("use-zstd-for-docker-images", false).(bool)
+}


### PR DESCRIPTION
### Change Summary

What and Why:
To improve performance and get better compression outcomes (save money on S3). This has already been implemented before, now it's time to roll it out as the default.
https://flyio.discourse.team/t/use-zstd-for-docker-registry-improve-perf-and-save-money-on-s3-bills/9194
https://github.com/superfly/flyctl/pull/4065

How:
Let's first control it with LaunchDarkly. Launch slowly over, say, course of a week. Then we get rid of this LaunchDarkly flag and just default to zstd at all times.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
