### PR TITLE
refactor: use Flaps CreateApp for app creation

### DIFF
--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/superfly/flyctl/ssh"
 
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appsecrets"
 	"github.com/superfly/flyctl/internal/buildinfo"
@@ -389,33 +390,27 @@ func (l *Launcher) getPostgresConfig(config *CreateClusterInput) *fly.MachineCon
 
 func (l *Launcher) createApp(ctx context.Context, config *CreateClusterInput) (*fly.AppCompact, error) {
 	fmt.Println("Creating app...")
-	appInput := fly.CreateAppInput{
-		OrganizationID:  config.Organization.ID,
-		Name:            config.AppName,
-		PreferredRegion: &config.Region,
-		AppRoleID:       "postgres_cluster",
-	}
-
-	app, err := l.client.CreateApp(ctx, appInput)
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	app, err := flapsClient.CreateApp(ctx, flaps.CreateAppRequest{
+		Org:       config.Organization.Slug,
+		Name:      config.AppName,
+		AppRoleID: "postgres_cluster",
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	f := flapsutil.ClientFromContext(ctx)
-	if err := f.WaitForApp(ctx, app.Name); err != nil {
+	if err := flapsClient.WaitForApp(ctx, app.Name); err != nil {
 		return nil, err
 	}
 
 	return &fly.AppCompact{
-		ID:       app.ID,
-		Name:     app.Name,
-		Status:   app.Status,
-		Deployed: app.Deployed,
-		Hostname: app.Hostname,
-		AppURL:   app.AppURL,
+		ID:     app.ID,
+		Name:   app.Name,
+		Status: app.Status,
 		Organization: &fly.OrganizationBasic{
-			ID:   app.Organization.ID,
-			Slug: app.Organization.Slug,
+			ID:   config.Organization.ID,
+			Slug: config.Organization.Slug,
 		},
 	}, nil
 }

--- a/internal/command/apps/create.go
+++ b/internal/command/apps/create.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -15,6 +15,7 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/haikunator"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/internal/state"
@@ -91,10 +92,13 @@ func RunCreate(ctx context.Context) (err error) {
 	case fName != "":
 		name = fName
 	case fGenerateName:
-		break
+		name = haikunator.GeneratedAppName()
 	default:
 		if name, err = prompt.SelectAppName(ctx); err != nil {
 			return
+		}
+		if name == "" {
+			name = haikunator.GeneratedAppName()
 		}
 	}
 
@@ -103,28 +107,32 @@ func RunCreate(ctx context.Context) (err error) {
 		return
 	}
 
-	input := fly.CreateAppInput{
-		Name:           name,
-		OrganizationID: org.ID,
-		Machines:       true,
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	createReq := flaps.CreateAppRequest{
+		Name: name,
+		Org:  org.Slug,
 	}
 
 	if v := flag.GetString(ctx, "network"); v != "" {
-		input.Network = new(v)
+		createReq.Network = v
 	}
 
-	app, err := apiClient.CreateApp(ctx, input)
+	app, err := flapsClient.CreateApp(ctx, createReq)
 	if err != nil {
 		return err
 	}
 
-	f := flapsutil.ClientFromContext(ctx)
-	if err := f.WaitForApp(ctx, app.Name); err != nil {
+	if err := flapsClient.WaitForApp(ctx, app.Name); err != nil {
 		return err
 	}
 
 	if cfg.JSONOutput {
-		return render.JSON(io.Out, app)
+		fullApp, err := apiClient.GetApp(ctx, app.Name)
+		if err != nil {
+			return err
+		}
+
+		return render.JSON(io.Out, fullApp)
 	}
 
 	fmt.Fprintf(io.Out, "New app created: %s\n", app.Name)

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/go-units"
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/appsecrets"
@@ -17,7 +18,6 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"github.com/superfly/flyctl/internal/flapsutil"
-	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/tracing"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -380,26 +380,30 @@ func (state *launchState) updateConfig(ctx context.Context) {
 
 // createApp creates the fly.io app for the plan
 func (state *launchState) createApp(ctx context.Context) (*fly.App, error) {
-	apiClient := flyutil.ClientFromContext(ctx)
-
 	org, err := state.orgCompact(ctx)
 	if err != nil {
 		return nil, err
 	}
-	app, err := apiClient.CreateApp(ctx, fly.CreateAppInput{
-		OrganizationID:  org.Id,
-		Name:            state.Plan.AppName,
-		PreferredRegion: &state.Plan.RegionCode,
-		Machines:        true,
+
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	app, err := flapsClient.CreateApp(ctx, flaps.CreateAppRequest{
+		Name: state.Plan.AppName,
+		Org:  org.Slug,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	f := flapsutil.ClientFromContext(ctx)
-	if err := f.WaitForApp(ctx, app.Name); err != nil {
+	if err := flapsClient.WaitForApp(ctx, app.Name); err != nil {
 		return nil, err
 	}
 
-	return app, nil
+	return &fly.App{
+		ID:     app.ID,
+		Name:   app.Name,
+		Status: app.Status,
+		Organization: fly.Organization{
+			Slug: app.Organization.Slug,
+		},
+	}, nil
 }

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -564,8 +565,9 @@ func getOrCreateEphemeralShellApp(ctx context.Context, client flyutil.Client) (*
 	if appc == nil {
 		shellAppName := fmt.Sprintf("flyctl-interactive-shells-%s-%d", strings.ToLower(org.ID), rand.Intn(1_000_000))
 		shellAppName = strings.TrimRight(shellAppName[:min(len(shellAppName), 63)], "-")
-		appc, err = client.CreateApp(ctx, fly.CreateAppInput{
-			OrganizationID: org.ID,
+		flapsClient := flapsutil.ClientFromContext(ctx)
+		createdApp, err := flapsClient.CreateApp(ctx, flaps.CreateAppRequest{
+			Org: org.Slug,
 			// I'll never find love again like the kind you give like the kind you send
 			Name: shellAppName,
 		})
@@ -573,10 +575,10 @@ func getOrCreateEphemeralShellApp(ctx context.Context, client flyutil.Client) (*
 			return nil, fmt.Errorf("create interactive shell app: %w", err)
 		}
 
-		f := flapsutil.ClientFromContext(ctx)
-		if err := f.WaitForApp(ctx, appc.Name); err != nil {
+		if err := flapsClient.WaitForApp(ctx, createdApp.Name); err != nil {
 			return nil, err
 		}
+		appc = &fly.App{Name: createdApp.Name}
 	}
 
 	// this app handle won't have all the metadata attached, so grab it
@@ -610,31 +612,26 @@ func createApp(ctx context.Context, message, name string, client flyutil.Client)
 		}
 	}
 
-	input := fly.CreateAppInput{
-		Name:           name,
-		OrganizationID: org.ID,
-	}
-
-	app, err := client.CreateApp(ctx, input)
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	app, err := flapsClient.CreateApp(ctx, flaps.CreateAppRequest{
+		Name: name,
+		Org:  org.Slug,
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	f := flapsutil.ClientFromContext(ctx)
-	if err := f.WaitForApp(ctx, app.Name); err != nil {
+	if err := flapsClient.WaitForApp(ctx, app.Name); err != nil {
 		return nil, err
 	}
 
 	return &fly.AppCompact{
-		ID:       app.ID,
-		Name:     app.Name,
-		Status:   app.Status,
-		Deployed: app.Deployed,
-		Hostname: app.Hostname,
-		AppURL:   app.AppURL,
+		ID:     app.ID,
+		Name:   app.Name,
+		Status: app.Status,
 		Organization: &fly.OrganizationBasic{
-			ID:   app.Organization.ID,
-			Slug: app.Organization.Slug,
+			ID:   org.ID,
+			Slug: org.Slug,
 		},
 	}, nil
 }

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/haikunator"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/iostreams"
@@ -44,6 +45,10 @@ func newCreate() *cobra.Command {
 			Name:        "name",
 			Shorthand:   "n",
 			Description: "The name of your Postgres app",
+		},
+		flag.Bool{
+			Name:        "generate-name",
+			Description: "Generate an app name",
 		},
 		flag.String{
 			Name:        "password",
@@ -109,8 +114,12 @@ func run(ctx context.Context) (err error) {
 	prompt.PlatformRegions(ctx)
 
 	if appName == "" {
-		if appName, err = prompt.SelectAppName(ctx); err != nil {
+		if flag.GetBool(ctx, "generate-name") {
+			appName = haikunator.GeneratedAppNameWithPrefix("upg")
+		} else if appName, err = prompt.SelectAppName(ctx); err != nil {
 			return
+		} else if appName == "" {
+			appName = haikunator.GeneratedAppNameWithPrefix("upg")
 		}
 	}
 

--- a/internal/haikunator/haikunator.go
+++ b/internal/haikunator/haikunator.go
@@ -20,6 +20,15 @@ var adjectives = strings.Fields(`
 	sparkling thrumming shy wandering withered wild black
 	young holy solitary fragrant aged snowy proud floral
 	restless divine polished ancient purple lively nameless
+	amber gentle bright calm silver golden mellow radiant
+	soft tranquil velvet lucid rosy tender dusky sunlit
+	starlit moonlit windblown graceful mellowed vivid mellowing
+	verdant russet glowing drifting rolling humming gleaming
+	peaceful faithful agile noble tidy ambered airy cinder
+	marbled lustrous dappled kind coral lilac copper willow
+	brisk serene curious plucky jaunty earnest honeyed satin
+	ivory azure ambergris evergreen rippling glimmering unfurling
+	shimmering buoyant wistful
 `)
 
 var nouns = strings.Fields(`
@@ -31,6 +40,14 @@ var nouns = strings.Fields(`
 	sound sky shape surf thunder violet water wildflower
 	wave stone resonance branch log dream cherry tree fog
 	frost voice paper frog smoke star
+	ocean canyon pebble harbor valley blossom petal lantern
+	comet aurora meadowlark shell driftwood cove ridge ember
+	stream island harborlight seastar meadowland hillside raindrop starlight
+	sunbeam moonbeam tide current lagoon harborbird skylark pinecone
+	acorn grove orchard garden pathway meadowbrook songbird beacon
+	marsh hollow coastline summit inlet woodland headland echo
+	horizon overbrook snowfall moonrise sunrise tidepool sandbar fern
+	willow reed coral shoreline song meadowstone harborwave glow
 `)
 
 type Builder struct {

--- a/internal/haikunator/haikunator.go
+++ b/internal/haikunator/haikunator.go
@@ -29,7 +29,7 @@ var nouns = strings.Fields(`
 	bush dew dust field fire flower firefly feather grass
 	haze mountain night pond darkness snowflake silence
 	sound sky shape surf thunder violet water wildflower
-	wave water resonance sun log dream cherry tree fog
+	wave stone resonance branch log dream cherry tree fog
 	frost voice paper frog smoke star
 `)
 
@@ -90,6 +90,22 @@ func (b *Builder) Build() string {
 
 func (b *Builder) String() string {
 	return b.Build()
+}
+
+func GeneratedAppName() string {
+	return GeneratedAppNameWithPrefix("")
+}
+
+func GeneratedAppNameWithPrefix(prefix string) string {
+	builder := Haikunator().TokenRange(0)
+	name := builder.Build()
+	token := strconv.FormatInt(int64(builder.RandN(1000)+1000), 10)[1:]
+
+	if prefix == "" {
+		return strings.Join([]string{name, token}, "-")
+	}
+
+	return strings.Join([]string{prefix, name, token}, "-")
 }
 
 // TrimSuffix removes a haiku name at the end of s, if it exists.


### PR DESCRIPTION
## Summary
- switch app creation paths from GraphQL `CreateApp` to Flaps `CreateApp`
- keep `fly apps create --json` compatible by refetching the full app before rendering
- simplify machine and postgres app-create helpers to return only the fields they actually use
- preserve existing launch output by adapting the Flaps response into the minimal app shape needed by callers

## Testing
- go test ./...
- golangci-lint run