### PR TITLE
fix(launch): use custom database name when attaching to existing MPG cluster

### DIFF
--- a/internal/command/launch/webui.go
+++ b/internal/command/launch/webui.go
@@ -123,7 +123,10 @@ func (state *launchState) EditInWebUi(ctx context.Context) error {
 			}
 
 			// Apply settings from the form
+			// Check both "db_name" (Go struct json tag) and "name" (API/UI convention)
 			if dbName, ok := mpgData["db_name"].(string); ok && dbName != "" {
+				state.Plan.Postgres.ManagedPostgres.DbName = dbName
+			} else if dbName, ok := mpgData["name"].(string); ok && dbName != "" {
 				state.Plan.Postgres.ManagedPostgres.DbName = dbName
 			}
 			if plan, ok := mpgData["plan"].(string); ok && plan != "" {


### PR DESCRIPTION
## Summary
- Fixes issue where `fly launch` with web customization always showed `fly-db` in the DATABASE_URL secret, even when the user specified a custom database name
- When attaching to an existing Managed Postgres cluster, the DATABASE_URL now correctly uses the database name provided in the web form
- Checks for both `"db_name"` and `"name"` keys in form data to handle API/UI naming conventions

## Test plan
- [x] Run `fly launch` and customize via web UI
- [x] Select an existing MPG cluster and provide a custom database name
- [x] Verify the DATABASE_URL secret shows the custom database name instead of `fly-db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)