### PR TITLE
Strip single quotes from secrets when parsing.

### DIFF
--- a/internal/command/secrets/parser.go
+++ b/internal/command/secrets/parser.go
@@ -53,6 +53,9 @@ func parseSecrets(reader io.Reader) (map[string]string, error) {
 				if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
 					// Remove double quotes
 					value = value[1 : len(value)-1]
+				} else if strings.HasPrefix(value, `'`) && strings.HasSuffix(value, `'`) {
+					// Remove single quotes
+					value = value[1 : len(value)-1]
 				}
 				secrets[key] = value
 			}

--- a/internal/command/secrets/parser_test.go
+++ b/internal/command/secrets/parser_test.go
@@ -111,6 +111,16 @@ func Test_parse_with_comment(t *testing.T) {
 	}, secrets)
 }
 
+func Test_parse_with_single_quotes(t *testing.T) {
+	reader := strings.NewReader("FOO='BAR BAZ'\nKEY='value'")
+	secrets, err := parseSecrets(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"FOO": "BAR BAZ",
+		"KEY": "value",
+	}, secrets)
+}
+
 // Test single-line triple-quoted strings
 func Test_parse_singleline_triple_quotes(t *testing.T) {
 	reader := strings.NewReader(`VARIABLE="""my-single-line-multiline-string"""


### PR DESCRIPTION
### Change Summary

What and Why:
- Currently single quotes are parsed as part of the secret value. We should instead strip them. 
  - All major .env implementations do this, and it matches shell semantics.

Related to:
- https://github.com/superfly/docs/issues/2353
- https://github.com/superfly/docs/pull/2354
