### PR TITLE
Substitute image_config "." with build image during deploy

### DIFF
--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -309,11 +309,21 @@ func skipLaunch(origMachineRaw *fly.Machine, mConfig *fly.MachineConfig) bool {
 }
 
 // updateContainerImage sets container.Image = mConfig.Image in any container where image == "."
+// It also substitutes image_config references of "." in files with the build image.
 func (md *machineDeployment) updateContainerImage(mConfig *fly.MachineConfig) error {
-	if len(mConfig.Containers) != 0 {
-		for i := range mConfig.Containers {
-			if mConfig.Containers[i].Image == "." {
-				mConfig.Containers[i].Image = mConfig.Image
+	for j := range mConfig.Files {
+		if mConfig.Files[j].ImageConfig != nil && *mConfig.Files[j].ImageConfig == "." {
+			mConfig.Files[j].ImageConfig = &mConfig.Image
+		}
+	}
+
+	for i := range mConfig.Containers {
+		if mConfig.Containers[i].Image == "." {
+			mConfig.Containers[i].Image = mConfig.Image
+		}
+		for j := range mConfig.Containers[i].Files {
+			if mConfig.Containers[i].Files[j].ImageConfig != nil && *mConfig.Containers[i].Files[j].ImageConfig == "." {
+				mConfig.Containers[i].Files[j].ImageConfig = &mConfig.Image
 			}
 		}
 	}

--- a/internal/command/deploy/machines_launchinput_test.go
+++ b/internal/command/deploy/machines_launchinput_test.go
@@ -34,6 +34,7 @@ func TestLaunchInputForUpdate(t *testing.T) {
 	t.Run("UpdateClearStandbysWithServices", testLaunchInputForUpdateClearStandbysWithServices)
 	t.Run("LaunchFiles", testLaunchInputForLaunchFiles)
 	t.Run("LaunchFiles", testLaunchInputForUpdateFiles)
+	t.Run("ImageConfigSubstitution", testUpdateContainerImageConfig)
 }
 
 // Test the basic flow of launching, restarting and updating a machine for default process group
@@ -569,4 +570,76 @@ func testLaunchInputForUpdateFiles(t *testing.T) {
 	assert.Equal(t, "SECRET_CONFIG", *li.Config.Files[0].SecretName)
 	assert.Equal(t, "/path/to/hello.txt", li.Config.Files[1].GuestPath)
 	assert.Equal(t, "Z29vZGJ5ZQo=", *li.Config.Files[1].RawValue)
+}
+
+func testUpdateContainerImageConfig(t *testing.T) {
+	md, err := stabMachineDeployment(&appconfig.Config{
+		AppName:       "my-cool-app",
+		PrimaryRegion: "scl",
+	})
+	require.NoError(t, err)
+
+	// Test top-level files image_config substitution
+	mConfig := &fly.MachineConfig{
+		Image: "registry.fly.io/myapp:deploy-1234",
+		Files: []*fly.File{
+			{
+				GuestPath:   "/app/image.json",
+				ImageConfig: fly.StringPointer("."),
+			},
+			{
+				GuestPath:   "/app/other.json",
+				ImageConfig: fly.StringPointer("nginx:latest"),
+			},
+			{
+				GuestPath: "/app/raw.txt",
+				RawValue:  fly.StringPointer("aGVsbG8="),
+			},
+		},
+	}
+	err = md.updateContainerImage(mConfig)
+	require.NoError(t, err)
+	assert.Equal(t, "registry.fly.io/myapp:deploy-1234", *mConfig.Files[0].ImageConfig)
+	assert.Equal(t, "nginx:latest", *mConfig.Files[1].ImageConfig)
+	assert.Nil(t, mConfig.Files[2].ImageConfig)
+
+	// Test container-level files image_config substitution
+	mConfig = &fly.MachineConfig{
+		Image: "registry.fly.io/myapp:deploy-5678",
+		Containers: []*fly.ContainerConfig{
+			{
+				Name:  "app",
+				Image: ".",
+				Files: []*fly.File{
+					{
+						GuestPath:   "/app/image.json",
+						ImageConfig: fly.StringPointer("."),
+					},
+					{
+						GuestPath:   "/app/sidecar.json",
+						ImageConfig: fly.StringPointer("redis:7"),
+					},
+				},
+			},
+			{
+				Name:  "sidecar",
+				Image: "nginx:latest",
+				Files: []*fly.File{
+					{
+						GuestPath:   "/etc/config.json",
+						ImageConfig: fly.StringPointer("."),
+					},
+				},
+			},
+		},
+	}
+	err = md.updateContainerImage(mConfig)
+	require.NoError(t, err)
+	// Container image substitution
+	assert.Equal(t, "registry.fly.io/myapp:deploy-5678", mConfig.Containers[0].Image)
+	assert.Equal(t, "nginx:latest", mConfig.Containers[1].Image)
+	// File image_config substitution
+	assert.Equal(t, "registry.fly.io/myapp:deploy-5678", *mConfig.Containers[0].Files[0].ImageConfig)
+	assert.Equal(t, "redis:7", *mConfig.Containers[0].Files[1].ImageConfig)
+	assert.Equal(t, "registry.fly.io/myapp:deploy-5678", *mConfig.Containers[1].Files[0].ImageConfig)
 }


### PR DESCRIPTION
## Summary

- Extend `updateContainerImage()` to substitute `image_config` references of `"."` with the build image, for both top-level `MachineConfig.Files` and per-container `ContainerConfig.Files`
- This follows the existing convention where `container.Image = "."` is replaced with the build image during deploy
- Adds unit tests covering top-level files, container-level files, explicit image refs (left untouched), and files without `image_config`

Fixes #4771

## Test plan

- [x] Unit tests pass (`go test ./internal/command/deploy/ -run TestLaunchInputForUpdate`)
- [ ] Preflight tests (run by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)