### PR TITLE
Add billing status check during fly launch flow

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -515,6 +515,11 @@ func (v *AppDataOrganization) GetName() string { return v.OrganizationData.Name 
 // GetBillable returns AppDataOrganization.Billable, and is useful for accessing the field via an interface.
 func (v *AppDataOrganization) GetBillable() bool { return v.OrganizationData.Billable }
 
+// GetBillingStatus returns AppDataOrganization.BillingStatus, and is useful for accessing the field via an interface.
+func (v *AppDataOrganization) GetBillingStatus() BillingStatus {
+	return v.OrganizationData.BillingStatus
+}
+
 func (v *AppDataOrganization) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -556,6 +561,8 @@ type __premarshalAppDataOrganization struct {
 	Name string `json:"name"`
 
 	Billable bool `json:"billable"`
+
+	BillingStatus BillingStatus `json:"billingStatus"`
 }
 
 func (v *AppDataOrganization) MarshalJSON() ([]byte, error) {
@@ -577,6 +584,7 @@ func (v *AppDataOrganization) __premarshalJSON() (*__premarshalAppDataOrganizati
 	retval.ProvisionsBetaExtensions = v.OrganizationData.ProvisionsBetaExtensions
 	retval.Name = v.OrganizationData.Name
 	retval.Billable = v.OrganizationData.Billable
+	retval.BillingStatus = v.OrganizationData.BillingStatus
 	return &retval, nil
 }
 
@@ -588,6 +596,28 @@ type AppDataSecretsSecret struct {
 
 // GetName returns AppDataSecretsSecret.Name, and is useful for accessing the field via an interface.
 func (v *AppDataSecretsSecret) GetName() string { return v.Name }
+
+type BillingStatus string
+
+const (
+	BillingStatusCurrent        BillingStatus = "CURRENT"
+	BillingStatusDelinquent     BillingStatus = "DELINQUENT"
+	BillingStatusPastDue        BillingStatus = "PAST_DUE"
+	BillingStatusSourceRequired BillingStatus = "SOURCE_REQUIRED"
+	BillingStatusSuspended      BillingStatus = "SUSPENDED"
+	BillingStatusTrialActive    BillingStatus = "TRIAL_ACTIVE"
+	BillingStatusTrialEnded     BillingStatus = "TRIAL_ENDED"
+)
+
+var AllBillingStatus = []BillingStatus{
+	BillingStatusCurrent,
+	BillingStatusDelinquent,
+	BillingStatusPastDue,
+	BillingStatusSourceRequired,
+	BillingStatusSuspended,
+	BillingStatusTrialActive,
+	BillingStatusTrialEnded,
+}
 
 // CreateAddOnCreateAddOnCreateAddOnPayload includes the requested fields of the GraphQL type CreateAddOnPayload.
 // The GraphQL type's documentation follows.
@@ -2391,6 +2421,11 @@ func (v *GetOrganizationOrganization) GetName() string { return v.OrganizationDa
 // GetBillable returns GetOrganizationOrganization.Billable, and is useful for accessing the field via an interface.
 func (v *GetOrganizationOrganization) GetBillable() bool { return v.OrganizationData.Billable }
 
+// GetBillingStatus returns GetOrganizationOrganization.BillingStatus, and is useful for accessing the field via an interface.
+func (v *GetOrganizationOrganization) GetBillingStatus() BillingStatus {
+	return v.OrganizationData.BillingStatus
+}
+
 func (v *GetOrganizationOrganization) UnmarshalJSON(b []byte) error {
 
 	if string(b) == "null" {
@@ -2432,6 +2467,8 @@ type __premarshalGetOrganizationOrganization struct {
 	Name string `json:"name"`
 
 	Billable bool `json:"billable"`
+
+	BillingStatus BillingStatus `json:"billingStatus"`
 }
 
 func (v *GetOrganizationOrganization) MarshalJSON() ([]byte, error) {
@@ -2453,6 +2490,7 @@ func (v *GetOrganizationOrganization) __premarshalJSON() (*__premarshalGetOrgani
 	retval.ProvisionsBetaExtensions = v.OrganizationData.ProvisionsBetaExtensions
 	retval.Name = v.OrganizationData.Name
 	retval.Billable = v.OrganizationData.Billable
+	retval.BillingStatus = v.OrganizationData.BillingStatus
 	return &retval, nil
 }
 
@@ -2660,8 +2698,9 @@ type OrganizationData struct {
 	// Whether the organization can provision beta extensions
 	ProvisionsBetaExtensions bool `json:"provisionsBetaExtensions"`
 	// Organization name
-	Name     string `json:"name"`
-	Billable bool   `json:"billable"`
+	Name          string        `json:"name"`
+	Billable      bool          `json:"billable"`
+	BillingStatus BillingStatus `json:"billingStatus"`
 }
 
 // GetId returns OrganizationData.Id, and is useful for accessing the field via an interface.
@@ -2687,6 +2726,9 @@ func (v *OrganizationData) GetName() string { return v.Name }
 
 // GetBillable returns OrganizationData.Billable, and is useful for accessing the field via an interface.
 func (v *OrganizationData) GetBillable() bool { return v.Billable }
+
+// GetBillingStatus returns OrganizationData.BillingStatus, and is useful for accessing the field via an interface.
+func (v *OrganizationData) GetBillingStatus() BillingStatus { return v.BillingStatus }
 
 type PlatformVersionEnum string
 
@@ -3436,6 +3478,7 @@ fragment OrganizationData on Organization {
 	provisionsBetaExtensions
 	name
 	billable
+	billingStatus
 }
 `
 
@@ -3740,6 +3783,7 @@ fragment OrganizationData on Organization {
 	provisionsBetaExtensions
 	name
 	billable
+	billingStatus
 }
 `
 
@@ -3854,6 +3898,7 @@ fragment OrganizationData on Organization {
 	provisionsBetaExtensions
 	name
 	billable
+	billingStatus
 }
 `
 
@@ -3925,6 +3970,7 @@ fragment OrganizationData on Organization {
 	provisionsBetaExtensions
 	name
 	billable
+	billingStatus
 }
 `
 
@@ -3986,6 +4032,7 @@ fragment OrganizationData on Organization {
 	provisionsBetaExtensions
 	name
 	billable
+	billingStatus
 }
 `
 
@@ -4100,6 +4147,7 @@ fragment OrganizationData on Organization {
 	provisionsBetaExtensions
 	name
 	billable
+	billingStatus
 }
 `
 

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -142,6 +142,7 @@ fragment OrganizationData on Organization {
 	provisionsBetaExtensions
 	name
 	billable
+	billingStatus
 }
 
 fragment AppData on App {

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -811,9 +811,8 @@ func determineCompute(ctx context.Context, config *appconfig.Config, srcInfo *sc
 
 func planValidateHighAvailability(ctx context.Context, p *plan.LaunchPlan, billable, print bool) bool {
 	if !billable && p.HighAvailability {
-		if print {
-			fmt.Fprintln(iostreams.FromContext(ctx).ErrOut, "Warning: This organization has no payment method, turning off high availability")
-		}
+		// Silently turn off high availability if no payment method
+		// The billing check will handle informing the user about payment methods
 		return false
 	}
 	return true


### PR DESCRIPTION
Adds a proactive billing status check during the launch flow so user's don't reach the end of the process and then discover that they need to add a cc.

  ## Changes

  ### Billing Status Display
  - Check organization billing status after displaying the launch summary table
  - Show status-appropriate messaging before the "tweak settings" prompt
  - Three distinct paths based on billing status:
    1. TRIAL_ACTIVE: "✓ Your free trial has you covered - ship it! ✨"
    2. SOURCE_REQUIRED/TRIAL_ENDED: "! You'll need to add a payment method in order to proceed."
    3. CURRENT/PAST_DUE/DELINQUENT: Continue silently

  ### Payment Method Flow
  - When no payment method exists, prompt user: "Would you like to do this now?"
  - If yes, open billing dashboard at https://fly.io/dashboard/{org}/billing
  - Clear next steps: "After adding a payment method, please run 'fly launch' again"

  ### GraphQL Updates
  - Added `billingStatus` field to OrganizationData fragment
  - Generated BillingStatus enum with all status constants
  - Leverages existing `orgCompact()` method for efficient API calls

  ### UX Improvements
  - Removed redundant "no payment method" warning from HA validation
  - Billing check happens after summary (user sees what they're getting first)
  - Non-interactive/CI environments skip the check to avoid blocking automation
  - Warnings logged but don't block launch on API errors
  - Billing check is only shown during interactive sessions (not in CI)