### PR TITLE
fix: default to "yes" for session renew prompt

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -629,7 +629,7 @@ func handleReLogin(ctx context.Context, reason string) (context.Context, error) 
 			promptMessage = "Would you like to sign in?"
 		}
 
-		confirmed, err := prompt.Confirm(ctx, promptMessage)
+		confirmed, err := prompt.ConfirmYes(ctx, promptMessage)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Change Summary

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
