### PR TITLE
Add support for `--deleted` flag for `flyctl mpg list`

### DIFF
--- a/internal/command/launch/plan/postgres_test.go
+++ b/internal/command/launch/plan/postgres_test.go
@@ -38,7 +38,7 @@ func (m *mockGenqClient) MakeRequest(ctx context.Context, req *genq.Request, res
 	return nil
 }
 
-func (m *mockUIEXClient) ListManagedClusters(ctx context.Context, orgSlug string) (uiex.ListManagedClustersResponse, error) {
+func (m *mockUIEXClient) ListManagedClusters(ctx context.Context, orgSlug string, deleted bool) (uiex.ListManagedClustersResponse, error) {
 	return uiex.ListManagedClustersResponse{}, nil
 }
 

--- a/internal/command/mpg/list.go
+++ b/internal/command/mpg/list.go
@@ -35,6 +35,11 @@ If no organization is specified, the user's personal organization is used.`
 
 	flag.Add(cmd, flag.JSONOutput())
 	flag.Add(cmd, flag.Org())
+	flag.Add(cmd, flag.Bool{
+		Name:        "deleted",
+		Description: "Show deleted clusters instead of active clusters",
+		Default:     false,
+	})
 
 	return cmd
 }
@@ -63,13 +68,18 @@ func runList(ctx context.Context) error {
 		return err
 	}
 
-	clusters, err := uiexClient.ListManagedClusters(ctx, fullOrg.Organization.RawSlug)
+	deleted := flag.GetBool(ctx, "deleted")
+	clusters, err := uiexClient.ListManagedClusters(ctx, fullOrg.Organization.RawSlug, deleted)
 	if err != nil {
 		return fmt.Errorf("failed to list managed clusters for organization %s: %w", org.Slug, err)
 	}
 
 	if len(clusters.Data) == 0 {
-		fmt.Fprintf(out, "No managed postgres clusters found in organization %s\n", org.Slug)
+		if deleted {
+			fmt.Fprintf(out, "No deleted managed postgres clusters found in organization %s\n", org.Slug)
+		} else {
+			fmt.Fprintf(out, "No managed postgres clusters found in organization %s\n", org.Slug)
+		}
 		return nil
 	}
 

