### PR TITLE
Fix deploy test to work in CI/CD environments

### DIFF
--- a/internal/command/deploy/deploy_test.go
+++ b/internal/command/deploy/deploy_test.go
@@ -24,6 +24,9 @@ var testdata embed.FS
 func TestCommand_Execute(t *testing.T) {
 	makeTerminalLoggerQuiet(t)
 
+	// Set FLY_ACCESS_TOKEN to simulate CI/CD environment
+	t.Setenv("FLY_ACCESS_TOKEN", "test-token")
+
 	dir := t.TempDir()
 	fsys, _ := fs.Sub(testdata, "testdata/basic")
 	if err := copyFS(fsys, dir); err != nil {


### PR DESCRIPTION
Set FLY_ACCESS_TOKEN environment variable in test to simulate CI/CD deployment scenarios where auth tokens come from env vars.

This ensures the test works correctly with features that may validate authentication differently for interactive vs automated environments.