### PR TITLE
appconfig: guard against nil config in DetermineCompression

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -267,7 +267,7 @@ func (c *Config) DetermineCompression(ctx context.Context) (compression string, 
 	}
 
 	// fly.toml overrides LaunchDarkly
-	if c.Build != nil {
+	if c != nil && c.Build != nil {
 		if c.Build.Compression != "" {
 			compression = c.Build.Compression
 		}


### PR DESCRIPTION
So that 'fly machine run' can be used without `fly.toml`.