### PR TITLE
fix(auth): include --access-token flag in session-timeout bypass

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -30,6 +30,7 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"github.com/superfly/flyctl/internal/incidents"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/metrics"
@@ -573,11 +574,7 @@ func RequireSession(ctx context.Context) (context.Context, error) {
 		return handleReLogin(ctx, "not_authenticated")
 	}
 
-	// Skip timestamp validation if token is from environment variable (CI/CD use case)
-	// This allows automated pipelines to continue working without session timeout
-	tokenFromEnv := env.First(config.AccessTokenEnvKey, config.APITokenEnvKey) != ""
-
-	if !tokenFromEnv {
+	if !hasExternallySuppliedToken(ctx) {
 		// Check if the token has expired due to age
 		// If LastLogin is zero, it means the user has an old config without the timestamp
 		if cfg.LastLogin.IsZero() {
@@ -597,6 +594,20 @@ func RequireSession(ctx context.Context) (context.Context, error) {
 	config.MonitorTokens(ctx, config.Tokens(ctx), tryOpenUserURL)
 
 	return ctx, nil
+}
+
+// hasExternallySuppliedToken reports whether the user supplied an auth token
+// via the FLY_ACCESS_TOKEN / FLY_API_TOKEN env vars or the --access-token
+// flag. These are non-interactive auth paths (CI/CD use cases) and must
+// bypass the interactive session-age re-login prompt — otherwise CI runs
+// without a LastLogin timestamp fail with ErrNoAuthToken even when the
+// caller explicitly provided a valid token.
+func hasExternallySuppliedToken(ctx context.Context) bool {
+	if env.First(config.AccessTokenEnvKey, config.APITokenEnvKey) != "" {
+		return true
+	}
+
+	return flag.GetString(ctx, flagnames.AccessToken) != ""
 }
 
 // handleReLogin prompts the user to log in and handles the re-login flow

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1,0 +1,54 @@
+package command
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flag/flagnames"
+)
+
+func TestHasExternallySuppliedToken(t *testing.T) {
+	t.Run("env var set", func(t *testing.T) {
+		t.Setenv("FLY_ACCESS_TOKEN", "x")
+		ctx := withAccessTokenFlagContext(context.Background(), "")
+
+		if !hasExternallySuppliedToken(ctx) {
+			t.Fatal("expected true when FLY_ACCESS_TOKEN is set")
+		}
+	})
+
+	t.Run("flag set", func(t *testing.T) {
+		t.Setenv("FLY_ACCESS_TOKEN", "")
+		t.Setenv("FLY_API_TOKEN", "")
+		ctx := withAccessTokenFlagContext(context.Background(), "tok")
+
+		if !hasExternallySuppliedToken(ctx) {
+			t.Fatal("expected true when --access-token flag is set")
+		}
+	})
+
+	t.Run("neither set", func(t *testing.T) {
+		t.Setenv("FLY_ACCESS_TOKEN", "")
+		t.Setenv("FLY_API_TOKEN", "")
+		ctx := withAccessTokenFlagContext(context.Background(), "")
+
+		if hasExternallySuppliedToken(ctx) {
+			t.Fatal("expected false when neither env nor flag is set")
+		}
+	})
+}
+
+// withAccessTokenFlagContext returns ctx with a flag set that has the
+// access-token flag registered (and optionally pre-set). Mirrors how cobra
+// constructs the flag context during command preparation.
+func withAccessTokenFlagContext(ctx context.Context, value string) context.Context {
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String(flagnames.AccessToken, "", "")
+	if value != "" {
+		_ = fs.Set(flagnames.AccessToken, value)
+	}
+
+	return flag.NewContext(ctx, fs)
+}


### PR DESCRIPTION
Fixes #4648.

[PR #4645](https://github.com/superfly/flyctl/pull/4645) added a 30-day re-login prompt with a CI bypass for `FLY_ACCESS_TOKEN` / `FLY_API_TOKEN` env vars but missed the `--access-token (-t)` persistent flag. The result: long-documented CI patterns like flyctl proxy --app $APP --access-token $TOKEN started failing with "no auth token" in v0.3.210 even when a valid token was supplied.

Extracts the bypass condition into a small hasExternallySuppliedToken helper and adds the flag to it. Token precedence is unchanged, applyFlags already populates cfg.Tokens from the flag during the LoadConfig preparer, before RequireSession runs. The bypass change just stops the re-login prompt from firing for an auth path that's already authenticated.

Adds a focused unit test for the helper covering env-only, flag-only, and neither-set cases. 