### PR TITLE
fix: error instead of panic on max_unavailable=0 in fly.toml (#4262)

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -246,6 +246,13 @@ func NewMachineDeployment(ctx context.Context, args MachineDeploymentArgs) (_ Ma
 	if appConfig.Deploy != nil && appConfig.Deploy.MaxUnavailable != nil {
 		maxUnavailable = *appConfig.Deploy.MaxUnavailable
 	}
+	// The --max-unavailable flag is validated in deploy.go, but a value read
+	// straight from fly.toml's [deploy] section bypasses that check. Guard it
+	// here so a max_unavailable of 0 yields a friendly error instead of an
+	// eventual "pool size must be > 0" panic. See #4262.
+	if maxUnavailable <= 0 {
+		return nil, fmt.Errorf("max_unavailable must be > 0 (got %v); set it to at least 1 or a fraction like 0.33", maxUnavailable)
+	}
 
 	maxConcurrent := max(args.MaxConcurrent, 1)
 

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -920,7 +920,9 @@ func (md *machineDeployment) getPoolSize(totalMachines int) int {
 	case mu >= 1:
 		return int(mu)
 	default:
-		return int(math.Ceil(float64(totalMachines) * mu))
+		// Never return a pool size below 1: a 0 (or negative) value would
+		// panic in acquireLeases ("pool size must be > 0"). See #4262.
+		return max(1, int(math.Ceil(float64(totalMachines)*mu)))
 	}
 }
 

--- a/internal/command/deploy/plan_test.go
+++ b/internal/command/deploy/plan_test.go
@@ -47,6 +47,30 @@ func TestCompareConfig(t *testing.T) {
 	assert.False(t, compareConfigs(ctx, config1, config2))
 }
 
+func TestGetPoolSize(t *testing.T) {
+	t.Parallel()
+
+	// Regression test for #4262: a max_unavailable of 0 (e.g. from fly.toml
+	// [deploy] max_unavailable = 0) must never produce a pool size of 0, which
+	// previously flowed into acquireLeases and panicked with
+	// "pool size must be > 0".
+	cases := []struct {
+		maxUnavailable float64
+		totalMachines  int
+		want           int
+	}{
+		{maxUnavailable: 0, totalMachines: 4, want: 1},
+		{maxUnavailable: 0.33, totalMachines: 4, want: 2},
+		{maxUnavailable: 1, totalMachines: 4, want: 1},
+		{maxUnavailable: 3, totalMachines: 4, want: 3},
+	}
+	for _, tc := range cases {
+		md := &machineDeployment{maxUnavailable: tc.maxUnavailable}
+		assert.GreaterOrEqual(t, md.getPoolSize(tc.totalMachines), 1)
+		assert.Equal(t, tc.want, md.getPoolSize(tc.totalMachines))
+	}
+}
+
 func TestAppState(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #4262.

`fly deploy` panicked with `pool size must be > 0` when `fly.toml` set `[deploy] max_unavailable = 0`. The config value was passed through unvalidated (only the `--max-unavailable` *flag* was checked), so the rolling planner computed a pool size of 0 and hit `panic("pool size must be > 0")`.

This validates `max_unavailable` coming from both the flag and `fly.toml`, returning a clear error instead of crashing.

**Testing:** added `TestGetPoolSize` — it fails on `master` (the panic path) and passes with the fix. `go test ./internal/command/deploy/...` is green.

---

✅ **Live-verified against a real org** (ephemeral app, cleaned up afterward):

- **Latest flyctl (master):** with `[deploy] max_unavailable = 0`, a second `fly deploy` panics — `panic: pool size must be > 0` at `internal/command/deploy/plan.go:411` (`acquireLeases`).
- **This branch:** same live app, same config → no panic; clean `Error: max_unavailable must be > 0 (got 0); set it to at least 1 or a fraction like 0.33`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
