### PR TITLE
Fix synthetics probe logging after blackbox exporter upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/ejcx/sshcert v1.1.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/getsentry/sentry-go v0.32.0
-	github.com/go-kit/log v0.2.1
 	github.com/go-logr/logr v1.4.3
 	github.com/gofrs/flock v0.12.1
 	github.com/google/go-cmp v0.7.0
@@ -202,7 +201,6 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
 	github.com/go-git/go-git/v5 v5.16.5 // indirect
-	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -309,12 +309,8 @@ github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod
 github.com/go-git/go-git/v5 v5.16.5 h1:mdkuqblwr57kVfXri5TTH+nMFLNUxIj9Z7F5ykFbw5s=
 github.com/go-git/go-git/v5 v5.16.5/go.mod h1:QOMLpNf1qxuSY4StA/ArOdfFR2TrKEjJiye2kel2m+M=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
-github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
-github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
-github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/metrics/synthetics/agent.go
+++ b/internal/metrics/synthetics/agent.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net"
 	"net/url"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/go-kit/log"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/superfly/flyctl/internal/logger"
 )
@@ -93,7 +93,7 @@ func processProbe(ctx context.Context, probeMessageJSON []byte, ws *SyntheticsWs
 		logBuf bytes.Buffer
 	)
 
-	sl := log.NewLogfmtLogger(log.NewSyncWriter(&logBuf))
+	sl := slog.New(slog.NewTextHandler(&logBuf, nil))
 
 	if !isFlyInfraTarget(probeMessage.Target) {
 		logger.Warnf("skipping probe message for non-fly infra endpoint %s", probeMessage.Target)

--- a/internal/metrics/synthetics/prober.go
+++ b/internal/metrics/synthetics/prober.go
@@ -2,17 +2,16 @@ package synthetics
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/blackbox_exporter/config"
 	"github.com/prometheus/blackbox_exporter/prober"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 )
 
-func probeHTTP(ctx context.Context, probeMessage ProbeMessage, sl log.Logger) (mfs []*dto.MetricFamily, err error) {
+func probeHTTP(ctx context.Context, probeMessage ProbeMessage, sl *slog.Logger) (mfs []*dto.MetricFamily, err error) {
 	probeSuccessGauge := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "probe_success",
 		Help: "Displays whether or not the probe was a success",
@@ -37,9 +36,9 @@ func probeHTTP(ctx context.Context, probeMessage ProbeMessage, sl log.Logger) (m
 
 	if success {
 		probeSuccessGauge.Set(1)
-		level.Info(sl).Log("msg", "Probe succeeded", "duration_seconds", duration)
+		sl.Info("Probe succeeded", "duration_seconds", duration)
 	} else {
-		level.Error(sl).Log("msg", "Probe failed", "duration_seconds", duration)
+		sl.Error("Probe failed", "duration_seconds", duration)
 	}
 
 	mfs, err = registry.Gather()


### PR DESCRIPTION
## Summary
- switch synthetics probe logging from go-kit logger to `slog` so it matches the updated `prober.ProbeHTTP` signature
- update probe success/failure logging calls to use structured `slog` methods
- remove now-unused go-kit logging dependencies from `go.mod` and `go.sum`