### PR TITLE
allow customizable port for fly mpg proxy

### DIFF
--- a/internal/command/mpg/proxy.go
+++ b/internal/command/mpg/proxy.go
@@ -32,6 +32,12 @@ func newProxy() (cmd *cobra.Command) {
 			Default:     "127.0.0.1",
 			Description: "Local address to bind to",
 		},
+		flag.String{
+			Name:        flagnames.LocalPort,
+			Shorthand:   "p",
+			Default:     "16380",
+			Description: "Local port to proxy on",
+		},
 	)
 
 	cmd.Args = cobra.MaximumNArgs(1)
@@ -45,7 +51,7 @@ func runProxy(ctx context.Context) (err error) {
 		return err
 	}
 
-	localProxyPort := "16380"
+	localProxyPort := flag.GetString(ctx, flagnames.LocalPort)
 	_, params, _, err := getMpgProxyParams(ctx, localProxyPort, "")
 	if err != nil {
 		return err

--- a/internal/flag/flagnames/constants.go
+++ b/internal/flag/flagnames/constants.go
@@ -49,6 +49,9 @@ const (
 	// BindAddr denotes the name of the local bind address flag.
 	BindAddr = "bind-addr"
 
+	// LocalPort denotes the name of the local MPG proxy port flag.
+	LocalPort = "local-port"
+
 	// ProcessGroup denotes the name of the process group flag.
 	ProcessGroup = "process-group"
 


### PR DESCRIPTION
This allows, for example, simultaneously proxying to two different MPG instances with different local ports, example use cases: having both staging and production DBs accessible locally, or data migration using pgcopydb.