### PR TITLE
fix(image): guard against downgrade suggestions on fly image show/update

### DIFF
--- a/internal/command/image/show.go
+++ b/internal/command/image/show.go
@@ -165,8 +165,11 @@ func showMachineImage(ctx context.Context, app *fly.AppCompact) error {
 			}
 		}
 
-		// Exclude machines that are already running the latest version
-		if machine.ImageRef.Digest == latest.Digest {
+		// Exclude machines that are already running the latest version, and
+		// skip cases where the resolver returned an older or non-newer build
+		// (e.g. a stale pinned minor tag at a lower fly.version than the
+		// machine's current rolling tag) to avoid suggesting downgrades.
+		if !IsUpdateCandidate(machine, latest) {
 			continue
 		}
 		updatable = append(updatable, machine)

--- a/internal/command/image/update_check.go
+++ b/internal/command/image/update_check.go
@@ -38,5 +38,6 @@ func IsUpdateCandidate(machine *fly.Machine, latest *fly.ImageVersion) bool {
 	if err != nil {
 		return true
 	}
+
 	return latV.GreaterThan(curV)
 }

--- a/internal/command/image/update_check.go
+++ b/internal/command/image/update_check.go
@@ -1,0 +1,42 @@
+package image
+
+import (
+	"strings"
+
+	"github.com/hashicorp/go-version"
+	fly "github.com/superfly/fly-go"
+)
+
+// IsUpdateCandidate reports whether latest is a strictly newer build than the
+// machine's current image. It guards against a backend resolver bug where
+// asking for the latest details of a rolling tag (e.g. "flyio/postgres-flex:16")
+// returns an older fly.version than the rolling tag's current one, which would
+// otherwise surface as a spurious "update available" — actually a downgrade.
+//
+// When either fly.version label is missing or unparseable (e.g. custom images),
+// falls back to a digest-inequality check so we preserve the prior behavior for
+// cases that don't use semver-tagged builds.
+func IsUpdateCandidate(machine *fly.Machine, latest *fly.ImageVersion) bool {
+	if machine == nil || latest == nil {
+		return false
+	}
+	if machine.ImageRef.Digest == latest.Digest {
+		return false
+	}
+
+	current := strings.TrimPrefix(machine.ImageVersion(), "v")
+	candidate := strings.TrimPrefix(latest.Version, "v")
+	if current == "" || candidate == "" {
+		return true
+	}
+
+	curV, err := version.NewVersion(current)
+	if err != nil {
+		return true
+	}
+	latV, err := version.NewVersion(candidate)
+	if err != nil {
+		return true
+	}
+	return latV.GreaterThan(curV)
+}

--- a/internal/command/image/update_machines.go
+++ b/internal/command/image/update_machines.go
@@ -288,7 +288,7 @@ func resolveImage(ctx context.Context, machine fly.Machine) (string, error) {
 			return "", err
 		}
 
-		if latestImage != nil {
+		if latestImage != nil && IsUpdateCandidate(&machine, latestImage) {
 			image = latestImage.FullImageRef()
 		}
 

--- a/internal/command/status/machines.go
+++ b/internal/command/status/machines.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	fly "github.com/superfly/fly-go"
+	imagecmd "github.com/superfly/flyctl/internal/command/image"
 	"github.com/superfly/flyctl/internal/command/postgres"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flapsutil"
@@ -125,8 +126,10 @@ func RenderMachineStatus(ctx context.Context, app *fly.AppCompact, out io.Writer
 			latest = latestImage
 		}
 
-		// Exclude machines that are already running the latest version
-		if machine.ImageRef.Digest == latest.Digest {
+		// Exclude machines that are already running the latest version, and
+		// skip cases where the resolver returned an older or non-newer build
+		// to avoid suggesting downgrades.
+		if !imagecmd.IsUpdateCandidate(machine, latest) {
 			continue
 		}
 		updatable = append(updatable, machine)
@@ -319,8 +322,10 @@ func renderPGStatus(ctx context.Context, app *fly.AppCompact, machines []*fly.Ma
 			return fmt.Errorf("major version mismatch detected")
 		}
 
-		// Exclude machines that are already running the latest version
-		if machine.ImageRef.Digest == latest.Digest {
+		// Exclude machines that are already running the latest version, and
+		// skip cases where the resolver returned an older or non-newer build
+		// to avoid suggesting downgrades.
+		if !imagecmd.IsUpdateCandidate(machine, latest) {
 			continue
 		}
 		updatable = append(updatable, machine)


### PR DESCRIPTION
Fixes #4812

The backend `latestImageDetails` resolver can return an image with a lower fly.version than the machine's current one (e.g. for flyio/postgres-flex:16 on v0.2.0 it returns the stale pinned tag 16.6 at v0.1.0). The previous digest-only update check treated any digest mismatch as an update, so users were prompted to downgrade.

Add an `IsUpdateCandidate` helper that only reports an update when the returned fly.version parses as strictly newer than the machine's current fly.version, falling back to digest inequality when either version is missing or unparseable (preserving prior behavior for custom images).

Wire it into the three call sites that previously compared digests directly: `fly image show`, `fly image update`'s resolveImage, and `fly status`.
