### PR TITLE
Add database flag to mpg connect command

### DIFF
--- a/internal/command/mpg/connect.go
+++ b/internal/command/mpg/connect.go
@@ -27,6 +27,11 @@ func newConnect() (cmd *cobra.Command) {
 
 	flag.Add(cmd,
 		flag.MPGCluster(),
+		flag.String{
+			Name:        "database",
+			Shorthand:   "d",
+			Description: "The database to connect to",
+		},
 	)
 
 	return cmd
@@ -65,6 +70,11 @@ func runConnect(ctx context.Context) (err error) {
 	user := credentials.User
 	password := credentials.Password
 	db := credentials.DBName
+
+	// Override database name if provided via flag
+	if database := flag.GetString(ctx, "database"); database != "" {
+		db = database
+	}
 
 	connectUrl := fmt.Sprintf("postgresql://%s:%s@localhost:%s/%s", user, password, localProxyPort, db)
 	cmd := exec.CommandContext(ctx, psqlPath, connectUrl)

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -323,6 +323,7 @@ func Org() String {
 func MPGCluster() String {
 	return String{
 		Name:        "cluster",
+		Shorthand:   "c",
 		Description: "The target cluster ID",
 	}
 }

--- a/internal/flag/flagnames/constants.go
+++ b/internal/flag/flagnames/constants.go
@@ -54,4 +54,7 @@ const (
 
 	// MPGClusterID denotes the name of the MPG cluster ID flag.
 	MPGClusterID = "cluster"
+
+	// MPGDatabase denotes the name of the MPG database flag.
+	MPGDatabase = "database"
 )


### PR DESCRIPTION
### Change Summary

What and Why:

Introduces a new --database (-d) flag to the mpg connect command, allowing users to specify the database to connect to. Also adds a shorthand -c for the cluster flag and updates flag name constants for consistency.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
