### PR TITLE
fix(panic): check Build section is not nil

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -266,7 +266,7 @@ func (c *Config) DetermineCompression(ctx context.Context) (compression string, 
 	}
 
 	// fly.toml overrides LaunchDarkly
-	if c.Experimental != nil {
+	if c.Build != nil {
 		if c.Build.Compression != "" {
 			compression = c.Build.Compression
 		}

--- a/internal/appconfig/validation.go
+++ b/internal/appconfig/validation.go
@@ -177,7 +177,7 @@ func (c *Config) validateServicesSection() (extraInfo string, err error) {
 					"Check docs at https://fly.io/docs/reference/configuration/#services-ports \n " +
 					"Validation for _services without ports_ will hard fail after February 15, 2024.",
 			)
-			//err = ValidationError
+			// err = ValidationError
 		}
 
 		for _, check := range service.TCPChecks {
@@ -359,7 +359,7 @@ func (c *Config) validateRestartPolicy() (extraInfo string, err error) {
 }
 
 func (c *Config) validateCompression() (extraInfo string, err error) {
-	if c.Experimental != nil {
+	if c.Build != nil {
 		if c.Build.Compression != "" {
 			if vErr := validation.ValidateCompressionFlag(c.Build.Compression); vErr != nil {
 				extraInfo += fmt.Sprintf("%s\n", vErr.Error())


### PR DESCRIPTION
### Change Summary

What and Why: Panic when `config.Build` is nil. It was protecting for `config.Experimental`

<img width="763" height="607" alt="image" src="https://github.com/user-attachments/assets/2062c193-a639-40c6-b3af-182078edb6b6" />

How:

Related to: https://flyio.sentry.io/issues/6913586839/?project=4492967

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
