### PR TITLE
Remove overlaybd client path; warn on lazy_load_images

### DIFF
--- a/internal/build/imgsrc/daemon_url_test.go
+++ b/internal/build/imgsrc/daemon_url_test.go
@@ -26,12 +26,6 @@ func TestBuilderAPIURL(t *testing.T) {
 			path:       "/flyio/v1/extendDeadline",
 			want:       "http://[fdaa:49:2bd7::2]:8080/flyio/v1/extendDeadline",
 		},
-		{
-			name:       "overlaybd path",
-			daemonHost: "tcp://[fdaa:49:2bd7::2]:2375",
-			path:       "/flyio/v1/buildOverlaybdImage",
-			want:       "http://[fdaa:49:2bd7::2]:8080/flyio/v1/buildOverlaybdImage",
-		},
 	}
 
 	for _, tc := range tests {

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -1,16 +1,13 @@
 package imgsrc
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -25,7 +22,6 @@ import (
 	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	"github.com/pkg/errors"
 	"github.com/superfly/flyctl/helpers"
-	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/cmdfmt"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/metrics"
@@ -306,85 +302,9 @@ func (*dockerfileBuilder) Run(ctx context.Context, dockerFactory *dockerClientFa
 		Size: img.Size,
 	}
 
-	if opts.UseOverlaybd && dockerFactory.IsRemote() {
-		obdImage, err := buildOverlaybdImage(ctx, dockerFactory.appName, docker, opts)
-		if err != nil {
-			terminal.Warnf("failed to build lazy-loaded image, not using lazy-loading: %v", err)
-		} else {
-			di = *obdImage
-		}
-	}
-
 	span.SetAttributes(di.ToSpanAttributes()...)
 
 	return &di, "", nil
-}
-
-func buildOverlaybdImage(ctx context.Context, appName string, docker *dockerclient.Client, opts ImageOptions) (*DeploymentImage, error) {
-	if !opts.Publish {
-		return nil, errors.New("lazy loaded images require --push")
-	}
-
-	terminal.Info("Building lazy-loading image, please wait...")
-
-	rchabUrl, err := builderAPIURL(docker.DaemonHost(), "/flyio/v1/buildOverlaybdImage")
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse daemon host: %w", err)
-	}
-
-	terminal.Debugf("rchab url: %s", rchabUrl)
-
-	repo := strings.Split(opts.Tag, ":")[0]
-	version := strings.Split(opts.Tag, ":")[1]
-
-	if !strings.HasPrefix(repo, "registry.fly.io/") {
-		return nil, fmt.Errorf("lazy loaded images must be pushed to registry.fly.io, not %s", repo)
-	}
-
-	terminal.Debugf("overlaybd repo: %s, version: %s", repo, version)
-
-	creds := registryAuth(config.Tokens(ctx).Docker())
-
-	body := map[string]string{
-		"repo":   repo,
-		"input":  version,
-		"output": version + "-obd",
-		"creds":  creds.Username + ":" + creds.Password,
-	}
-	jsonBody, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal body: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", rchabUrl, bytes.NewBuffer(jsonBody))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", fmt.Sprintf("flyctl/%s", buildinfo.Version().String()))
-	req.SetBasicAuth(appName, config.Tokens(ctx).Docker())
-
-	res, err := docker.HTTPClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to post to /buildOverlaybdImage: %w", err)
-	}
-	defer res.Body.Close() //skipcq: GO-S2307
-
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(res.Body)
-	terminal.Debugf("rchab response: %s", buf.String())
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("building lazy image returned status %d: %s", res.StatusCode, buf.String())
-	}
-	hash := buf.String()
-
-	terminal.Info("Lazy-loading image built successfully!")
-
-	return &DeploymentImage{
-		ID:   hash,
-		Tag:  repo + ":" + version + "-obd",
-		Size: 0,
-	}, nil
 }
 
 func normalizeBuildArgsForDocker(buildArgs map[string]string) (map[string]*string, error) {

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -54,8 +54,7 @@ type ImageOptions struct {
 	Label                map[string]string
 	BuildpacksDockerHost string
 	BuildpacksVolumes    []string
-	UseOverlaybd         bool
-	Compression          string
+	Compression string
 	CompressionLevel     int
 }
 

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -54,7 +54,7 @@ type ImageOptions struct {
 	Label                map[string]string
 	BuildpacksDockerHost string
 	BuildpacksVolumes    []string
-	Compression string
+	Compression          string
 	CompressionLevel     int
 }
 

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -189,8 +189,8 @@ func determineImage(ctx context.Context, app *flaps.App, appConfig *appconfig.Co
 		BuildpacksVolumes:    flag.GetStringSlice(ctx, flag.BuildpacksVolume),
 	}
 
-	if appConfig.Experimental != nil {
-		opts.UseOverlaybd = appConfig.Experimental.LazyLoadImages
+	if appConfig.Experimental != nil && appConfig.Experimental.LazyLoadImages {
+		terminal.Warnf("[experimental] lazy_load_images is no longer supported (the overlaybd platform feature was removed May 2025). Remove it from fly.toml.\n")
 	}
 
 	// Determine compression based on CLI flags, then app config, then LaunchDarkly, then default to gzip


### PR DESCRIPTION
## Summary

The overlaybd/lazy-loading image feature is dead on the platform side:

- **flyd** no longer processes `ImageRef.Layers` — the overlaybd snapshotter was removed from hosts (nomad-firecracker#3341, merged 2025-05-22).
- **rchab** no longer serves the `/flyio/v1/buildOverlaybdImage` endpoint — the overlaybd build stages were removed (rchab#43).

Today, a customer with `[experimental] lazy_load_images = true` in `fly.toml` gets a silently broken deploy: flyctl converts the image, but the platform ignores the layers. After the rchab endpoint removal, the POST would 404 and fall through to a normal build via the existing `terminal.Warnf` — strictly better, but we shouldn't leave dead code and a misleading config flag around.

### What changed

- **Removed** the `buildOverlaybdImage` function and the `UseOverlaybd` call path from `dockerfile_builder.go`
- **Removed** `UseOverlaybd bool` from the `ImageOptions` struct in `resolver.go`
- **Removed** the overlaybd-specific test case from `daemon_url_test.go`
- **Removed** the `opts.UseOverlaybd` plumbing from `deploy_build.go`
- **Added** a deprecation warning when `[experimental] lazy_load_images = true` is set in `fly.toml`
- **Kept** `Experimental.LazyLoadImages` in the config schema so existing `fly.toml` files still parse without error

### Design decision: warn, don't error

Customers who have `lazy_load_images = true` in their `fly.toml` get a clear warning and a successful deploy — not a hard failure. This gives them a migration window to remove the stale flag without breaking their CI/CD pipelines.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./internal/...` passes
- [x] `go test ./internal/build/imgsrc/...` passes
- [ ] Manual: set `[experimental] lazy_load_images = true` in a test app's `fly.toml`, run `fly deploy --remote-only`, verify:
  - No network request to `/flyio/v1/buildOverlaybdImage`
  - Warning about the flag is printed exactly once
  - Deploy succeeds as a normal image build
- [ ] Manual: remove the flag, verify no warning printed and deploy still works