### PR TITLE
fix(deploy): nil panic if machine is unreachable and dedication is set

### DIFF
--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -218,7 +218,7 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *fly.Machine) (
 		delete(mConfig.Env, "FLY_STANDBY_FOR")
 	}
 
-	if hdid := md.appConfig.HostDedicationID; hdid != "" && hdid != oConfig.Guest.HostDedicationID {
+	if hdid := md.appConfig.HostDedicationID; hdid != "" && hdid != machineHostDedicationID(origMachineRaw) {
 		if len(oMounts) > 0 && len(mMounts) > 0 {
 			// Attempting to rellocate a machine with a volume attached to a different host
 			return nil, fmt.Errorf("can't rellocate machine '%s' to dedication id '%s' because it has an attached volume."+
@@ -229,6 +229,10 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *fly.Machine) (
 		// but sets it as a top level directive.
 		// This also works when top level HDID is different than [compute.host_dedication_id]
 		// because a flatten config also overrides the top level directive
+		if mConfig.Guest == nil {
+			// No existing guest config to inherit (unreachable host + no [[compute]] section)
+			mConfig.Guest = &fly.MachineGuest{}
+		}
 		mConfig.Guest.HostDedicationID = hdid
 	}
 

--- a/internal/command/deploy/machines_launchinput_test.go
+++ b/internal/command/deploy/machines_launchinput_test.go
@@ -28,6 +28,7 @@ func TestLaunchInputForUpdate(t *testing.T) {
 
 	t.Run("Basic", testLaunchInputForBasic)
 	t.Run("HostStatusUnreachable", testLaunchInputForUpdateHostStatusUnreachable)
+	t.Run("HostStatusUnreachableWithDedicationID", testLaunchInputForUpdateHostStatusUnreachableWithDedicationID)
 	t.Run("Mounts", testLaunchInputForOnMounts)
 	t.Run("MountsAndAutoResize", testLaunchInputForOnMountsAndAutoResize)
 	t.Run("UpdateKeepUnmanagedFields", testLaunchInputForUpdateKeepUnmanagedFields)
@@ -165,6 +166,30 @@ func testLaunchInputForUpdateHostStatusUnreachable(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, li.RequiresReplacement)
 	require.Equal(t, li.Config.Mounts, []fly.MachineMount{{Path: "/data", Volume: "vol_10001", Name: "data"}})
+}
+
+// Regression for a nil pointer dereference: deploying an app with a
+// host_dedication_id set while one of its machines is on an unreachable host
+// (so Config is nil) used to panic.
+func testLaunchInputForUpdateHostStatusUnreachableWithDedicationID(t *testing.T) {
+	md, err := stabMachineDeployment(&appconfig.Config{
+		AppName:          "my-cool-app",
+		PrimaryRegion:    "scl",
+		HostDedicationID: "host-a",
+	})
+	require.NoError(t, err)
+
+	li, err := md.launchInputForUpdate(&fly.Machine{
+		ID:     "ab1234567890",
+		Region: "ord",
+		IncompleteConfig: &fly.MachineConfig{
+			Metadata: map[string]string{"fly_process_group": "app"},
+		},
+		HostStatus: fly.HostStatusUnreachable,
+	})
+	require.NoError(t, err)
+	require.True(t, li.RequiresReplacement)
+	require.Equal(t, "ord", li.Region)
 }
 
 // Test Mounts

--- a/internal/command/deploy/machines_releasecommand.go
+++ b/internal/command/deploy/machines_releasecommand.go
@@ -212,10 +212,22 @@ func waitForLogs(md *machineDeployment, ctx context.Context, stream logs.LogStre
 	}
 }
 
+// machineHostDedicationID resolves the host dedication ID from whichever machine
+// config is available - the full Config, or the partial IncompleteConfig that's
+// all we get for a machine on a non-ok host.
+func machineHostDedicationID(m *fly.Machine) string {
+	cfg := m.GetConfig()
+	if cfg == nil || cfg.Guest == nil {
+		return ""
+	}
+
+	return cfg.Guest.HostDedicationID
+}
+
 // dedicatedHostIdMismatch checks if the dedicatedHostID on a machine is the same as the one set in the fly.toml
 // a mismatch will result in a delete+recreate op
 func dedicatedHostIdMismatch(m *fly.Machine, ac *appconfig.Config) bool {
-	return strings.TrimSpace(ac.HostDedicationID) != "" && m.Config.Guest.HostDedicationID != ac.HostDedicationID
+	return strings.TrimSpace(ac.HostDedicationID) != "" && machineHostDedicationID(m) != ac.HostDedicationID
 }
 
 func (md *machineDeployment) createOrUpdateReleaseCmdMachine(ctx context.Context) error {

--- a/internal/command/deploy/machines_releasecommand.go
+++ b/internal/command/deploy/machines_releasecommand.go
@@ -217,10 +217,22 @@ func waitForLogs(md *machineDeployment, ctx context.Context, stream logs.LogStre
 	}
 }
 
+// machineHostDedicationID resolves the host dedication ID from whichever machine
+// config is available - the full Config, or the partial IncompleteConfig that's
+// all we get for a machine on a non-ok host.
+func machineHostDedicationID(m *fly.Machine) string {
+	cfg := m.GetConfig()
+	if cfg == nil || cfg.Guest == nil {
+		return ""
+	}
+
+	return cfg.Guest.HostDedicationID
+}
+
 // dedicatedHostIdMismatch checks if the dedicatedHostID on a machine is the same as the one set in the fly.toml
 // a mismatch will result in a delete+recreate op
 func dedicatedHostIdMismatch(m *fly.Machine, ac *appconfig.Config) bool {
-	return strings.TrimSpace(ac.HostDedicationID) != "" && m.Config.Guest.HostDedicationID != ac.HostDedicationID
+	return strings.TrimSpace(ac.HostDedicationID) != "" && machineHostDedicationID(m) != ac.HostDedicationID
 }
 
 func (md *machineDeployment) createOrUpdateReleaseCmdMachine(ctx context.Context) error {


### PR DESCRIPTION
### Change Summary

What and Why:

Deploying an app with a `host_dedication_id` while one of its machines is on an unreachable host panics.

If the machine API can't reach a host, it sets `IncompleteConfig` instead of `Config` for the unreachable machines. This triggered a nil panic in the host dedication code.