### PR TITLE
Prompt before creating Managed Postgres during launch

### DIFF
--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -246,6 +246,7 @@ func (state *launchState) confirmManagedPostgresCreation(ctx context.Context, cr
 		return nil
 	case 1:
 		state.launchWithoutManagedPostgresCluster()
+
 		return nil
 	}
 

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -2,6 +2,7 @@ package launch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -18,6 +19,7 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/tracing"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -49,12 +51,14 @@ func (state *launchState) Launch(ctx context.Context) error {
 	}
 
 	planStep := plan.GetPlanStep(ctx)
+	createdAppName := ""
 
 	if !flag.GetBool(ctx, "no-create") && (planStep == "" || planStep == "create") {
 		app, err := state.createApp(ctx)
 		if err != nil {
 			return err
 		}
+		createdAppName = app.Name
 
 		colorize := io.ColorScheme()
 		fmt.Fprintf(io.Out, "%s\n\n", colorize.Green(fmt.Sprintf("Created app '%s' in organization '%s'", app.Name, app.Organization.Slug)))
@@ -63,6 +67,12 @@ func (state *launchState) Launch(ctx context.Context) error {
 
 		if planStep == "create" {
 			return nil
+		}
+	}
+
+	if !flag.GetBool(ctx, "no-create") {
+		if err = state.confirmManagedPostgresCreation(ctx, createdAppName, planStep); err != nil {
+			return err
 		}
 	}
 
@@ -209,6 +219,41 @@ func (state *launchState) Launch(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (state *launchState) confirmManagedPostgresCreation(ctx context.Context, createdAppName, planStep string) error {
+	if !state.willCreateManagedPostgresCluster(planStep) {
+		return nil
+	}
+
+	io := iostreams.FromContext(ctx)
+	if !io.IsInteractive() || flag.GetYes(ctx) {
+		return nil
+	}
+
+	confirmed, err := prompt.Confirm(ctx, "This launch will create a new Managed Postgres database which may add cost to your account. Do you want to proceed?")
+	if err != nil {
+		return err
+	}
+	if confirmed {
+		return nil
+	}
+
+	if createdAppName != "" {
+		fmt.Fprintf(io.Out, "Deleting app %s...\n", createdAppName)
+		if err := flapsutil.ClientFromContext(ctx).DeleteApp(ctx, createdAppName); err != nil {
+			return fmt.Errorf("launch canceled, but failed to delete app %s: %w", createdAppName, err)
+		}
+		fmt.Fprintf(io.Out, "Deleted app %s\n", createdAppName)
+	}
+
+	return errors.New("launch canceled")
+}
+
+func (state *launchState) willCreateManagedPostgresCluster(planStep string) bool {
+	return state.Plan.Postgres.ManagedPostgres != nil &&
+		state.Plan.Postgres.ManagedPostgres.ClusterID == "" &&
+		(planStep == "" || planStep == "postgres")
 }
 
 func ParseMountOptions(mount *appconfig.Mount, options string) error {

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/appsecrets"
 	"github.com/superfly/flyctl/internal/command/launch/plan"
+	"github.com/superfly/flyctl/internal/command/mpg"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"github.com/superfly/flyctl/internal/flapsutil"
@@ -231,7 +232,7 @@ func (state *launchState) confirmManagedPostgresCreation(ctx context.Context, cr
 		return nil
 	}
 
-	confirmed, err := prompt.Confirm(ctx, "This launch will create a new Managed Postgres database which may add cost to your account. Do you want to proceed?")
+	confirmed, err := prompt.Confirm(ctx, state.managedPostgresCreationPrompt())
 	if err != nil {
 		return err
 	}
@@ -248,6 +249,20 @@ func (state *launchState) confirmManagedPostgresCreation(ctx context.Context, cr
 	}
 
 	return errors.New("launch canceled")
+}
+
+func (state *launchState) managedPostgresCreationPrompt() string {
+	pgPlan := state.Plan.Postgres.ManagedPostgres
+	dbName := pgPlan.GetDbName(state.Plan)
+	region := pgPlan.GetRegion(state.Plan)
+
+	if planDetails, ok := mpg.MPGPlans[pgPlan.Plan]; ok {
+		return fmt.Sprintf("This launch will create a new Managed Postgres database, %q, on the %s plan ($%d/mo) in %s. This is an additional paid resource. Do you want to proceed?",
+			dbName, planDetails.Name, planDetails.PricePerMo, region)
+	}
+
+	return fmt.Sprintf("This launch will create a new Managed Postgres database, %q, on plan %s in %s. This is an additional paid resource. Do you want to proceed?",
+		dbName, pgPlan.Plan, region)
 }
 
 func (state *launchState) willCreateManagedPostgresCluster(planStep string) bool {

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -232,11 +232,20 @@ func (state *launchState) confirmManagedPostgresCreation(ctx context.Context, cr
 		return nil
 	}
 
-	confirmed, err := prompt.Confirm(ctx, state.managedPostgresCreationPrompt())
-	if err != nil {
+	var selectedIndex int
+	if err := prompt.Select(ctx, &selectedIndex, state.managedPostgresCreationPrompt(), "",
+		"Yes, proceed and create the MPG cluster",
+		"No, launch the app without the MPG cluster",
+		"No, cancel this launch and let me start over",
+	); err != nil {
 		return err
 	}
-	if confirmed {
+
+	switch selectedIndex {
+	case 0:
+		return nil
+	case 1:
+		state.launchWithoutManagedPostgresCluster()
 		return nil
 	}
 
@@ -251,17 +260,21 @@ func (state *launchState) confirmManagedPostgresCreation(ctx context.Context, cr
 	return errors.New("launch canceled")
 }
 
+func (state *launchState) launchWithoutManagedPostgresCluster() {
+	state.Plan.Postgres.ManagedPostgres = nil
+}
+
 func (state *launchState) managedPostgresCreationPrompt() string {
 	pgPlan := state.Plan.Postgres.ManagedPostgres
 	dbName := pgPlan.GetDbName(state.Plan)
 	region := pgPlan.GetRegion(state.Plan)
 
 	if planDetails, ok := mpg.MPGPlans[pgPlan.Plan]; ok {
-		return fmt.Sprintf("This launch will create a new Managed Postgres database, %q, on the %s plan ($%d/mo) in %s. This is an additional paid resource. Do you want to proceed?",
+		return fmt.Sprintf("This launch will create a new Managed Postgres database, %q, on the %s plan ($%d/mo) in %s. This is an additional paid resource. How would you like to proceed?",
 			dbName, planDetails.Name, planDetails.PricePerMo, region)
 	}
 
-	return fmt.Sprintf("This launch will create a new Managed Postgres database, %q, on plan %s in %s. This is an additional paid resource. Do you want to proceed?",
+	return fmt.Sprintf("This launch will create a new Managed Postgres database, %q, on plan %s in %s. This is an additional paid resource. How would you like to proceed?",
 		dbName, pgPlan.Plan, region)
 }
 

--- a/internal/command/launch/launch_test.go
+++ b/internal/command/launch/launch_test.go
@@ -6,7 +6,72 @@ import (
 	"github.com/stretchr/testify/assert"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command/launch/plan"
 )
+
+func TestWillCreateManagedPostgresCluster(t *testing.T) {
+	tests := []struct {
+		name     string
+		postgres plan.PostgresPlan
+		planStep string
+		expected bool
+	}{
+		{
+			name: "new managed postgres",
+			postgres: plan.PostgresPlan{
+				ManagedPostgres: &plan.ManagedPostgresPlan{},
+			},
+			expected: true,
+		},
+		{
+			name: "postgres plan step",
+			postgres: plan.PostgresPlan{
+				ManagedPostgres: &plan.ManagedPostgresPlan{},
+			},
+			planStep: "postgres",
+			expected: true,
+		},
+		{
+			name: "deploy plan step",
+			postgres: plan.PostgresPlan{
+				ManagedPostgres: &plan.ManagedPostgresPlan{},
+			},
+			planStep: "deploy",
+			expected: false,
+		},
+		{
+			name: "existing managed postgres",
+			postgres: plan.PostgresPlan{
+				ManagedPostgres: &plan.ManagedPostgresPlan{ClusterID: "mpg_123"},
+			},
+			expected: false,
+		},
+		{
+			name: "unmanaged postgres",
+			postgres: plan.PostgresPlan{
+				FlyPostgres: &plan.FlyPostgresPlan{},
+			},
+			expected: false,
+		},
+		{
+			name:     "no postgres",
+			postgres: plan.PostgresPlan{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &launchState{
+				LaunchManifest: LaunchManifest{
+					Plan: &plan.LaunchPlan{Postgres: tt.postgres},
+				},
+			}
+
+			assert.Equal(t, tt.expected, state.willCreateManagedPostgresCluster(tt.planStep))
+		})
+	}
+}
 
 func TestIsComputeValid(t *testing.T) {
 	tests := []struct {

--- a/internal/command/launch/launch_test.go
+++ b/internal/command/launch/launch_test.go
@@ -73,6 +73,27 @@ func TestWillCreateManagedPostgresCluster(t *testing.T) {
 	}
 }
 
+func TestManagedPostgresCreationPrompt(t *testing.T) {
+	state := &launchState{
+		LaunchManifest: LaunchManifest{
+			Plan: &plan.LaunchPlan{
+				AppName:    "my-app",
+				RegionCode: "iad",
+				Postgres: plan.PostgresPlan{
+					ManagedPostgres: &plan.ManagedPostgresPlan{
+						Plan: "basic",
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t,
+		`This launch will create a new Managed Postgres database, "my-app-db", on the Basic plan ($38/mo) in iad. This is an additional paid resource. Do you want to proceed?`,
+		state.managedPostgresCreationPrompt(),
+	)
+}
+
 func TestIsComputeValid(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/command/launch/launch_test.go
+++ b/internal/command/launch/launch_test.go
@@ -89,9 +89,28 @@ func TestManagedPostgresCreationPrompt(t *testing.T) {
 	}
 
 	assert.Equal(t,
-		`This launch will create a new Managed Postgres database, "my-app-db", on the Basic plan ($38/mo) in iad. This is an additional paid resource. Do you want to proceed?`,
+		`This launch will create a new Managed Postgres database, "my-app-db", on the Basic plan ($38/mo) in iad. This is an additional paid resource. How would you like to proceed?`,
 		state.managedPostgresCreationPrompt(),
 	)
+}
+
+func TestLaunchWithoutManagedPostgresCluster(t *testing.T) {
+	state := &launchState{
+		LaunchManifest: LaunchManifest{
+			Plan: &plan.LaunchPlan{
+				Postgres: plan.PostgresPlan{
+					ManagedPostgres: &plan.ManagedPostgresPlan{
+						Plan: "basic",
+					},
+				},
+			},
+		},
+	}
+
+	state.launchWithoutManagedPostgresCluster()
+
+	assert.Nil(t, state.Plan.Postgres.ManagedPostgres)
+	assert.False(t, state.willCreateManagedPostgresCluster(""))
 }
 
 func TestIsComputeValid(t *testing.T) {


### PR DESCRIPTION
## Summary
- Replace the binary Managed Postgres launch confirmation with a three-choice prompt for interactive launches
- Show the planned database name, MPG plan price, and region before asking the user how to proceed
- Allow users to create the MPG cluster, continue launching without the MPG cluster, or cancel and clean up the newly-created app
- Skip the prompt for non-interactive, --yes, --no-create, non-postgres launch steps, and existing Managed Postgres attachments

## New prompt flow
When a launch plan would create a new Managed Postgres cluster, users now see the planned paid resource details and can choose:

1. Yes, proceed and create the MPG cluster
   - Launch continues with the Managed Postgres plan intact.

2. No, launch the app without the MPG cluster
   - flyctl removes the Managed Postgres plan from the launch state and continues launching the app.
   - No MPG cluster is created and Postgres setup/init work is skipped because the launch plan no longer has a Postgres provider.

3. No, cancel this launch and let me start over
   - Launch aborts.
   - If flyctl already created the app during this launch, it deletes that app before returning the cancellation error.

## User impact
Users get a clearer warning before launch creates an additional paid Managed Postgres resource, while still having a low-friction way to continue launching their app without the database. Existing unattended launch behavior is preserved.
