### PR TITLE
fix(deploy): nil pointer dereference when creating new machines during deploy

### DIFF
--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -559,7 +559,7 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 	}
 
 	if !healthcheckResult.machineChecksPassed || !healthcheckResult.smokeChecksPassed {
-		sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach a good state", oldMachine.ID))
+		sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach a good state", machine.ID))
 		_, err := waitForMachineState(ctx, lm, []string{"stopped", "started", "suspended"}, md.waitTimeout, sl)
 		if err != nil {
 			span.RecordError(err)


### PR DESCRIPTION
## Summary

- Fixes a nil pointer dereference panic in `updateMachineWChecks` that occurs when scaling up (creating new machines with no corresponding old machine).
- When `oldMachine` is nil (new machine being created), the health check wait log message at `plan.go:562` accessed `oldMachine.ID`, causing a SIGSEGV. Changed to use `machine.ID` (the return value from `updateOrCreateMachine`) which is guaranteed non-nil at that point.
- Adds `TestUpdateMachinesWithNewMachine` to exercise this exact code path: deploying with a new machine in the app state that has no old machine counterpart, with smoke checks enabled.