### PR TITLE
Fix session timeout check with -t tokens

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -566,11 +566,13 @@ func RequireSession(ctx context.Context) (context.Context, error) {
 		return handleReLogin(ctx, "not_authenticated")
 	}
 
-	// Skip timestamp validation if token is from environment variable (CI/CD use case)
-	// This allows automated pipelines to continue working without session timeout
-	tokenFromEnv := env.First(config.AccessTokenEnvKey, config.APITokenEnvKey) != ""
+	// Skip timestamp validation if token is explicitly provided via environment
+	// variable or -t flag (CI/CD and scripted use cases).
+	// This allows automated pipelines to continue working without session timeout.
+	tokenExplicit := env.First(config.AccessTokenEnvKey, config.APITokenEnvKey) != "" ||
+		flag.IsSpecified(ctx, "access-token")
 
-	if !tokenFromEnv {
+	if !tokenExplicit {
 		// Check if the token has expired due to age
 		// If LastLogin is zero, it means the user has an old config without the timestamp
 		if cfg.LastLogin.IsZero() {


### PR DESCRIPTION
This apparently broke on flyctl 0.3.210, probably went unnoticed since it's not a frequently used feature; user who reported it was stuck on 0.3.208.

With a freshly-generated token passed via -t:

```
$ fly -t "$FLY_ACCESS_TOKEN_NO_API" deploy
Welcome back!
Your session has expired, please log in to continue using flyctl.

? Would you like to sign in? No
Error: No access token available. Please login with 'flyctl auth login'
```

The 30-day session timeout feature has had a bumpy history:

1. 1f90b745f — "Introducing 30-day cli session timeout" (#4630, Nov 5 2025) — the original version had no bypass at all, meaning even env var tokens would hit the timeout.
2. 80affc2eb — "Revert session timeout feature" (#4633) — reverted due to issues.
3. 5a396deda — "session timeout-improved" (#4645, Nov 10 2025) — reintroduced with an env var bypass for CI/CD, but missed the -t flag. This is the commit that introduced the bug the reporting user hit.

So the -t flag was never accounted for — it was an oversight in the improved version (#4645)
 when the env var bypass was added.

This code applies the env var timeout bypass for a token passed via -t as well.