### PR TITLE
fix: avoid client.GetOrganizationBySlug which queries too much fields

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -509,6 +509,12 @@ func (v *AppDataOrganization) GetProvisionsBetaExtensions() bool {
 	return v.OrganizationData.ProvisionsBetaExtensions
 }
 
+// GetName returns AppDataOrganization.Name, and is useful for accessing the field via an interface.
+func (v *AppDataOrganization) GetName() string { return v.OrganizationData.Name }
+
+// GetBillable returns AppDataOrganization.Billable, and is useful for accessing the field via an interface.
+func (v *AppDataOrganization) GetBillable() bool { return v.OrganizationData.Billable }
+
 func (v *AppDataOrganization) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -546,6 +552,10 @@ type __premarshalAppDataOrganization struct {
 	AddOnSsoLink string `json:"addOnSsoLink"`
 
 	ProvisionsBetaExtensions bool `json:"provisionsBetaExtensions"`
+
+	Name string `json:"name"`
+
+	Billable bool `json:"billable"`
 }
 
 func (v *AppDataOrganization) MarshalJSON() ([]byte, error) {
@@ -565,6 +575,8 @@ func (v *AppDataOrganization) __premarshalJSON() (*__premarshalAppDataOrganizati
 	retval.PaidPlan = v.OrganizationData.PaidPlan
 	retval.AddOnSsoLink = v.OrganizationData.AddOnSsoLink
 	retval.ProvisionsBetaExtensions = v.OrganizationData.ProvisionsBetaExtensions
+	retval.Name = v.OrganizationData.Name
+	retval.Billable = v.OrganizationData.Billable
 	return &retval, nil
 }
 
@@ -2373,6 +2385,12 @@ func (v *GetOrganizationOrganization) GetProvisionsBetaExtensions() bool {
 	return v.OrganizationData.ProvisionsBetaExtensions
 }
 
+// GetName returns GetOrganizationOrganization.Name, and is useful for accessing the field via an interface.
+func (v *GetOrganizationOrganization) GetName() string { return v.OrganizationData.Name }
+
+// GetBillable returns GetOrganizationOrganization.Billable, and is useful for accessing the field via an interface.
+func (v *GetOrganizationOrganization) GetBillable() bool { return v.OrganizationData.Billable }
+
 func (v *GetOrganizationOrganization) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -2410,6 +2428,10 @@ type __premarshalGetOrganizationOrganization struct {
 	AddOnSsoLink string `json:"addOnSsoLink"`
 
 	ProvisionsBetaExtensions bool `json:"provisionsBetaExtensions"`
+
+	Name string `json:"name"`
+
+	Billable bool `json:"billable"`
 }
 
 func (v *GetOrganizationOrganization) MarshalJSON() ([]byte, error) {
@@ -2429,6 +2451,8 @@ func (v *GetOrganizationOrganization) __premarshalJSON() (*__premarshalGetOrgani
 	retval.PaidPlan = v.OrganizationData.PaidPlan
 	retval.AddOnSsoLink = v.OrganizationData.AddOnSsoLink
 	retval.ProvisionsBetaExtensions = v.OrganizationData.ProvisionsBetaExtensions
+	retval.Name = v.OrganizationData.Name
+	retval.Billable = v.OrganizationData.Billable
 	return &retval, nil
 }
 
@@ -2635,6 +2659,9 @@ type OrganizationData struct {
 	AddOnSsoLink string `json:"addOnSsoLink"`
 	// Whether the organization can provision beta extensions
 	ProvisionsBetaExtensions bool `json:"provisionsBetaExtensions"`
+	// Organization name
+	Name     string `json:"name"`
+	Billable bool   `json:"billable"`
 }
 
 // GetId returns OrganizationData.Id, and is useful for accessing the field via an interface.
@@ -2654,6 +2681,12 @@ func (v *OrganizationData) GetAddOnSsoLink() string { return v.AddOnSsoLink }
 
 // GetProvisionsBetaExtensions returns OrganizationData.ProvisionsBetaExtensions, and is useful for accessing the field via an interface.
 func (v *OrganizationData) GetProvisionsBetaExtensions() bool { return v.ProvisionsBetaExtensions }
+
+// GetName returns OrganizationData.Name, and is useful for accessing the field via an interface.
+func (v *OrganizationData) GetName() string { return v.Name }
+
+// GetBillable returns OrganizationData.Billable, and is useful for accessing the field via an interface.
+func (v *OrganizationData) GetBillable() bool { return v.Billable }
 
 type PlatformVersionEnum string
 
@@ -3401,6 +3434,8 @@ fragment OrganizationData on Organization {
 	paidPlan
 	addOnSsoLink
 	provisionsBetaExtensions
+	name
+	billable
 }
 `
 
@@ -3703,6 +3738,8 @@ fragment OrganizationData on Organization {
 	paidPlan
 	addOnSsoLink
 	provisionsBetaExtensions
+	name
+	billable
 }
 `
 
@@ -3815,6 +3852,8 @@ fragment OrganizationData on Organization {
 	paidPlan
 	addOnSsoLink
 	provisionsBetaExtensions
+	name
+	billable
 }
 `
 
@@ -3884,6 +3923,8 @@ fragment OrganizationData on Organization {
 	paidPlan
 	addOnSsoLink
 	provisionsBetaExtensions
+	name
+	billable
 }
 `
 
@@ -3943,6 +3984,8 @@ fragment OrganizationData on Organization {
 	paidPlan
 	addOnSsoLink
 	provisionsBetaExtensions
+	name
+	billable
 }
 `
 
@@ -4055,6 +4098,8 @@ fragment OrganizationData on Organization {
 	paidPlan
 	addOnSsoLink
 	provisionsBetaExtensions
+	name
+	billable
 }
 `
 

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -140,6 +140,8 @@ fragment OrganizationData on Organization {
 	paidPlan
 	addOnSsoLink
 	provisionsBetaExtensions
+	name
+	billable
 }
 
 fragment AppData on App {

--- a/internal/command/launch/describe_plan.go
+++ b/internal/command/launch/describe_plan.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command/launch/plan"
 	"github.com/superfly/flyctl/internal/command/mpg"
 	"github.com/superfly/flyctl/internal/command/redis"
@@ -54,17 +53,17 @@ func describeSupabasePostgresPlan(p *plan.SupabasePostgresPlan, launchPlan *plan
 	return fmt.Sprintf("(Supabase) %s in %s", p.GetDbName(launchPlan), p.GetRegion(launchPlan)), nil
 }
 
-func describeRedisPlan(ctx context.Context, p plan.RedisPlan, org *fly.Organization) (string, error) {
+func describeRedisPlan(ctx context.Context, p plan.RedisPlan) (string, error) {
 
 	switch provider := p.Provider().(type) {
 	case *plan.UpstashRedisPlan:
-		return describeUpstashRedisPlan(ctx, provider, org)
+		return describeUpstashRedisPlan(ctx, provider)
 	}
 	return descriptionNone, nil
 }
 
-func describeUpstashRedisPlan(ctx context.Context, p *plan.UpstashRedisPlan, org *fly.Organization) (string, error) {
-	plan, err := redis.DeterminePlan(ctx, org)
+func describeUpstashRedisPlan(ctx context.Context, p *plan.UpstashRedisPlan) (string, error) {
+	plan, err := redis.DeterminePlan(ctx)
 	if err != nil {
 		return "<plan not found, this is an error>", fmt.Errorf("redis plan not found: %w", err)
 	}

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -40,11 +40,11 @@ func (state *launchState) Launch(ctx context.Context) error {
 		return err
 	}
 
-	org, err := state.Org(ctx)
+	org, err := state.orgCompact(ctx)
 	if err != nil {
 		return err
 	}
-	if !planValidateHighAvailability(ctx, state.Plan, org, !state.warnedNoCcHa) {
+	if !planValidateHighAvailability(ctx, state.Plan, org.Billable, !state.warnedNoCcHa) {
 		state.Plan.HighAvailability = false
 		state.warnedNoCcHa = true
 	}
@@ -338,12 +338,13 @@ func (state *launchState) updateConfig(ctx context.Context) {
 // createApp creates the fly.io app for the plan
 func (state *launchState) createApp(ctx context.Context) (flapsutil.FlapsClient, *fly.App, error) {
 	apiClient := flyutil.ClientFromContext(ctx)
-	org, err := state.Org(ctx)
+
+	org, err := state.orgCompact(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 	app, err := apiClient.CreateApp(ctx, fly.CreateAppInput{
-		OrganizationID:  org.ID,
+		OrganizationID:  org.Id,
 		Name:            state.Plan.AppName,
 		PreferredRegion: &state.Plan.RegionCode,
 		Machines:        true,

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -220,7 +220,7 @@ func buildManifest(ctx context.Context, parentConfig *appconfig.Config, recovera
 		warnedNoCcHa:     false,
 	}
 
-	if planValidateHighAvailability(ctx, lp, org, true) {
+	if planValidateHighAvailability(ctx, lp, org.Billable, true) {
 		buildCache.warnedNoCcHa = true
 	}
 
@@ -799,8 +799,8 @@ func determineCompute(ctx context.Context, config *appconfig.Config, srcInfo *sc
 	return []*appconfig.Compute{guestToCompute(guest)}, reason, nil
 }
 
-func planValidateHighAvailability(ctx context.Context, p *plan.LaunchPlan, org *fly.Organization, print bool) bool {
-	if !org.Billable && p.HighAvailability {
+func planValidateHighAvailability(ctx context.Context, p *plan.LaunchPlan, billable, print bool) bool {
+	if !billable && p.HighAvailability {
 		if print {
 			fmt.Fprintln(iostreams.FromContext(ctx).ErrOut, "Warning: This organization has no payment method, turning off high availability")
 		}

--- a/internal/command/launch/webui.go
+++ b/internal/command/launch/webui.go
@@ -97,7 +97,7 @@ func (state *launchState) EditInWebUi(ctx context.Context) error {
 				region = r
 			}
 
-			org, err := state.Org(ctx)
+			org, err := state.orgCompact(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to get organization: %w", err)
 			}

--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -146,7 +146,7 @@ func Create(ctx context.Context, org *fly.Organization, name string, region *fly
 		}
 	}
 
-	plan, err := DeterminePlan(ctx, org)
+	plan, err := DeterminePlan(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func ProvisionDatabase(ctx context.Context, org *fly.Organization, config RedisC
 	return &response.CreateAddOn.AddOn, nil
 }
 
-func DeterminePlan(ctx context.Context, org *fly.Organization) (*gql.ListAddOnPlansAddOnPlansAddOnPlanConnectionNodesAddOnPlan, error) {
+func DeterminePlan(ctx context.Context) (*gql.ListAddOnPlansAddOnPlansAddOnPlanConnectionNodesAddOnPlan, error) {
 	client := flyutil.ClientFromContext(ctx)
 
 	planId := redisPlanPayAsYouGo


### PR DESCRIPTION
stage.Org() calls client.GetOrganizationBySlug() which queries too much fields, and times out occasionally.
    
This change adds stateCompact() which queries less and more reliable.


### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
