### PR TITLE
fix: detect machine update failures

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -200,6 +200,12 @@ func (md *machineDeployment) waitForMachine(ctx context.Context, e *machineUpdat
 			return err
 		}
 
+		if e.previousInstanceID != "" {
+			if _, err := machine.VerifyUpdateApplied(ctx, md.app.Name, lm.Machine().ID, lm.Machine().InstanceID, e.previousInstanceID); err != nil {
+				return err
+			}
+		}
+
 		if err := md.runTestMachines(ctx, e.leasableMachine.Machine(), sl); err != nil {
 			return err
 		}
@@ -492,8 +498,9 @@ func (md *machineDeployment) deployMachinesApp(ctx context.Context) error {
 }
 
 type machineUpdateEntry struct {
-	leasableMachine machine.LeasableMachine
-	launchInput     *fly.LaunchMachineInput
+	leasableMachine    machine.LeasableMachine
+	launchInput        *fly.LaunchMachineInput
+	previousInstanceID string
 }
 
 type machineUpdateEntries []*machineUpdateEntry
@@ -1049,6 +1056,7 @@ func (md *machineDeployment) updateMachineByReplace(ctx context.Context, e *mach
 
 func (md *machineDeployment) updateMachineInPlace(ctx context.Context, e *machineUpdateEntry) error {
 	lm := e.leasableMachine
+	e.previousInstanceID = lm.Machine().InstanceID
 
 	return lm.Update(ctx, *e.launchInput)
 }

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -599,6 +599,12 @@ func (md *machineDeployment) updateMachineWChecks(ctx context.Context, oldMachin
 
 			return err
 		}
+
+		if oldMachine != nil {
+			if _, err := mach.VerifyUpdateApplied(ctx, md.app.Name, machine.ID, machine.InstanceID, oldMachine.InstanceID); err != nil {
+				return err
+			}
+		}
 	}
 
 	if !shouldStart {

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -189,7 +189,7 @@ func (bg *blueGreen) CreateGreenMachines(ctx context.Context) error {
 			lock.Lock()
 			defer lock.Unlock()
 
-			bg.greenMachines = append(bg.greenMachines, &machineUpdateEntry{greenMachine, launchInput})
+			bg.greenMachines = append(bg.greenMachines, &machineUpdateEntry{leasableMachine: greenMachine, launchInput: launchInput})
 
 			fmt.Fprintf(bg.io.ErrOut, "  Created machine %s\n", bg.colorize.Bold(greenMachine.FormattedMachineId()))
 

--- a/internal/machine/update.go
+++ b/internal/machine/update.go
@@ -98,17 +98,21 @@ func Update(ctx context.Context, appName string, m *fly.Machine, input *fly.Laun
 		waitTimeout = time.Duration(input.Timeout) * time.Second
 	}
 
-	state, err := WaitForState(ctx, appName, updatedMachine, "settled", waitTimeout)
-	if err != nil {
+	if err := WaitForStartOrStop(ctx, appName, updatedMachine, "settled", waitTimeout); err != nil {
 		return fmt.Errorf("error while waiting for machine to update: %w", err)
 	}
 
-	if state == "failed" {
-		return fmt.Errorf("machine %s update failed: machine entered %q state", m.ID, state)
+	settledMachine, err := VerifyUpdateApplied(ctx, appName, m.ID, updatedMachine.InstanceID, m.InstanceID)
+	if err != nil {
+		return err
 	}
 
-	if state == "started" && !input.SkipHealthChecks {
-		if err := watch.MachinesChecks(ctx, appName, []*fly.Machine{updatedMachine}); err != nil {
+	if settledMachine.State == "failed" {
+		return fmt.Errorf("machine %s update failed: machine entered %q state", m.ID, settledMachine.State)
+	}
+
+	if settledMachine.State == "started" && !input.SkipHealthChecks {
+		if err := watch.MachinesChecks(ctx, appName, []*fly.Machine{settledMachine}); err != nil {
 			return fmt.Errorf("failed to wait for health checks to pass: %w", err)
 		}
 	}
@@ -116,6 +120,26 @@ func Update(ctx context.Context, appName string, m *fly.Machine, input *fly.Laun
 	fmt.Fprintf(io.Out, "Machine %s updated successfully!\n", colorize.Bold(m.ID))
 
 	return nil
+}
+
+// VerifyUpdateApplied fetches the machine and returns it if its InstanceID
+// matches targetInstanceID. Otherwise it returns an error distinguishing
+// whether the machine remains on previousInstanceID or some unexpected
+// version.
+func VerifyUpdateApplied(ctx context.Context, appName, machineID, targetInstanceID, previousInstanceID string) (*fly.Machine, error) {
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	current, err := flapsClient.Get(ctx, appName, machineID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get machine: %w", err)
+	}
+	switch current.InstanceID {
+	case targetInstanceID:
+		return current, nil
+	case previousInstanceID:
+		return nil, fmt.Errorf("machine %s update failed: machine remains on previous version %s (state: %s)", machineID, current.InstanceID, current.State)
+	default:
+		return nil, fmt.Errorf("machine %s update failed: unexpected version %s (state: %s)", machineID, current.InstanceID, current.State)
+	}
 }
 
 type invalidConfigReason string

--- a/internal/machine/wait.go
+++ b/internal/machine/wait.go
@@ -15,24 +15,6 @@ import (
 	"github.com/superfly/flyctl/internal/flyerr"
 )
 
-func WaitForState(ctx context.Context, appName string, machine *fly.Machine, desiredState string, timeout time.Duration) (string, error) {
-	flapsClient := flapsutil.ClientFromContext(ctx)
-
-	if err := WaitForStartOrStop(ctx, appName, machine, desiredState, timeout); err != nil {
-		return "", err
-	}
-	if desiredState == "settled" {
-		m, err := flapsClient.Get(ctx, appName, machine.ID)
-		if err != nil {
-			return "", fmt.Errorf("failed to get machine after waiting for it to settle: %w", err)
-		}
-
-		return m.State, nil
-	}
-
-	return desiredState, nil
-}
-
 func WaitForStartOrStop(ctx context.Context, appName string, machine *fly.Machine, action string, timeout time.Duration) error {
 	flapsClient := flapsutil.ClientFromContext(ctx)
 


### PR DESCRIPTION
### Change Summary

What and Why:

Previously, when we gave up on an update and reverted a machine to its previous version (eg. if pulling the image from the registry failed), flyctl saw the machine in the "started" state (the old version still running) and treated the deploy as successful. Health checks would pass against the old image, so users had no indication their new code wasn't deployed.

Affects both `flyctl deploy` (in-place updates) and standalone `flyctl machine update`.

How:

Check the machine version is what we expected after wait succeeds.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
