### PR TITLE
refactor: use Flaps DeleteApp for app deletion

### DIFF
--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -135,8 +135,8 @@ func (p *Provisioner) EnsureBuilder(ctx context.Context, region string, recreate
 
 		if validateBuilderErr != NoBuilderApp {
 			span.AddEvent(fmt.Sprintf("deleting existing invalid builder due to %s", validateBuilderErr))
-			client := flyutil.ClientFromContext(ctx)
-			err := client.DeleteApp(ctx, builderApp.Name)
+			flapsClient := flapsutil.ClientFromContext(ctx)
+			err := flapsClient.DeleteApp(ctx, builderApp.Name)
 			if err != nil {
 				tracing.RecordError(span, err, "error deleting invalid builder app")
 
@@ -148,8 +148,8 @@ func (p *Provisioner) EnsureBuilder(ctx context.Context, region string, recreate
 	} else {
 		span.AddEvent("recreating builder")
 		if builderApp != nil {
-			client := flyutil.ClientFromContext(ctx)
-			err := client.DeleteApp(ctx, builderApp.Name)
+			flapsClient := flapsutil.ClientFromContext(ctx)
+			err := flapsClient.DeleteApp(ctx, builderApp.Name)
 			if err != nil {
 				tracing.RecordError(span, err, "error deleting existing builder app")
 
@@ -385,7 +385,7 @@ func (p *Provisioner) createBuilder(ctx context.Context, region, builderName str
 	defer func() {
 		if retErr != nil {
 			span.AddEvent("cleaning up new builder app due to error")
-			client.DeleteApp(ctx, builderName)
+			flapsClient.DeleteApp(ctx, builderName)
 			_ = appsecrets.DeleteMinvers(ctx, builderName)
 		}
 	}()

--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command/deploy/statics"
 	"github.com/superfly/flyctl/internal/flag/completion"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 
 	"github.com/superfly/flyctl/iostreams"
@@ -48,6 +49,7 @@ func RunDestroy(ctx context.Context) error {
 	colorize := io.ColorScheme()
 	apps := flag.Args(ctx)
 	client := flyutil.ClientFromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	if len(apps) == 0 {
 		return fmt.Errorf("no app names provided")
@@ -93,7 +95,7 @@ func RunDestroy(ctx context.Context) error {
 			fmt.Fprintf(io.Out, "Destroyed statics bucket %s\n", bucket.Name)
 		}
 
-		if err := client.DeleteApp(ctx, appName); err != nil {
+		if err := flapsClient.DeleteApp(ctx, appName); err != nil {
 			return err
 		}
 

--- a/internal/mock/flaps_client.go
+++ b/internal/mock/flaps_client.go
@@ -108,6 +108,10 @@ func (m *FlapsClient) CreateVolumeSnapshot(ctx context.Context, appName, volumeI
 }
 
 func (m *FlapsClient) DeleteApp(ctx context.Context, name string) error {
+	if m.DeleteAppFunc == nil {
+		return nil
+	}
+
 	return m.DeleteAppFunc(ctx, name)
 }
 


### PR DESCRIPTION
## Summary
- switch app deletion paths from API client `DeleteApp` to Flaps `DeleteApp`
- update builder cleanup paths to use Flaps for deleting builder apps
- make the mock Flaps client `DeleteApp` nil-safe for tests

## Testing
- go test ./...
- golangci-lint run