### PR TITLE
Fix plan key casing for 'Performance' in MPGPlans

### DIFF
--- a/internal/command/mpg/plans.go
+++ b/internal/command/mpg/plans.go
@@ -33,7 +33,7 @@ var MPGPlans = map[string]PlanDetails{
 		Memory:     "33 GB",
 		PricePerMo: 962,
 	},
-	"performance": {
+	"Performance": {
 		Name:       "Performance",
 		CPU:        "Performance x 8",
 		Memory:     "64 GB",


### PR DESCRIPTION
### Change Summary

What and Why:

This PR updates the performance plan key to use capital-case Performance to match the backend's plan identifier.

Related to:

- https://github.com/superfly/flyctl/pull/4608

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
