### PR TITLE
Swap 'status' with 'owner' value in machine lease.

### DIFF
--- a/internal/command/machine/leases.go
+++ b/internal/command/machine/leases.go
@@ -139,8 +139,8 @@ func runLeaseView(ctx context.Context) (err error) {
 		rows = append(rows, []string{
 			machine,
 			lease.Data.Nonce,
-			lease.Data.Owner,
 			lease.Status,
+			lease.Data.Owner,
 			expires,
 		})
 	}


### PR DESCRIPTION
### Change Summary

What and Why:

So far, the following command would show the wrong values for a lease's status and owner:

    $ fly machine leases view
    MACHINE        │ NONCE        │ STATUS                                             │ OWNER   │ EXPIRES
    48ee9eea362098 │ cd051d40de89 │ 140e4bb3-fdb4-5ea2-aff7-835ed9803014@tokens.fly.io │ success │ 2026-06-22T11:39:51-05:00

How:

This PR fixes the problem by swapping these two values.

Fixes https://github.com/superfly/flyctl/issues/3336.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
