### PR TITLE
Fix deploy test failing due to new session timeout feature

### DIFF
--- a/internal/command/deploy/deploy_test.go
+++ b/internal/command/deploy/deploy_test.go
@@ -8,8 +8,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/tokens"
+	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/inmem"
@@ -41,6 +44,13 @@ func TestCommand_Execute(t *testing.T) {
 	ctx = iostreams.NewContext(ctx, &iostreams.IOStreams{Out: &buf, ErrOut: &buf})
 	ctx = task.NewWithContext(ctx)
 	ctx = logger.NewContext(ctx, logger.New(&buf, logger.Info, true))
+
+	// Set up config with LastLogin timestamp to satisfy session timeout check
+	cfg := &config.Config{
+		Tokens:    tokens.Parse("test-token"),
+		LastLogin: time.Now(),
+	}
+	ctx = config.NewContext(ctx, cfg)
 
 	server := inmem.NewServer()
 	server.CreateApp(&fly.App{


### PR DESCRIPTION
The session timeout feature introduced in 1f90b745f added a check for LastLogin timestamp in RequireSession. This broke the deploy unit test which didn't set up a config context with the required timestamp.

This fix adds proper config initialization in TestCommand_Execute with:
- Mock authentication tokens
- Current LastLogin timestamp

This ensures the test passes the session timeout validation while maintaining the security feature for production code.

Fixes CI failures on master branch.

### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
