### PR TITLE
fix: scope statics addon lookup by org

### DIFF
--- a/gql/generated.go
+++ b/gql/generated.go
@@ -2671,6 +2671,144 @@ type ListAddOnsResponse struct {
 // GetAddOns returns ListAddOnsResponse.AddOns, and is useful for accessing the field via an interface.
 func (v *ListAddOnsResponse) GetAddOns() ListAddOnsAddOnsAddOnConnection { return v.AddOns }
 
+// ListOrganizationAddOnsOrganization includes the requested fields of the GraphQL type Organization.
+type ListOrganizationAddOnsOrganization struct {
+	// List third party integrations associated with an organization
+	AddOns ListOrganizationAddOnsOrganizationAddOnsAddOnConnection `json:"addOns"`
+}
+
+// GetAddOns returns ListOrganizationAddOnsOrganization.AddOns, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganization) GetAddOns() ListOrganizationAddOnsOrganizationAddOnsAddOnConnection {
+	return v.AddOns
+}
+
+// ListOrganizationAddOnsOrganizationAddOnsAddOnConnection includes the requested fields of the GraphQL type AddOnConnection.
+// The GraphQL type's documentation follows.
+//
+// The connection type for AddOn.
+type ListOrganizationAddOnsOrganizationAddOnsAddOnConnection struct {
+	// A list of nodes.
+	Nodes []ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn `json:"nodes"`
+}
+
+// GetNodes returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnection.Nodes, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnection) GetNodes() []ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn {
+	return v.Nodes
+}
+
+// ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn includes the requested fields of the GraphQL type AddOn.
+type ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn struct {
+	AddOnData `json:"-"`
+}
+
+// GetId returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Id, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetId() string {
+	return v.AddOnData.Id
+}
+
+// GetName returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Name, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetName() string {
+	return v.AddOnData.Name
+}
+
+// GetPrimaryRegion returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.PrimaryRegion, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetPrimaryRegion() string {
+	return v.AddOnData.PrimaryRegion
+}
+
+// GetStatus returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Status, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetStatus() string {
+	return v.AddOnData.Status
+}
+
+// GetErrorMessage returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.ErrorMessage, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetErrorMessage() string {
+	return v.AddOnData.ErrorMessage
+}
+
+// GetMetadata returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Metadata, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetMetadata() interface{} {
+	return v.AddOnData.Metadata
+}
+
+// GetOptions returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Options, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetOptions() interface{} {
+	return v.AddOnData.Options
+}
+
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) UnmarshalJSON(b []byte) error {
+
+	if string(b) == "null" {
+		return nil
+	}
+
+	var firstPass struct {
+		*ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn
+		graphql.NoUnmarshalJSON
+	}
+	firstPass.ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn = v
+
+	err := json.Unmarshal(b, &firstPass)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(
+		b, &v.AddOnData)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type __premarshalListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn struct {
+	Id string `json:"id"`
+
+	Name string `json:"name"`
+
+	PrimaryRegion string `json:"primaryRegion"`
+
+	Status string `json:"status"`
+
+	ErrorMessage string `json:"errorMessage"`
+
+	Metadata interface{} `json:"metadata"`
+
+	Options interface{} `json:"options"`
+}
+
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) MarshalJSON() ([]byte, error) {
+	premarshaled, err := v.__premarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(premarshaled)
+}
+
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) __premarshalJSON() (*__premarshalListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn, error) {
+	var retval __premarshalListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn
+
+	retval.Id = v.AddOnData.Id
+	retval.Name = v.AddOnData.Name
+	retval.PrimaryRegion = v.AddOnData.PrimaryRegion
+	retval.Status = v.AddOnData.Status
+	retval.ErrorMessage = v.AddOnData.ErrorMessage
+	retval.Metadata = v.AddOnData.Metadata
+	retval.Options = v.AddOnData.Options
+	return &retval, nil
+}
+
+// ListOrganizationAddOnsResponse is returned by ListOrganizationAddOns on success.
+type ListOrganizationAddOnsResponse struct {
+	// Find an organization by ID
+	Organization ListOrganizationAddOnsOrganization `json:"organization"`
+}
+
+// GetOrganization returns ListOrganizationAddOnsResponse.Organization, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsResponse) GetOrganization() ListOrganizationAddOnsOrganization {
+	return v.Organization
+}
+
 // LogOutLogOutLogOutPayload includes the requested fields of the GraphQL type LogOutPayload.
 // The GraphQL type's documentation follows.
 //
