### PR TITLE
Update UPG http client to fix close before read bug

### DIFF
--- a/flypg/http.go
+++ b/flypg/http.go
@@ -72,7 +72,6 @@ func (c *Client) doRequest(ctx context.Context, method, path string, in interfac
 	}
 
 	if res.StatusCode > 299 {
-		// newError will read the response body; ensure we close it before returning
 		err := newError(res.StatusCode, res)
 		_ = res.Body.Close()
 		return nil, err
@@ -86,7 +85,7 @@ func (c *Client) Do(ctx context.Context, method, path string, in, out interface{
 	if err != nil {
 		return err
 	}
-	// Ensure the response body is always closed
+	// Ensure the response body is closed by the client
 	defer body.Close()
 
 	if out == nil {


### PR DESCRIPTION
### Change Summary

What and Why: Flyctl v0.3.198 seemed to surface a latent timing bug in the unmanaged postgres http client. That client is used for communicating with Postgres flex's tiny server in order to get admin / config details about the cluster, in order for commands like `fly pg attach` and `fly config show` to work. 



How: The bug was causing us to close the response body before returning it to flyctl, causing those commands to fail with `read on closed response body`. This PR moves the `Body.Close()` to the client call, so that it's closed after it's been returned and used.

Tested and confirmed that the pg attach / config / etc commands are working with this patch when run against clusters that showed the error on v0.3.198

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
