### PR TITLE
Allow users to self-serve promoting machine egress IPs to app-scoped

### DIFF
--- a/internal/command/launch/plan/postgres_test.go
+++ b/internal/command/launch/plan/postgres_test.go
@@ -29,6 +29,10 @@ func (m *mockUIEXClient) GetOrganization(ctx context.Context, orgSlug string) (*
 	return &uiex.Organization{Slug: orgSlug}, nil
 }
 
+func (m *mockUIEXClient) PromoteMachineEgressIP(ctx context.Context, appName string, egressIP string) error {
+	return nil
+}
+
 func (m *mockUIEXClient) ListMPGRegions(ctx context.Context, orgSlug string) (uiex.ListMPGRegionsResponse, error) {
 	return uiex.ListMPGRegionsResponse{Data: m.mpgRegions}, nil
 }

--- a/internal/command/machine/egress_ip.go
+++ b/internal/command/machine/egress_ip.go
@@ -25,6 +25,7 @@ func newEgressIp() *cobra.Command {
 	cmd := command.New(usage, short, long, nil)
 
 	cmd.Args = cobra.NoArgs
+	cmd.Deprecated = "consider using app-scoped egress IPs (fly ip allocate-egress) instead."
 
 	cmd.AddCommand(
 		newAllocateEgressIp(),
@@ -55,6 +56,7 @@ func newAllocateEgressIp() *cobra.Command {
 	)
 
 	cmd.Args = cobra.ExactArgs(1)
+	cmd.Hidden = true
 
 	return cmd
 }

--- a/internal/command/machine/egress_ip.go
+++ b/internal/command/machine/egress_ip.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -28,6 +29,7 @@ func newEgressIp() *cobra.Command {
 	cmd.AddCommand(
 		newAllocateEgressIp(),
 		newListEgressIps(),
+		newPromoteEgressIP(),
 		newReleaseEgressIP(),
 	)
 
@@ -87,6 +89,29 @@ func newReleaseEgressIP() *cobra.Command {
 	)
 
 	cmd := command.New(usage, short, long, runReleaseEgressIP,
+		command.RequireSession,
+		command.LoadAppNameIfPresent,
+	)
+
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+		flag.Yes(),
+	)
+
+	cmd.Args = cobra.ExactArgs(1)
+
+	return cmd
+}
+
+func newPromoteEgressIP() *cobra.Command {
+	const (
+		long  = `Promote all machine-scoped egress IP addresses for a machine to app-scoped`
+		short = `Promote machine egress IPs`
+		usage = "promote <machine-id>"
+	)
+
+	cmd := command.New(usage, short, long, runPromoteEgressIP,
 		command.RequireSession,
 		command.LoadAppNameIfPresent,
 	)
@@ -195,6 +220,59 @@ func runReleaseEgressIP(ctx context.Context) (err error) {
 	fmt.Printf("Egress IP released for the machine %s\n", machineId)
 	fmt.Printf("IPv4: %s\n", v4.String())
 	fmt.Printf("IPv6: %s\n", v6.String())
+
+	return nil
+}
+
+func runPromoteEgressIP(ctx context.Context) (err error) {
+	var (
+		args       = flag.Args(ctx)
+		client     = flyutil.ClientFromContext(ctx)
+		uiexClient = uiexutil.ClientFromContext(ctx)
+		appName    = appconfig.NameFromContext(ctx)
+		machineID  = args[0]
+	)
+
+	machineIPs, err := client.GetEgressIPAddresses(ctx, appName)
+	if err != nil {
+		return err
+	}
+
+	ips, ok := machineIPs[machineID]
+	if !ok || len(ips) == 0 {
+		return fmt.Errorf("no machine-scoped egress IPs found for machine %s", machineID)
+	}
+
+	rows := make([][]string, 0, len(ips))
+	for _, ip := range ips {
+		rows = append(rows, []string{machineID, ip.Region, fmt.Sprintf("v%d", ip.Version), ip.IP})
+	}
+
+	out := iostreams.FromContext(ctx).Out
+	render.Table(out, "", rows, "Machine ID", "Region", "Type", "Egress IP")
+
+	if !flag.GetYes(ctx) {
+		msg := fmt.Sprintf("Are you sure you want to promote these %d egress IP(s) for machine %s to app-scoped?\nThis may result in up to a few minutes of downtime as the egress IP is removed and re-applied.", len(ips), machineID)
+
+		switch confirmed, err := prompt.Confirm(ctx, msg); {
+		case err == nil:
+			if !confirmed {
+				return nil
+			}
+		case prompt.IsNonInteractive(err):
+			return prompt.NonInteractiveError("yes flag must be specified when not running interactively")
+		default:
+			return err
+		}
+	}
+
+	for _, ip := range ips {
+		if err := uiexClient.PromoteMachineEgressIP(ctx, appName, ip.IP); err != nil {
+			return fmt.Errorf("failed to promote egress IP %s: %w", ip.IP, err)
+		}
+	}
+
+	fmt.Printf("Promoted %d egress IP(s) for machine %s to app-scoped egress IPs\n", len(ips), machineID)
 
 	return nil
 }

--- a/internal/command/machine/egress_ip.go
+++ b/internal/command/machine/egress_ip.go
@@ -108,8 +108,8 @@ func newReleaseEgressIP() *cobra.Command {
 
 func newPromoteEgressIP() *cobra.Command {
 	const (
-		long  = `Promote all machine-scoped egress IP addresses for a machine to app-scoped`
-		short = `Promote machine egress IPs`
+		long  = `Promote all machine-scoped egress IP addresses of a machine to app-scoped in the same region`
+		short = `Promote machine egress IPs to app-scoped`
 		usage = "promote <machine-id>"
 	)
 
@@ -275,6 +275,7 @@ func runPromoteEgressIP(ctx context.Context) (err error) {
 	}
 
 	fmt.Printf("Promoted %d egress IP(s) for machine %s to app-scoped egress IPs\n", len(ips), machineID)
+	fmt.Printf("Note that app-scoped egress IPs are regional; if you run machines in multiple regions, promote at least 1 for every region.\n")
 
 	return nil
 }

--- a/internal/mock/uiex_client.go
+++ b/internal/mock/uiex_client.go
@@ -14,6 +14,7 @@ var _ uiexutil.Client = (*UiexClient)(nil)
 type UiexClient struct {
 	ListOrganizationsFunc                  func(ctx context.Context, admin bool) ([]uiex.Organization, error)
 	GetOrganizationFunc                    func(ctx context.Context, orgSlug string) (*uiex.Organization, error)
+	PromoteMachineEgressIPFunc             func(ctx context.Context, appName string, egressIP string) error
 	ListMPGRegionsFunc                     func(ctx context.Context, orgSlug string) (uiex.ListMPGRegionsResponse, error)
 	ListManagedClustersFunc                func(ctx context.Context, orgSlug string, deleted bool) (uiex.ListManagedClustersResponse, error)
 	GetManagedClusterFunc                  func(ctx context.Context, orgSlug string, id string) (uiex.GetManagedClusterResponse, error)
@@ -58,6 +59,14 @@ func (m *UiexClient) GetOrganization(ctx context.Context, orgSlug string) (*uiex
 	}
 
 	return &uiex.Organization{Slug: orgSlug}, nil
+}
+
+func (m *UiexClient) PromoteMachineEgressIP(ctx context.Context, appName string, egressIP string) error {
+	if m.PromoteMachineEgressIPFunc != nil {
+		return m.PromoteMachineEgressIPFunc(ctx, appName, egressIP)
+	}
+
+	return nil
 }
 
 func (m *UiexClient) ListMPGRegions(ctx context.Context, orgSlug string) (uiex.ListMPGRegionsResponse, error) {

--- a/internal/uiex/egress_ips.go
+++ b/internal/uiex/egress_ips.go
@@ -1,0 +1,41 @@
+package uiex
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/superfly/flyctl/internal/config"
+)
+
+func (c *Client) PromoteMachineEgressIP(ctx context.Context, appName string, egressIP string) error {
+	cfg := config.FromContext(ctx)
+	url := fmt.Sprintf("%s/api/v1/apps/%s/egress_ips/%s/promote", c.baseUrl, appName, egressIP)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Add("Authorization", "Bearer "+cfg.Tokens.GraphQL())
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+		return nil
+	default:
+		return fmt.Errorf("failed to promote egress IP (status %d): %s", res.StatusCode, string(body))
+	}
+}

--- a/internal/uiexutil/client.go
+++ b/internal/uiexutil/client.go
@@ -12,6 +12,9 @@ type Client interface {
 	ListOrganizations(ctx context.Context, admin bool) ([]uiex.Organization, error)
 	GetOrganization(ctx context.Context, orgSlug string) (*uiex.Organization, error)
 
+	// Egress IPs
+	PromoteMachineEgressIP(ctx context.Context, appName string, egressIP string) error
+
 	// MPGs
 	ListMPGRegions(ctx context.Context, orgSlug string) (uiex.ListMPGRegionsResponse, error)
 	ListManagedClusters(ctx context.Context, orgSlug string, deleted bool) (uiex.ListManagedClustersResponse, error)


### PR DESCRIPTION
### Change Summary

What and Why: We're deprecating machine-scoped egress IPs. This is a common request since we made app-scoped egress IPs available, so just allow users to do it themselves. There doesn't seem to be major concerns doing this other than the typical short blip in connectivity while we remove and re-add the IPs.

How: A new command is added (API deployment pending) to promote a machine's egress IPs to app-scoped in the same region.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
