### PR TITLE
fix panic for missing a cmd to check flag on

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -147,7 +147,7 @@ func isValidTraceID(id string) bool {
 }
 
 func printError(io *iostreams.IOStreams, cs *iostreams.ColorScheme, cmd *cobra.Command, err error) {
-	if env.IS_GH_ACTION() && env.IsTruthy("FLY_GHA_ERROR_ANNOTATION") {
+	if cmd != nil && env.IS_GH_ACTION() && env.IsTruthy("FLY_GHA_ERROR_ANNOTATION") {
 		printGHAErrorAnnotation(cmd, err)
 	}
 
@@ -181,8 +181,10 @@ func printError(io *iostreams.IOStreams, cs *iostreams.ColorScheme, cmd *cobra.C
 		fmt.Fprintln(io.ErrOut)
 	}
 
-	if bool, err := cmd.Flags().GetBool(flagnames.Debug); err == nil && bool {
-		fmt.Fprintf(io.ErrOut, "Stacktrace:\n%s\n", debug.Stack())
+	if cmd != nil {
+		if bool, err := cmd.Flags().GetBool(flagnames.Debug); err == nil && bool {
+			fmt.Fprintf(io.ErrOut, "Stacktrace:\n%s\n", debug.Stack())
+		}
 	}
 }
 


### PR DESCRIPTION
### Change Summary

What and Why:

Fixes a few panics that crop up and wind up showing as vague errors

* https://github.com/superfly/flyctl/issues/4116
* https://github.com/superfly/flyctl/issues/3393
* https://community.fly.io/t/next-js-launch-plan-generate-unsuccessful/23366
