### PR TITLE
fix: upgrade sinatra to clear GHSA-hxx2-7vcw-mqr3

### DIFF
--- a/test/preflight/fixtures/example-buildpack/Gemfile
+++ b/test/preflight/fixtures/example-buildpack/Gemfile
@@ -11,4 +11,4 @@ gem "rack"
 # https://bugs.ruby-lang.org/issues/17303
 gem "puma"
 
-gem "sinatra"
+gem "sinatra", "~> 4.1"

--- a/test/preflight/fixtures/example-buildpack/Gemfile.lock
+++ b/test/preflight/fixtures/example-buildpack/Gemfile.lock
@@ -1,19 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    mustermann (2.0.2)
+    base64 (0.3.0)
+    logger (1.7.0)
+    mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
     nio4r (2.7.4)
     puma (6.5.0)
       nio4r (~> 2.0)
-    rack (2.2.18)
-    rack-protection (2.2.3)
-      rack
+    rack (3.2.1)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     ruby2_keywords (0.0.5)
-    sinatra (2.2.3)
-      mustermann (~> 2.0)
-      rack (~> 2.2)
-      rack-protection (= 2.2.3)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
     tilt (2.1.0)
 
@@ -23,7 +32,7 @@ PLATFORMS
 DEPENDENCIES
   puma
   rack
-  sinatra
+  sinatra (~> 4.1)
 
 BUNDLED WITH
    2.6.1


### PR DESCRIPTION
We are not affected, but it is better to clear the Dependabot alert.

https://github.com/advisories/GHSA-hxx2-7vcw-mqr3

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
