### PR TITLE
statics: link auto-provisioned tigris bucket to its app

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -2671,6 +2671,141 @@ type ListAddOnsResponse struct {
 // GetAddOns returns ListAddOnsResponse.AddOns, and is useful for accessing the field via an interface.
 func (v *ListAddOnsResponse) GetAddOns() ListAddOnsAddOnsAddOnConnection { return v.AddOns }
 
+// ListOrganizationAddOnsOrganization includes the requested fields of the GraphQL type Organization.
+type ListOrganizationAddOnsOrganization struct {
+	// List third party integrations associated with an organization
+	AddOns ListOrganizationAddOnsOrganizationAddOnsAddOnConnection `json:"addOns"`
+}
+
+// GetAddOns returns ListOrganizationAddOnsOrganization.AddOns, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganization) GetAddOns() ListOrganizationAddOnsOrganizationAddOnsAddOnConnection {
+	return v.AddOns
+}
+
+// ListOrganizationAddOnsOrganizationAddOnsAddOnConnection includes the requested fields of the GraphQL type AddOnConnection.
+// The GraphQL type's documentation follows.
+//
+// The connection type for AddOn.
+type ListOrganizationAddOnsOrganizationAddOnsAddOnConnection struct {
+	// A list of nodes.
+	Nodes []ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn `json:"nodes"`
+}
+
+// GetNodes returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnection) GetNodes() []ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn {
+	return v.Nodes
+}
+
+// ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn includes the requested fields of the GraphQL type AddOn.
+type ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn struct {
+	Id string `json:"id"`
+	// The service name according to the provider
+	Name string `json:"name"`
+	// The add-on plan
+	AddOnPlan ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan `json:"addOnPlan"`
+	// Private flycast IP address of the add-on
+	PrivateIp string `json:"privateIp"`
+	// Region where the primary instance is deployed
+	PrimaryRegion string `json:"primaryRegion"`
+	// Regions where replica instances are deployed
+	ReadRegions []string `json:"readRegions"`
+	// Add-on options
+	Options interface{} `json:"options"`
+	// Add-on metadata
+	Metadata interface{} `json:"metadata"`
+	// Organization that owns this service
+	Organization ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnOrganization `json:"organization"`
+}
+
+// GetId returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Id, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetId() string {
+	return v.Id
+}
+
+// GetName returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Name, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetName() string {
+	return v.Name
+}
+
+// GetAddOnPlan returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.AddOnPlan, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetAddOnPlan() ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan {
+	return v.AddOnPlan
+}
+
+// GetPrivateIp returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.PrivateIp, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetPrivateIp() string {
+	return v.PrivateIp
+}
+
+// GetPrimaryRegion returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.PrimaryRegion, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetPrimaryRegion() string {
+	return v.PrimaryRegion
+}
+
+// GetReadRegions returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.ReadRegions, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetReadRegions() []string {
+	return v.ReadRegions
+}
+
+// GetOptions returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Options, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetOptions() interface{} {
+	return v.Options
+}
+
+// GetMetadata returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Metadata, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetMetadata() interface{} {
+	return v.Metadata
+}
+
+// GetOrganization returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Organization, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetOrganization() ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnOrganization {
+	return v.Organization
+}
+
+// ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan includes the requested fields of the GraphQL type AddOnPlan.
+type ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan struct {
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
+}
+
+// GetDisplayName returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan.DisplayName, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan) GetDisplayName() string {
+	return v.DisplayName
+}
+
+// GetDescription returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan.Description, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan) GetDescription() string {
+	return v.Description
+}
+
+// ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnOrganization includes the requested fields of the GraphQL type Organization.
+type ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnOrganization struct {
+	Id string `json:"id"`
+	// Unique organization slug
+	Slug string `json:"slug"`
+}
+
+// GetId returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnOrganization.Id, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnOrganization) GetId() string {
+	return v.Id
+}
+
+// GetSlug returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnOrganization.Slug, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnOrganization) GetSlug() string {
+	return v.Slug
+}
+
+// ListOrganizationAddOnsResponse is returned by ListOrganizationAddOns on success.
+type ListOrganizationAddOnsResponse struct {
+	// Find an organization by ID
+	Organization ListOrganizationAddOnsOrganization `json:"organization"`
+}
+
+// GetOrganization returns ListOrganizationAddOnsResponse.Organization, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsResponse) GetOrganization() ListOrganizationAddOnsOrganization {
+	return v.Organization
+}
+
 // LogOutLogOutLogOutPayload includes the requested fields of the GraphQL type LogOutPayload.
 // The GraphQL type's documentation follows.
 //