@@ -3223,6 +3361,18 @@ type __ListAddOnsInput struct {
 
 // GetAddOnType returns __ListAddOnsInput.AddOnType, and is useful for accessing the field via an interface.
 func (v *__ListAddOnsInput) GetAddOnType() AddOnType { return v.AddOnType }
+
+// __ListOrganizationAddOnsInput is used internally by genqlient
+type __ListOrganizationAddOnsInput struct {
+	OrgSlug   string    `json:"orgSlug"`
+	AddOnType AddOnType `json:"addOnType"`
+}
+
+// GetOrgSlug returns __ListOrganizationAddOnsInput.OrgSlug, and is useful for accessing the field via an interface.
+func (v *__ListOrganizationAddOnsInput) GetOrgSlug() string { return v.OrgSlug }
+
+// GetAddOnType returns __ListOrganizationAddOnsInput.AddOnType, and is useful for accessing the field via an interface.
+func (v *__ListOrganizationAddOnsInput) GetAddOnType() AddOnType { return v.AddOnType }
 
 // __ResetAddOnPasswordInput is used internally by genqlient
 type __ResetAddOnPasswordInput struct {
@@ -4261,6 +4411,55 @@ func ListAddOns(
 	}
 
 	data_ = &ListAddOnsResponse{}
+	resp_ := &graphql.Response{Data: data_}
+
+	err_ = client_.MakeRequest(
+		ctx_,
+		req_,
+		resp_,
+	)
+
+	return data_, err_
+}
+
+// The query executed by ListOrganizationAddOns.
+const ListOrganizationAddOns_Operation = `
+query ListOrganizationAddOns ($orgSlug: String!, $addOnType: AddOnType) {
+	organization(slug: $orgSlug) {
+		addOns(type: $addOnType) {
+			nodes {
+				... AddOnData
+			}
+		}
+	}
+}
+fragment AddOnData on AddOn {
+	id
+	name
+	primaryRegion
+	status
+	errorMessage
+	metadata
+	options
+}
+`
+
+func ListOrganizationAddOns(
+	ctx_ context.Context,
+	client_ graphql.Client,
+	orgSlug string,
+	addOnType AddOnType,
+) (data_ *ListOrganizationAddOnsResponse, err_ error) {
+	req_ := &graphql.Request{
+		OpName: "ListOrganizationAddOns",
+		Query:  ListOrganizationAddOns_Operation,
+		Variables: &__ListOrganizationAddOnsInput{
+			OrgSlug:   orgSlug,
+			AddOnType: addOnType,
+		},
+	}
+
+	data_ = &ListOrganizationAddOnsResponse{}
 	resp_ := &graphql.Response{Data: data_}
 
 	err_ = client_.MakeRequest(

--- a/gql/generated.go
+++ b/gql/generated.go
@@ -2698,104 +2698,77 @@ func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnection) GetNodes() []L
 
 // ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn includes the requested fields of the GraphQL type AddOn.
 type ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn struct {
-	AddOnData `json:"-"`
+	Id string `json:"id"`
+	// The service name according to the provider
+	Name string `json:"name"`
+	// The add-on plan
+	AddOnPlan ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan `json:"addOnPlan"`
+	// Private flycast IP address of the add-on
+	PrivateIp string `json:"privateIp"`
+	// Region where the primary instance is deployed
+	PrimaryRegion string `json:"primaryRegion"`
+	// Regions where replica instances are deployed
+	ReadRegions []string `json:"readRegions"`
+	// Add-on options
+	Options interface{} `json:"options"`
+	// Add-on metadata
+	Metadata interface{} `json:"metadata"`
 }
 
 // GetId returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Id, and is useful for accessing the field via an interface.
 func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetId() string {
-	return v.AddOnData.Id
+	return v.Id
 }
 
 // GetName returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Name, and is useful for accessing the field via an interface.
 func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetName() string {
-	return v.AddOnData.Name
+	return v.Name
+}
+
+// GetAddOnPlan returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.AddOnPlan, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetAddOnPlan() ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan {
+	return v.AddOnPlan
+}
+
+// GetPrivateIp returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.PrivateIp, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetPrivateIp() string {
+	return v.PrivateIp
 }
 
 // GetPrimaryRegion returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.PrimaryRegion, and is useful for accessing the field via an interface.
 func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetPrimaryRegion() string {
-	return v.AddOnData.PrimaryRegion
+	return v.PrimaryRegion
 }
 
