### PR TITLE
fix(build): build moby client with matching conn config for buildpacks

### DIFF
--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -9,7 +9,6 @@ import (
 
 	packclient "github.com/buildpacks/pack/pkg/client"
 	projectTypes "github.com/buildpacks/pack/pkg/project/types"
-	mobyclient "github.com/moby/moby/client"
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/internal/cmdfmt"
 	"github.com/superfly/flyctl/internal/metrics"
@@ -71,13 +70,22 @@ func (*buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 	defer docker.Close() // skipcq: GO-S2307
 	defer clearDeploymentTags(ctx, docker, opts.Tag)
 
-	// pack v0.40+ uses github.com/moby/moby/client types; create a moby client
-	// from the existing docker connection (same HTTP client + host) to satisfy the interface.
-	mobyClient, err := mobyclient.New(
-		mobyclient.WithHTTPClient(docker.HTTPClient()),
-		mobyclient.WithHost(docker.DaemonHost()),
-		mobyclient.WithAPIVersionNegotiation(),
-	)
+	// pack v0.40+ uses github.com/moby/moby/client types. Build a moby client
+	// with the same connection config as the docker client (same host, dialer,
+	// auth headers). We can't just forward docker.HTTPClient() to moby because
+	// docker client v27+ wraps its transport in *otelhttp.Transport, and
+	// moby's WithHost only accepts *http.Transport — it fails with "cannot
+	// apply host to transport: *otelhttp.Transport". dockerFactory.mobyBuildFn
+	// is wired up alongside buildFn to produce an equivalent moby client that
+	// gets its own otelhttp wrap inside moby's New().
+	if dockerFactory.mobyBuildFn == nil {
+		err := errors.New("internal: mobyBuildFn not populated for this docker factory mode")
+		build.BuilderInitFinish()
+		build.BuildFinish()
+		tracing.RecordError(span, err, "missing moby client builder")
+		return nil, "", err
+	}
+	mobyClient, err := dockerFactory.mobyBuildFn(ctx)
 	if err != nil {
 		build.BuilderInitFinish()
 		build.BuildFinish()

--- a/internal/build/imgsrc/buildpacks_builder.go
+++ b/internal/build/imgsrc/buildpacks_builder.go
@@ -83,6 +83,7 @@ func (*buildpacksBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 		build.BuilderInitFinish()
 		build.BuildFinish()
 		tracing.RecordError(span, err, "missing moby client builder")
+
 		return nil, "", err
 	}
 	mobyClient, err := dockerFactory.mobyBuildFn(ctx)

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -21,6 +21,7 @@ import (
 	dockerclient "github.com/docker/docker/client"
 	"github.com/docker/go-connections/sockets"
 	"github.com/jpillora/backoff"
+	mobyclient "github.com/moby/moby/client"
 	"github.com/morikuni/aec"
 	"github.com/oklog/ulid/v2"
 	"github.com/pkg/errors"
@@ -58,58 +59,95 @@ type dockerClientFactory struct {
 	buildFn   func(ctx context.Context, build *build) (*dockerclient.Client, error)
 	apiClient flyutil.Client
 	appName   string
+	// mobyBuildFn creates a moby client matching the connection config of the
+	// docker client produced by buildFn (same host, dialer, and auth headers).
+	// Callers that need a moby-typed client (e.g. the buildpacks/pack library)
+	// must use this rather than reusing docker.HTTPClient(), because docker
+	// client v27+ wraps its transport with *otelhttp.Transport, and moby
+	// client's WithHost rejects any non-*http.Transport.
+	mobyBuildFn func(ctx context.Context) (*mobyclient.Client, error)
 }
 
 func newDockerClientFactory(daemonType DockerDaemonType, apiClient flyutil.Client, appName string, streams *iostreams.IOStreams, connectOverWireguard, recreateBuilder bool) *dockerClientFactory {
 	remoteFactory := func() *dockerClientFactory {
 		terminal.Debug("trying remote docker daemon")
 
-		return &dockerClientFactory{
-			mode:   daemonType,
-			remote: true,
-			buildFn: func(ctx context.Context, build *build) (*dockerclient.Client, error) {
-				cfg := config.FromContext(ctx)
-				var (
-					builderMachine *fly.Machine
-					builderApp     *flaps.App
-					err            error
-				)
+		f := &dockerClientFactory{
+			mode:      daemonType,
+			remote:    true,
+			apiClient: apiClient,
+			appName:   appName,
+		}
+		f.buildFn = func(ctx context.Context, build *build) (*dockerclient.Client, error) {
+			cfg := config.FromContext(ctx)
+			var (
+				builderMachine *fly.Machine
+				builderApp     *flaps.App
+				err            error
+			)
 
-				flapsClient := flapsutil.ClientFromContext(ctx)
-				app, err := flapsClient.GetApp(ctx, appName)
+			flapsClient := flapsutil.ClientFromContext(ctx)
+			app, err := flapsClient.GetApp(ctx, appName)
+			if err != nil {
+				return nil, err
+			}
+
+			managed := daemonType.UseManagedBuilder()
+			if cfg.DisableManagedBuilders {
+				managed = false
+			}
+			if managed {
+				connectOverWireguard = false
+				builderMachine, builderApp, err = remoteManagedBuilderMachine(ctx, app.Organization.Slug)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				uiexClient := uiexutil.ClientFromContext(ctx)
+				org, err := uiexClient.GetOrganization(ctx, app.Organization.Slug)
 				if err != nil {
 					return nil, err
 				}
 
-				managed := daemonType.UseManagedBuilder()
-				if cfg.DisableManagedBuilders {
-					managed = false
+				provisioner := NewProvisionerUiexOrg(org)
+				builderMachine, builderApp, err = provisioner.EnsureBuilder(ctx, os.Getenv("FLY_REMOTE_BUILDER_REGION"), recreateBuilder)
+				if err != nil {
+					return nil, err
 				}
-				if managed {
-					connectOverWireguard = false
-					builderMachine, builderApp, err = remoteManagedBuilderMachine(ctx, app.Organization.Slug)
-					if err != nil {
-						return nil, err
-					}
+			}
+
+			dc, err := newRemoteDockerClient(ctx, apiClient, flapsClient, appName, streams, build, cachedDocker, connectOverWireguard, builderApp, builderMachine)
+			if err != nil {
+				return nil, err
+			}
+
+			// Capture the path taken (WG vs wgless) and the final host
+			// (post-FLY_RCHAB_OVERRIDE_HOST) so we can build a parallel moby
+			// client for buildpacks using the same connection config. We
+			// can't reuse docker's HTTPClient() because v27+ wraps its
+			// transport in *otelhttp.Transport, which moby's WithHost
+			// rejects (only *http.Transport is accepted).
+			finalHost := dc.DaemonHost()
+			wg := connectOverWireguard
+			f.mobyBuildFn = func(ctx context.Context) (*mobyclient.Client, error) {
+				var (
+					opts    []mobyclient.Opt
+					optsErr error
+				)
+				if wg {
+					opts, optsErr = buildRemoteMobyOpts(ctx, apiClient, appName, finalHost)
 				} else {
-					uiexClient := uiexutil.ClientFromContext(ctx)
-					org, err := uiexClient.GetOrganization(ctx, app.Organization.Slug)
-					if err != nil {
-						return nil, err
-					}
-
-					provisioner := NewProvisionerUiexOrg(org)
-					builderMachine, builderApp, err = provisioner.EnsureBuilder(ctx, os.Getenv("FLY_REMOTE_BUILDER_REGION"), recreateBuilder)
-					if err != nil {
-						return nil, err
-					}
+					opts, optsErr = buildWireguardlessMobyOpts(ctx, finalHost, appName)
 				}
+				if optsErr != nil {
+					return nil, optsErr
+				}
+				return mobyclient.New(opts...)
+			}
 
-				return newRemoteDockerClient(ctx, apiClient, flapsClient, appName, streams, build, cachedDocker, connectOverWireguard, builderApp, builderMachine)
-			},
-			apiClient: apiClient,
-			appName:   appName,
+			return dc, nil
 		}
+		return f
 	}
 
 	localFactory := func() *dockerClientFactory {
@@ -122,6 +160,9 @@ func newDockerClientFactory(daemonType DockerDaemonType, apiClient flyutil.Clien
 					build.SetBuilderMetaPart1(localBuilderType, "", "")
 
 					return c, nil
+				},
+				mobyBuildFn: func(ctx context.Context) (*mobyclient.Client, error) {
+					return mobyclient.New(mobyclient.FromEnv)
 				},
 				appName: appName,
 			}
@@ -580,6 +621,52 @@ func buildWireguardlessClientOpts(ctx context.Context, host, appName string) ([]
 		}),
 	}
 
+	return opts, nil
+}
+
+// buildWireguardlessMobyOpts mirrors buildWireguardlessClientOpts for the
+// moby client type. Keep the two in sync: same host, same TLS dialer to :443,
+// same Basic auth header.
+func buildWireguardlessMobyOpts(ctx context.Context, host, appName string) ([]mobyclient.Opt, error) {
+	parsedHostUrl, err := dockerclient.ParseHostURL(host)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse host: %w", err)
+	}
+	return []mobyclient.Opt{
+		mobyclient.WithHost(host),
+		mobyclient.WithHTTPHeaders(map[string]string{
+			"Authorization": "Basic " + basicAuth(appName, config.Tokens(ctx).Docker()),
+		}),
+		mobyclient.WithDialContext(func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return tls.Dial("tcp", net.JoinHostPort(parsedHostUrl.Hostname(), "443"), &tls.Config{})
+		}),
+	}, nil
+}
+
+// buildRemoteMobyOpts mirrors buildRemoteClientOpts for the moby client type.
+// Keep the two in sync: same host, same WireGuard agent dialer (when
+// FLY_REMOTE_BUILDER_HOST_WG is unset).
+func buildRemoteMobyOpts(ctx context.Context, apiClient flyutil.Client, appName, host string) ([]mobyclient.Opt, error) {
+	opts := []mobyclient.Opt{
+		mobyclient.WithHost(host),
+	}
+
+	if os.Getenv("FLY_REMOTE_BUILDER_HOST_WG") != "" {
+		return opts, nil
+	}
+
+	flapClient := flapsutil.ClientFromContext(ctx)
+	app, err := flapClient.GetApp(ctx, appName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get app: %w", err)
+	}
+
+	_, dialer, err := agent.BringUpAgentOrgSlug(ctx, apiClient, app.Organization.Slug, app.Network, true)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, mobyclient.WithDialContext(dialer.DialContext))
 	return opts, nil
 }
 

--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -142,11 +142,13 @@ func newDockerClientFactory(daemonType DockerDaemonType, apiClient flyutil.Clien
 				if optsErr != nil {
 					return nil, optsErr
 				}
+
 				return mobyclient.New(opts...)
 			}
 
 			return dc, nil
 		}
+
 		return f
 	}
 
