### PR TITLE
Fly launch ux +

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/command/deploycontext"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/ctrlc"
 	"github.com/superfly/flyctl/internal/flag"
@@ -411,9 +412,7 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, userID i
 	}
 	if appURL := appConfig.URL(); appURL != nil && ip == "public" {
 		// Check if this is a first launch (celebratory mode) or regular deploy (simple mode)
-		// Using a string literal here to match the key set in internal/command/launch/deploy.go
-		type contextKey string
-		isFirstLaunch, _ := ctx.Value(contextKey("isFirstLaunch")).(bool)
+		isFirstLaunch, _ := ctx.Value(deploycontext.IsFirstLaunchKey).(bool)
 		colorize := io.ColorScheme()
 
 		if isFirstLaunch {

--- a/internal/command/deploycontext/context.go
+++ b/internal/command/deploycontext/context.go
@@ -1,0 +1,7 @@
+package deploycontext
+
+// ContextKey is a custom type for deploy-related context keys to avoid collisions
+type ContextKey string
+
+// IsFirstLaunchKey is the context key for marking a deployment as the first launch
+const IsFirstLaunchKey ContextKey = "isFirstLaunch"

--- a/internal/command/launch/deploy.go
+++ b/internal/command/launch/deploy.go
@@ -7,14 +7,10 @@ import (
 	"github.com/samber/lo"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command/deploy"
+	"github.com/superfly/flyctl/internal/command/deploycontext"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/iostreams"
 )
-
-// contextKey is a custom type for context keys to avoid collisions
-type contextKey string
-
-const isFirstLaunchKey contextKey = "isFirstLaunch"
 
 // firstDeploy performs the first deploy of an app.
 // Note that this function checks and respects the --no-deploy flag, so it may not actually deploy.
@@ -86,7 +82,7 @@ func (state *launchState) firstDeploy(ctx context.Context) error {
 			}
 		}
 		// Mark this as a first launch to show celebratory output
-		ctx = context.WithValue(ctx, isFirstLaunchKey, true)
+		ctx = context.WithValue(ctx, deploycontext.IsFirstLaunchKey, true)
 		return deploy.DeployWithConfig(ctx, state.appConfig, 0, flag.GetBool(ctx, "now"))
 	}
 


### PR DESCRIPTION
 This commit differentiates the deployment success output based on context:

   ## First Launch (fly launch)
   - Is exciting and celebratory

   ## Regular Deploy (fly deploy)
   - Is to the point and just feels reliable and fast

   ## Implementation
   - Uses context.WithValue() to pass isFirstLaunch flag from launch flow
   - Checks ctx.Value("isFirstLaunch") in deploy success output
   - Defaults to simple mode when flag is not set (backward compatible)