### PR TITLE
Fix "concurrent update in progress" errors during canary deploys

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -702,7 +702,14 @@ func (md *machineDeployment) updateExistingMachinesWRecovery(ctx context.Context
 			return err
 		}
 
-		return md.updateMachinesWRecovery(ctx, oldAppState, &newAppState, nil, updateMachineSettings{
+		// Refresh app state so phase 2 sees the canary's updated config and
+		// won't re-update it.
+		refreshedState, err := md.appState(ctx, oldAppState)
+		if err != nil {
+			return fmt.Errorf("failed to refresh app state after canary: %w", err)
+		}
+
+		return md.updateMachinesWRecovery(ctx, refreshedState, &newAppState, nil, updateMachineSettings{
 			pushForward:          true,
 			skipHealthChecks:     md.skipHealthChecks,
 			skipSmokeChecks:      md.skipSmokeChecks,

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -680,16 +680,26 @@ func (md *machineDeployment) updateExistingMachinesWRecovery(ctx context.Context
 			skipLeaseAcquisition: false,
 		})
 	case "canary":
-		// create a new app state with just a single machine being updated, then the rest of the machines
+		// Prefer a started machine as the canary, otherwise take the first machine.
+		canaryIdx := 0
+		for i, m := range oldAppState.Machines {
+			if m.State == "started" {
+				canaryIdx = i
+
+				break
+			}
+		}
+		canaryOld := oldAppState.Machines[canaryIdx]
+
 		canaryAppState := *oldAppState
-		canaryAppState.Machines = []*fly.Machine{oldAppState.Machines[0]}
+		canaryAppState.Machines = []*fly.Machine{canaryOld}
 
 		newCanaryAppState := newAppState
 		canaryMach, exists := lo.Find(newAppState.Machines, func(m *fly.Machine) bool {
-			return m.ID == oldAppState.Machines[0].ID
+			return m.ID == canaryOld.ID
 		})
 		if !exists {
-			return fmt.Errorf("failed to find machine %s under app %s", oldAppState.Machines[0].ID, md.app.Name)
+			return fmt.Errorf("failed to find machine %s under app %s", canaryOld.ID, md.app.Name)
 		}
 		newCanaryAppState.Machines = []*fly.Machine{canaryMach}
 

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -531,21 +532,37 @@ func compareConfigs(ctx context.Context, oldConfig, newConfig *fly.MachineConfig
 	_, span := tracing.GetTracer().Start(ctx, "compare_configs")
 	defer span.End()
 
-	opt := cmp.FilterPath(func(p cmp.Path) bool {
-		vx := p.Last().String()
+	opt := cmp.Options{
+		cmp.FilterPath(func(p cmp.Path) bool {
+			vx := p.Last().String()
 
-		// ignore the flyctl version used for the deployment. this is mostly useful for testing
-		if vx == `["fly_flyctl_version"]` {
-			return true
-		}
+			// ignore the flyctl version used for the deployment. this is mostly useful for testing
+			if vx == `["fly_flyctl_version"]` {
+				return true
+			}
 
-		return false
-	}, cmp.Ignore())
+			return false
+		}, cmp.Ignore()),
+		// Treat nil slices and empty slices as equal to avoid spurious diffs
+		// from JSON roundtripping (e.g. API returns [] where flyctl sent nil).
+		cmp.FilterValues(func(x, y interface{}) bool {
+			return isEmptyOrNilSlice(x) && isEmptyOrNilSlice(y)
+		}, cmp.Ignore()),
+	}
 
 	isEqual := cmp.Equal(oldConfig, newConfig, opt)
 	span.SetAttributes(attribute.Bool("configs_equal", isEqual))
 
 	return isEqual
+}
+
+func isEmptyOrNilSlice(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+
+	return rv.Kind() == reflect.Slice && rv.Len() == 0
 }
 
 func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachine, newMachine *fly.Machine, sl statuslogger.StatusLine, io *iostreams.IOStreams, healthcheckResult *healthcheckResult) error {

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -574,12 +574,6 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 	shouldStart := lo.Contains([]string{"started", "replacing"}, newMachine.State)
 	span.SetAttributes(attribute.Bool("should_start", shouldStart))
 
-	if !shouldStart {
-		sl.LogStatus(statuslogger.StatusSuccess, fmt.Sprintf("Machine %s is now in a good state", machine.ID))
-
-		return nil
-	}
-
 	if !healthcheckResult.machineChecksPassed || !healthcheckResult.smokeChecksPassed {
 		sl.LogStatus(statuslogger.StatusRunning, fmt.Sprintf("Waiting for machine %s to reach a good state", machine.ID))
 		_, err := waitForMachineState(ctx, lm, []string{"stopped", "started", "suspended"}, md.waitTimeout, sl)
@@ -588,6 +582,12 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 
 			return err
 		}
+	}
+
+	if !shouldStart {
+		sl.LogStatus(statuslogger.StatusSuccess, fmt.Sprintf("Machine %s is now in a good state", machine.ID))
+
+		return nil
 	}
 
 	md.warnAboutIncorrectListenAddress(ctx, lm)


### PR DESCRIPTION
### Change Summary

What and Why:

Avoid possibility of failure during a canary deploy if the machine that we run the canary update on is currently stopped.

Example error:
`Failed to update machines: failed to update machine <machine id>: failed to update VM <machine id>: aborted: machine is replacing: concurrent update in progress Retrying...`

The machines API blocks concurrent updates to a machine, so we need to ensure that doesn't happen.

How:

Fix all the things

* When updating a non-started machine, we now wait for the machine update to fully complete (eg. machine transitions from `replacing` back to `stopped`) before continuing
* Avoid updating the canary machine twice
* Prefer a started machine for the canary where possible