### PR TITLE
feat(deploy): warn when the Docker build context is unexpectedly large

### DIFF
--- a/internal/build/imgsrc/context_size.go
+++ b/internal/build/imgsrc/context_size.go
@@ -1,0 +1,304 @@
+package imgsrc
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/docker/go-units"
+	humanize "github.com/dustin/go-humanize"
+	"github.com/moby/patternmatcher"
+	"github.com/superfly/flyctl/helpers"
+	"github.com/superfly/flyctl/internal/env"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/iostreams"
+	"github.com/superfly/flyctl/terminal"
+)
+
+// defaultBuildContextWarnSize is the build context size above which flyctl warns
+// that the context being uploaded to the builder is unexpectedly large. It can
+// be overridden per-build with the --build-context-warn-size flag or the
+// FLY_BUILD_CONTEXT_WARN_SIZE environment variable (set either to 0 to disable
+// the warning). Values accept a plain number (in MB) or a human-readable size
+// such as "512mb" or "1gb".
+const defaultBuildContextWarnSize = "100mb"
+
+const buildContextWarnEnvVar = "FLY_BUILD_CONTEXT_WARN_SIZE"
+
+// maxLargeContextPaths is the number of largest paths listed in the warning.
+const maxLargeContextPaths = 5
+
+// minLargeContextPathBytes is the smallest a path can be and still be worth
+// listing as an offender in the warning.
+const minLargeContextPathBytes = 1_000_000
+
+type buildContextEntry struct {
+	name  string
+	bytes int64
+	isDir bool
+}
+
+func (e buildContextEntry) displayName() string {
+	if e.isDir {
+		return e.name + "/"
+	}
+
+	return e.name
+}
+
+type buildContextStats struct {
+	totalBytes int64
+	fileCount  int
+	// entries holds the top-level files and directories of the build context,
+	// each carrying the combined size of the (non-ignored) files beneath it,
+	// sorted largest first.
+	entries []buildContextEntry
+}
+
+// warnOnLargeBuildContext prints a warning when the Docker build context that
+// will be uploaded to the builder is larger than the configured threshold,
+// listing the largest paths so the user can add anything unnecessary to their
+// .dockerignore. flagValue is the value of the --build-context-warn-size flag,
+// or "" when it was not set. It is best-effort: any error simply skips the
+// warning, so a deploy is never blocked or slowed meaningfully by it.
+func warnOnLargeBuildContext(streams *iostreams.IOStreams, opts ImageOptions, flagValue string) {
+	// Only plain Dockerfile builds upload a .dockerignore-filtered context.
+	// Buildpacks, builtins and custom builders manage their own context, so the
+	// estimate below wouldn't reflect what they send.
+	if opts.Builder != "" || opts.BuiltIn != "" || len(opts.Buildpacks) > 0 {
+		return
+	}
+	if opts.WorkingDir == "" {
+		return
+	}
+
+	thresholdBytes, enabled := resolveBuildContextWarnBytes(flagValue, env.First(buildContextWarnEnvVar))
+	if !enabled {
+		return
+	}
+
+	dockerfile := opts.DockerfilePath
+	if dockerfile == "" {
+		dockerfile = ResolveDockerfile(opts.WorkingDir)
+	}
+	if dockerfile == "" {
+		return
+	}
+
+	stats, err := analyzeBuildContext(opts.WorkingDir, dockerfile, opts.IgnorefilePath)
+	if err != nil {
+		terminal.Debugf("skipping build context size check: %v\n", err)
+
+		return
+	}
+
+	if stats.totalBytes < thresholdBytes {
+		return
+	}
+
+	fmt.Fprint(streams.ErrOut, formatLargeBuildContextWarning(streams.ColorScheme(), stats))
+}
+
+// resolveBuildContextWarnBytes turns the flag value (or "" when
+// --build-context-warn-size was not set) and the environment variable value into
+// a threshold in bytes. An explicit flag takes precedence over the env var,
+// which takes precedence over the default. Each accepts a plain number (in MB)
+// or a human-readable size such as "512mb" or "1gb". The boolean is false when
+// the warning has been disabled (threshold resolved to 0 or below).
+func resolveBuildContextWarnBytes(flagValue, envValue string) (int64, bool) {
+	raw := defaultBuildContextWarnSize
+	if envValue != "" {
+		raw = envValue
+	}
+	if flagValue != "" {
+		raw = flagValue
+	}
+
+	mb, err := helpers.ParseSize(raw, units.RAMInBytes, units.MiB)
+	if err != nil {
+		terminal.Debugf("ignoring invalid build context warn size %q: %v\n", raw, err)
+		mb, _ = helpers.ParseSize(defaultBuildContextWarnSize, units.RAMInBytes, units.MiB)
+	}
+
+	if mb <= 0 {
+		return 0, false
+	}
+
+	return int64(mb) * units.MiB, true
+}
+
+// analyzeBuildContext walks workingDir applying the same .dockerignore rules
+// flyctl uses when building the image, and returns the total size of the
+// resulting build context along with its largest top-level paths. It only
+// stats files (never reads them), and prunes ignored directories, so it stays
+// cheap relative to the upload it is warning about.
+func analyzeBuildContext(workingDir, dockerfile, ignoreFile string) (buildContextStats, error) {
+	var stats buildContextStats
+
+	relDockerfile := ""
+	if isPathInRoot(dockerfile, workingDir) {
+		if p, err := filepath.Rel(workingDir, dockerfile); err == nil {
+			relDockerfile = filepath.ToSlash(p)
+		}
+	}
+
+	excludes, err := readDockerignore(workingDir, ignoreFile, relDockerfile)
+	if err != nil {
+		return stats, err
+	}
+
+	pm, err := patternmatcher.New(excludes)
+	if err != nil {
+		return stats, err
+	}
+
+	byTopLevel := map[string]*buildContextEntry{}
+
+	walkErr := filepath.WalkDir(workingDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Skip entries we can't read rather than aborting the whole estimate.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(workingDir, path)
+		if relErr != nil || rel == "." {
+			return nil
+		}
+		slashRel := filepath.ToSlash(rel)
+
+		// Match the file against .dockerignore exactly like the archiver does,
+		// taking parent directory matches into account.
+		if excluded, _ := pm.MatchesOrParentMatches(slashRel); excluded {
+			// A directory may be skipped wholesale unless a negated pattern
+			// (e.g. !build/keep) could re-include something beneath it.
+			if d.IsDir() && canSkipExcludedDir(pm, rel) {
+				return fs.SkipDir
+			}
+
+			return nil
+		}
+
+		top := slashRel
+		if i := strings.IndexByte(slashRel, '/'); i >= 0 {
+			top = slashRel[:i]
+		}
+		entry := byTopLevel[top]
+		if entry == nil {
+			entry = &buildContextEntry{name: top}
+			byTopLevel[top] = entry
+		}
+		if slashRel != top || d.IsDir() {
+			entry.isDir = true
+		}
+
+		if d.Type().IsRegular() {
+			info, infoErr := d.Info()
+			if infoErr != nil {
+				return nil
+			}
+			entry.bytes += info.Size()
+			stats.totalBytes += info.Size()
+			stats.fileCount++
+		}
+
+		return nil
+	})
+	if walkErr != nil {
+		return stats, walkErr
+	}
+
+	stats.entries = make([]buildContextEntry, 0, len(byTopLevel))
+	for _, e := range byTopLevel {
+		stats.entries = append(stats.entries, *e)
+	}
+	sort.Slice(stats.entries, func(i, j int) bool {
+		if stats.entries[i].bytes != stats.entries[j].bytes {
+			return stats.entries[i].bytes > stats.entries[j].bytes
+		}
+
+		return stats.entries[i].name < stats.entries[j].name
+	})
+
+	return stats, nil
+}
+
+// canSkipExcludedDir reports whether an excluded directory can be skipped
+// entirely, i.e. no negated (re-include) pattern could match a file beneath it.
+// This mirrors the directory-skipping logic in
+// github.com/docker/docker/pkg/archive so our estimate matches what is sent.
+func canSkipExcludedDir(pm *patternmatcher.PatternMatcher, relDir string) bool {
+	if !pm.Exclusions() {
+		return true
+	}
+
+	dirSlash := relDir + string(filepath.Separator)
+	for _, pat := range pm.Patterns() {
+		if !pat.Exclusion() {
+			continue
+		}
+		if strings.HasPrefix(pat.String()+string(filepath.Separator), dirSlash) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// largeContextPaths returns the entries worth surfacing as likely offenders:
+// the largest few that are individually big enough to matter.
+func largeContextPaths(stats buildContextStats) []buildContextEntry {
+	out := make([]buildContextEntry, 0, maxLargeContextPaths)
+	for _, e := range stats.entries {
+		if e.bytes < minLargeContextPathBytes {
+			break // entries are sorted largest first
+		}
+		out = append(out, e)
+		if len(out) == maxLargeContextPaths {
+			break
+		}
+	}
+
+	return out
+}
+
+func formatLargeBuildContextWarning(cs *iostreams.ColorScheme, stats buildContextStats) string {
+	fileWord := "files"
+	if stats.fileCount == 1 {
+		fileWord = "file"
+	}
+
+	var b strings.Builder
+	b.WriteByte('\n')
+	fmt.Fprintf(&b, "%s Build context is %s across %s %s. It is uploaded to the builder on\n",
+		cs.Yellow("WARN"),
+		humanize.Bytes(uint64(stats.totalBytes)),
+		humanize.Comma(int64(stats.fileCount)),
+		fileWord,
+	)
+	fmt.Fprint(&b, "     every deploy, and a large context can make builds noticeably slower.\n")
+
+	if shown := largeContextPaths(stats); len(shown) > 0 {
+		fmt.Fprint(&b, "     Largest paths in the context:\n")
+		nameWidth := 0
+		for _, e := range shown {
+			if n := len(e.displayName()); n > nameWidth {
+				nameWidth = n
+			}
+		}
+		for _, e := range shown {
+			fmt.Fprintf(&b, "       %-*s  %s\n", nameWidth, e.displayName(), humanize.Bytes(uint64(e.bytes)))
+		}
+	}
+
+	fmt.Fprint(&b, "     If some of these don't need to be in the image, add them to .dockerignore:\n")
+	fmt.Fprintf(&b, "     %s\n", cs.Gray("https://docs.docker.com/build/concepts/context/#dockerignore-files"))
+	fmt.Fprintf(&b, "     %s\n", cs.Gray(fmt.Sprintf("(disable with --%s 0)", flag.BuildContextWarnSizeName)))
+
+	return b.String()
+}

--- a/internal/build/imgsrc/context_size_test.go
+++ b/internal/build/imgsrc/context_size_test.go
@@ -1,0 +1,133 @@
+package imgsrc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeSizedFile writes a file of exactly size bytes at rel within dir,
+// creating parent directories as needed.
+func writeSizedFile(t *testing.T, dir, rel string, size int) {
+	t.Helper()
+	full := filepath.Join(dir, filepath.FromSlash(rel))
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, make([]byte, size), 0o644))
+}
+
+func entryByName(entries []buildContextEntry, name string) (buildContextEntry, bool) {
+	for _, e := range entries {
+		if e.name == name {
+			return e, true
+		}
+	}
+
+	return buildContextEntry{}, false
+}
+
+func TestAnalyzeBuildContext_TotalsAndLargestPaths(t *testing.T) {
+	dir := t.TempDir()
+	writeSizedFile(t, dir, "Dockerfile", 100)
+	writeSizedFile(t, dir, "app/main.go", 500)
+	writeSizedFile(t, dir, ".cache/blob.bin", 4000)
+	writeSizedFile(t, dir, ".cache/nested/more.bin", 1000)
+	writeSizedFile(t, dir, "keep.txt", 250)
+
+	stats, err := analyzeBuildContext(dir, filepath.Join(dir, "Dockerfile"), "")
+	require.NoError(t, err)
+
+	// Without a .dockerignore, everything but fly.toml (absent here) is included.
+	assert.Equal(t, int64(100+500+4000+1000+250), stats.totalBytes)
+	assert.Equal(t, 5, stats.fileCount)
+
+	// Largest top-level path is .cache, aggregating its nested files, and is
+	// reported as a directory.
+	require.NotEmpty(t, stats.entries)
+	assert.Equal(t, ".cache", stats.entries[0].name)
+	assert.Equal(t, int64(5000), stats.entries[0].bytes)
+	assert.True(t, stats.entries[0].isDir)
+	assert.Equal(t, ".cache/", stats.entries[0].displayName())
+
+	app, ok := entryByName(stats.entries, "app")
+	require.True(t, ok)
+	assert.Equal(t, int64(500), app.bytes)
+	assert.True(t, app.isDir)
+
+	keep, ok := entryByName(stats.entries, "keep.txt")
+	require.True(t, ok)
+	assert.False(t, keep.isDir)
+}
+
+func TestAnalyzeBuildContext_HonorsDockerignore(t *testing.T) {
+	dir := t.TempDir()
+	writeSizedFile(t, dir, "Dockerfile", 100)
+	writeSizedFile(t, dir, "app/main.go", 500)
+	writeSizedFile(t, dir, ".cache/blob.bin", 9000)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".dockerignore"), []byte(".cache\n"), 0o644))
+
+	stats, err := analyzeBuildContext(dir, filepath.Join(dir, "Dockerfile"), "")
+	require.NoError(t, err)
+
+	_, found := entryByName(stats.entries, ".cache")
+	assert.False(t, found, "ignored .cache should not be counted")
+	assert.Less(t, stats.totalBytes, int64(9000), "ignored bytes should be excluded")
+
+	app, ok := entryByName(stats.entries, "app")
+	require.True(t, ok)
+	assert.Equal(t, int64(500), app.bytes)
+}
+
+func TestAnalyzeBuildContext_NegatedReinclude(t *testing.T) {
+	dir := t.TempDir()
+	writeSizedFile(t, dir, "Dockerfile", 100)
+	writeSizedFile(t, dir, "logs/big.log", 8000)
+	writeSizedFile(t, dir, "logs/keep.log", 30)
+
+	ignore := "logs\n!logs/keep.log\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".dockerignore"), []byte(ignore), 0o644))
+
+	stats, err := analyzeBuildContext(dir, filepath.Join(dir, "Dockerfile"), "")
+	require.NoError(t, err)
+
+	// big.log is ignored, but the negated keep.log is walked back in.
+	logs, ok := entryByName(stats.entries, "logs")
+	require.True(t, ok, "re-included logs/keep.log should be counted")
+	assert.Equal(t, int64(30), logs.bytes)
+}
+
+func TestResolveBuildContextWarnBytes(t *testing.T) {
+	const mib = int64(1 << 20) // matches units.MiB
+	defaultBytes := 100 * mib
+
+	cases := []struct {
+		name      string
+		flagValue string // "" means the flag was not set
+		envValue  string
+		wantBytes int64
+		wantOn    bool
+	}{
+		{"default", "", "", defaultBytes, true},
+		{"env plain number is MB", "", "250", 250 * mib, true},
+		{"env human size", "", "2gb", 2048 * mib, true},
+		{"env disables", "", "0", 0, false},
+		{"env invalid falls back to default", "", "not-a-size", defaultBytes, true},
+		{"flag plain number is MB", "300", "", 300 * mib, true},
+		{"flag human size", "1gb", "", 1024 * mib, true},
+		{"flag disables", "0", "", 0, false},
+		{"flag beats env", "300", "200", 300 * mib, true},
+		{"flag disable beats env", "0", "500", 0, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBytes, gotOn := resolveBuildContextWarnBytes(tc.flagValue, tc.envValue)
+			assert.Equal(t, tc.wantOn, gotOn)
+			if tc.wantOn {
+				assert.Equal(t, tc.wantBytes, gotBytes)
+			}
+		})
+	}
+}

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -245,6 +245,11 @@ func (r *Resolver) BuildImage(ctx context.Context, streams *iostreams.IOStreams,
 
 	span.SetAttributes(attribute.String("tag", opts.Tag))
 
+	// Warn early if the build context we're about to upload looks unexpectedly
+	// large, so users can spot a missing .dockerignore entry before the slow
+	// transfer happens. Best-effort: never blocks the build.
+	warnOnLargeBuildContext(streams, opts, flag.GetString(ctx, flag.BuildContextWarnSizeName))
+
 	strategies := []imageBuilder{}
 
 	var builderScope depotBuilderScope

--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -121,6 +121,7 @@ func New() *cobra.Command {
 			Description: "Set the target build stage to build if the Dockerfile has more than one stage",
 			Hidden:      true,
 		},
+		flag.BuildContextWarnSize(),
 		flag.Bool{
 			Name:        "no-build-cache",
 			Description: "Do not use the cache when building the image",

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -50,6 +50,7 @@ var CommonFlags = flag.Set{
 	flag.BuildArg(),
 	flag.BuildSecret(),
 	flag.BuildTarget(),
+	flag.BuildContextWarnSize(),
 	flag.NoCache(),
 	flag.Depot(),
 	flag.DepotScope(),

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -93,6 +93,7 @@ var sharedFlags = flag.Set{
 		Description: "Set the target build stage to build if the Dockerfile has more than one stage",
 		Hidden:      true,
 	},
+	flag.BuildContextWarnSize(),
 	flag.Bool{
 		Name:        "no-build-cache",
 		Description: "Do not use the cache when building the image",

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -560,6 +560,19 @@ func BuildTarget() String {
 	}
 }
 
+const BuildContextWarnSizeName = "build-context-warn-size"
+
+// BuildContextWarnSize controls the size at which flyctl warns that the Docker
+// build context being uploaded to the builder is unexpectedly large. Setting it
+// to 0 disables the warning. The effective default lives in imgsrc as
+// defaultBuildContextWarnSize.
+func BuildContextWarnSize() String {
+	return String{
+		Name:        BuildContextWarnSizeName,
+		Description: "Warn when the Docker build context is larger than this. Accepts a plain number (in MB) or a human-readable size (e.g. 512mb, 1gb). Set to 0 to disable. Also set with FLY_BUILD_CONTEXT_WARN_SIZE.",
+	}
+}
+
 func Depot() String {
 	return String{
 		Name:        "depot",


### PR DESCRIPTION
## What

`fly deploy` now prints a warning when the Docker build context it is about to
upload to the builder is unexpectedly large, and lists the largest paths so you
can spot anything that should be in `.dockerignore`.

Example:

```
WARN Build context is 1.3 GB across 48,213 files. It is uploaded to the builder on
     every deploy, and a large context can make builds noticeably slower.
     Largest paths in the context:
       .cache/        1.0 GB
       node_modules/  220 MB
       .npm/          93 MB
     If some of these don't need to be in the image, add them to .dockerignore:
     https://docs.docker.com/build/concepts/context/#dockerignore-files
     (disable with --build-context-warn-size 0)
```

## Why

I recently had deploys that were mysteriously slow. The cause turned out to be a
`.dockerignore` that was missing some large folders (Playwright browsers and
assorted tool caches), so ~1.3 GB of context was being uploaded to the builder
on every deploy before the image build even started. Adding the missing entries
fixed it immediately.

`flyctl` already walks the working directory and applies `.dockerignore` to send
the context, so it is well placed to gently point out when a context is far
larger than you probably intended — before you sit through the slow transfer.
Discussion: https://community.fly.io/t/feature-request-warn-or-require-an-override-when-the-docker-build-context-is-unexpectedly-large/28163

## How

- New `internal/build/imgsrc/context_size.go` walks the build context applying
  the same `.dockerignore` rules used when building (including parent-dir matches
  and negated re-includes, mirroring `docker/pkg/archive`), and sums the largest
  top-level paths. It only `stat`s files (never reads them) and prunes ignored
  directories, so the cost is bounded by the context it is warning about.
- `Resolver.BuildImage` calls it once, up front, for Dockerfile builds.
- Adds a `--build-context-warn-size` flag (also settable via
  `FLY_BUILD_CONTEXT_WARN_SIZE`) on every command that builds from a Dockerfile —
  `deploy`, `launch`, `machine run`, `machine update`, `console` — so the warning
  can be tuned or turned off (`--build-context-warn-size 0`). It follows the
  existing `*-size` flag convention (`swap-size`, `rootfs-size`, …): a `String`
  parsed with `helpers.ParseSize`, accepting a plain number (MB) or a
  human-readable size like `512mb`/`1gb`.

Design notes / things I'd love feedback on:

- **Non-blocking and best-effort.** It only ever prints a warning; any error
  (unreadable dir, etc.) silently skips the check so a deploy is never blocked or
  meaningfully slowed by it. The thread floated optionally *requiring* an
  override — happy to add a stricter mode, but a warning felt like the right
  default to start with.
- **Threshold.** Defaults to 100 MB, tunable per build with
  `--build-context-warn-size` or globally with `FLY_BUILD_CONTEXT_WARN_SIZE`, and
  disabled by setting either to `0`. I'm genuinely unsure 100 MB is the right
  number — I took it from the figure in the thread, but folks who've seen far
  more app setups than I have will have a much better sense of what counts as
  "normal" versus genuinely surprising. The main thing I want to avoid is the
  warning firing so often on legitimately-sized contexts that people reflexively
  set it to `0` and forget about it — at which point it's worse than useless. So
  I'd lean towards erring high if in doubt, and I'd really value your read on a
  sensible default (or a smarter heuristic than a flat byte count).
- **Scope.** Limited to plain Dockerfile builds, which are the ones that upload a
  `.dockerignore`-filtered context. Buildpacks/builtins/custom builders manage
  their own context and are skipped. Could be extended later.

## Testing

- Unit tests in `internal/build/imgsrc/context_size_test.go` cover the size
  totals, largest-path ordering, `.dockerignore` exclusion, nested-directory
  aggregation, negated re-includes, and flag/env threshold precedence.
- `go test ./internal/build/imgsrc/...` and `golangci-lint run` both pass.
