### PR TITLE
ci: pin golangci-lint to v2.11.3

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,4 +37,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.11.3


### PR DESCRIPTION
`version: latest` is picking up new errors. We'll bump it deliberately later.

v2.11.3 matches pre-commit config.