### PR TITLE
refactor: Bound WireGuard connect context

### DIFF
--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -246,11 +246,11 @@ func (s *server) buildTunnel(ctx context.Context, org *fly.Organization, reestab
 
 	// WIP: can't stay this way, need something more clever than this
 	if env.IsCI() || os.Getenv("WSWG") != "" || s.ConfigWebsockets {
-		if tunnel, err = wg.ConnectWS(context.Background(), state); err != nil {
+		if tunnel, err = wg.ConnectWS(ctx, state); err != nil {
 			return
 		}
 	} else {
-		if tunnel, err = wg.Connect(context.Background(), state); err != nil {
+		if tunnel, err = wg.Connect(ctx, state); err != nil {
 			return
 		}
 	}

--- a/wg/tunnel.go
+++ b/wg/tunnel.go
@@ -71,9 +71,14 @@ func doConnect(ctx context.Context, state *WireGuardState, wswg bool) (*Tunnel, 
 	endpointIP := endpointIPs[rand.Intn(len(endpointIPs))]
 	endpointAddr := net.JoinHostPort(endpointIP.String(), endpointPort)
 
+	var wscancel context.CancelFunc
 	if wswg {
-		port, err := websocketConnect(ctx, endpointHost)
+		var lifetimeCtx context.Context
+		lifetimeCtx, wscancel = context.WithCancel(context.Background())
+		port, err := websocketConnect(ctx, lifetimeCtx, endpointHost)
 		if err != nil {
+			wscancel()
+
 			return nil, err
 		}
 
@@ -90,17 +95,22 @@ func doConnect(ctx context.Context, state *WireGuardState, wswg bool) (*Tunnel, 
 	fmt.Fprintf(wgConf, "persistent_keepalive_interval=%d\n", cfg.KeepAlive)
 
 	if err := wgDev.IpcSetOperation(bufio.NewReader(wgConf)); err != nil {
+		if wscancel != nil {
+			wscancel()
+		}
+
 		return nil, err
 	}
 	wgDev.Up()
 
 	return &Tunnel{
-		dev:    wgDev,
-		tun:    tunDev,
-		net:    gNet,
-		dnsIP:  cfg.DNS,
-		Config: cfg,
-		State:  state,
+		dev:      wgDev,
+		tun:      tunDev,
+		net:      gNet,
+		dnsIP:    cfg.DNS,
+		Config:   cfg,
+		State:    state,
+		wscancel: wscancel,
 
 		resolv: &net.Resolver{
 			PreferGo: true,

--- a/wg/ws.go
+++ b/wg/ws.go
@@ -19,16 +19,7 @@ import (
 )
 
 func ConnectWS(ctx context.Context, state *WireGuardState) (*Tunnel, error) {
-	ctx, cancel := context.WithCancel(ctx)
-
-	t, err := doConnect(ctx, state, true)
-	if err == nil {
-		t.wscancel = cancel
-	} else {
-		cancel()
-	}
-
-	return t, err
+	return doConnect(ctx, state, true)
 }
 
 func read(r io.Reader, rbuf []byte) ([]byte, error) {
@@ -124,7 +115,7 @@ func (wswg *WsWgProxy) Port() (int, error) {
 	return udpBindAddr.Port, nil
 }
 
-func (wswg *WsWgProxy) Connect(ctx context.Context, endpoint string) error {
+func (wswg *WsWgProxy) Connect(dialCtx, lifetimeCtx context.Context, endpoint string) error {
 	rurl := (&url.URL{
 		Scheme: "wss",
 		Host:   net.JoinHostPort(endpoint, "443"),
@@ -133,7 +124,7 @@ func (wswg *WsWgProxy) Connect(ctx context.Context, endpoint string) error {
 
 	log.Printf("(re-)connecting to %s", rurl)
 
-	ws, _, err := websocket.Dial(ctx, rurl, &websocket.DialOptions{ // nolint: bodyclose
+	ws, _, err := websocket.Dial(dialCtx, rurl, &websocket.DialOptions{ // nolint: bodyclose
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{
 				Proxy: http.ProxyFromEnvironment,
@@ -151,7 +142,7 @@ func (wswg *WsWgProxy) Connect(ctx context.Context, endpoint string) error {
 		return fmt.Errorf("websocket: %w", err)
 	}
 
-	wsConn := websocket.NetConn(ctx, ws, websocket.MessageText)
+	wsConn := websocket.NetConn(lifetimeCtx, ws, websocket.MessageText)
 
 	var magic [4]byte
 	binary.BigEndian.PutUint32(magic[:], 0x2FACED77)
@@ -239,7 +230,7 @@ func (wswg *WsWgProxy) wg2ws(ctx context.Context) {
 	}
 }
 
-func websocketConnect(ctx context.Context, endpoint string) (int, error) {
+func websocketConnect(dialCtx, lifetimeCtx context.Context, endpoint string) (int, error) {
 	wswg, err := NewWsWgProxy()
 	if err != nil {
 		return 0, err
@@ -250,7 +241,9 @@ func websocketConnect(ctx context.Context, endpoint string) (int, error) {
 		return 0, err
 	}
 
-	if err = wswg.Connect(ctx, endpoint); err != nil {
+	if err = wswg.Connect(dialCtx, lifetimeCtx, endpoint); err != nil {
+		wswg.plugConn.Close()
+
 		return 0, err
 	}
 
@@ -271,13 +264,13 @@ func websocketConnect(ctx context.Context, endpoint string) (int, error) {
 			case <-tick.C:
 				if !reconnectAt.IsZero() && reconnectAt.Before(time.Now()) {
 					wswg.lock.Lock()
-					wswg.Connect(ctx, endpoint)
+					wswg.Connect(lifetimeCtx, lifetimeCtx, endpoint)
 					wswg.lock.Unlock()
 
 					reconnectAt = time.Time{}
 				}
 
-			case <-ctx.Done():
+			case <-lifetimeCtx.Done():
 				return
 
 			case <-c:
@@ -294,12 +287,12 @@ func websocketConnect(ctx context.Context, endpoint string) (int, error) {
 	}()
 
 	go func() {
-		go wswg.ws2wg(ctx)
-		go wswg.wg2ws(ctx)
+		go wswg.ws2wg(lifetimeCtx)
+		go wswg.wg2ws(lifetimeCtx)
 
 		zeroLenMsg := make([]byte, 4)
 
-		for ctx.Err() == nil {
+		for lifetimeCtx.Err() == nil {
 			time.Sleep(1 * time.Second)
 
 			if wswg.lastIo() > (1 * time.Second) {


### PR DESCRIPTION
Previously, the context used by initiating and maintaining WireGuard
connections was the same. This forced the fly agent to pass in an
unbound context which could hang forever if attempting to connect to a
nonexistant service.

---
This PR is part of a stack:
- #4942
- -> #4941