### PR TITLE
deploy fix: use image ref directly if image resolver fails

### DIFF
--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -143,7 +143,11 @@ func determineImage(ctx context.Context, appConfig *appconfig.Config, useWG, rec
 		img, err = resolver.ResolveReference(ctx, io, opts)
 		if err != nil {
 			tracing.RecordError(span, err, "failed to resolve reference for prebuilt docker image")
-			return
+			img = &imgsrc.DeploymentImage{
+				ID:  imageRef,
+				Tag: imageRef,
+			}
+			err = nil
 		}
 
 		span.AddEvent("using pre-built docker image")


### PR DESCRIPTION
`flyctl deploy --image [ref]` uses a graphql function to resolve the remote image against the upstream registry. When the image is pushed to a local mirror, it may not be immediately available upstream. In this case, we want to ignore the error and continue with the deployment. (`CreateRelease` will again attempt to resolve the image, and will block up to a minute waiting for it to upload.)