### PR TITLE
Filter deprecated regions in remaining flyctl commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.9
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/fly-go v0.1.63
+	github.com/superfly/fly-go v0.1.64
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -635,8 +635,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.63 h1:u5QlVBXkQgBMfA+KiRFvZzTnOAYi6YTabXalj5EOvrk=
-github.com/superfly/fly-go v0.1.63/go.mod h1:wpq4XNor10w9KurA15CBYRnhtT2mnemAXYHuqkhp2vI=
+github.com/superfly/fly-go v0.1.64 h1:kKpr1qcNn0ZM3IvMz7AthDrSt/4Haor7c7AE/t6lEqw=
+github.com/superfly/fly-go v0.1.64/go.mod h1:wpq4XNor10w9KurA15CBYRnhtT2mnemAXYHuqkhp2vI=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -8892,6 +8892,7 @@ type Region {
   """
   code: String!
   gatewayAvailable: Boolean!
+  deprecated: Boolean!
 
   """
   The latitude of this region

--- a/internal/command/curl/curl.go
+++ b/internal/command/curl/curl.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
 	fly "github.com/superfly/fly-go"
@@ -89,6 +90,11 @@ func fetchRegionCodes(ctx context.Context) (codes []string, err error) {
 
 		return
 	}
+
+	// Filter out deprecated regions
+	regions = lo.Filter(regions, func(r fly.Region, _ int) bool {
+		return !r.Deprecated
+	})
 
 	for _, region := range regions {
 		codes = append(codes, region.Code)

--- a/internal/command/launch/launch_databases.go
+++ b/internal/command/launch/launch_databases.go
@@ -389,6 +389,10 @@ func (state *launchState) createUpstashRedis(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		// Filter out deprecated regions
+		regions = lo.Filter(regions, func(r fly.Region, _ int) bool {
+			return !r.Deprecated
+		})
 		for _, code := range redisPlan.ReadReplicas {
 			if region, ok := lo.Find(regions, func(r fly.Region) bool { return r.Code == code }); ok {
 				readReplicaRegions = append(readReplicaRegions, region)

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/samber/lo"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -724,6 +725,11 @@ func getRegionByCode(ctx context.Context, regionCode string) (*fly.Region, error
 	if err != nil {
 		return nil, err
 	}
+
+	// Filter out deprecated regions
+	allRegions = lo.Filter(allRegions, func(r fly.Region, _ int) bool {
+		return !r.Deprecated
+	})
 
 	for _, r := range allRegions {
 		if r.Code == regionCode {

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -79,6 +79,10 @@ func (state *launchState) Region(ctx context.Context) (fly.Region, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Filter out deprecated regions
+		regions = lo.Filter(regions, func(r fly.Region, _ int) bool {
+			return !r.Deprecated
+		})
 		return regions, nil
 	})
 	if err != nil {

--- a/internal/command/lfsc/regions.go
+++ b/internal/command/lfsc/regions.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/samber/lo"
 	"github.com/spf13/cobra"
+	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -39,6 +41,11 @@ func runRegions(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed retrieving regions: %w", err)
 	}
+
+	// Filter out deprecated regions
+	flyRegions = lo.Filter(flyRegions, func(r fly.Region, _ int) bool {
+		return !r.Deprecated
+	})
 
 	lfscClient := lfsc.NewClient()
 	lfscClient.URL = flag.GetString(ctx, "url")

--- a/internal/flag/completion/completions.go
+++ b/internal/flag/completion/completions.go
@@ -104,6 +104,12 @@ func CompleteRegions(
 	if err != nil {
 		return nil, err
 	}
+
+	// Filter out deprecated regions
+	regions = lo.Filter(regions, func(r fly.Region, _ int) bool {
+		return !r.Deprecated
+	})
+
 	regionNames := lo.FilterMap(regions, func(region fly.Region, _ int) (string, bool) {
 		if strings.HasPrefix(region.Code, partial) {
 			return format(region), true


### PR DESCRIPTION
### Change Summary

What and Why:
We shouldn't allow/suggest users to deploy resources to regions we have flagged as deprecated

How:
Already did this for flaps (platform regions uses it), this does it for the other commands, which use graphQL (web and fly-go already updated to expose the new field)

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
