### PR TITLE
fix(mcp): allow JSON comments and trailing commas in editor settings files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0
 	github.com/superfly/tokenizer v0.0.3-0.20240826174224-a17a2e0a9dc0
+	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd
 	github.com/vektah/gqlparser/v2 v2.5.33
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0
 	go.opentelemetry.io/otel v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -677,6 +677,8 @@ github.com/superfly/macaroon v0.3.0 h1:tdRq5VqBCNJIlvYByZZ3bGDOKX/v0llQM/Ljd27Db
 github.com/superfly/macaroon v0.3.0/go.mod h1:ZAmlRD/Hmp/ddTxE8IonZ7NdTny2DcOffRvZhapQwJw=
 github.com/superfly/tokenizer v0.0.3-0.20240826174224-a17a2e0a9dc0 h1:0GZOxvuQ2u3XUY7Hr8N02zn4ZN9Iz2xgi3aNNaUpRO4=
 github.com/superfly/tokenizer v0.0.3-0.20240826174224-a17a2e0a9dc0/go.mod h1:w38ieJ28pCyIpQJzuDOKfN5z6Q6R92vOkAYtUv6FL9k=
+github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd h1:Rf9uhF1+VJ7ZHqxrG8pJ6YacmHvVCmByDmGbAWCc/gA=
+github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd/go.mod h1:EbW0wDK/qEUYI0A5bqq0C2kF8JTQwWONmGDBbzsxxHo=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
 github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=

