### PR TITLE
Add closest region remapping for `fly launch`

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -2337,6 +2337,7 @@ type GetNearestRegionNearestRegion struct {
 	// The name of this region
 	Name             string `json:"name"`
 	GatewayAvailable bool   `json:"gatewayAvailable"`
+	Deprecated       bool   `json:"deprecated"`
 }
 
 // GetCode returns GetNearestRegionNearestRegion.Code, and is useful for accessing the field via an interface.
@@ -2347,6 +2348,9 @@ func (v *GetNearestRegionNearestRegion) GetName() string { return v.Name }
 
 // GetGatewayAvailable returns GetNearestRegionNearestRegion.GatewayAvailable, and is useful for accessing the field via an interface.
 func (v *GetNearestRegionNearestRegion) GetGatewayAvailable() bool { return v.GatewayAvailable }
+
+// GetDeprecated returns GetNearestRegionNearestRegion.Deprecated, and is useful for accessing the field via an interface.
+func (v *GetNearestRegionNearestRegion) GetDeprecated() bool { return v.Deprecated }
 
 // GetNearestRegionResponse is returned by GetNearestRegion on success.
 type GetNearestRegionResponse struct {
@@ -4059,6 +4063,7 @@ query GetNearestRegion {
 		code
 		name
 		gatewayAvailable
+		deprecated
 	}
 }
 `

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -181,6 +181,7 @@ query GetNearestRegion{
 		code
 		name
 		gatewayAvailable
+		deprecated
 	}
 }
 


### PR DESCRIPTION
### Change Summary

What and Why:
Currently the getNearestRegion Graphql call includes deprecated regions in the response. We use that in flyctl for determining the optimal region for users to deploy to. However for users close to the deprecated regions, they'll get a non-usable region in the response, and since we now filter out deprecated regions it throws an `unknown region` error. 

This adds a region remap for fly launch that re-writes the autodetected nearest region to it's replacement region, if the nearest region is deprecated. Right now this change only handles rewrites for the auto-detected regions. Specifying a deprecated region in `fly.toml` or with ` fly launch --region` will not re-write it, but will throw an error. 


How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
