### PR TITLE
Bump fly-go to v0.4.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/fly-go v0.4.3
+	github.com/superfly/fly-go v0.4.5
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -669,8 +669,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.4.3 h1:vJd7t3gY0VfXTJacKYFIqZJ1WnMjJE5gHZxQbgKUe6g=
-github.com/superfly/fly-go v0.4.3/go.mod h1:9ZPc5Yagx2y4gQJ0yP1+xxHyWR9U9lA2QSKjb5h4944=
+github.com/superfly/fly-go v0.4.5 h1:FYsFAHmVyNe5/Ye4T5wFQG9upiqybtKBXMI1exwY1V8=
+github.com/superfly/fly-go v0.4.5/go.mod h1:9ZPc5Yagx2y4gQJ0yP1+xxHyWR9U9lA2QSKjb5h4944=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=


### PR DESCRIPTION
## Summary
- bump github.com/superfly/fly-go from v0.4.3 to v0.4.5
- refresh go.sum entries for the upgraded module

## Testing
- go test ./...