### PR TITLE
Fix: Region-locked machine log filtering when running flyctl on Fly.io

### DIFF
--- a/internal/command/logs/logs.go
+++ b/internal/command/logs/logs.go
@@ -67,10 +67,20 @@ Use --no-tail to only fetch the logs in the buffer.
 func run(ctx context.Context) error {
 	client := flyutil.ClientFromContext(ctx)
 
+	regionCode := config.FromContext(ctx).Region
+	vmid := flag.GetString(ctx, "machine")
+
+	// When filtering by machine ID, ignore region filter since machine IDs are globally unique.
+	// This prevents region-locked NATS subscriptions when running on Fly.io machines where
+	// FLY_REGION is set, allowing logs to be retrieved from machines in any region.
+	if vmid != "" {
+		regionCode = ""
+	}
+
 	opts := &logs.LogOptions{
 		AppName:    appconfig.NameFromContext(ctx),
-		RegionCode: config.FromContext(ctx).Region,
-		VMID:       flag.GetString(ctx, "machine"),
+		RegionCode: regionCode,
+		VMID:       vmid,
 		NoTail:     flag.GetBool(ctx, "no-tail"),
 	}
 


### PR DESCRIPTION
### Change Summary

  **Problem**

  When running `flyctl logs --machine <machine_id>` from a deployed Fly.io application, the command only returns logs
  from machines in the same region as the executing machine, rather than from any region. This causes the command to
  hang when querying logs from machines in different regions.

  **Reproduction Steps**

  1. Deploy an app with machines in multiple regions (e.g., AMS and FRA)
  2. SSH into a machine in region A (e.g., AMS)
  3. Run `flyctl logs -a <app> --machine <machine_id_from_region_B>`
  4. Expected: Logs from the machine in region B are returned
  5. Actual: Command hangs indefinitely

  **Root Cause**

  The bug occurs because Fly.io machines automatically set the **FLY_REGION** environment variable to their local region.
   This variable is used by flyctl to populate the region filter in the logs command at
  internal/command/logs/logs.go:72:

```
  RegionCode: config.FromContext(ctx).Region,  // Gets "ams" from FLY_REGION env var
```

  This region code is then used to construct the NATS subject pattern at logs/logs.go:40:
```
  add(opts.RegionCode)  // Creates: logs.app.ams.machine_id
```

  The resulting NATS subscription pattern` logs.app.ams.machine_id` only subscribes to logs from the AMS region, even
  though the machine ID might be in FRA. Since NATS log streams are region-scoped, this causes cross-region machine
  queries to fail.

  **Solution**

  Since machine IDs are globally unique across all regions, there's no need to filter by region when querying logs
  for a specific machine. This fix clears the region code when a machine ID is specified, ensuring the NATS
  subscription uses a wildcard for the region component.

  - ✅ Fixes cross-region machine log queries when running flyctl on Fly.io
  - ✅ No breaking changes - machine IDs are already globally unique
  - ✅ Maintains existing behavior for localhost and region-only filtering
  - ✅ No performance impact - wildcard region matching is already used in other scenarios

Related to: -

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
