### PR TITLE
fix(sftp): honor ctx cancellation in find and recursive get

### DIFF
--- a/internal/command/ssh/sftp.go
+++ b/internal/command/ssh/sftp.go
@@ -189,6 +189,9 @@ func runLs(ctx context.Context) error {
 
 	walker := ftp.Walk(root)
 	for walker.Step() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err = walker.Err(); err != nil {
 			return err
 		}
@@ -285,6 +288,9 @@ func runGetDir(ctx context.Context, ftp *sftp.Client, remote, local string) erro
 
 	// Download all files into ZIP
 	for walker.Step() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err = walker.Err(); err != nil {
 			return fmt.Errorf("walk remote directory: %w", err)
 		}


### PR DESCRIPTION
Fixes #4657

`fly sftp find` and `fly sftp get -R` iterate a `pkg/sftp` walker over remote directory listings without ever checking the context passed into the command. flyctl's root context is already wired to SIGINT via `signal.NotifyContext` in main.go, so Ctrl-C cancels the context immediately — but the walker loops never ask, leaving the command running until the tree is exhausted.

Add a per-iteration `ctx.Err()` check at the top of each loop body. Also, returning `context.Canceled` is silenced by the root handler in internal/cli/cli.go, producing a clean exit with code 127 — same UX as `fly ssh console` on Ctrl-C.