### PR TITLE
fix(mpgv2): correctly populate cluster version

### DIFF
--- a/internal/command/mpg/mpg.go
+++ b/internal/command/mpg/mpg.go
@@ -96,7 +96,7 @@ func ClusterFromArgOrSelect(ctx context.Context, clusterID, orgSlug string) (*mp
 
 		// There's nothing that List can tell us that Get won't, so if we didn't
 		// find the cluster, let's just exit early.
-		return nil, orgSlug, fmt.Errorf("no managed postgres cluster found with ID %s", clusterID)
+		return nil, orgSlug, fmt.Errorf("managed postgres cluster %q not found", clusterID)
 	}
 
 	// Prompt for org if empty

--- a/internal/command/mpg/mpg.go
+++ b/internal/command/mpg/mpg.go
@@ -55,7 +55,27 @@ func ClusterFromArgOrSelect(ctx context.Context, clusterID, orgSlug string) (*mp
 	mpgv1Client := mpgv1.ClientFromContext(ctx)
 	mpgv2Client := mpgv2.ClientFromContext(ctx)
 
+	// If user told us which cluster they want
 	if clusterID != "" {
+		// Check if its a V2 cluster. Otherwise, fallback to V1.
+		if c, err := mpgv2Client.GetClusterById(ctx, clusterID); err == nil && c.Data.MpgdClusterId != "" {
+			cluster := &mpg.Cluster{
+				Id:            c.Data.Id,
+				Name:          c.Data.Name,
+				Region:        c.Data.Region,
+				Status:        c.Data.Status,
+				Plan:          c.Data.Plan,
+				Disk:          c.Data.Disk,
+				Replicas:      c.Data.Replicas,
+				Organization:  c.Data.Organization,
+				IpAssignments: c.Data.IpAssignments,
+				AttachedApps:  c.Data.AttachedApps,
+				Version:       mpg.VersionV2,
+			}
+
+			return cluster, cluster.Organization.Slug, nil
+		}
+
 		if c, err := mpgv1Client.GetManagedClusterById(ctx, clusterID); err == nil {
 			cluster := &mpg.Cluster{
 				Id:            c.Data.Id,
@@ -73,25 +93,13 @@ func ClusterFromArgOrSelect(ctx context.Context, clusterID, orgSlug string) (*mp
 
 			return cluster, cluster.Organization.Slug, nil
 		}
-		if c, err := mpgv2Client.GetClusterById(ctx, clusterID); err == nil {
-			cluster := &mpg.Cluster{
-				Id:            c.Data.Id,
-				Name:          c.Data.Name,
-				Region:        c.Data.Region,
-				Status:        c.Data.Status,
-				Plan:          c.Data.Plan,
-				Disk:          c.Data.Disk,
-				Replicas:      c.Data.Replicas,
-				Organization:  c.Data.Organization,
-				IpAssignments: c.Data.IpAssignments,
-				AttachedApps:  c.Data.AttachedApps,
-				Version:       mpg.VersionV2,
-			}
 
-			return cluster, cluster.Organization.Slug, nil
-		}
+		// There's nothing that List can tell us that Get won't, so if we didn't
+		// find the cluster, let's just exit early.
+		return nil, orgSlug, fmt.Errorf("no managed postgres cluster found with ID %s", clusterID)
 	}
 
+	// Prompt for org if empty
 	if orgSlug == "" {
 		org, err := prompt.Org(ctx)
 		if err != nil {
@@ -113,18 +121,16 @@ func ClusterFromArgOrSelect(ctx context.Context, clusterID, orgSlug string) (*mp
 	}
 
 	clusters := make([]*mpg.Cluster, 0, len(mc.Data))
+	options := make([]string, 0, len(mc.Data))
+
 	for _, cluster := range mc.Data {
 		version := mpg.VersionV1
 		if cluster.Version == 2 {
 			version = mpg.VersionV2
 		}
-		clusterId := ""
-		if cluster.Version == 2 {
-			clusterId = cluster.ClusterId
-		}
+
 		clusters = append(clusters, &mpg.Cluster{
 			Id:           cluster.Id,
-			ClusterId:    clusterId,
 			Name:         cluster.Name,
 			Region:       cluster.Region,
 			Status:       cluster.Status,
@@ -134,29 +140,13 @@ func ClusterFromArgOrSelect(ctx context.Context, clusterID, orgSlug string) (*mp
 			Organization: cluster.Organization,
 			Version:      version,
 		})
-	}
 
-	// If a cluster ID is provided via flag, find it
-	if clusterID != "" {
-		for _, cluster := range clusters {
-			if cluster.Id == clusterID {
-				return cluster, orgSlug, nil
-			}
-		}
-
-		return nil, orgSlug, fmt.Errorf("managed postgres cluster %q not found in organization %s", clusterID, orgSlug)
-	}
-
-	// Otherwise, prompt the user to select a cluster
-	var options []string
-	for _, cluster := range clusters {
 		options = append(options, fmt.Sprintf("%s [%s] (%s)", cluster.Name, cluster.Id, cluster.Region))
 	}
 
 	var index int
-	selectErr := prompt.Select(ctx, &index, "Select a Postgres cluster", "", options...)
-	if selectErr != nil {
-		return nil, orgSlug, selectErr
+	if err := prompt.Select(ctx, &index, "Select a Postgres cluster", "", options...); err != nil {
+		return nil, orgSlug, err
 	}
 
 	return clusters[index], orgSlug, nil

--- a/internal/command/mpg/mpg_test.go
+++ b/internal/command/mpg/mpg_test.go
@@ -158,6 +158,7 @@ func TestClusterFromFlagOrSelect_WithFlagContext(t *testing.T) {
 			if id == expectedCluster.Id {
 				return mpgv1.GetManagedClusterResponse{Data: expectedCluster}, nil
 			}
+
 			return mpgv1.GetManagedClusterResponse{}, errors.New("managed postgres cluster not found")
 		},
 	}

--- a/internal/command/mpg/mpg_test.go
+++ b/internal/command/mpg/mpg_test.go
@@ -154,14 +154,10 @@ func TestClusterFromFlagOrSelect_WithFlagContext(t *testing.T) {
 	})
 
 	mockv1 = &mock.MpgV1Client{
-		ListManagedClustersFunc: func(ctx context.Context, orgSlug string, deleted bool) (mpgv1.ListManagedClustersResponse, error) {
-			assert.Equal(t, "test-org", orgSlug)
-
-			return mpgv1.ListManagedClustersResponse{
-				Data: []mpgv1.ManagedCluster{expectedCluster},
-			}, nil
-		},
 		GetManagedClusterByIdFunc: func(ctx context.Context, id string) (mpgv1.GetManagedClusterResponse, error) {
+			if id == expectedCluster.Id {
+				return mpgv1.GetManagedClusterResponse{Data: expectedCluster}, nil
+			}
 			return mpgv1.GetManagedClusterResponse{}, errors.New("managed postgres cluster not found")
 		},
 	}

--- a/internal/uiex/mpg/types.go
+++ b/internal/uiex/mpg/types.go
@@ -14,7 +14,6 @@ const (
 // Unified type for v1 and v2 MPG clusters
 type Cluster struct {
 	Id            string
-	ClusterId     string
 	Name          string
 	Region        string
 	Status        string


### PR DESCRIPTION
Also removes ClusterId from Cluster object (unused).

Signed-off-by: Juliana Oliveira <juliana@fly.io>
