### PR TITLE
fix(wg create): break endless loop when file exists

### DIFF
--- a/internal/command/wireguard/wireguard.go
+++ b/internal/command/wireguard/wireguard.go
@@ -129,17 +129,8 @@ func runWireguardCreate(ctx context.Context) error {
 		return err
 	}
 
-	args := flag.Args(ctx)
-	var region string
-	var name string
-
-	if len(args) > 1 && args[1] != "" {
-		region = args[1]
-	}
-
-	if len(args) > 2 && args[2] != "" {
-		name = args[2]
-	}
+	region := flag.GetArg(ctx, 1)
+	name := flag.GetArg(ctx, 2)
 
 	network := flag.GetString(ctx, "network")
 
@@ -183,11 +174,8 @@ func runWireguardRemove(ctx context.Context) error {
 		return err
 	}
 
-	args := flag.Args(ctx)
-	var name string
-	if len(args) >= 2 {
-		name = args[1]
-	} else {
+	name := flag.GetArg(ctx, 1)
+	if name == "" {
 		name, err = selectWireGuardPeer(ctx, apiClient, org.Slug)
 		if err != nil {
 			return err

--- a/internal/flag/context.go
+++ b/internal/flag/context.go
@@ -28,14 +28,18 @@ func Args(ctx context.Context) []string {
 	return FromContext(ctx).Args()
 }
 
+// GetArg returns argument specified by zero-based idx or an empty string.
+func GetArg(ctx context.Context, idx int) string {
+	if args := Args(ctx); len(args) > idx {
+		return args[idx]
+	}
+	return ""
+}
+
 // FirstArg returns the first arg ctx carries or an empty string in case ctx
 // carries an empty argument set. It panics in case ctx carries no FlagSet.
 func FirstArg(ctx context.Context) string {
-	if args := Args(ctx); len(args) > 0 {
-		return args[0]
-	}
-
-	return ""
+	return GetArg(ctx, 0)
 }
 
 // GetString returns the value of the named string flag ctx carries.


### PR DESCRIPTION
Fixes https://github.com/superfly/flyctl/issues/4665

### Change Summary

What and Why:

This fixes endless loop in when supplied `wg create` filename already exists. The problem was caused by `argOrPrompt` helper, which always returns the command line argument if it is set, so the prompt never appears in this case.

How:

Added `flag.GetArg(ctx, idx)` helper to clean up the logic. Then reworked the loop so that it first checks for all favorable conditions, and then runs prompt without the helper that attempts to do too much.

Now if there is a problem with config file supplied as cmdline argument, `flyctl` enters the interactive prompt to allow to fix the mistake.

Related to:

https://github.com/superfly/flyctl/issues/4665

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
