### PR TITLE
Fix machine update wait action when machine is not started

### DIFF
--- a/internal/machine/update.go
+++ b/internal/machine/update.go
@@ -86,7 +86,7 @@ func Update(ctx context.Context, appName string, m *fly.Machine, input *fly.Laun
 	}
 
 	waitForAction := "start"
-	if input.SkipLaunch || m.Config.Schedule != "" {
+	if input.SkipLaunch || m.Config.Schedule != "" || m.State != fly.MachineStateStarted {
 		waitForAction = "stop"
 	}
 
@@ -151,7 +151,7 @@ func (e InvalidConfigErr) Suggestion() string {
 		validNumCpus := cpusPerKind[e.guest.CPUKind]
 		return fmt.Sprintf("Valid numbers are %v", validNumCpus)
 	case invalidMemorySize:
-		var incrementSize = 1024
+		incrementSize := 1024
 		switch e.guest.CPUKind {
 		case "shared":
 			incrementSize = 256


### PR DESCRIPTION
## Summary
- set update `waitForAction` to `stop` when the current machine state is not `started`, avoiding waits for a start action that will not occur
- keep existing stop-wait behavior for `--skip-launch` and scheduled machines

```
~/tt/nginxapp
❯ fly status
App
  Name     = livedan-nginx
  Owner    = personal
  Hostname = livedan-nginx.fly.dev
  Image    = library/nginx:1

Machines
PROCESS	ID            	VERSION	REGION	STATE  	ROLE	CHECKS	LAST UPDATED
app    	287d9d3b062098	2      	iad   	started	    	      	2026-03-03T22:46:44Z	
app    	48e64d2f3114e8	2      	iad   	stopped	    	      	2026-03-03T22:45:22Z	


~/tt/nginxapp took 2s
❯ fly image update --image nginx:1.28 -y
Updating machine 48e64d2f3114e8
No health checks found
Machine 48e64d2f3114e8 updated successfully!
Updating machine 287d9d3b062098
No health checks found
Machine 287d9d3b062098 updated successfully!
Machines successfully updated

~/tt/nginxapp took 19s
❯ fly status
App
  Name     = livedan-nginx
  Owner    = personal
  Hostname = livedan-nginx.fly.dev
  Image    = library/nginx:1.28

Machines
PROCESS	ID            	VERSION	REGION	STATE  	ROLE	CHECKS	LAST UPDATED
app    	287d9d3b062098	2      	iad   	started	    	      	2026-03-03T22:47:28Z	
app    	48e64d2f3114e8	2      	iad   	stopped	    	      	2026-03-03T22:47:20Z	


~/tt/nginxapp took 2s
❯ fly image show
Image Details
MACHINE ID    	REGISTRY                	REPOSITORY   	TAG 	VERSION	DIGEST                                                                 	LABELS                   
287d9d3b062098	docker-hub-mirror.fly.io	library/nginx	1.28	N/A    	sha256:1f8a873cacc42b3ccfdb4702f92397da1bb33cd903b954225ef51339bbf2f6a4	maintainer=NGINX Docker Maintainers <docker-maint@nginx.com>	
48e64d2f3114e8	docker-hub-mirror.fly.io	library/nginx	1.28	N/A    	sha256:1f8a873cacc42b3ccfdb4702f92397da1bb33cd903b954225ef51339bbf2f6a4	maintainer=NGINX Docker Maintainers <docker-maint@nginx.com>	
```