--- a/internal/command/mpg/mpg.go
+++ b/internal/command/mpg/mpg.go
@@ -89,7 +89,7 @@ func ClusterFromFlagOrSelect(ctx context.Context, orgSlug string) (*uiex.Managed
 	clusterID := flag.GetMPGClusterID(ctx)
 	uiexClient := uiexutil.ClientFromContext(ctx)
 
-	clustersResponse, err := uiexClient.ListManagedClusters(ctx, orgSlug)
+	clustersResponse, err := uiexClient.ListManagedClusters(ctx, orgSlug, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed retrieving postgres clusters: %w", err)
 	}

--- a/internal/command/mpg/mpg_test.go
+++ b/internal/command/mpg/mpg_test.go
@@ -23,7 +23,7 @@ import (
 // MockUiexClient implements the uiexutil.Client interface for testing
 type MockUiexClient struct {
 	ListMPGRegionsFunc              func(ctx context.Context, orgSlug string) (uiex.ListMPGRegionsResponse, error)
-	ListManagedClustersFunc         func(ctx context.Context, orgSlug string) (uiex.ListManagedClustersResponse, error)
+	ListManagedClustersFunc         func(ctx context.Context, orgSlug string, deleted bool) (uiex.ListManagedClustersResponse, error)
 	GetManagedClusterFunc           func(ctx context.Context, orgSlug string, id string) (uiex.GetManagedClusterResponse, error)
 	GetManagedClusterByIdFunc       func(ctx context.Context, id string) (uiex.GetManagedClusterResponse, error)
 	CreateUserFunc                  func(ctx context.Context, id string, input uiex.CreateUserInput) (uiex.CreateUserResponse, error)
@@ -42,9 +42,9 @@ func (m *MockUiexClient) ListMPGRegions(ctx context.Context, orgSlug string) (ui
 	return uiex.ListMPGRegionsResponse{}, nil
 }
 
-func (m *MockUiexClient) ListManagedClusters(ctx context.Context, orgSlug string) (uiex.ListManagedClustersResponse, error) {
+func (m *MockUiexClient) ListManagedClusters(ctx context.Context, orgSlug string, deleted bool) (uiex.ListManagedClustersResponse, error) {
 	if m.ListManagedClustersFunc != nil {
-		return m.ListManagedClustersFunc(ctx, orgSlug)
+		return m.ListManagedClustersFunc(ctx, orgSlug, deleted)
 	}
 	return uiex.ListManagedClustersResponse{}, nil
 }
@@ -198,7 +198,7 @@ func TestClusterFromFlagOrSelect_WithFlagContext(t *testing.T) {
 	}
 
 	mockUiex := &MockUiexClient{
-		ListManagedClustersFunc: func(ctx context.Context, orgSlug string) (uiex.ListManagedClustersResponse, error) {
+		ListManagedClustersFunc: func(ctx context.Context, orgSlug string, deleted bool) (uiex.ListManagedClustersResponse, error) {
 			assert.Equal(t, "test-org", orgSlug)
 			return uiex.ListManagedClustersResponse{
 				Data: []uiex.ManagedCluster{expectedCluster},
@@ -210,7 +210,7 @@ func TestClusterFromFlagOrSelect_WithFlagContext(t *testing.T) {
 
 	t.Run("no clusters found", func(t *testing.T) {
 		mockEmpty := &MockUiexClient{
-			ListManagedClustersFunc: func(ctx context.Context, orgSlug string) (uiex.ListManagedClustersResponse, error) {
+			ListManagedClustersFunc: func(ctx context.Context, orgSlug string, deleted bool) (uiex.ListManagedClustersResponse, error) {
 				return uiex.ListManagedClustersResponse{Data: []uiex.ManagedCluster{}}, nil
 			},
 		}
@@ -488,7 +488,7 @@ func TestListCommand_Logic(t *testing.T) {
 	}
 
 	mockUiex := &MockUiexClient{
-		ListManagedClustersFunc: func(ctx context.Context, orgSlug string) (uiex.ListManagedClustersResponse, error) {
+		ListManagedClustersFunc: func(ctx context.Context, orgSlug string, deleted bool) (uiex.ListManagedClustersResponse, error) {
 			assert.Equal(t, "test-org", orgSlug)
 			return uiex.ListManagedClustersResponse{
 				Data: expectedClusters,
@@ -499,7 +499,7 @@ func TestListCommand_Logic(t *testing.T) {
 	ctx = uiexutil.NewContextWithClient(ctx, mockUiex)
 
 	// Test successful cluster listing
-	clusters, err := mockUiex.ListManagedClusters(ctx, "test-org")
+	clusters, err := mockUiex.ListManagedClusters(ctx, "test-org", false)
 	require.NoError(t, err)
 	assert.Len(t, clusters.Data, 2)
 
@@ -523,7 +523,7 @@ func TestErrorHandling(t *testing.T) {
 
 	t.Run("ListManagedClusters error", func(t *testing.T) {
 		mockUiex := &MockUiexClient{
-			ListManagedClustersFunc: func(ctx context.Context, orgSlug string) (uiex.ListManagedClustersResponse, error) {
+			ListManagedClustersFunc: func(ctx context.Context, orgSlug string, deleted bool) (uiex.ListManagedClustersResponse, error) {
 				return uiex.ListManagedClustersResponse{}, fmt.Errorf("API error")
 			},
 		}

--- a/internal/uiexutil/client.go
+++ b/internal/uiexutil/client.go
@@ -9,7 +9,7 @@ import (
 type Client interface {
 	// MPGs
 	ListMPGRegions(ctx context.Context, orgSlug string) (uiex.ListMPGRegionsResponse, error)
-	ListManagedClusters(ctx context.Context, orgSlug string) (uiex.ListManagedClustersResponse, error)
+	ListManagedClusters(ctx context.Context, orgSlug string, deleted bool) (uiex.ListManagedClustersResponse, error)
 	GetManagedCluster(ctx context.Context, orgSlug string, id string) (uiex.GetManagedClusterResponse, error)
 	GetManagedClusterById(ctx context.Context, id string) (uiex.GetManagedClusterResponse, error)
 	CreateUser(ctx context.Context, id string, input uiex.CreateUserInput) (uiex.CreateUserResponse, error)


### PR DESCRIPTION
So we can query deleted mpg clusters - 

```
./bin/flyctl mpg list --org simon-mpg --deleted | head -n 3
ID                      NAME                                                                                       ORG             REGION  STATUS  PLAN
z23750vxz2lr96d1        my-mpg-ams restored 2025-10-24 08:11:33.055697Z                                            simon-mpg       ams     deleted basic
w86750826kj03pk4        my-mpg-ams restored 2025-10-24 06:31:06.114211Z                                            simon-mpg       ams     deleted basic
```