@@ -3223,6 +3358,18 @@ type __ListAddOnsInput struct {
 
 // GetAddOnType returns __ListAddOnsInput.AddOnType, and is useful for accessing the field via an interface.
 func (v *__ListAddOnsInput) GetAddOnType() AddOnType { return v.AddOnType }
+
+// __ListOrganizationAddOnsInput is used internally by genqlient
+type __ListOrganizationAddOnsInput struct {
+	OrgSlug   string    `json:"orgSlug"`
+	AddOnType AddOnType `json:"addOnType"`
+}
+
+// GetOrgSlug returns __ListOrganizationAddOnsInput.OrgSlug, and is useful for accessing the field via an interface.
+func (v *__ListOrganizationAddOnsInput) GetOrgSlug() string { return v.OrgSlug }
+
+// GetAddOnType returns __ListOrganizationAddOnsInput.AddOnType, and is useful for accessing the field via an interface.
+func (v *__ListOrganizationAddOnsInput) GetAddOnType() AddOnType { return v.AddOnType }
 
 // __ResetAddOnPasswordInput is used internally by genqlient
 type __ResetAddOnPasswordInput struct {
@@ -4261,6 +4408,60 @@ func ListAddOns(
 	}
 
 	data_ = &ListAddOnsResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by ListOrganizationAddOns.
+const ListOrganizationAddOns_Operation = `
+query ListOrganizationAddOns ($orgSlug: String!, $addOnType: AddOnType) {
+	organization(slug: $orgSlug) {
+		addOns(type: $addOnType) {
+			nodes {
+				id
+				name
+				addOnPlan {
+					displayName
+					description
+				}
+				privateIp
+				primaryRegion
+				readRegions
+				options
+				metadata
+				organization {
+					id
+					slug
+				}
+			}
+		}
+	}
+}
+`
+
+func ListOrganizationAddOns(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	orgSlug string,
+	addOnType AddOnType,
+) (data_ *ListOrganizationAddOnsResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "ListOrganizationAddOns",
+		Query:  ListOrganizationAddOns_Operation,
+		Variables: &__ListOrganizationAddOnsInput{
+			OrgSlug:   orgSlug,
+			AddOnType: addOnType,
+		},
+	}
+
+	data_ = &ListOrganizationAddOnsResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -265,6 +265,30 @@ query ListAddOns($addOnType: AddOnType) {
 	}
 }
 
+query ListOrganizationAddOns($orgSlug: String!, $addOnType: AddOnType) {
+	organization(slug: $orgSlug) {
+		addOns(type: $addOnType) {
+			nodes {
+				id
+				name
+				addOnPlan {
+					displayName
+					description
+				}
+				privateIp
+				primaryRegion
+				readRegions
+				options
+				metadata
+				organization {
+					id
+					slug
+				}
+			}
+		}
+	}
+}
+
  mutation UpdateAddOn($addOnId: ID!, $planId: ID!, $readRegions: [String!]!, $options: JSON!, $metadata: JSON!) {
 		updateAddOn(input: {addOnId: $addOnId, planId: $planId, readRegions: $readRegions, options: $options, metadata: $metadata}) {
 			addOn {

--- a/internal/command/deploy/statics/addon.go
+++ b/internal/command/deploy/statics/addon.go
@@ -19,14 +19,25 @@ import (
 	"github.com/superfly/tokenizer"
 )
 
+// Bucket is a tigris statics add-on as returned by FindBucket. It is an alias
+// for the generated type of the ListOrganizationAddOns query's node fields so
+// callers don't have to deal with the unwieldy generated name directly.
+type Bucket = gql.ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn
+
 // FindBucket finds the tigris statics bucket for the given app and org.
 // Returns nil, nil if no bucket is found.
-func FindBucket(ctx context.Context, app *fly.App, org *fly.Organization) (*gql.ListAddOnsAddOnsAddOnConnectionNodesAddOn, error) {
+//
+// The query is scoped to the app's organization so accounts with many tigris
+// add-ons don't have to transfer (and filter client-side) every tigris add-on
+// visible to the caller. Once new statics buckets are created with an app_id
+// link (see ensureBucketCreated), this can be tightened further to an
+// app-scoped query; until then we still match by the metadata pointer.
+func FindBucket(ctx context.Context, app *fly.App, org *fly.Organization) (*Bucket, error) {
 
 	client := flyutil.ClientFromContext(ctx)
 	gqlClient := client.GenqClient()
 
-	response, err := gql.ListAddOns(ctx, gqlClient, "tigris")
+	response, err := gql.ListOrganizationAddOns(ctx, gqlClient, org.Slug, "tigris")
 	if err != nil {
 		return nil, err
 	}
@@ -34,11 +45,8 @@ func FindBucket(ctx context.Context, app *fly.App, org *fly.Organization) (*gql.
 	// Using string comparison here because we might want to use BigInt app IDs in the future.
 	internalAppIdStr := strconv.FormatUint(uint64(app.InternalNumericID), 10)
 
-	for _, extension := range response.AddOns.Nodes {
+	for _, extension := range response.Organization.AddOns.Nodes {
 		if extension.Metadata == nil {
-			continue
-		}
-		if extension.Organization.Slug != org.Slug {
 			continue
 		}
 		if extension.Metadata.(map[string]any)[staticsMetaKeyAppId] == internalAppIdStr {

--- a/internal/command/deploy/statics/addon.go
+++ b/internal/command/deploy/statics/addon.go
@@ -19,38 +19,73 @@ import (
 	"github.com/superfly/tokenizer"
 )
 
-// Bucket is a tigris statics add-on as returned by FindBucket. It is an alias
-// for the generated type of the ListOrganizationAddOns query's node fields so
-// callers don't have to deal with the unwieldy generated name directly.
-type Bucket = gql.ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn
+// Bucket is the subset of a tigris statics add-on that FindBucket's callers
+// (destroy.go, move.go, ensureBucketCreated) need. It deliberately hides
+// which GraphQL query produced the record so FindBucket can pick the most
+// targeted path at runtime.
+type Bucket struct {
+	Name     string
+	Metadata map[string]any
+}
+
+// bucketFromMetadata returns a Bucket if the given generated add-on node has
+// the staticsMetaKeyAppId pointer matching app, else nil.
+func bucketFromMetadata(name string, metadata interface{}, internalAppIdStr string) *Bucket {
+	if metadata == nil {
+		return nil
+	}
+	meta, ok := metadata.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if meta[staticsMetaKeyAppId] != internalAppIdStr {
+		return nil
+	}
+	return &Bucket{Name: name, Metadata: meta}
+}
 
 // FindBucket finds the tigris statics bucket for the given app and org.
 // Returns nil, nil if no bucket is found.
 //
-// The query is scoped to the app's organization so accounts with many tigris
-// add-ons don't have to transfer (and filter client-side) every tigris add-on
-// visible to the caller. Once new statics buckets are created with an app_id
-// link (see ensureBucketCreated), this can be tightened further to an
-// app-scoped query; until then we still match by the metadata pointer.
+// Lookup is tiered so common cases stay fast:
+//  1. App-scoped: GetAppWithAddons resolves add-ons linked to the app via
+//     add_ons.app_id. New buckets created by ensureBucketCreated are linked
+//     this way and this is the only path they need.
+//  2. Org-scoped fallback: ListOrganizationAddOns scans the org's tigris
+//     add-ons and matches on the staticsMetaKeyAppId metadata pointer. This
+//     catches legacy buckets created before app_id linking, which are not
+//     being backfilled.
+//
+// Both paths verify the staticsMetaKeyAppId pointer — a user-provisioned
+// tigris add-on that happens to be attached to the same app won't match.
 func FindBucket(ctx context.Context, app *fly.App, org *fly.Organization) (*Bucket, error) {
 
 	client := flyutil.ClientFromContext(ctx)
 	gqlClient := client.GenqClient()
 
-	response, err := gql.ListOrganizationAddOns(ctx, gqlClient, org.Slug, "tigris")
-	if err != nil {
-		return nil, err
-	}
-
 	// Using string comparison here because we might want to use BigInt app IDs in the future.
 	internalAppIdStr := strconv.FormatUint(uint64(app.InternalNumericID), 10)
 
-	for _, extension := range response.Organization.AddOns.Nodes {
-		if extension.Metadata == nil {
-			continue
+	appResp, err := gql.GetAppWithAddons(ctx, gqlClient, app.Name, gql.AddOnTypeTigris)
+	if err != nil {
+		return nil, err
+	}
+	for _, extension := range appResp.App.AddOns.Nodes {
+		if bucket := bucketFromMetadata(extension.Name, extension.Metadata, internalAppIdStr); bucket != nil {
+			return bucket, nil
 		}
-		if extension.Metadata.(map[string]any)[staticsMetaKeyAppId] == internalAppIdStr {
-			return &extension, nil
+	}
+
+	// Legacy fallback: old statics buckets weren't linked via add_ons.app_id,
+	// so they only surface via the org-scoped query. Safe to drop once all
+	// surviving buckets are known to be linked (or backfilled) by app_id.
+	orgResp, err := gql.ListOrganizationAddOns(ctx, gqlClient, org.Slug, "tigris")
+	if err != nil {
+		return nil, err
+	}
+	for _, extension := range orgResp.Organization.AddOns.Nodes {
+		if bucket := bucketFromMetadata(extension.Name, extension.Metadata, internalAppIdStr); bucket != nil {
+			return bucket, nil
 		}
 	}
 
@@ -66,10 +101,9 @@ func (deployer *DeployerState) ensureBucketCreated(ctx context.Context) (tokeniz
 		return "", err
 	}
 	if bucket != nil {
-		meta := bucket.Metadata.(map[string]any)
-		deployer.bucket = meta[staticsMetaBucketName].(string)
+		deployer.bucket = bucket.Metadata[staticsMetaBucketName].(string)
 
-		return meta[staticsMetaTokenizedAuth].(string), nil
+		return bucket.Metadata[staticsMetaTokenizedAuth].(string), nil
 	}
 
 	// Using string comparison here because we might want to use BigInt app IDs in the future.
@@ -84,6 +118,12 @@ func (deployer *DeployerState) ensureBucketCreated(ctx context.Context) (tokeniz
 		ErrorCaptureCallback: nil,
 		OverrideRegion:       deployer.appConfig.PrimaryRegion,
 		OverrideName:         &extName,
+		// AppName links the new add-on to the app via add_ons.app_id on the
+		// server side. Without this, FindBucket has to fall back to matching
+		// the staticsMetaKeyAppId metadata pointer, which forces a broader
+		// (and slower) org-scoped search on every `fly apps destroy` and
+		// `fly apps move`.
+		AppName: deployer.appConfig.AppName,
 	}
 	params.Options["website"] = map[string]any{
 		"domain_name": "",

--- a/internal/command/deploy/statics/addon.go
+++ b/internal/command/deploy/statics/addon.go
@@ -41,6 +41,7 @@ func bucketFromMetadata(name string, metadata interface{}, internalAppIdStr stri
 	if meta[staticsMetaKeyAppId] != internalAppIdStr {
 		return nil
 	}
+
 	return &Bucket{Name: name, Metadata: meta}
 }
 

--- a/internal/command/deploy/statics/move.go
+++ b/internal/command/deploy/statics/move.go
@@ -19,7 +19,7 @@ import (
 // all the files from the old bucket to the new bucket - then deletes the old bucket.
 func MoveBucket(
 	ctx context.Context,
-	prevBucket *gql.ListAddOnsAddOnsAddOnConnectionNodesAddOn,
+	prevBucket *Bucket,
 	prevOrg *fly.Organization,
 	app *fly.App,
 	targetOrg *fly.Organization,

--- a/internal/command/deploy/statics/move.go
+++ b/internal/command/deploy/statics/move.go
@@ -36,14 +36,13 @@ func MoveBucket(
 		return err
 	}
 
-	prevBucketMeta := prevBucket.Metadata.(map[string]any)
-	prevBucketAuth := prevBucketMeta[staticsMetaTokenizedAuth].(string)
+	prevBucketAuth := prevBucket.Metadata[staticsMetaTokenizedAuth].(string)
 	oldBucketS3Client, err := s3ClientWithAuth(ctx, prevBucketAuth, prevOrg)
 	if err != nil {
 		return err
 	}
 
-	prevBucketName := prevBucketMeta[staticsMetaBucketName].(string)
+	prevBucketName := prevBucket.Metadata[staticsMetaBucketName].(string)
 
 	deployer := Deployer(appConfig, app, targetOrg, app.CurrentRelease.Version)
 	err = deployer.Configure(ctx)


### PR DESCRIPTION
## Summary

- `statics.ensureBucketCreated` now passes `AppName` when provisioning the tigris bucket so web's `create_add_on` mutation populates `add_ons.app_id` (`internal/command/deploy/statics/addon.go`). New buckets are linked by FK, not just by the `staticsMetaKeyAppId` metadata pointer.
- `statics.FindBucket` is now tiered: it tries `GetAppWithAddons` (app-scoped) first and falls back to `ListOrganizationAddOns` (the org-scoped query from #4826) only if no match is found. Legacy buckets created before the FK link still resolve via the fallback, no backfill needed.
- Both paths verify the `staticsMetaKeyAppId` metadata pointer. A user-provisioned tigris add-on that happens to be attached to the same app via `fly ext create tigris` will not be mistaken for a statics bucket and will not be touched by `fly apps destroy`.
- `Bucket` moves from a generated-type alias to a small local struct so both GraphQL paths can feed into it.

> **Base branch:** this PR is stacked on top of #4826 (needs the `ListOrganizationAddOns` query) — please merge that one first.

## Why stacked / why in one PR

The user explicitly asked for the backwards-compatible app-scoped lookup in this PR: "we can assume we're not backfilling so both should work, new stuff should work better." Keeping the FK write and the FK read in the same change means we never ship a flyctl version that writes the link but doesn't read it (or vice versa), and the legacy fallback is always present.

## Behavior change worth calling out

`extensions.ProvisionExtension` errors with "already exists for app" when `AppName` is set and the app already has any tigris add-on (`internal/command/extensions/core/core.go:74-87`). Previously, with `AppName` empty, statics could silently create a second tigris bucket alongside a user's manually-provisioned one. Now it will refuse. That seems like the better behavior — there's no sane way for statics to share a bucket with a user-owned tigris — but reviewers should confirm.

## Test plan

- [ ] `go build ./...` (passes locally)
- [ ] `go vet ./internal/command/deploy/statics/... ./internal/command/apps/... ./gql/...` (passes locally)
- [ ] Manual: deploy a fresh app with statics, confirm the tigris add-on shows up under `fly ext list --app <name>` (proves app_id is set).
- [ ] Manual: redeploy the same app, confirm no new bucket is created (proves `FindBucket`'s app-scoped path hits).
- [ ] Manual: `fly apps destroy <app>` — confirm the statics bucket is still cleaned up.
- [ ] Manual: against an account with a legacy statics bucket (created before this PR), confirm `fly apps destroy` still finds and removes it via the org-scoped fallback.
- [ ] Manual: against an account with many tigris add-ons, confirm `fly apps destroy` returns quickly on apps that do not have a statics bucket (the app-scoped query short-circuits before the fallback ever runs).