### PR TITLE
Remove reference to "Launch Plan+"/GPUs/Gateways from flyctl region details to avoid confusing users

### DIFF
--- a/internal/command/platform/regions.go
+++ b/internal/command/platform/regions.go
@@ -19,10 +19,6 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 )
 
-// Hardcoded list of regions with GPUs
-// TODO: fetch this list from the graphql endpoint once it is there
-var gpuRegions = []string{"iad", "sjc", "syd", "ams"}
-
 const RegionsCommandDesc = `View a list of regions where Fly has datacenters.
 'Capacity' shows how many performance-1x VMs can currently be launched in each region.
 `
@@ -69,32 +65,16 @@ func runRegions(ctx context.Context) error {
 		rows = append(rows, []string{""})
 		rows = append(rows, []string{io.ColorScheme().Underline(key.String())})
 		for _, region := range regionGroup {
-			gateway := ""
-			if region.GatewayAvailable {
-				gateway = "✓"
-			}
-			paidPlan := ""
-			if region.RequiresPaidPlan {
-				paidPlan = "✓"
-			}
-			gpuAvailable := ""
-			if slices.Contains(gpuRegions, region.Code) {
-				gpuAvailable = "✓"
-			}
-
 			capacity := fmt.Sprint(region.Capacity)
 			capacity = io.ColorScheme().RedGreenGradient(capacity, float64(region.Capacity)/1000)
 
 			rows = append(rows, []string{
 				region.Name,
 				region.Code,
-				gateway,
-				gpuAvailable,
 				capacity,
-				paidPlan,
 			})
 		}
 	}
 
-	return render.Table(out, "", rows, "Name", "Code", "Gateway", "GPUs", "Capacity", "Launch Plan+")
+	return render.Table(out, "", rows, "Name", "Code", "Capacity")
 }


### PR DESCRIPTION
### Change Summary

What and Why:
We previously had multiple plans before we switched to the simpler Pay-as-you-go model. Flyctl still had a reference to certain regions requiring "Launch Plan+", so I've removed that. There are a couple of other places deeper down that still have references to it but changing those would require refactoring, and since I'm new at Fly.io I have to keep away from refactoring for now.

Upon discussion on Discourse, it was decided to remove all but name/code/capacity

Test it with `fly platform regions`

<img width="596" height="596" alt="Screenshot 2025-10-10 at 4 17 06 AM" src="https://github.com/user-attachments/assets/70fe07fa-ffd3-4cb8-a28d-f25a88d564f9" />

How:
Just removes the columns from the regions command output.

<img width="481" height="686" alt="image" src="https://github.com/user-attachments/assets/68ab1411-443e-4946-b2a5-d29a9b393c2e" />


Related to:
Discussed on Discourse

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
