### PR TITLE
Add support for custom database/user in `mpg attach`

### DIFF
--- a/internal/uiex/managed_postgres.go
+++ b/internal/uiex/managed_postgres.go
@@ -157,6 +157,7 @@ func (c *Client) GetManagedClusterById(ctx context.Context, id string) (GetManag
 type CreateUserInput struct {
 	DbName   string `json:"db_name"`
 	UserName string `json:"user_name"`
+	AppName  string `json:"app_name"`
 }
 
 type DetailedErrors struct {


### PR DESCRIPTION
The attach command now accepts --database-name and --database-user flags to create a custom database and user when attaching a Postgres cluster. The CreateUserInput struct and API call were updated to include the app name for context.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