@@ -632,6 +634,7 @@ func buildWireguardlessMobyOpts(ctx context.Context, host, appName string) ([]mo
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse host: %w", err)
 	}
+
 	return []mobyclient.Opt{
 		mobyclient.WithHost(host),
 		mobyclient.WithHTTPHeaders(map[string]string{
@@ -667,6 +670,7 @@ func buildRemoteMobyOpts(ctx context.Context, apiClient flyutil.Client, appName,
 	}
 
 	opts = append(opts, mobyclient.WithDialContext(dialer.DialContext))
+
 	return opts, nil
 }
 


### PR DESCRIPTION
## Summary

Buildpacks deploys via `flyctl deploy` fail with:

```
cannot apply host to transport: *otelhttp.Transport
```

…followed by a fallback that errors with `Cannot connect to the Docker daemon at unix:///var/run/docker.sock` on every retry. I think this blocks every buildpacks-based deploy, remote or local.

The moby client's `WithHost` option requires `c.client.Transport` to be a raw `*http.Transport` ([moby/moby client@v0.4.0 client_options.go:118-138](https://github.com/moby/moby/blob/master/client/client_options.go)). But docker/docker v27+ wraps its transport in `otelhttp.NewTransport(...)` at the end of `NewClientWithOpts` ([docker/docker v27.5.1 client.go:~100](https://github.com/moby/moby/blob/v27.5.1/client/client.go)), so the HTTP client returned by `docker.HTTPClient()` always has `*otelhttp.Transport` and can never satisfy moby's `WithHost`. `buildpacks_builder.go` was doing exactly that:

```go
mobyClient, err := mobyclient.New(
    mobyclient.WithHTTPClient(docker.HTTPClient()),   // transport is *otelhttp.Transport
    mobyclient.WithHost(docker.DaemonHost()),         // fails
    mobyclient.WithAPIVersionNegotiation(),
)
```

### Fix

Build the moby client independently, with its own options that mirror the docker client's connection config (same host, dialer, and auth headers). The docker factory now exposes `mobyBuildFn`, a closure populated alongside `buildFn` once the final host (post-`FLY_RCHAB_OVERRIDE_HOST`) and the WG-vs-wgless path are known.

Two new helpers mirror the existing docker opt-builders so the two types stay in sync:

- `buildRemoteMobyOpts` ↔ `buildRemoteClientOpts` (WG agent `DialContext`, or bare `WithHost` under `FLY_REMOTE_BUILDER_HOST_WG=1`)
- `buildWireguardlessMobyOpts` ↔ `buildWireguardlessClientOpts` (TLS dial to `:443` + `Basic` auth header)

Local-daemon mode uses `mobyclient.FromEnv`.

### Observability is preserved

moby's `New()` unconditionally wraps the final transport in `otelhttp.NewTransport(...)` ([moby/moby client@v0.4.0 client.go:~61](https://github.com/moby/moby/blob/v0.4.0/client/client.go)), so the moby client still gets otel tracing — it just comes from moby's wrap, not from reusing docker's transport. Net-zero loss.

### How this was hit

This shows up in every buildpacks deploy (`heroku/builder:24`, etc.). Reproducible with a minimal Rack app, a `[build] builder = "heroku/builder:24"` stanza in `fly.toml`, and `flyctl deploy --remote-only`. The error comes out of `Resolver.Resolve` as:

```
DEBUG result image:<nil> error:cannot apply host to transport: *otelhttp.Transport
```

…and the build is reported as failed to `/api/v1/builds/finish`.

### Not fixed here (but worth knowing)

After a retry there are a bunch of logs citing `unix:///var/run/docker.sock` instead of the builder host — it seems like `FLY_RCHAB_OVERRIDE_HOST` plumbing doesn't carry through to a fresh client construction on retry. That's a separate bug in the retry/fallback path; this PR only addresses the primary failure.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./internal/build/imgsrc/...` passes
- [ ] `go test ./internal/build/imgsrc/...` passes
- [ ] `flyctl deploy --remote-only` with `[build] builder = "heroku/builder:24"` succeeds against a real remote builder (WG path)
- [ ] Same with `FLY_REMOTE_BUILDER_HOST_WG=1 FLY_RCHAB_OVERRIDE_HOST=tcp://127.0.0.1:2375` against a local rchab container (local dev path)
- [ ] `flyctl deploy` with local docker daemon + buildpacks builder succeeds
- [ ] `flyctl deploy --remote-only` with a Dockerfile (non-buildpacks) still works (regression check — this path goes through the docker client only, not moby)