### PR TITLE
chore(deps): bump fly-go to v0.5.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/fly-go v0.5.1
+	github.com/superfly/fly-go v0.5.2
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/fly-go v0.5.2
+	github.com/superfly/fly-go v0.5.3
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/fly-go v0.5.3
+	github.com/superfly/fly-go v0.5.4
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -663,8 +663,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.5.2 h1:9kg+rtnI+FA7YPeeWz9veE2y5UuU6vIUm89DM/rmEZw=
-github.com/superfly/fly-go v0.5.2/go.mod h1:RYus6RQFZ5iXjAqo1G8w8imIkbfp3KW8czMRyDlMgCY=
+github.com/superfly/fly-go v0.5.3 h1:UmJWtEKxbdwpYG9vjgUoHgpnTMRmooiVrZeYcOlsvX0=
+github.com/superfly/fly-go v0.5.3/go.mod h1:RYus6RQFZ5iXjAqo1G8w8imIkbfp3KW8czMRyDlMgCY=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/go.sum
+++ b/go.sum
@@ -663,8 +663,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.5.3 h1:UmJWtEKxbdwpYG9vjgUoHgpnTMRmooiVrZeYcOlsvX0=
-github.com/superfly/fly-go v0.5.3/go.mod h1:RYus6RQFZ5iXjAqo1G8w8imIkbfp3KW8czMRyDlMgCY=
+github.com/superfly/fly-go v0.5.4 h1:OuDdWwrpVs6ETZ7M/+Go/x2zAr5RHRhSoWOuM2xhb8I=
+github.com/superfly/fly-go v0.5.4/go.mod h1:RYus6RQFZ5iXjAqo1G8w8imIkbfp3KW8czMRyDlMgCY=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/go.sum
+++ b/go.sum
@@ -663,8 +663,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.5.1 h1:KzTFJE3tKavzGbGbTwsYVyJ5mip+UnuiK9j+BC0RvpQ=
-github.com/superfly/fly-go v0.5.1/go.mod h1:RYus6RQFZ5iXjAqo1G8w8imIkbfp3KW8czMRyDlMgCY=
+github.com/superfly/fly-go v0.5.2 h1:9kg+rtnI+FA7YPeeWz9veE2y5UuU6vIUm89DM/rmEZw=
+github.com/superfly/fly-go v0.5.2/go.mod h1:RYus6RQFZ5iXjAqo1G8w8imIkbfp3KW8czMRyDlMgCY=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=


### PR DESCRIPTION
## Summary
- bump `github.com/superfly/fly-go` from `v0.5.1` to `v0.5.4`
- update `go.sum` entries via `go get`
