### PR TITLE
fix(certs): respect --json output in certs setup

### DIFF
--- a/internal/command/certificates/root.go
+++ b/internal/command/certificates/root.go
@@ -509,6 +509,12 @@ func runCertificatesSetup(ctx context.Context) error {
 		return err
 	}
 
+	io := iostreams.FromContext(ctx)
+	if config.FromContext(ctx).JSONOutput {
+		render.JSON(io.Out, resp)
+		return nil
+	}
+
 	printDNSOptions(ctx, hostname, resp)
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes `fly certs setup` ignoring `--json` output mode.

- Add JSON output handling in `runCertificatesSetup` in `internal/command/certificates/root.go`
- When `--json` is set, return API response via `render.JSON(...)` and skip human-readable DNS instructions
- Preserve existing non-JSON behavior unchanged

Fixes #4724.

## Why

`fly certs setup --json` should be machine-readable for automation/IaC workflows.  
Before this change, the command always printed human-oriented setup text, which broke JSON-driven scripting.

## Test plan

- [x] Build local binary:
  - `go build -o .\bin\flyctl.exe .`
- [x] Manual verify JSON mode:
  - `.\bin\flyctl.exe certs setup <hostname> --json -a <app>`
  - Confirm output is JSON (no `DNS Setup Options` human text)
- [x] Manual verify default mode:
  - `.\bin\flyctl.exe certs setup <hostname> -a <app>`
  - Confirm existing human-readable DNS setup output remains

## Notes

- This PR is intentionally scoped to issue #4724 (`certs setup`).
- No behavior changes to other certs subcommands in this PR.