### PR TITLE
Bump fly-go from v0.1.65 to v0.1.66

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.9
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/fly-go v0.1.65
+	github.com/superfly/fly-go v0.1.66
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -635,8 +635,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.1.65 h1:lNMh/jIdyHH3HVx0NOQHCbJDM6kFy0xcdHo6NL1AfwQ=
-github.com/superfly/fly-go v0.1.65/go.mod h1:wpq4XNor10w9KurA15CBYRnhtT2mnemAXYHuqkhp2vI=
+github.com/superfly/fly-go v0.1.66 h1:3Kw2fF7y14UXgZ1uhNwSgDICI7JSiufqqC5++60wiu0=
+github.com/superfly/fly-go v0.1.66/go.mod h1:wpq4XNor10w9KurA15CBYRnhtT2mnemAXYHuqkhp2vI=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=


### PR DESCRIPTION
### Change Summary

What and Why:

For https://github.com/superfly/fly-go/pull/189
