### PR TITLE
Refine 'plan' flag description for Postgres cluster

### DIFF
--- a/internal/command/mpg/create.go
+++ b/internal/command/mpg/create.go
@@ -42,7 +42,7 @@ func newCreate() *cobra.Command {
 		},
 		flag.String{
 			Name:        "plan",
-			Description: "The plan to use for the Postgres cluster (development, production, etc)",
+			Description: "The plan to use for the Postgres cluster: Basic, Starter, Launch, Scale, Performance",
 		},
 		flag.Int{
 			Name:        "volume-size",


### PR DESCRIPTION
Updated the description for the 'plan' flag to specify available options. Previously just listed `development` and `production`, neither of which is a valid MPG plan :) 