-// GetStatus returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Status, and is useful for accessing the field via an interface.
-func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetStatus() string {
-	return v.AddOnData.Status
-}
-
-// GetErrorMessage returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.ErrorMessage, and is useful for accessing the field via an interface.
-func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetErrorMessage() string {
-	return v.AddOnData.ErrorMessage
-}
-
-// GetMetadata returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Metadata, and is useful for accessing the field via an interface.
-func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetMetadata() interface{} {
-	return v.AddOnData.Metadata
+// GetReadRegions returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.ReadRegions, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetReadRegions() []string {
+	return v.ReadRegions
 }
 
 // GetOptions returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Options, and is useful for accessing the field via an interface.
 func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetOptions() interface{} {
-	return v.AddOnData.Options
+	return v.Options
 }
 
-func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) UnmarshalJSON(b []byte) error {
-
-	if string(b) == "null" {
-		return nil
-	}
-
-	var firstPass struct {
-		*ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn
-		graphql.NoUnmarshalJSON
-	}
-	firstPass.ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn = v
-
-	err := json.Unmarshal(b, &firstPass)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(
-		b, &v.AddOnData)
-	if err != nil {
-		return err
-	}
-	return nil
+// GetMetadata returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn.Metadata, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) GetMetadata() interface{} {
+	return v.Metadata
 }
 
-type __premarshalListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn struct {
-	Id string `json:"id"`
-
-	Name string `json:"name"`
-
-	PrimaryRegion string `json:"primaryRegion"`
-
-	Status string `json:"status"`
-
-	ErrorMessage string `json:"errorMessage"`
-
-	Metadata interface{} `json:"metadata"`
-
-	Options interface{} `json:"options"`
+// ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan includes the requested fields of the GraphQL type AddOnPlan.
+type ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan struct {
+	DisplayName string `json:"displayName"`
+	Description string `json:"description"`
 }
 
-func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) MarshalJSON() ([]byte, error) {
-	premarshaled, err := v.__premarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(premarshaled)
+// GetDisplayName returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan.DisplayName, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan) GetDisplayName() string {
+	return v.DisplayName
 }
 
