### PR TITLE
When region is unspecified and a volume is present, default to volume's region

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -430,8 +430,7 @@ func runMachineRun(ctx context.Context) error {
 		return nil
 	}
 
-	// If region is unspecified when a volume is present, default the machine's
-	// region to the specified volume's region.
+	// If region is unspecified when a volume is present, inherit the volume's region.
 	if input.Region == "" && len(machineConf.Mounts) > 0 {
 		volID := machineConf.Mounts[0].Volume
 		if volID != "" {


### PR DESCRIPTION
### Change Summary

Previously, running fly machine run without specifying a region but with a volume caused the CLI to default to the user’s nearest region. If the volume existed in a different region, this led to a confusing `insufficient resources to create new machine` error.

This change updates the default behavior: when a volume is specified and no region is provided, the machine will now inherit the region from the specified volume.