### PR TITLE
Configure scheduled_snapshots via fly.toml and flyctl launch

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -158,6 +158,7 @@ type Mount struct {
 	Destination             string   `toml:"destination,omitempty" json:"destination,omitempty"`
 	InitialSize             string   `toml:"initial_size,omitempty" json:"initial_size,omitempty"`
 	SnapshotRetention       *int     `toml:"snapshot_retention,omitempty" json:"snapshot_retention,omitempty"`
+	ScheduledSnapshots      *bool    `toml:"scheduled_snapshots,omitempty" json:"scheduled_snapshots,omitempty"`
 	AutoExtendSizeThreshold int      `toml:"auto_extend_size_threshold,omitempty" json:"auto_extend_size_threshold,omitempty"`
 	AutoExtendSizeIncrement string   `toml:"auto_extend_size_increment,omitempty" json:"auto_extend_size_increment,omitempty"`
 	AutoExtendSizeLimit     string   `toml:"auto_extend_size_limit,omitempty" json:"auto_extend_size_limit,omitempty"`

--- a/internal/appconfig/definition_test.go
+++ b/internal/appconfig/definition_test.go
@@ -304,10 +304,11 @@ func TestToDefinition(t *testing.T) {
 			},
 		},
 		"mounts": []any{map[string]any{
-			"source":             "data",
-			"destination":        "/data",
-			"initial_size":       "30gb",
-			"snapshot_retention": int64(17),
+			"source":              "data",
+			"destination":         "/data",
+			"initial_size":        "30gb",
+			"snapshot_retention":  int64(17),
+			"scheduled_snapshots": true,
 		}},
 		"processes": map[string]any{
 			"web":  "run web",

--- a/internal/appconfig/serde_test.go
+++ b/internal/appconfig/serde_test.go
@@ -592,10 +592,11 @@ func TestLoadTOMLAppConfigReferenceFormat(t *testing.T) {
 		},
 
 		Mounts: []Mount{{
-			Source:            "data",
-			Destination:       "/data",
-			InitialSize:       "30gb",
-			SnapshotRetention: fly.Pointer(17),
+			Source:             "data",
+			Destination:        "/data",
+			InitialSize:        "30gb",
+			SnapshotRetention:  fly.Pointer(17),
+			ScheduledSnapshots: fly.BoolPointer(true),
 		}},
 
 		Processes: map[string]string{

--- a/internal/appconfig/testdata/full-reference.toml
+++ b/internal/appconfig/testdata/full-reference.toml
@@ -128,6 +128,7 @@ host_dedication_id = "06031957"
   initial_size = "30gb"
   destination = "/data"
   snapshot_retention = 17
+  scheduled_snapshots = true
 
 [[vm]]
   size = "shared-cpu-1x"

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -154,6 +154,7 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 				ComputeRequirements: guest,
 				ComputeImage:        md.img,
 				SnapshotRetention:   m.SnapshotRetention,
+				AutoBackupEnabled:   m.ScheduledSnapshots,
 			}
 
 			vol, err := md.flapsClient.CreateVolume(ctx, input)

--- a/internal/command/launch/cmd_test.go
+++ b/internal/command/launch/cmd_test.go
@@ -2,9 +2,13 @@ package launch
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag/flagctx"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -89,7 +93,7 @@ func TestValidatePostgresFlags(t *testing.T) {
 					t.Errorf("expected error but got none")
 					return
 				}
-				if tt.errorMsg != "" && !containsString(err.Error(), tt.errorMsg) {
+				if tt.errorMsg != "" && !strings.Contains(err.Error(), tt.errorMsg) {
 					t.Errorf("expected error message to contain '%s', got '%s'", tt.errorMsg, err.Error())
 				}
 			} else {
@@ -101,12 +105,130 @@ func TestValidatePostgresFlags(t *testing.T) {
 	}
 }
 
