### PR TITLE
Fix incorrect use of `fmt.Println`.

### DIFF
--- a/internal/command/launch/launch_frameworks.go
+++ b/internal/command/launch/launch_frameworks.go
@@ -75,7 +75,7 @@ func (state *launchState) setupGitHubActions(ctx context.Context, appName string
 				err = cmd.Run()
 
 				if err != nil {
-					fmt.Println("failed setting FLY_API_TOKEN secret in GitHub repository settings: %w", err)
+					fmt.Printf("failed setting FLY_API_TOKEN secret in GitHub repository settings: %s\n", err)
 				}
 			}
 		}


### PR DESCRIPTION
### Change Summary

What and Why:

I just noticed the following in a `fly launch` run:

    failed setting FLY_API_TOKEN secret in GitHub repository settings: %w exit status 1

The `%w` shouldn't be printed.

How:

This PR replaces `fmt.Println` with `fmt.Printf` to have that error displayed correctly.

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