-func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn) __premarshalJSON() (*__premarshalListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn, error) {
-	var retval __premarshalListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn
-
-	retval.Id = v.AddOnData.Id
-	retval.Name = v.AddOnData.Name
-	retval.PrimaryRegion = v.AddOnData.PrimaryRegion
-	retval.Status = v.AddOnData.Status
-	retval.ErrorMessage = v.AddOnData.ErrorMessage
-	retval.Metadata = v.AddOnData.Metadata
-	retval.Options = v.AddOnData.Options
-	return &retval, nil
+// GetDescription returns ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan.Description, and is useful for accessing the field via an interface.
+func (v *ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOnAddOnPlan) GetDescription() string {
+	return v.Description
 }
 
 // ListOrganizationAddOnsResponse is returned by ListOrganizationAddOns on success.
@@ -4428,19 +4401,20 @@ query ListOrganizationAddOns ($orgSlug: String!, $addOnType: AddOnType) {
 	organization(slug: $orgSlug) {
 		addOns(type: $addOnType) {
 			nodes {
-				... AddOnData
+				id
+				name
+				addOnPlan {
+					displayName
+					description
+				}
+				privateIp
+				primaryRegion
+				readRegions
+				options
+				metadata
 			}
 		}
 	}
-}
-fragment AddOnData on AddOn {
-	id
-	name
-	primaryRegion
-	status
-	errorMessage
-	metadata
-	options
 }
 `
 

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -265,6 +265,16 @@ query ListAddOns($addOnType: AddOnType) {
 	}
 }
 
+query ListOrganizationAddOns($orgSlug: String!, $addOnType: AddOnType) {
+	organization(slug: $orgSlug) {
+		addOns(type: $addOnType) {
+			nodes {
+				...AddOnData
+			}
+		}
+	}
+}
+
  mutation UpdateAddOn($addOnId: ID!, $planId: ID!, $readRegions: [String!]!, $options: JSON!, $metadata: JSON!) {
 		updateAddOn(input: {addOnId: $addOnId, planId: $planId, readRegions: $readRegions, options: $options, metadata: $metadata}) {
 			addOn {

--- a/gql/genqclient.graphql
+++ b/gql/genqclient.graphql
@@ -269,7 +269,17 @@ query ListOrganizationAddOns($orgSlug: String!, $addOnType: AddOnType) {
 	organization(slug: $orgSlug) {
 		addOns(type: $addOnType) {
 			nodes {
-				...AddOnData
+				id
+				name
+				addOnPlan {
+					displayName
+					description
+				}
+				privateIp
+				primaryRegion
+				readRegions
+				options
+				metadata
 			}
 		}
 	}

--- a/gql/types.go
+++ b/gql/types.go
@@ -2,6 +2,7 @@ package gql
 
 // Alias unwieldy types from GraphQL generated code
 type AddOn = CreateAddOnCreateAddOnCreateAddOnPayloadAddOn
+type StaticsAddOn = ListOrganizationAddOnsOrganizationAddOnsAddOnConnectionNodesAddOn
 type AddOnOptions map[string]any
 type LimitedAccessTokenOptions map[string]any
 type AddOnEnvironment map[string]any

--- a/internal/command/deploy/statics/addon.go
+++ b/internal/command/deploy/statics/addon.go
@@ -21,12 +21,11 @@ import (
 
 // FindBucket finds the tigris statics bucket for the given app and org.
 // Returns nil, nil if no bucket is found.
-func FindBucket(ctx context.Context, app *fly.App, org *fly.Organization) (*gql.ListAddOnsAddOnsAddOnConnectionNodesAddOn, error) {
-
+func FindBucket(ctx context.Context, app *fly.App, org *fly.Organization) (*gql.StaticsAddOn, error) {
 	client := flyutil.ClientFromContext(ctx)
 	gqlClient := client.GenqClient()
 
-	response, err := gql.ListAddOns(ctx, gqlClient, "tigris")
+	response, err := gql.ListOrganizationAddOns(ctx, gqlClient, org.Slug, "tigris")
 	if err != nil {
 		return nil, err
 	}
@@ -34,11 +33,8 @@ func FindBucket(ctx context.Context, app *fly.App, org *fly.Organization) (*gql.
 	// Using string comparison here because we might want to use BigInt app IDs in the future.
 	internalAppIdStr := strconv.FormatUint(uint64(app.InternalNumericID), 10)
 
-	for _, extension := range response.AddOns.Nodes {
+	for _, extension := range response.Organization.AddOns.Nodes {
 		if extension.Metadata == nil {
-			continue
-		}
-		if extension.Organization.Slug != org.Slug {
 			continue
 		}
 		if extension.Metadata.(map[string]any)[staticsMetaKeyAppId] == internalAppIdStr {

--- a/internal/command/deploy/statics/addon.go
+++ b/internal/command/deploy/statics/addon.go
@@ -34,10 +34,15 @@ func FindBucket(ctx context.Context, app *fly.App, org *fly.Organization) (*gql.
 	internalAppIdStr := strconv.FormatUint(uint64(app.InternalNumericID), 10)
 
 	for _, extension := range response.Organization.AddOns.Nodes {
-		if extension.Metadata == nil {
+		meta, ok := extension.Metadata.(map[string]any)
+		if !ok {
 			continue
 		}
-		if extension.Metadata.(map[string]any)[staticsMetaKeyAppId] == internalAppIdStr {
+		appID, ok := meta[staticsMetaKeyAppId].(string)
+		if !ok {
+			continue
+		}
+		if appID == internalAppIdStr {
 			return &extension, nil
 		}
 	}

--- a/internal/command/deploy/statics/move.go
+++ b/internal/command/deploy/statics/move.go
@@ -19,7 +19,7 @@ import (
 // all the files from the old bucket to the new bucket - then deletes the old bucket.
 func MoveBucket(
 	ctx context.Context,
-	prevBucket *gql.ListAddOnsAddOnsAddOnConnectionNodesAddOn,
+	prevBucket *gql.StaticsAddOn,
 	prevOrg *fly.Organization,
 	app *fly.App,
 	targetOrg *fly.Organization,

--- a/internal/command/extensions/arcjet/list.go
+++ b/internal/command/extensions/arcjet/list.go
@@ -36,20 +36,36 @@ func list() (cmd *cobra.Command) {
 
 func runList(ctx context.Context) (err error) {
 	var (
-		out    = iostreams.FromContext(ctx).Out
-		client = flyutil.ClientFromContext(ctx).GenqClient()
+		out       = iostreams.FromContext(ctx).Out
+		apiClient = flyutil.ClientFromContext(ctx)
+		client    = apiClient.GenqClient()
+		orgSlug   = flag.GetOrg(ctx)
 	)
-
-	response, err := gql.ListAddOns(ctx, client, gql.AddOnTypeArcjet)
 
 	var rows [][]string
 
-	for _, addon := range response.AddOns.Nodes {
-		rows = append(rows, []string{
-			addon.Name,
-			addon.Organization.Slug,
-			addon.PrimaryRegion,
-		})
+	if orgSlug != "" {
+		if _, err := apiClient.GetOrganizationBySlug(ctx, orgSlug); err != nil {
+			return err
+		}
+
+		response, err := gql.ListOrganizationAddOns(ctx, client, orgSlug, gql.AddOnTypeArcjet)
+		if err != nil {
+			return err
+		}
+
+		for _, addon := range response.Organization.AddOns.Nodes {
+			rows = append(rows, []string{addon.Name, orgSlug, addon.PrimaryRegion})
+		}
+	} else {
+		response, err := gql.ListAddOns(ctx, client, gql.AddOnTypeArcjet)
+		if err != nil {
+			return err
+		}
+
+		for _, addon := range response.AddOns.Nodes {
+			rows = append(rows, []string{addon.Name, addon.Organization.Slug, addon.PrimaryRegion})
+		}
 	}
 
 	_ = render.Table(out, "", rows, "Name", "Org")

--- a/internal/command/extensions/fly_mysql/list.go
+++ b/internal/command/extensions/fly_mysql/list.go
@@ -36,20 +36,36 @@ func list() (cmd *cobra.Command) {
 
 func runList(ctx context.Context) (err error) {
 	var (
-		out    = iostreams.FromContext(ctx).Out
-		client = flyutil.ClientFromContext(ctx).GenqClient()
+		out       = iostreams.FromContext(ctx).Out
+		apiClient = flyutil.ClientFromContext(ctx)
+		client    = apiClient.GenqClient()
+		orgSlug   = flag.GetOrg(ctx)
 	)
-
-	response, err := gql.ListAddOns(ctx, client, "fly_mysql")
 
 	var rows [][]string
 
-	for _, addon := range response.AddOns.Nodes {
-		rows = append(rows, []string{
-			addon.Name,
-			addon.Organization.Slug,
-			addon.PrimaryRegion,
-		})
+	if orgSlug != "" {
+		if _, err := apiClient.GetOrganizationBySlug(ctx, orgSlug); err != nil {
+			return err
+		}
+
+		response, err := gql.ListOrganizationAddOns(ctx, client, orgSlug, "fly_mysql")
+		if err != nil {
+			return err
+		}
+
+		for _, addon := range response.Organization.AddOns.Nodes {
+			rows = append(rows, []string{addon.Name, orgSlug, addon.PrimaryRegion})
+		}
+	} else {
+		response, err := gql.ListAddOns(ctx, client, "fly_mysql")
+		if err != nil {
+			return err
+		}
+
+		for _, addon := range response.AddOns.Nodes {
+			rows = append(rows, []string{addon.Name, addon.Organization.Slug, addon.PrimaryRegion})
+		}
 	}
 
 	_ = render.Table(out, "", rows, "Name", "Org", "Primary Region")

--- a/internal/command/extensions/sentry/list.go
+++ b/internal/command/extensions/sentry/list.go
@@ -36,19 +36,36 @@ func list() (cmd *cobra.Command) {
 
 func runList(ctx context.Context) (err error) {
 	var (
-		out    = iostreams.FromContext(ctx).Out
-		client = flyutil.ClientFromContext(ctx).GenqClient()
+		out       = iostreams.FromContext(ctx).Out
+		apiClient = flyutil.ClientFromContext(ctx)
+		client    = apiClient.GenqClient()
+		orgSlug   = flag.GetOrg(ctx)
 	)
-
-	response, err := gql.ListAddOns(ctx, client, "sentry")
 
 	var rows [][]string
 
-	for _, extension := range response.AddOns.Nodes {
-		rows = append(rows, []string{
-			extension.Name,
-			extension.Organization.Slug,
-		})
+	if orgSlug != "" {
+		if _, err := apiClient.GetOrganizationBySlug(ctx, orgSlug); err != nil {
+			return err
+		}
+
+		response, err := gql.ListOrganizationAddOns(ctx, client, orgSlug, "sentry")
+		if err != nil {
+			return err
+		}
+
+		for _, extension := range response.Organization.AddOns.Nodes {
+			rows = append(rows, []string{extension.Name, orgSlug})
+		}
+	} else {
+		response, err := gql.ListAddOns(ctx, client, "sentry")
+		if err != nil {
+			return err
+		}
+
+		for _, extension := range response.AddOns.Nodes {
+			rows = append(rows, []string{extension.Name, extension.Organization.Slug})
+		}
 	}
 
 	_ = render.Table(out, "", rows, "Name", "Org")

--- a/internal/command/extensions/supabase/list.go
+++ b/internal/command/extensions/supabase/list.go
@@ -36,20 +36,36 @@ func list() (cmd *cobra.Command) {
 
 func runList(ctx context.Context) (err error) {
 	var (
-		out    = iostreams.FromContext(ctx).Out
-		client = flyutil.ClientFromContext(ctx).GenqClient()
+		out       = iostreams.FromContext(ctx).Out
+		apiClient = flyutil.ClientFromContext(ctx)
+		client    = apiClient.GenqClient()
+		orgSlug   = flag.GetOrg(ctx)
 	)
-
-	response, err := gql.ListAddOns(ctx, client, "supabase")
 
 	var rows [][]string
 
-	for _, addon := range response.AddOns.Nodes {
-		rows = append(rows, []string{
-			addon.Name,
-			addon.Organization.Slug,
-			addon.PrimaryRegion,
-		})
+	if orgSlug != "" {
+		if _, err := apiClient.GetOrganizationBySlug(ctx, orgSlug); err != nil {
+			return err
+		}
+
+		response, err := gql.ListOrganizationAddOns(ctx, client, orgSlug, "supabase")
+		if err != nil {
+			return err
+		}
+
+		for _, addon := range response.Organization.AddOns.Nodes {
+			rows = append(rows, []string{addon.Name, orgSlug, addon.PrimaryRegion})
+		}
+	} else {
+		response, err := gql.ListAddOns(ctx, client, "supabase")
+		if err != nil {
+			return err
+		}
+
+		for _, addon := range response.AddOns.Nodes {
+			rows = append(rows, []string{addon.Name, addon.Organization.Slug, addon.PrimaryRegion})
+		}
 	}
 
 	_ = render.Table(out, "", rows, "Name", "Org", "Primary Region")

--- a/internal/command/extensions/tigris/list.go
+++ b/internal/command/extensions/tigris/list.go
@@ -36,19 +36,36 @@ func list() (cmd *cobra.Command) {
 
 func runList(ctx context.Context) (err error) {
 	var (
-		out    = iostreams.FromContext(ctx).Out
-		client = flyutil.ClientFromContext(ctx).GenqClient()
+		out       = iostreams.FromContext(ctx).Out
+		apiClient = flyutil.ClientFromContext(ctx)
+		client    = apiClient.GenqClient()
+		orgSlug   = flag.GetOrg(ctx)
 	)
-
-	response, err := gql.ListAddOns(ctx, client, "tigris")
 
 	var rows [][]string
 
-	for _, extension := range response.AddOns.Nodes {
-		rows = append(rows, []string{
-			extension.Name,
-			extension.Organization.Slug,
-		})
+	if orgSlug != "" {
+		if _, err := apiClient.GetOrganizationBySlug(ctx, orgSlug); err != nil {
+			return err
+		}
+
+		response, err := gql.ListOrganizationAddOns(ctx, client, orgSlug, "tigris")
+		if err != nil {
+			return err
+		}
+
+		for _, extension := range response.Organization.AddOns.Nodes {
+			rows = append(rows, []string{extension.Name, orgSlug})
+		}
+	} else {
+		response, err := gql.ListAddOns(ctx, client, "tigris")
+		if err != nil {
+			return err
+		}
+
+		for _, extension := range response.AddOns.Nodes {
+			rows = append(rows, []string{extension.Name, extension.Organization.Slug})
+		}
 	}
 
 	_ = render.Table(out, "", rows, "Name", "Org")

--- a/internal/command/extensions/vector/list.go
+++ b/internal/command/extensions/vector/list.go
@@ -32,19 +32,33 @@ func list() (cmd *cobra.Command) {
 }
 
 func runList(ctx context.Context) (err error) {
-	client := flyutil.ClientFromContext(ctx).GenqClient()
-	response, err := gql.ListAddOns(ctx, client, "upstash_vector")
-	if err != nil {
-		return err
-	}
+	apiClient := flyutil.ClientFromContext(ctx)
+	client := apiClient.GenqClient()
+	orgSlug := flag.GetOrg(ctx)
 
 	var rows [][]string
-	for _, extension := range response.AddOns.Nodes {
-		rows = append(rows, []string{
-			extension.Name,
-			extension.Organization.Slug,
-			extension.PrimaryRegion,
-		})
+	if orgSlug != "" {
+		if _, err := apiClient.GetOrganizationBySlug(ctx, orgSlug); err != nil {
+			return err
+		}
+
+		response, err := gql.ListOrganizationAddOns(ctx, client, orgSlug, "upstash_vector")
+		if err != nil {
+			return err
+		}
+
+		for _, extension := range response.Organization.AddOns.Nodes {
+			rows = append(rows, []string{extension.Name, orgSlug, extension.PrimaryRegion})
+		}
+	} else {
+		response, err := gql.ListAddOns(ctx, client, "upstash_vector")
+		if err != nil {
+			return err
+		}
+
+		for _, extension := range response.AddOns.Nodes {
+			rows = append(rows, []string{extension.Name, extension.Organization.Slug, extension.PrimaryRegion})
+		}
 	}
 
 	out := iostreams.FromContext(ctx).Out

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -232,18 +232,18 @@ func (state *launchState) validateExtensions(ctx context.Context) error {
 			return nil
 		}
 
-		// We're using Supabase. Ensure that we're within plan limits.
+		// We're using Supabase. Ensure that we're within plan limits for the target org.
 		client := flyutil.ClientFromContext(ctx).GenqClient()
 
-		response, err := gql.ListAddOns(ctx, client, "supabase")
+		response, err := gql.ListOrganizationAddOns(ctx, client, org.Slug, "supabase")
 		if err != nil {
-			return fmt.Errorf("failed to list Supabase databases: %w", err)
+			return fmt.Errorf("failed to list Supabase databases for org %q: %w", org.Slug, err)
 		}
 
 		// TODO: We'd like to be able to query the user's plan to see if they're on a paid plan.
 		//       For now, we'll just nag when they create their second database, every time.
 
-		if len(response.AddOns.Nodes) != 1 {
+		if len(response.Organization.AddOns.Nodes) != 1 {
 			// If we're at zero databases, we're within the free plan.
 			// If we're at >=2 databases, we know we're on a paid plan.
 			// It's only 1 existing database where we need to validate the plan.

--- a/internal/command/redis/list.go
+++ b/internal/command/redis/list.go
@@ -35,34 +35,49 @@ func newList() (cmd *cobra.Command) {
 
 func runList(ctx context.Context) (err error) {
 	var (
-		out    = iostreams.FromContext(ctx).Out
-		client = flyutil.ClientFromContext(ctx).GenqClient()
+		out       = iostreams.FromContext(ctx).Out
+		apiClient = flyutil.ClientFromContext(ctx)
+		client    = apiClient.GenqClient()
+		orgSlug   = flag.GetOrg(ctx)
 	)
 
-	response, err := gql.ListAddOns(ctx, client, "upstash_redis")
-
 	var rows [][]string
-
-	for _, addon := range response.AddOns.Nodes {
-		options, _ := addon.Options.(map[string]any)
-
+	appendRow := func(name, org, plan, primaryRegion string, readRegions []string, options map[string]any) {
 		if options == nil {
 			options = make(map[string]any)
 		}
 		eviction := "Disabled"
-
 		if options["eviction"] != nil && options["eviction"].(bool) {
 			eviction = "Enabled"
 		}
 
-		rows = append(rows, []string{
-			addon.Name,
-			addon.Organization.Slug,
-			addon.AddOnPlan.DisplayName,
-			eviction,
-			addon.PrimaryRegion,
-			strings.Join(addon.ReadRegions, ","),
-		})
+		rows = append(rows, []string{name, org, plan, eviction, primaryRegion, strings.Join(readRegions, ",")})
+	}
+
+	if orgSlug != "" {
+		if _, err := apiClient.GetOrganizationBySlug(ctx, orgSlug); err != nil {
+			return err
+		}
+
+		response, err := gql.ListOrganizationAddOns(ctx, client, orgSlug, "upstash_redis")
+		if err != nil {
+			return err
+		}
+
+		for _, addon := range response.Organization.AddOns.Nodes {
+			options, _ := addon.Options.(map[string]any)
+			appendRow(addon.Name, orgSlug, addon.AddOnPlan.DisplayName, addon.PrimaryRegion, addon.ReadRegions, options)
+		}
+	} else {
+		response, err := gql.ListAddOns(ctx, client, "upstash_redis")
+		if err != nil {
+			return err
+		}
+
+		for _, addon := range response.AddOns.Nodes {
+			options, _ := addon.Options.(map[string]any)
+			appendRow(addon.Name, addon.Organization.Slug, addon.AddOnPlan.DisplayName, addon.PrimaryRegion, addon.ReadRegions, options)
+		}
 	}
 
 	_ = render.Table(out, "", rows, "Name", "Org", "Plan", "Eviction", "Primary Region", "Read Regions")

--- a/internal/command/redis/proxy.go
+++ b/internal/command/redis/proxy.go
@@ -47,27 +47,44 @@ func runProxy(ctx context.Context) (err error) {
 
 func getRedisProxyParams(ctx context.Context, localProxyPort string) (*proxy.ConnectParams, string, error) {
 	client := flyutil.ClientFromContext(ctx)
+	orgSlug := flag.GetOrg(ctx)
 
 	var index int
 	var options []string
+	var databaseNames []string
 
-	result, err := gql.ListAddOns(ctx, client.GenqClient(), "upstash_redis")
+	if orgSlug != "" {
+		if _, err := client.GetOrganizationBySlug(ctx, orgSlug); err != nil {
+			return nil, "", err
+		}
+
+		result, err := gql.ListOrganizationAddOns(ctx, client.GenqClient(), orgSlug, "upstash_redis")
+		if err != nil {
+			return nil, "", err
+		}
+
+		for _, database := range result.Organization.AddOns.Nodes {
+			databaseNames = append(databaseNames, database.Name)
+			options = append(options, fmt.Sprintf("%s (%s) %s", database.Name, database.PrimaryRegion, orgSlug))
+		}
+	} else {
+		result, err := gql.ListAddOns(ctx, client.GenqClient(), "upstash_redis")
+		if err != nil {
+			return nil, "", err
+		}
+
+		for _, database := range result.AddOns.Nodes {
+			databaseNames = append(databaseNames, database.Name)
+			options = append(options, fmt.Sprintf("%s (%s) %s", database.Name, database.PrimaryRegion, database.Organization.Slug))
+		}
+	}
+
+	err := prompt.Select(ctx, &index, "Select a database to connect to", "", options...)
 	if err != nil {
 		return nil, "", err
 	}
 
-	databases := result.AddOns.Nodes
-
-	for _, database := range databases {
-		options = append(options, fmt.Sprintf("%s (%s) %s", database.Name, database.PrimaryRegion, database.Organization.Slug))
-	}
-
-	err = prompt.Select(ctx, &index, "Select a database to connect to", "", options...)
-	if err != nil {
-		return nil, "", err
-	}
-
-	response, err := gql.GetAddOn(ctx, client.GenqClient(), databases[index].Name, string(gql.AddOnTypeUpstashRedis))
+	response, err := gql.GetAddOn(ctx, client.GenqClient(), databaseNames[index], string(gql.AddOnTypeUpstashRedis))
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
## Summary
- scope statics bucket lookup to the app organization
- use an organization-scoped addons query instead of listing all Tigris addons
- regenerate GraphQL bindings and update statics addon type alias

## Testing
- go test ./internal/command/apps ./internal/command/deploy/statics ./internal/command/extensions/core