### PR TITLE
Revert "Remove GraphQL from deploy command"

### DIFF
--- a/agent/remote.go
+++ b/agent/remote.go
@@ -6,12 +6,11 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/superfly/fly-go"
-	"github.com/superfly/flyctl/internal/uiexutil"
-	"github.com/superfly/flyctl/internal/wireguard"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
-func BringUpAgent(ctx context.Context, client wireguard.WebClient, app *fly.AppCompact, network string, quiet bool) (*Client, Dialer, error) {
+func BringUpAgent(ctx context.Context, client flyutil.Client, app *fly.AppCompact, network string, quiet bool) (*Client, Dialer, error) {
 	io := iostreams.FromContext(ctx)
 
 	agentclient, err := Establish(ctx, client)
@@ -40,38 +39,4 @@ func BringUpAgent(ctx context.Context, client wireguard.WebClient, app *fly.AppC
 	}
 
 	return agentclient, dialer, nil
-}
-
-func BringUpAgentOrgSlug(ctx context.Context, client wireguard.WebClient, orgSlug string, network string, quiet bool) (*Client, Dialer, error) {
-	if orgSlug != "personal" {
-		// The agent keys tunnels based on web's org Slug, rather than RawSlug,
-		// so we need to use "personal" if the orgSlug belongs to the current
-		// user's personal org.
-		//
-		// It'd be good to standardize on RawSlug instead, but there are lots of
-		// callers to the agent and we don't want to touch them all at once.
-		uiexClient := uiexutil.ClientFromContext(ctx)
-		uiexOrg, err := uiexClient.GetOrganization(ctx, orgSlug)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		orgSlug = uiexOrg.Slug
-	}
-
-	appCompact := &fly.AppCompact{
-		// Name is only used for additional context in error reporting, so for
-		// simplicity we're going to ignore it.
-		Name: "",
-		Organization: &fly.OrganizationBasic{
-			Slug: orgSlug,
-		},
-	}
-
-	// The default network is referred "default" by flaps and "" by web.
-	if network == "default" {
-		network = ""
-	}
-
-	return BringUpAgent(ctx, client, appCompact, network, quiet)
 }

--- a/internal/build/imgsrc/buildkit_builder.go
+++ b/internal/build/imgsrc/buildkit_builder.go
@@ -9,12 +9,11 @@ import (
 
 	"github.com/containerd/containerd/api/services/content/v1"
 	"github.com/moby/buildkit/client"
-	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/cmdfmt"
 	"github.com/superfly/flyctl/internal/flag"
-	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/tracing"
 	"github.com/superfly/flyctl/iostreams"
@@ -91,10 +90,7 @@ func (r *BuildkitBuilder) buildWithBuildkit(ctx context.Context, streams *iostre
 		span.End()
 	}()
 
-	app, err := r.provisioner.GetRemoteBuilderApp(ctx)
-	if err != nil {
-		return nil, err
-	}
+	app := r.provisioner.org.RemoteBuilderApp
 	if r.addr == "" && app != nil {
 		r.addr = fmt.Sprintf("%s.flycast:%d", app.Name, buildkitGRPCPort)
 	}
@@ -105,7 +101,7 @@ func (r *BuildkitBuilder) buildWithBuildkit(ctx context.Context, streams *iostre
 
 	streams.StartProgressIndicator()
 
-	buildkitClient, err := r.connectClient(ctx, app, opts.AppName)
+	buildkitClient, err := r.connectClient(ctx, appToAppCompact(app), opts.AppName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create buildkit client: %w", err)
 	}
@@ -124,24 +120,25 @@ func (r *BuildkitBuilder) buildWithBuildkit(ctx context.Context, streams *iostre
 	return newDeploymentImage(ctx, buildkitClient, res, opts.Tag)
 }
 
-func (r *BuildkitBuilder) connectClient(ctx context.Context, app *flaps.App, appName string) (*client.Client, error) {
+func (r *BuildkitBuilder) connectClient(ctx context.Context, app *fly.AppCompact, appName string) (*client.Client, error) {
 	recreateBuilder := flag.GetRecreateBuilder(ctx)
 	ensureBuilder := false
 	if r.addr == "" || recreateBuilder {
 		updateProgress(ctx, "Updating remote builder...")
-		_, app, err := r.provisioner.EnsureBuilder(
+		_, builderApp, err := r.provisioner.EnsureBuilder(
 			ctx, os.Getenv("FLY_REMOTE_BUILDER_REGION"), recreateBuilder,
 		)
 		if err != nil {
 			return nil, err
 		}
+		app = appToAppCompact(builderApp)
 		r.addr = fmt.Sprintf("%s.flycast:%d", app.Name, buildkitGRPCPort)
 		ensureBuilder = true
 	}
 	var opts []client.ClientOpt
 	apiClient := flyutil.ClientFromContext(ctx)
 	if app != nil {
-		_, dialer, err := agent.BringUpAgentOrgSlug(ctx, apiClient, app.Organization.Slug, app.Network, true)
+		_, dialer, err := agent.BringUpAgent(ctx, apiClient, app, app.Network, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed wireguard connection: %w", err)
 		}
@@ -158,8 +155,7 @@ func (r *BuildkitBuilder) connectClient(ctx context.Context, app *flaps.App, app
 	_, err = buildkitClient.Info(ctx)
 	if err != nil {
 		if app == nil { // Retry with Wireguard connection
-			flapsClient := flapsutil.ClientFromContext(ctx)
-			app, err = flapsClient.GetApp(ctx, appName)
+			app, err = apiClient.GetAppCompact(ctx, appName)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get app: %w", err)
 			}

--- a/internal/build/imgsrc/depot_test.go
+++ b/internal/build/imgsrc/depot_test.go
@@ -2,31 +2,19 @@ package imgsrc
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/flyutil"
-	"github.com/superfly/flyctl/internal/mock"
-	"github.com/superfly/flyctl/internal/uiex"
-	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
 func TestInitBuilder(t *testing.T) {
 	ctx := context.Background()
 	ctx = flyutil.NewContextWithClient(ctx, flyutil.NewClientFromOptions(ctx, fly.ClientOptions{BaseURL: "invalid://localhost"}))
-
-	mockUiex := &mock.UiexClient{
-		EnsureDepotBuilderFunc: func(ctx context.Context, in uiex.EnsureDepotBuilderRequest) (*uiex.EnsureDepotBuilderResponse, error) {
-			return nil, errors.New(`unsupported protocol scheme "invalid"`)
-		},
-	}
-	ctx = uiexutil.NewContextWithClient(ctx, mockUiex)
-
 	ios, _, _, _ := iostreams.Test()
-	build := newBuild(1, false)
+	build := newBuild("build1", false)
 
 	// The invocation below doesn't test things much, but it may be better than nothing.
 	_, _, err := initBuilder(ctx, build, "app1", ios, DepotBuilderScopeOrganization)

--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -14,52 +14,31 @@ import (
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/haikunator"
 	"github.com/superfly/flyctl/internal/tracing"
-	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/internal/uiexutil"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
 type Provisioner struct {
-	orgID                 string
-	orgSlug               string
-	orgPaidPlan           bool
-	orgRemoteBuilderImage string
-	useVolume             bool
-	buildkitAddr          string
-	buildkitImage         string
+	org           *fly.Organization
+	useVolume     bool
+	buildkitAddr  string
+	buildkitImage string
 }
 
-// NewProvisioner is deprecated and will be replaced by NewProvisionerUiexOrg
 func NewProvisioner(org *fly.Organization) *Provisioner {
 	return &Provisioner{
-		orgID:                 org.ID,
-		orgSlug:               org.Slug,
-		orgPaidPlan:           org.PaidPlan,
-		orgRemoteBuilderImage: org.RemoteBuilderImage,
-		useVolume:             true,
+		org:       org,
+		useVolume: true,
 	}
 }
 
-func NewProvisionerUiexOrg(org *uiex.Organization) *Provisioner {
+func NewBuildkitProvisioner(org *fly.Organization, addr, image string) *Provisioner {
 	return &Provisioner{
-		orgID:                 org.ID,
-		orgSlug:               org.Slug,
-		orgPaidPlan:           org.PaidPlan,
-		orgRemoteBuilderImage: org.RemoteBuilderImage,
-		useVolume:             true,
-	}
-}
-
-func NewBuildkitProvisioner(org *uiex.Organization, addr, image string) *Provisioner {
-	return &Provisioner{
-		orgID:                 org.ID,
-		orgSlug:               org.Slug,
-		orgPaidPlan:           org.PaidPlan,
-		orgRemoteBuilderImage: org.RemoteBuilderImage,
-		useVolume:             true,
-		buildkitAddr:          addr,
-		buildkitImage:         image,
+		org:           org,
+		useVolume:     true,
+		buildkitAddr:  addr,
+		buildkitImage: image,
 	}
 }
 
@@ -69,47 +48,47 @@ func (p *Provisioner) UseBuildkit() bool {
 
 const defaultImage = "docker-hub-mirror.fly.io/flyio/rchab:sha-9346699"
 const DefaultBuildkitImage = "docker-hub-mirror.fly.io/flyio/buildkit@sha256:0fe49e6f506f0961cb2fc45d56171df0e852229facf352f834090345658b7e1c"
-const appRoleRemoteBuilder = "remote-docker-builder"
 
 func (p *Provisioner) image() string {
 	if p.buildkitImage != "" {
 		return p.buildkitImage
 	}
-	if p.orgRemoteBuilderImage != "" {
-		return p.orgRemoteBuilderImage
+	if p.org.RemoteBuilderImage != "" {
+		return p.org.RemoteBuilderImage
 	}
 	return defaultImage
 }
 
-// GetRemoteBuilderApp returns the org's first app with appRoleRemoteBuilder, or nil if it none exist
-func (p *Provisioner) GetRemoteBuilderApp(ctx context.Context) (*flaps.App, error) {
-	flapsClient := flapsutil.ClientFromContext(ctx)
-
-	apps, err := flapsClient.ListApps(ctx, flaps.ListAppsRequest{
-		OrgSlug: p.orgSlug,
-		AppRole: appRoleRemoteBuilder,
-	})
-	if err != nil {
-		return nil, err
+func appToAppCompact(app *fly.App) *fly.AppCompact {
+	if app == nil {
+		return nil
 	}
-
-	if len(apps) == 0 {
-		return nil, nil
+	return &fly.AppCompact{
+		ID:       app.ID,
+		Name:     app.Name,
+		Status:   app.Status,
+		Deployed: app.Deployed,
+		Hostname: app.Hostname,
+		AppURL:   app.AppURL,
+		Organization: &fly.OrganizationBasic{
+			ID:       app.Organization.ID,
+			Name:     app.Organization.Name,
+			Slug:     app.Organization.Slug,
+			RawSlug:  app.Organization.RawSlug,
+			PaidPlan: app.Organization.PaidPlan,
+		},
+		PlatformVersion: app.PlatformVersion,
+		PostgresAppRole: app.PostgresAppRole,
 	}
-
-	return &apps[0], nil
 }
 
-func (p *Provisioner) EnsureBuilder(ctx context.Context, region string, recreateBuilder bool) (*fly.Machine, *flaps.App, error) {
+func (p *Provisioner) EnsureBuilder(ctx context.Context, region string, recreateBuilder bool) (*fly.Machine, *fly.App, error) {
+	org := p.org
 	ctx, span := tracing.GetTracer().Start(ctx, "ensure_builder")
 	defer span.End()
 
-	builderApp, err := p.GetRemoteBuilderApp(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	if !recreateBuilder {
+		builderApp := org.RemoteBuilderApp
 		if builderApp != nil {
 			span.SetAttributes(attribute.String("builder_app", builderApp.Name))
 		}
@@ -152,15 +131,15 @@ func (p *Provisioner) EnsureBuilder(ctx context.Context, region string, recreate
 		}
 	} else {
 		span.AddEvent("recreating builder")
-		if builderApp != nil {
+		if org.RemoteBuilderApp != nil {
 			client := flyutil.ClientFromContext(ctx)
-			err := client.DeleteApp(ctx, builderApp.Name)
+			err := client.DeleteApp(ctx, org.RemoteBuilderApp.Name)
 			if err != nil {
 				tracing.RecordError(span, err, "error deleting existing builder app")
 				return nil, nil, err
 			}
 
-			_ = appsecrets.DeleteMinvers(ctx, builderApp.Name)
+			_ = appsecrets.DeleteMinvers(ctx, org.RemoteBuilderApp.Name)
 		}
 	}
 
@@ -175,11 +154,11 @@ func (p *Provisioner) EnsureBuilder(ctx context.Context, region string, recreate
 	return machine, app, nil
 }
 
-func EnsureFlyManagedBuilder(ctx context.Context, orgSlug string, region string) (*fly.Machine, *flaps.App, error) {
+func EnsureFlyManagedBuilder(ctx context.Context, org *fly.Organization, region string) (*fly.Machine, *fly.App, error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "ensure_fly_managed_builder")
 	defer span.End()
 
-	app, machine, err := createFlyManagedBuilder(ctx, orgSlug, region)
+	app, machine, err := createFlyManagedBuilder(ctx, org, region)
 	if err != nil {
 		tracing.RecordError(span, err, "error creating fly managed builder")
 		return nil, nil, err
@@ -217,7 +196,7 @@ const (
 )
 
 // validateBuilder returns a machine if it is available for building images.
-func (p *Provisioner) validateBuilder(ctx context.Context, app *flaps.App) (*fly.Machine, error) {
+func (p *Provisioner) validateBuilder(ctx context.Context, app *fly.App) (*fly.Machine, error) {
 	machine, err := p.validateBuilderMachine(ctx, app)
 	if err != nil {
 		// validateBuilderMachine returns a machine even if there is an error.
@@ -236,7 +215,7 @@ func (p *Provisioner) validateBuilder(ctx context.Context, app *flaps.App) (*fly
 	return nil, ShouldReplaceBuilderMachine
 }
 
-func (p *Provisioner) validateBuilderMachine(ctx context.Context, app *flaps.App) (*fly.Machine, error) {
+func (p *Provisioner) validateBuilderMachine(ctx context.Context, app *fly.App) (*fly.Machine, error) {
 	var builderAppName string
 	if app != nil {
 		builderAppName = app.Name
@@ -351,19 +330,22 @@ func validateBuilderMachines(ctx context.Context, flapsClient flapsutil.FlapsCli
 	return machines[0], nil
 }
 
-func (p *Provisioner) createBuilder(ctx context.Context, region, builderName string) (app *flaps.App, mach *fly.Machine, retErr error) {
+func (p *Provisioner) createBuilder(ctx context.Context, region, builderName string) (app *fly.App, mach *fly.Machine, retErr error) {
 	buildkit := p.UseBuildkit()
 
+	org := p.org
 	ctx, span := tracing.GetTracer().Start(ctx, "create_builder")
 	defer span.End()
 
 	client := flyutil.ClientFromContext(ctx)
 	flapsClient := flapsutil.ClientFromContext(ctx)
 
-	app, retErr = flapsClient.CreateApp(ctx, flaps.CreateAppRequest{
-		Org:       p.orgSlug,
-		Name:      builderName,
-		AppRoleID: appRoleRemoteBuilder,
+	app, retErr = client.CreateApp(ctx, fly.CreateAppInput{
+		OrganizationID:  org.ID,
+		Name:            builderName,
+		AppRoleID:       "remote-docker-builder",
+		Machines:        true,
+		PreferredRegion: fly.StringPointer(region),
 	})
 	if retErr != nil {
 		tracing.RecordError(span, retErr, "error creating app")
@@ -378,14 +360,19 @@ func (p *Provisioner) createBuilder(ctx context.Context, region, builderName str
 		}
 	}()
 
+	orgID := ""
+	if org != nil {
+		orgID = org.ID
+	}
+
 	if buildkit {
-		_, retErr = client.AllocateIPAddress(ctx, app.Name, "private_v6", "", p.orgID, "")
+		_, retErr = client.AllocateIPAddress(ctx, app.Name, "private_v6", "", orgID, "")
 		if retErr != nil {
 			tracing.RecordError(span, retErr, "error allocating ip address")
 			return nil, nil, retErr
 		}
 	} else {
-		_, retErr = client.AllocateIPAddress(ctx, app.Name, "shared_v4", "", p.orgID, "")
+		_, retErr = client.AllocateIPAddress(ctx, app.Name, "shared_v4", "", orgID, "")
 		if retErr != nil {
 			tracing.RecordError(span, retErr, "error allocating ip address")
 			return nil, nil, retErr
@@ -397,7 +384,7 @@ func (p *Provisioner) createBuilder(ctx context.Context, region, builderName str
 		CPUs:     4,
 		MemoryMB: 4096,
 	}
-	if p.orgPaidPlan {
+	if org.PaidPlan {
 		guest = fly.MachineGuest{
 			CPUKind:  "shared",
 			CPUs:     8,
@@ -413,7 +400,7 @@ func (p *Provisioner) createBuilder(ctx context.Context, region, builderName str
 
 	config := &fly.MachineConfig{
 		Env: map[string]string{
-			"ALLOW_ORG_SLUG": p.orgSlug,
+			"ALLOW_ORG_SLUG": org.Slug,
 			"LOG_LEVEL":      "debug",
 		},
 		Guest: &guest,
@@ -540,19 +527,19 @@ func (p *Provisioner) createBuilder(ctx context.Context, region, builderName str
 	return
 }
 
-func createFlyManagedBuilder(ctx context.Context, orgSlug string, region string) (app *flaps.App, mach *fly.Machine, retErr error) {
+func createFlyManagedBuilder(ctx context.Context, org *fly.Organization, region string) (app *fly.App, mach *fly.Machine, retErr error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "create_builder")
 	defer span.End()
 
 	uiexClient := uiexutil.ClientFromContext(ctx)
 
-	response, error := uiexClient.CreateFlyManagedBuilder(ctx, orgSlug, region)
+	response, error := uiexClient.CreateFlyManagedBuilder(ctx, org.Slug, region)
 	if error != nil {
 		tracing.RecordError(span, retErr, "error creating managed builder")
 		return nil, nil, retErr
 	}
 
-	builderApp := &flaps.App{
+	builderApp := &fly.App{
 		Name: response.Data.AppName,
 	}
 

--- a/internal/build/imgsrc/ensure_builder_test.go
+++ b/internal/build/imgsrc/ensure_builder_test.go
@@ -57,15 +57,15 @@ func TestValidateBuilder(t *testing.T) {
 	_, err := p.validateBuilder(ctx, nil)
 	assert.EqualError(t, err, NoBuilderApp.Error())
 
-	_, err = p.validateBuilder(ctx, &flaps.App{})
+	_, err = p.validateBuilder(ctx, &fly.App{})
 	assert.EqualError(t, err, NoBuilderVolume.Error())
 
 	hasVolumes = true
-	_, err = p.validateBuilder(ctx, &flaps.App{})
+	_, err = p.validateBuilder(ctx, &fly.App{})
 	assert.EqualError(t, err, InvalidMachineCount.Error())
 
 	hasMachines = true
-	_, err = p.validateBuilder(ctx, &flaps.App{})
+	_, err = p.validateBuilder(ctx, &fly.App{})
 	assert.NoError(t, err)
 }
 
@@ -120,18 +120,18 @@ func TestValidateBuilderAPIErrors(t *testing.T) {
 	ctx = flapsutil.NewContextWithClient(ctx, &flapsClient)
 
 	volumesShouldFail = true
-	_, err := p.validateBuilder(ctx, &flaps.App{})
+	_, err := p.validateBuilder(ctx, &fly.App{})
 	assert.NoError(t, err)
 
 	volumeRetries = 0
 	maxVolumeRetries = 7
-	_, err = p.validateBuilder(ctx, &flaps.App{})
+	_, err = p.validateBuilder(ctx, &fly.App{})
 	assert.Error(t, err)
 
 	volumeRetries = 0
 	responseStatusCode = 404
 	// we should only try once if the error is not a server error
-	_, err = p.validateBuilder(ctx, &flaps.App{})
+	_, err = p.validateBuilder(ctx, &fly.App{})
 	var flapsErr *flaps.FlapsError
 	assert.True(t, errors.As(err, &flapsErr))
 	assert.Equal(t, 404, flapsErr.ResponseStatusCode)
@@ -140,18 +140,18 @@ func TestValidateBuilderAPIErrors(t *testing.T) {
 	volumesShouldFail = false
 	machinesShouldFail = true
 	responseStatusCode = 500
-	_, err = p.validateBuilder(ctx, &flaps.App{})
+	_, err = p.validateBuilder(ctx, &fly.App{})
 	assert.NoError(t, err)
 
 	machineRetries = 0
 	maxMachineRetries = 7
-	_, err = p.validateBuilder(ctx, &flaps.App{})
+	_, err = p.validateBuilder(ctx, &fly.App{})
 	assert.Error(t, err)
 
 	machineRetries = 0
 	responseStatusCode = 404
 	// we should only try once if the error is not a server error
-	_, err = p.validateBuilder(ctx, &flaps.App{})
+	_, err = p.validateBuilder(ctx, &fly.App{})
 	assert.True(t, errors.As(err, &flapsErr))
 	assert.Equal(t, 404, flapsErr.ResponseStatusCode)
 	assert.Equal(t, 1, machineRetries)
@@ -172,7 +172,7 @@ func TestValidateBuilderNotStarted(t *testing.T) {
 	client.EXPECT().List(gomock.Any(), gomock.Eq(""), gomock.Any()).Return([]*fly.Machine{
 		{State: "stopped"},
 	}, nil)
-	machine, err := provisioner.validateBuilder(ctx, &flaps.App{})
+	machine, err := provisioner.validateBuilder(ctx, &fly.App{})
 	assert.ErrorIs(t, err, BuilderMachineNotStarted)
 	assert.NotNil(t, machine, "Go functions usually return either a value or an error, but this is not")
 }
@@ -214,14 +214,6 @@ func TestCreateBuilder(t *testing.T) {
 	createVolumeAttempts := 0
 
 	flapsClient := mock.FlapsClient{
-		CreateAppFunc: func(ctx context.Context, req flaps.CreateAppRequest) (*flaps.App, error) {
-			if createAppShouldFail {
-				return nil, errors.New("create app failed")
-			}
-			return &flaps.App{
-				Name: req.Name,
-			}, nil
-		},
 		WaitForAppFunc: func(ctx context.Context, name string) error {
 			if waitForAppShouldFail {
 				return errors.New("wait for app failed")

--- a/internal/build/imgsrc/nixpacks_builder.go
+++ b/internal/build/imgsrc/nixpacks_builder.go
@@ -125,6 +125,13 @@ func (b *nixpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 	dockerHost := docker.DaemonHost()
 
 	if dockerFactory.IsRemote() {
+		agentclient, err := agent.Establish(ctx, dockerFactory.apiClient)
+		if err != nil {
+			build.BuilderInitFinish()
+			build.BuildFinish()
+			return nil, "", err
+		}
+
 		machine, app, err := b.provisioner.EnsureBuilder(ctx, os.Getenv("FLY_REMOTE_BUILDER_REGION"), false)
 		if err != nil {
 			return nil, "", err
@@ -137,7 +144,7 @@ func (b *nixpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 			return nil, "", fmt.Errorf("could not find machine IP")
 		}
 
-		_, dialer, err := agent.BringUpAgentOrgSlug(ctx, dockerFactory.apiClient, app.Organization.Slug, "", false)
+		dialer, err := agentclient.ConnectToTunnel(ctx, app.Organization.Slug, "", false)
 		if err != nil {
 			build.BuilderInitFinish()
 			build.BuildFinish()

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/go-units"
 	"github.com/samber/lo"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/prompt"
 )
@@ -32,15 +31,15 @@ func (md *machineDeployment) provisionIpsOnFirstDeploy(ctx context.Context, ipTy
 	}
 
 	// Do not touch IPs if there are already allocated
-	ipRes, err := md.flapsClient.GetIPAssignments(ctx, md.app.Name)
+	ipAddrs, err := md.apiClient.GetIPAddresses(ctx, md.app.Name)
 	if err != nil {
 		return fmt.Errorf("error detecting ip addresses allocated to %s app: %w", md.app.Name, err)
 	}
-	if len(ipRes.IPs) > 0 {
+	if len(ipAddrs) > 0 {
 		return nil
 	}
 
-	region, network := "", ""
+	region, orgID, network := "", "", ""
 
 	switch md.appConfig.DetermineIPType(ipType) {
 	case "dedicated":
@@ -53,68 +52,43 @@ func (md *machineDeployment) provisionIpsOnFirstDeploy(ctx context.Context, ipTy
 
 		confirmDedicatedIp, err := prompt.Confirmf(ctx, "Would you like to allocate %s now?", ipStuffStr)
 		if confirmDedicatedIp && err == nil {
-			v4Dedicated, err := md.flapsClient.AssignIP(ctx, md.app.Name, flaps.AssignIPRequest{
-				Type:         "v4",
-				Region:       region,
-				Organization: org,
-				Network:      network,
-			})
+			v4Dedicated, err := md.apiClient.AllocateIPAddress(ctx, md.app.Name, "v4", region, orgID, network)
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(md.io.Out, "Allocated dedicated ipv4: %s\n", v4Dedicated.IP)
+			fmt.Fprintf(md.io.Out, "Allocated dedicated ipv4: %s\n", v4Dedicated.Address)
 
 			if !hasUdpService {
-				v6Dedicated, err := md.flapsClient.AssignIP(ctx, md.app.Name, flaps.AssignIPRequest{
-					Type:         "v6",
-					Region:       region,
-					Organization: org,
-					Network:      network,
-				})
+				v6Dedicated, err := md.apiClient.AllocateIPAddress(ctx, md.app.Name, "v6", region, orgID, network)
 				if err != nil {
 					return err
 				}
-				fmt.Fprintf(md.io.Out, "Allocated dedicated ipv6: %s\n", v6Dedicated.IP)
+				fmt.Fprintf(md.io.Out, "Allocated dedicated ipv6: %s\n", v6Dedicated.Address)
 			}
 		}
 
 	case "shared":
 		fmt.Fprintf(md.io.Out, "Provisioning ips for %s\n", md.colorize.Bold(md.app.Name))
-		v6Addr, err := md.flapsClient.AssignIP(ctx, md.app.Name, flaps.AssignIPRequest{
-			Type:         "v6",
-			Region:       region,
-			Organization: org,
-			Network:      network,
-		})
+		v6Addr, err := md.apiClient.AllocateIPAddress(ctx, md.app.Name, "v6", region, orgID, network)
 		if err != nil {
 			return fmt.Errorf("error allocating ipv6 after detecting first deploy and presence of services: %w", err)
 		}
-		fmt.Fprintf(md.io.Out, "  Dedicated ipv6: %s\n", md.colorize.Purple(v6Addr.IP))
+		fmt.Fprintf(md.io.Out, "  Dedicated ipv6: %s\n", md.colorize.Purple(v6Addr.Address))
 
-		v4Shared, err := md.flapsClient.AssignIP(ctx, md.app.Name, flaps.AssignIPRequest{
-			Type:         "shared_v4",
-			Region:       region,
-			Organization: org,
-			Network:      network,
-		})
+		v4Shared, err := md.apiClient.AllocateSharedIPAddress(ctx, md.app.Name)
 		if err != nil {
 			return fmt.Errorf("error allocating shared ipv4 after detecting first deploy and presence of services: %w", err)
 		}
-		fmt.Fprintf(md.io.Out, "  Shared ipv4: %s\n", md.colorize.Purple(v4Shared.IP))
+		fmt.Fprintf(md.io.Out, "  Shared ipv4: %s\n", md.colorize.Purple(v4Shared.String()))
 		fmt.Fprintf(md.io.Out, "  Add a dedicated ipv4 with: %s\n", md.colorize.Purple("fly ips allocate-v4"))
 
 	case "private":
 		fmt.Fprintf(md.io.Out, "Provisioning ip address for %s\n", md.colorize.Bold(md.app.Name))
-		v6Addr, err := md.flapsClient.AssignIP(ctx, md.app.Name, flaps.AssignIPRequest{
-			Type:         "private_v6",
-			Region:       region,
-			Organization: org,
-			Network:      network,
-		})
+		v6Addr, err := md.apiClient.AllocateIPAddress(ctx, md.app.Name, "private_v6", region, orgID, network)
 		if err != nil {
 			return fmt.Errorf("error allocating ipv6 after detecting first deploy and presence of services: %w", err)
 		}
-		fmt.Fprintf(md.io.Out, "  Private ipv6: %s\n", v6Addr.IP)
+		fmt.Fprintf(md.io.Out, "  Private ipv6: %s\n", v6Addr.Address)
 	}
 
 	fmt.Fprintln(md.io.Out)

--- a/internal/command/deploy/deploy_test.go
+++ b/internal/command/deploy/deploy_test.go
@@ -17,9 +17,7 @@ import (
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/inmem"
 	"github.com/superfly/flyctl/internal/logger"
-	"github.com/superfly/flyctl/internal/mock"
 	"github.com/superfly/flyctl/internal/task"
-	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -72,7 +70,6 @@ func TestCommand_Execute(t *testing.T) {
 
 	ctx = flyutil.NewContextWithClient(ctx, server.Client())
 	ctx = flapsutil.NewContextWithClient(ctx, server.FlapsClient("test-basic"))
-	ctx = uiexutil.NewContextWithClient(ctx, &mock.UiexClient{})
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		t.Fatal(err)

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -23,8 +23,8 @@ import (
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/command/deploy/statics"
 	machcmd "github.com/superfly/flyctl/internal/command/machine"
-	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyerr"
+	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/statuslogger"
 	"github.com/superfly/flyctl/internal/tracing"
@@ -295,7 +295,7 @@ func (md *machineDeployment) deployCanaryMachines(ctx context.Context) (err erro
 
 			defer func() {
 				if err == nil {
-					if destroyErr := machcmd.Destroy(ctx, md.app.Name, lm.Machine(), true); destroyErr != nil {
+					if destroyErr := machcmd.Destroy(ctx, md.app, lm.Machine(), true); destroyErr != nil {
 						err = destroyErr
 					}
 				}
@@ -449,7 +449,7 @@ func (md *machineDeployment) deployMachinesApp(ctx context.Context) error {
 		return err
 	}
 	for _, mach := range processGroupMachineDiff.machinesToRemove {
-		if err := machcmd.Destroy(ctx, md.app.Name, mach.Machine(), true); err != nil {
+		if err := machcmd.Destroy(ctx, md.app, mach.Machine(), true); err != nil {
 			return err
 		}
 	}
@@ -1350,13 +1350,12 @@ func (md *machineDeployment) checkDNS(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*70)
 	defer cancel()
 
-	flapsClient := flapsutil.ClientFromContext(ctx)
-	ipRes, err := flapsClient.GetIPAssignments(ctx, md.appConfig.AppName)
+	client := flyutil.ClientFromContext(ctx)
+	ipAddrs, err := client.GetIPAddresses(ctx, md.appConfig.AppName)
 	if err != nil {
 		tracing.RecordError(span, err, "failed to get ip addresses")
 		return err
 	}
-	ipAddrs := ipRes.IPs
 
 	if appURL := md.appConfig.URL(); appURL != nil && len(ipAddrs) > 0 {
 		iostreams := iostreams.FromContext(ctx)
@@ -1380,9 +1379,9 @@ func (md *machineDeployment) checkDNS(ctx context.Context) error {
 
 			var numIPv4, numIPv6 int
 			for _, ipAddr := range ipAddrs {
-				if strings.Contains(ipAddr.IP, ".") && (ipAddr.Region == "global" || ipAddr.Shared) {
+				if (ipAddr.Type == "v4" && ipAddr.Region == "global") || ipAddr.Type == "shared_v4" {
 					numIPv4 += 1
-				} else if strings.Contains(ipAddr.IP, ":") && ipAddr.Region == "global" {
+				} else if ipAddr.Type == "v6" && ipAddr.Region == "global" {
 					numIPv6 += 1
 				}
 			}

--- a/internal/command/deploy/machines_deploymachinesapp_test.go
+++ b/internal/command/deploy/machines_deploymachinesapp_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/machine"
@@ -20,7 +19,7 @@ func TestUpdateExistingMachinesWRecovery(t *testing.T) {
 	client := &mockFlapsClient{}
 	client.machines = []*fly.Machine{{ID: "test-machine-id", LeaseNonce: "foobar"}}
 	md := &machineDeployment{
-		app:         &flaps.App{},
+		app:         &fly.AppCompact{},
 		io:          ios,
 		colorize:    ios.ColorScheme(),
 		flapsClient: client,
@@ -55,7 +54,7 @@ func TestDeployMachinesApp(t *testing.T) {
 		{ID: "m4", LeaseNonce: "m4-lease", Config: &fly.MachineConfig{Metadata: map[string]string{fly.MachineConfigMetadataKeyFlyProcessGroup: "app"}}},
 	}
 	md := &machineDeployment{
-		app:             &flaps.App{},
+		app:             &fly.AppCompact{},
 		io:              ios,
 		colorize:        ios.ColorScheme(),
 		flapsClient:     client,

--- a/internal/command/deploy/machines_releasecommand.go
+++ b/internal/command/deploy/machines_releasecommand.go
@@ -88,7 +88,7 @@ func (md *machineDeployment) runReleaseCommand(ctx context.Context, commandType 
 		return nil
 	})
 	eg.Go(func() error {
-		stream, err = logs.NewNatsStream(ctx, md.apiClient, md.flapsClient, logOpts)
+		stream, err = logs.NewNatsStream(ctx, md.apiClient, logOpts)
 		if err != nil {
 			// Silently fallback to app logs polling if NATS streaming client is unavailable.
 			stream = logs.NewPollingStream(md.apiClient)

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/machine"
@@ -14,10 +13,10 @@ import (
 
 func stabMachineDeployment(appConfig *appconfig.Config) (*machineDeployment, error) {
 	md := &machineDeployment{
-		app: &flaps.App{
-			Name: "my-cool-app",
-			Organization: flaps.AppOrganizationInfo{
-				Slug: "my-org",
+		app: &fly.AppCompact{
+			ID: "my-cool-app",
+			Organization: &fly.OrganizationBasic{
+				ID: "my-dangling-org",
 			},
 		},
 		img:        "super/balloon",

--- a/internal/command/deploy/plan_test.go
+++ b/internal/command/deploy/plan_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/mock"
@@ -70,7 +69,7 @@ func TestAppState(t *testing.T) {
 	ctx := context.Background()
 	md := &machineDeployment{
 		flapsClient: flapsClient,
-		app:         &flaps.App{Name: "test-app"},
+		app:         &fly.AppCompact{Name: "test-app"},
 	}
 	appState, error := md.appState(ctx, nil)
 	assert.NoError(t, error)
@@ -114,7 +113,7 @@ func TestUpdateMachineConfig(t *testing.T) {
 	md := &machineDeployment{
 		flapsClient: badFlapsClient,
 		io:          iostreams.FromContext(ctx),
-		app: &flaps.App{
+		app: &fly.AppCompact{
 			Name: "myapp",
 		},
 		appConfig: &appconfig.Config{AppName: "myapp"},
@@ -290,7 +289,7 @@ func TestUpdateMachines(t *testing.T) {
 	md := &machineDeployment{
 		flapsClient: flapsClient,
 		io:          iostreams.FromContext(ctx),
-		app: &flaps.App{
+		app: &fly.AppCompact{
 			Name: "myapp",
 		},
 		appConfig:       &appconfig.Config{AppName: "myapp"},
@@ -438,7 +437,7 @@ func TestUpdateOrCreateMachine(t *testing.T) {
 	md := &machineDeployment{
 		flapsClient: flapsClient,
 		io:          iostreams.FromContext(ctx),
-		app: &flaps.App{
+		app: &fly.AppCompact{
 			Name: "myapp",
 		},
 		appConfig: &appconfig.Config{AppName: "myapp"},

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -20,7 +20,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	fly "github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/ctrlc"
 	"github.com/superfly/flyctl/internal/flapsutil"
@@ -79,7 +78,7 @@ type blueGreen struct {
 	hangingBlueMachines []string
 	timestamp           string
 	maxConcurrent       int
-	app                 *flaps.App
+	app                 *fly.AppCompact
 
 	rollbackLog RollbackLog
 

--- a/internal/command/deploy/strategy_bluegreen_test.go
+++ b/internal/command/deploy/strategy_bluegreen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/machine"
@@ -46,7 +45,7 @@ func newBlueGreenStrategy(client flapsutil.FlapsClient, numberOfExistingMachines
 		colorize:      ios.ColorScheme(),
 		timeout:       1 * time.Second,
 		blueMachines:  machines,
-		app:           &flaps.App{Name: "test-app"},
+		app:           &fly.AppCompact{Name: "test-app"},
 	}
 	strategy.initialize()
 

--- a/internal/command/machine/destroy.go
+++ b/internal/command/machine/destroy.go
@@ -146,7 +146,7 @@ func singleDestroyRun(ctx context.Context, machine *fly.Machine) error {
 		return fmt.Errorf("could not get app '%s': %w", appName, err)
 	}
 
-	err = Destroy(ctx, app.Name, machine, force)
+	err = Destroy(ctx, app, machine, force)
 	if err != nil {
 		return err
 	}
@@ -156,7 +156,7 @@ func singleDestroyRun(ctx context.Context, machine *fly.Machine) error {
 	return nil
 }
 
-func Destroy(ctx context.Context, appName string, machine *fly.Machine, force bool) error {
+func Destroy(ctx context.Context, app *fly.AppCompact, machine *fly.Machine, force bool) error {
 	var (
 		out         = iostreams.FromContext(ctx).Out
 		flapsClient = flapsutil.ClientFromContext(ctx)
@@ -183,7 +183,7 @@ func Destroy(ctx context.Context, appName string, machine *fly.Machine, force bo
 	}
 	fmt.Fprintf(out, "machine %s was found and is currently in %s state, attempting to destroy...\n", machine.ID, machine.State)
 
-	err := flapsClient.Destroy(ctx, appName, input, machine.LeaseNonce)
+	err := flapsClient.Destroy(ctx, app.Name, input, machine.LeaseNonce)
 	if err != nil {
 		if err := rewriteMachineNotFoundErrors(ctx, err, machine.ID); err != nil {
 			return err
@@ -192,7 +192,7 @@ func Destroy(ctx context.Context, appName string, machine *fly.Machine, force bo
 	}
 
 	// Best effort post-deletion hook.
-	runOnDeletionHook(ctx, appName, machine)
+	runOnDeletionHook(ctx, app, machine)
 
 	return nil
 }

--- a/internal/command/machine/lifecycle_hooks.go
+++ b/internal/command/machine/lifecycle_hooks.go
@@ -7,11 +7,10 @@ import (
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/command/postgres"
-	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
-func runOnDeletionHook(ctx context.Context, appName string, machine *fly.Machine) {
+func runOnDeletionHook(ctx context.Context, app *fly.AppCompact, machine *fly.Machine) {
 	var (
 		io     = iostreams.FromContext(ctx)
 		labels = machine.ImageRef.Labels
@@ -19,16 +18,7 @@ func runOnDeletionHook(ctx context.Context, appName string, machine *fly.Machine
 
 	if labels["fly.pg-manager"] == flypg.ReplicationManager {
 		fmt.Fprintf(io.Out, "unregistering postgres member '%s' from the cluster... ", machine.PrivateIP)
-
-		apiClient := flyutil.ClientFromContext(ctx)
-		appCompact, err := apiClient.GetAppCompact(ctx, appName)
-		if err != nil {
-			fmt.Fprintln(io.Out, "(failed)")
-			fmt.Fprintf(io.Out, "failed to unregister postgres member: %v\n", err)
-			return
-		}
-
-		if err := postgres.UnregisterMember(ctx, appCompact, machine); err != nil {
+		if err := postgres.UnregisterMember(ctx, app, machine); err != nil {
 			fmt.Fprintln(io.Out, "(failed)")
 			fmt.Fprintf(io.Out, "failed to unregister postgres member: %v\n", err)
 			return

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -488,7 +488,7 @@ func runMachineRun(ctx context.Context) error {
 
 		err = ssh.Console(ctx, sshClient, flag.GetString(ctx, "command"), true, "")
 		if destroy {
-			err = soManyErrors("console", err, "destroy machine", Destroy(ctx, app.Name, machine, true))
+			err = soManyErrors("console", err, "destroy machine", Destroy(ctx, app, machine, true))
 		}
 
 		if err != nil {

--- a/internal/inmem/flaps_client.go
+++ b/internal/inmem/flaps_client.go
@@ -119,7 +119,7 @@ func (m *FlapsClient) GetAllVolumes(ctx context.Context, appName string) ([]fly.
 }
 
 func (m *FlapsClient) GetIPAssignments(ctx context.Context, appName string) (res *flaps.ListIPAssignmentsResponse, err error) {
-	return &flaps.ListIPAssignmentsResponse{}, nil
+	panic("TODO")
 }
 
 func (m *FlapsClient) GetMany(ctx context.Context, appName string, machineIDs []string) ([]*fly.Machine, error) {

--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -169,51 +169,6 @@ func CaptureExceptionWithAppInfo(ctx context.Context, err error, featureName str
 	)
 }
 
-func CaptureExceptionWithFlapsAppInfo(ctx context.Context, err error, featureName string, app *flaps.App) {
-	if app == nil {
-		CaptureException(
-			err,
-			WithTag("feature", featureName),
-		)
-		return
-	}
-
-	var flapsErr *flaps.FlapsError
-
-	if errors.As(err, &flapsErr) {
-		CaptureException(
-			flapsErr,
-			WithTag("feature", featureName),
-			WithContexts(map[string]sentry.Context{
-				"app": map[string]interface{}{
-					"name": app.Name,
-				},
-				"organization": map[string]interface{}{
-					"slug": app.Organization.Slug,
-				},
-			}),
-			WithTraceID(ctx),
-			WithRequestID(flapsErr.FlyRequestId),
-			WithStatusCode(flapsErr.ResponseStatusCode),
-		)
-		return
-	}
-
-	CaptureException(
-		err,
-		WithTag("feature", featureName),
-		WithContexts(map[string]sentry.Context{
-			"app": map[string]interface{}{
-				"name": app.Name,
-			},
-			"organization": map[string]interface{}{
-				"slug": app.Organization.Slug,
-			},
-		}),
-		WithTraceID(ctx),
-	)
-}
-
 // Recover records the given panic to sentry.
 func Recover(v interface{}) {
 	if !isInitialized() {

--- a/logs/nats.go
+++ b/logs/nats.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/config"
-	"github.com/superfly/flyctl/internal/flapsutil"
 )
 
 type natsLogStream struct {
@@ -18,18 +17,27 @@ type natsLogStream struct {
 	err error
 }
 
-func NewNatsStream(ctx context.Context, apiClient WebClient, flapsClient flapsutil.FlapsClient, opts *LogOptions) (LogStream, error) {
-	app, err := flapsClient.GetApp(ctx, opts.AppName)
+func NewNatsStream(ctx context.Context, apiClient WebClient, opts *LogOptions) (LogStream, error) {
+	app, err := apiClient.GetAppBasic(ctx, opts.AppName)
 	if err != nil {
 		return nil, fmt.Errorf("failed fetching target app: %w", err)
 	}
 
-	_, dialer, err := agent.BringUpAgentOrgSlug(ctx, apiClient, app.Organization.Slug, app.Network, true)
+	agentclient, err := agent.Establish(ctx, apiClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed establishing agent: %w", err)
+	}
+
+	dialer, err := agentclient.Dialer(ctx, app.Organization.Slug, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed establishing wireguard connection for %s organization: %w", app.Organization.Slug, err)
 	}
 
-	nc, err := newNatsClient(ctx, dialer, app.Organization.Slug)
+	if err = agentclient.WaitForTunnel(ctx, app.Organization.Slug, ""); err != nil {
+		return nil, fmt.Errorf("failed connecting to WireGuard tunnel: %w", err)
+	}
+
+	nc, err := newNatsClient(ctx, dialer, app.Organization.RawSlug)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating nats connection: %w", err)
 	}


### PR DESCRIPTION
Reverts superfly/flyctl#4684

Seeing some errors reported when bringing up the agent to stream release command logs.

These errors are handled and shouldn't be affecting deploys, but reverting to investigate.