--- a/internal/command/mcp/config.go
+++ b/internal/command/mcp/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/tailscale/hujson"
 )
 
 var McpClients = map[string]string{
@@ -339,16 +340,14 @@ func ServerMap(configPaths []ConfigPath) (map[string]any, error) {
 		}
 
 		// read the configuration file
-		file, err := os.Open(configPath.Path)
+		fileData, err := os.ReadFile(configPath.Path)
 		if err != nil {
 			return nil, err
 		}
-		defer file.Close()
 
-		// parse the configuration file as JSON
+		// parse the configuration file as JSON (tolerating comments and trailing commas)
 		var data map[string]any
-		decoder := json.NewDecoder(file)
-		if err := decoder.Decode(&data); err != nil {
+		if err := unmarshalJSONC(fileData, &data); err != nil {
 			return nil, fmt.Errorf("failed to parse %s: %w", configPath.Path, err)
 		}
 
@@ -517,8 +516,8 @@ func UpdateConfig(ctx context.Context, path string, configKey string, server str
 	fileData, err := os.ReadFile(path)
 	if err == nil {
 		fileExists = true
-		// File exists, parse it
-		err = json.Unmarshal(fileData, &configData)
+		// File exists, parse it (tolerating comments and trailing commas)
+		err = unmarshalJSONC(fileData, &configData)
 		if err != nil {
 			return fmt.Errorf("failed to parse existing configuration at %s: %w", path, err)
 		} else {
@@ -612,9 +611,9 @@ func removeConfig(ctx context.Context, path string, configKey string, name strin
 		return fmt.Errorf("failed to read configuration at %s: %w", path, err)
 	}
 
-	// Parse the existing configuration
+	// Parse the existing configuration (tolerating comments and trailing commas)
 	configData := make(map[string]any)
-	err = json.Unmarshal(fileData, &configData)
+	err = unmarshalJSONC(fileData, &configData)
 	if err != nil {
 		return fmt.Errorf("failed to parse existing configuration at %s: %w", path, err)
 	} else {
@@ -679,9 +678,9 @@ func configExtract(config ConfigPath, server string) (map[string]any, error) {
 		return nil, fmt.Errorf("Error reading file: %v", err)
 	}
 
-	// Parse the JSON data
+	// Parse the JSON data (tolerating comments and trailing commas)
 	jsonConfig := make(map[string]any)
-	if err := json.Unmarshal(data, &jsonConfig); err != nil {
+	if err := unmarshalJSONC(data, &jsonConfig); err != nil {
 		return nil, fmt.Errorf("Error parsing JSON: %v", err)
 	}
 
@@ -725,4 +724,17 @@ func configExtract(config ConfigPath, server string) (map[string]any, error) {
 	}
 
 	return serverConfig, nil
+}
+
+// unmarshalJSONC unmarshals JSONC (JSON with line/block comments and trailing
+// commas) into v. Editor settings files — Zed, VS Code, Cursor, Neovim,
+// Windsurf — commonly use JSONC, and flyctl needs to tolerate that on the
+// read side. Writes still emit strict JSON; see #4430 for context.
+func unmarshalJSONC(data []byte, v any) error {
+	standardized, err := hujson.Standardize(data)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(standardized, v)
 }

--- a/internal/command/mcp/config_test.go
+++ b/internal/command/mcp/config_test.go
@@ -1,0 +1,102 @@
+package mcp
+
+import (
+	"testing"
+)
+
+func TestUnmarshalJSONC(t *testing.T) {
+	t.Run("plain JSON, no comments", func(t *testing.T) {
+		input := []byte(`{"name": "Alice", "n": 42}`)
+		var got map[string]any
+		if err := unmarshalJSONC(input, &got); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["name"] != "Alice" || got["n"].(float64) != 42 {
+			t.Errorf("unexpected unmarshal result: %v", got)
+		}
+	})
+
+	t.Run("with line comments", func(t *testing.T) {
+		input := []byte(`{
+            // top-level comment
+            "name": "Alice", // trailing comment
+            "n": 42
+        }`)
+		var got map[string]any
+		if err := unmarshalJSONC(input, &got); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["name"] != "Alice" || got["n"].(float64) != 42 {
+			t.Errorf("unexpected unmarshal result: %v", got)
+		}
+	})
+
+	t.Run("with block comments", func(t *testing.T) {
+		input := []byte(`{
+            /* top-level block comment */
+            "name": "Alice",
+            /* multi-line
+               block comment */
+            "n": 42
+        }`)
+		var got map[string]any
+		if err := unmarshalJSONC(input, &got); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["name"] != "Alice" || got["n"].(float64) != 42 {
+			t.Errorf("unexpected unmarshal result: %v", got)
+		}
+	})
+
+	t.Run("with trailing commas", func(t *testing.T) {
+		input := []byte(`{
+            "name": "Alice",
+            "items": [1, 2, 3,],
+            "n": 42,
+        }`)
+		var got map[string]any
+		if err := unmarshalJSONC(input, &got); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["name"] != "Alice" || got["n"].(float64) != 42 {
+			t.Errorf("unexpected unmarshal result: %v", got)
+		}
+		if items, ok := got["items"].([]any); !ok || len(items) != 3 {
+			t.Errorf("expected items=[1,2,3], got %v", got["items"])
+		}
+	})
+
+	t.Run("realistic Zed-style settings", func(t *testing.T) {
+		// Mirrors the actual #4430 reproducer: a settings.json with both
+		// comment styles AND trailing commas in the same file.
+		input := []byte(`// Settings for Zed
+{
+    /* MCP server registry */
+    "context_servers": {
+        "test-mcp": {
+            "command": "/bin/echo",
+            "args": ["hello"], // arg list
+        }, // trailing comma in object too
+    },
+}`)
+		var got map[string]any
+		if err := unmarshalJSONC(input, &got); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		servers, ok := got["context_servers"].(map[string]any)
+		if !ok {
+			t.Fatalf("missing context_servers map")
+		}
+		if _, ok := servers["test-mcp"].(map[string]any); !ok {
+			t.Errorf("missing test-mcp entry: %v", servers)
+		}
+	})
+
+	t.Run("malformed input returns error", func(t *testing.T) {
+		input := []byte(`{ this is not valid json or jsonc`)
+		var got map[string]any
+		if err := unmarshalJSONC(input, &got); err == nil {
+			t.Fatal("expected error for malformed input, got nil")
+		}
+	})
+}

--- a/internal/command/mcp/list.go
+++ b/internal/command/mcp/list.go
@@ -79,16 +79,14 @@ func runList(ctx context.Context) error {
 		}
 
 		// read the configuration file
-		file, err := os.Open(configPath.Path)
+		fileData, err := os.ReadFile(configPath.Path)
 		if err != nil {
 			return err
 		}
-		defer file.Close()
 
-		// parse the configuration file as JSON
+		// parse the configuration file as JSON (tolerating comments and trailing commas)
 		var data map[string]any
-		decoder := json.NewDecoder(file)
-		if err := decoder.Decode(&data); err != nil {
+		if err := unmarshalJSONC(fileData, &data); err != nil {
 			return fmt.Errorf("failed to parse %s: %w", configPath.Path, err)
 		}
 


### PR DESCRIPTION
Fixes #4430

`fly mcp list` (and `fly mcp add`/`remove`/etc.) was failing on editor settings files that contain `//` or `/* */` comments. Zed, VS Code, Cursor, Neovim, Windsurf all use JSONC for their settings, and `encoding/json` rejects it strictly.

Add a small `unmarshalJSONC` helper that runs `hujson.Standardize` before `json.Unmarshal` and use it at the 5 read sites in `internal/command/mcp/`. Plain JSON files are pass-through unchanged. Writes are deliberately untouched, as most tools don't accept JSONC and we'd corrupt their configs.

Picks up the approach pre-approved by Ruby's in #4485 (which the original author abandoned). This one also includes regression tests covering line comments, block comments, trailing commas, plain JSON, and a realistic Zed-style fixture.