### PR TITLE
Make `deploy` more robust to propagation delays

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -190,8 +190,7 @@ func (md *machineDeployment) waitForMachine(ctx context.Context, e *machineUpdat
 	}
 
 	if !md.skipHealthChecks {
-		justCreated := true
-		if err := lm.WaitForState(ctx, fly.MachineStateStarted, md.waitTimeout, false, justCreated); err != nil {
+		if err := lm.WaitForState(ctx, fly.MachineStateStarted, md.waitTimeout, machine.WithJustCreated()); err != nil {
 			err = suggestChangeWaitTimeout(err, "wait-timeout")
 			return err
 		}
@@ -1097,8 +1096,7 @@ func (md *machineDeployment) spawnMachineInGroup(ctx context.Context, groupName 
 	// And wait (or not) for successful health checks
 	if !md.skipHealthChecks {
 		// Don't wait for state if the --detach flag isn't specified
-		justCreated := true
-		if err := lm.WaitForState(ctx, fly.MachineStateStarted, md.waitTimeout, false, justCreated); err != nil {
+		if err := lm.WaitForState(ctx, fly.MachineStateStarted, md.waitTimeout, machine.WithJustCreated()); err != nil {
 			err = suggestChangeWaitTimeout(err, "wait-timeout")
 			return nil, err
 		}

--- a/internal/command/deploy/machines_releasecommand.go
+++ b/internal/command/deploy/machines_releasecommand.go
@@ -248,8 +248,7 @@ func (md *machineDeployment) createReleaseCommandMachine(ctx context.Context) er
 	md.releaseCommandMachine = machine.NewMachineSet(md.flapsClient, md.io, []*fly.Machine{releaseCmdMachine}, true)
 
 	lm := md.releaseCommandMachine.GetMachines()[0]
-	justCreated := true
-	if err := lm.WaitForState(ctx, fly.MachineStateStopped, md.waitTimeout, false, justCreated); err != nil {
+	if err := lm.WaitForState(ctx, fly.MachineStateStopped, md.waitTimeout, machine.WithJustCreated()); err != nil {
 		err = suggestChangeWaitTimeout(err, "wait-timeout")
 		return err
 	}
@@ -318,7 +317,7 @@ func (md *machineDeployment) inferReleaseCommandGuest() *fly.MachineGuest {
 }
 
 func (md *machineDeployment) waitForReleaseCommandToFinish(ctx context.Context, releaseCmdMachine machine.LeasableMachine) error {
-	err := releaseCmdMachine.WaitForState(ctx, fly.MachineStateStarted, md.waitTimeout, false, false)
+	err := releaseCmdMachine.WaitForState(ctx, fly.MachineStateStarted, md.waitTimeout)
 	if err != nil {
 		var flapsErr *flaps.FlapsError
 		if errors.As(err, &flapsErr) && flapsErr.ResponseStatusCode == http.StatusNotFound {
@@ -328,7 +327,7 @@ func (md *machineDeployment) waitForReleaseCommandToFinish(ctx context.Context, 
 		err = suggestChangeWaitTimeout(err, "wait-timeout")
 		return fmt.Errorf("error waiting for release_command machine %s to start: %w", releaseCmdMachine.Machine().ID, err)
 	}
-	err = releaseCmdMachine.WaitForState(ctx, fly.MachineStateDestroyed, md.releaseCmdTimeout, true, false)
+	err = releaseCmdMachine.WaitForState(ctx, fly.MachineStateDestroyed, md.releaseCmdTimeout, machine.WithAllowInfinite(true))
 	if err != nil {
 		err = suggestChangeWaitTimeout(err, "release-command-timeout")
 		return fmt.Errorf("error waiting for release_command machine %s to finish running: %w", releaseCmdMachine.Machine().ID, err)

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -704,7 +704,7 @@ func waitForMachineState(ctx context.Context, lm mach.LeasableMachine, possibleS
 	for _, state := range possibleStates {
 		state := state
 		go func() {
-			err := lm.WaitForState(ctx, state, timeout, false, false)
+			err := lm.WaitForState(ctx, state, timeout)
 			mutex.Lock()
 			defer func() {
 				numCompleted += 1

--- a/internal/machine/machine_set.go
+++ b/internal/machine/machine_set.go
@@ -162,7 +162,7 @@ func (ms *machineSet) WaitForMachineSetState(ctx context.Context, state string, 
 		wg.Add(1)
 		go func(m LeasableMachine) {
 			defer wg.Done()
-			err := m.WaitForState(ctx, state, timeout, allowInfinite, false)
+			err := m.WaitForState(ctx, state, timeout, WithAllowInfinite(allowInfinite))
 
 			var flapsErr *flaps.FlapsError
 			if errors.As(err, &flapsErr) {


### PR DESCRIPTION
### Change Summary

#### What and Why:

We've had reports of errors like this while running `deploy`:
```
Error: release command failed - aborting deployment. error running release_command machine: failed to wait for VM abcabcabcabc in stopped state: machine not found (Request ID: 01K7E5VVGVHAZY5BN49P4NMEAW-fra) (Trace ID: 689f4888f1dafcef34865fe85ae323c3)
```

The Fly machines API is eventually consistent. If you've just [created a machine](https://docs.machines.dev/#tag/machines/post/apps/{app_name}/machines), there's no guarantee that a subsequent request to [wait for state](https://docs.machines.dev/#tag/machines/get/apps/{app_name}/machines/{machine_id}/wait) will be able to find that machine.

#### How:

When we're waiting for a newly created machine to reach a particular state, we should retry on a 404 rather than failing.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
