### PR TITLE
fix: Add timeout when connecting to NATS

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp_test.go
+++ b/internal/command/deploy/machines_deploymachinesapp_test.go
@@ -67,6 +67,9 @@ func TestDeployMachinesApp(t *testing.T) {
 		waitTimeout:     1 * time.Second,
 	}
 
+	// Shorten the NATS timeout since it's likely to require the fallback in CI
+	natsConnectTimeout = md.waitTimeout
+
 	ctx := context.Background()
 	ctx = iostreams.NewContext(ctx, ios)
 	ctx = flapsutil.NewContextWithClient(ctx, client)

--- a/internal/command/deploy/machines_releasecommand.go
+++ b/internal/command/deploy/machines_releasecommand.go
@@ -29,6 +29,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+var natsConnectTimeout = 10 * time.Second
+
 func (md *machineDeployment) runReleaseCommands(ctx context.Context) error {
 	err := md.runReleaseCommand(ctx, "release")
 
@@ -91,6 +93,9 @@ func (md *machineDeployment) runReleaseCommand(ctx context.Context, commandType 
 		return nil
 	})
 	eg.Go(func() error {
+		ctx, cancel := context.WithTimeout(ctx, natsConnectTimeout)
+		defer cancel()
+
 		stream, err = logs.NewNatsStream(ctx, md.apiClient, md.flapsClient, logOpts)
 		if err != nil {
 			// Silently fallback to app logs polling if NATS streaming client is unavailable.


### PR DESCRIPTION
Adds a timeout to switch to the polling fallback if it takes too long to
connect to NATS.

---
This PR is part of a stack:
- -> #4942
- #4941