-// Helper function to check if a string contains a substring
-func containsString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
+func TestParseMountOptions(t *testing.T) {
+	tests := []struct {
+		name          string
+		options       string
+		expectedMount appconfig.Mount
+		expectError   bool
+		errMsg        string
+	}{
+		{
+			name:          "empty options",
+			options:       "",
+			expectedMount: appconfig.Mount{},
+		},
+		{
+			name:    "scheduled_snapshots true",
+			options: "scheduled_snapshots=true",
+			expectedMount: appconfig.Mount{
+				ScheduledSnapshots: fly.Pointer(true),
+			},
+		},
+		{
+			name:    "scheduled_snapshots false",
+			options: "scheduled_snapshots=false",
+			expectedMount: appconfig.Mount{
+				ScheduledSnapshots: fly.Pointer(false),
+			},
+		},
+		{
+			name:        "scheduled_snapshots invalid value",
+			options:     "scheduled_snapshots=invalid",
+			expectError: true,
+			errMsg:      "invalid value for scheduled_snapshots",
+		},
+		{
+			name:    "snapshot_retention",
+			options: "snapshot_retention=7",
+			expectedMount: appconfig.Mount{
+				SnapshotRetention: fly.Pointer(7),
+			},
+		},
+		{
+			name:        "snapshot_retention invalid",
+			options:     "snapshot_retention=invalid",
+			expectError: true,
+			errMsg:      "invalid value for snapshot_retention",
+		},
+		{
+			name:    "initial_size",
+			options: "initial_size=10GB",
+			expectedMount: appconfig.Mount{
+				InitialSize: "10GB",
+			},
+		},
+		{
+			name:    "auto_extend_size_threshold",
+			options: "auto_extend_size_threshold=80",
+			expectedMount: appconfig.Mount{
+				AutoExtendSizeThreshold: 80,
+			},
+		},
+		{
+			name:        "auto_extend_size_threshold invalid",
+			options:     "auto_extend_size_threshold=invalid",
+			expectError: true,
+			errMsg:      "invalid value for auto_extend_size_threshold",
+		},
+		{
+			name:    "auto_extend_size_increment",
+			options: "auto_extend_size_increment=1GB",
+			expectedMount: appconfig.Mount{
+				AutoExtendSizeIncrement: "1GB",
+			},
+		},
+		{
+			name:    "auto_extend_size_limit",
+			options: "auto_extend_size_limit=100GB",
+			expectedMount: appconfig.Mount{
+				AutoExtendSizeLimit: "100GB",
+			},
+		},
+		{
+			name:    "multiple options",
+			options: "initial_size=10GB,scheduled_snapshots=true,snapshot_retention=14",
+			expectedMount: appconfig.Mount{
+				InitialSize:        "10GB",
+				ScheduledSnapshots: fly.Pointer(true),
+				SnapshotRetention:  fly.Pointer(14),
+			},
+		},
+		{
+			name:        "unknown option",
+			options:     "unknown_option=value",
+			expectError: true,
+			errMsg:      "unknown mount option",
+		},
+		{
+			name:        "invalid format",
+			options:     "invalid_format",
+			expectError: true,
+			errMsg:      "invalid mount option",
+		},
 	}
-	return false
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mount := &appconfig.Mount{}
+			err := ParseMountOptions(mount, tt.options)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+					return
+				}
+				if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error message to contain '%s', got '%s'", tt.errMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+					return
+				}
+
+				assert.Equal(t, tt.expectedMount, *mount)
+			}
+		})
+	}
 }

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -235,6 +235,12 @@ func ParseMountOptions(mount *appconfig.Mount, options string) error {
 				return fmt.Errorf("invalid value for snapshot_retention: %s", value)
 			}
 			mount.SnapshotRetention = &ret
+		case "scheduled_snapshots":
+			ret, err := strconv.ParseBool(value)
+			if err != nil {
+				return fmt.Errorf("invalid value for scheduled_snapshots: %s", value)
+			}
+			mount.ScheduledSnapshots = &ret
 		case "auto_extend_size_threshold":
 			threshold, err := strconv.Atoi(value)
 			if err != nil {


### PR DESCRIPTION
### Change Summary

What and Why:
Also allow volume `scheduled_snapshots` to be configured via fly.toml `[mount]` and the `flyctl launch --volume` option.

Related to:
* https://github.com/superfly/flyctl/pull/4579

---

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a
