### PR TITLE
App-scoped egress IPs are no longer beta

### DIFF
--- a/internal/command/ips/allocate.go
+++ b/internal/command/ips/allocate.go
@@ -92,8 +92,8 @@ func newAllocatev6() *cobra.Command {
 
 func newAllocateEgress() *cobra.Command {
 	const (
-		long  = `(Beta) Allocates a pair of egress IP addresses for an app`
-		short = `(Beta) Allocate app-scoped egress IPs`
+		long  = `Allocates a pair of egress IP addresses for an app`
+		short = `Allocate app-scoped egress IPs`
 	)
 
 	cmd := command.New("allocate-egress", short, long, runAllocateEgressIPAddresses,

--- a/internal/command/machine/egress_ip.go
+++ b/internal/command/machine/egress_ip.go
@@ -16,7 +16,7 @@ import (
 
 func newEgressIp() *cobra.Command {
 	const (
-		long  = `Manage static egress (outgoing) IP addresses for machines`
+		long  = `(Deprecated) Manage static egress (outgoing) IP addresses for machines`
 		short = `Manage static egress IPs`
 		usage = "egress-ip <command>"
 	)
@@ -36,7 +36,7 @@ func newEgressIp() *cobra.Command {
 
 func newAllocateEgressIp() *cobra.Command {
 	const (
-		long  = `Allocate a pair of static egress IPv4 and IPv6 for a machine`
+		long  = `(Deprecated) Allocate a pair of static egress IPv4 and IPv6 for a machine`
 		short = `Allocate static egress IPs`
 		usage = "allocate <machine-id>"
 	)
@@ -111,7 +111,8 @@ func runAllocateEgressIP(ctx context.Context) (err error) {
 	)
 
 	if !flag.GetYes(ctx) {
-		msg := `Looks like you're allocating a static egress (outgoing) IP. This is an advanced feature, and is not needed by most apps.
+		msg := `You're allocating a machine-scoped static egress (outgoing) IP.
+This is deprecated, and new apps should use app-scoped egress IPs instead (using the command 'fly ip allocate-egress -r <region>').
 Are you sure this is what you want?`
 
 		switch confirmed, err := prompt.Confirm(ctx, msg); {


### PR DESCRIPTION
...and in the mean time, also flag old machine-scoped egress IPs as deprecated.

---

### Documentation

- [x] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a
