### PR TITLE
refactor: bye gopkg.in/yaml.v2

### DIFF
--- a/flyctl/flyctl.go
+++ b/flyctl/flyctl.go
@@ -10,7 +10,7 @@ import (
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/instrument"
 	"github.com/superfly/flyctl/terminal"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var configDir string

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,6 @@ require (
 	golang.org/x/time v0.13.0
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 	google.golang.org/grpc v1.75.0
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -108,6 +107,7 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 require (

--- a/internal/appconfig/serde.go
+++ b/internal/appconfig/serde.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pelletier/go-toml/v2"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/iostreams"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const flyConfigHeader = `# fly.%s app configuration file generated for %s on %s

--- a/scanner/rails.go
+++ b/scanner/rails.go
@@ -15,7 +15,7 @@ import (
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/command/launch/plan"
 	"github.com/superfly/flyctl/internal/flyerr"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 var healthcheck_channel = make(chan string)


### PR DESCRIPTION
We don't have to use both gopkg.in/yaml.v3 and gopkg.in/yaml.v2.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
