### PR TITLE
Fix/wg create infinite loop

### DIFF
--- a/internal/command/wireguard/others.go
+++ b/internal/command/wireguard/others.go
@@ -52,7 +52,7 @@ func resolveOutputWriter(ctx context.Context, idx int, prompt string) (w io.Writ
 	io := iostreams.FromContext(ctx)
 
 	args := flag.Args(ctx)
-	fromCLI := len(args) > idx && args[idx] != ""
+	fromCLI := len(args) > idx
 	var filename string
 
 	for {
@@ -62,6 +62,10 @@ func resolveOutputWriter(ctx context.Context, idx int, prompt string) (w io.Writ
 		}
 
 		if filename == "" {
+			if fromCLI {
+				return nil, false, fmt.Errorf("output filename cannot be empty")
+			}
+
 			fmt.Fprintln(io.Out, "Provide a filename (or 'stdout')")
 
 			continue

--- a/internal/command/wireguard/others.go
+++ b/internal/command/wireguard/others.go
@@ -50,7 +50,9 @@ func orgByArg(ctx context.Context) (*fly.Organization, error) {
 
 func resolveOutputWriter(ctx context.Context, idx int, prompt string) (w io.WriteCloser, mustClose bool, err error) {
 	io := iostreams.FromContext(ctx)
-	var f *os.File
+
+	args := flag.Args(ctx)
+	fromCLI := len(args) > idx && args[idx] != ""
 	var filename string
 
 	for {
@@ -69,12 +71,17 @@ func resolveOutputWriter(ctx context.Context, idx int, prompt string) (w io.Writ
 			return os.Stdout, false, nil
 		}
 
-		f, err = os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-		if err == nil {
+		f, openErr := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if openErr == nil {
 			return f, true, nil
 		}
 
-		fmt.Fprintf(io.Out, "Can't create '%s': %s\n", filename, err)
+		if fromCLI {
+			return nil, false, openErr
+		}
+
+		fmt.Fprintf(io.Out, "Can't create '%s': %s\n", filename, openErr)
+		fromCLI = false
 	}
 }
 

--- a/internal/command/wireguard/others_test.go
+++ b/internal/command/wireguard/others_test.go
@@ -1,0 +1,128 @@
+package wireguard
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+// withCtx builds a minimal context with iostreams + a flag set populated with
+// the given positional args. Mirrors what the cobra preparer chain produces
+// for resolveOutputWriter at runtime.
+func withCtx(t *testing.T, args []string) context.Context {
+	t.Helper()
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("flag parse: %v", err)
+	}
+
+	ctx := flag.NewContext(context.Background(), fs)
+	ios, _, _, _ := iostreams.Test()
+
+	return iostreams.NewContext(ctx, ios)
+}
+
+// runWithDeadline runs fn in a goroutine and fails the test if it doesn't
+// return within d. Critical for catching infinite-loop regressions in
+// resolveOutputWriter — the function under test is the same one that hung
+// indefinitely in flyctl issue #4665.
+func runWithDeadline(t *testing.T, d time.Duration, fn func()) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		fn()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("function did not return within %v — likely infinite loop regression", d)
+	}
+}
+
+func TestResolveOutputWriter_CLIArg_FileExists(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "exists.conf")
+	if err := os.WriteFile(existing, []byte{}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx := withCtx(t, []string{existing})
+
+	runWithDeadline(t, time.Second, func() {
+		w, mustClose, err := resolveOutputWriter(ctx, 0, "test prompt: ")
+		if err == nil {
+			t.Fatal("expected error for file-exists CLI arg, got nil")
+		}
+		if w != nil {
+			t.Errorf("expected nil writer, got %v", w)
+		}
+		if mustClose {
+			t.Errorf("expected mustClose=false, got true")
+		}
+	})
+}
+
+func TestResolveOutputWriter_CLIArg_EmptyString(t *testing.T) {
+	ctx := withCtx(t, []string{""})
+
+	runWithDeadline(t, time.Second, func() {
+		w, _, err := resolveOutputWriter(ctx, 0, "test prompt: ")
+		if err == nil {
+			t.Fatal("expected error for empty CLI arg, got nil")
+		}
+		if w != nil {
+			t.Errorf("expected nil writer, got %v", w)
+		}
+	})
+}
+
+func TestResolveOutputWriter_CLIArg_Stdout(t *testing.T) {
+	ctx := withCtx(t, []string{"stdout"})
+
+	runWithDeadline(t, time.Second, func() {
+		w, mustClose, err := resolveOutputWriter(ctx, 0, "test prompt: ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if w != os.Stdout {
+			t.Errorf("expected os.Stdout, got %v", w)
+		}
+		if mustClose {
+			t.Errorf("expected mustClose=false for stdout, got true")
+		}
+	})
+}
+
+func TestResolveOutputWriter_CLIArg_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "new.conf")
+	ctx := withCtx(t, []string{target})
+
+	runWithDeadline(t, time.Second, func() {
+		w, mustClose, err := resolveOutputWriter(ctx, 0, "test prompt: ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if w == nil {
+			t.Fatal("expected non-nil writer")
+		}
+		if !mustClose {
+			t.Errorf("expected mustClose=true for opened file")
+		}
+		if _, statErr := os.Stat(target); statErr != nil {
+			t.Errorf("file not created at %s: %v", target, statErr)
+		}
+		if err := w.Close(); err != nil {
+			t.Errorf("close error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #4665.

`fly wg create` was getting stuck in an infinite loop whenever the file you tried to save the wg config to already existed. It'd just keep printing "Can't create" over and over with no way out except killing the process.

Found a second one while testing as well, same loop happens if you pass an empty filename (""). Same underlying cause: the function just kept trying the same broken arg every iteration.

Both now exit cleanly with a real error when the bad filename came from a CLI arg. Interactive mode (where you type the filename yourself) is unchanged. Threw in regression tests so if either loop ever sneaks back in, CI catches it fast.