### PR TITLE
feat(tokens): add -o/--org flag to `tokens create readonly`

### DIFF
--- a/internal/command/tokens/create.go
+++ b/internal/command/tokens/create.go
@@ -137,6 +137,7 @@ func newOrgRead() *cobra.Command {
 			Description: "Token name",
 			Default:     "Read-only org token",
 		},
+		flag.Org(),
 	)
 
 	return cmd


### PR DESCRIPTION
## Summary

- Adds the standard `-o`/`--org` flag to `fly tokens create readonly` so it can be used non-interactively (e.g. in CI).
- The underlying org resolver (`OrgFromEnvVarOrFirstArgOrSelect`) already reads `flag.GetOrg(ctx)` and only falls back to the interactive picker when empty — the flag just wasn't registered on this subcommand. The sibling `tokens create org` and `tokens create litefs-cloud` already register it.

Before: `fly tokens create readonly` always opened the org picker, so it couldn't be scripted (besides via the `FLY_ORG` env var).
After: `fly tokens create readonly -o my-org` works.

(Re-opens #4875 from a branch in the main repo so preflight CI can access secrets.)

## Test plan

- [ ] `fly tokens create readonly -o <slug>` returns a token without prompting
- [ ] `fly tokens create readonly` (no flag, no `FLY_ORG`) still falls back to the interactive picker
- [ ] `FLY_ORG=<slug> fly tokens create readonly` still works (env-var path unchanged)
- [ ] `fly tokens create readonly --help` shows `-o, --org` in the flag list

🤖 Generated with [Claude Code](https://claude.com/claude-code)