### PR TITLE
fix: avoid nil pointer deref on restart for machines on unreachable hosts (#4190)

### DIFF
--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -21,7 +21,13 @@ func (md *machineDeployment) launchInputForRestart(origMachineRaw *fly.Machine) 
 		return nil, err
 	}
 
-	mConfig := machine.CloneConfig(origMachineRaw.Config)
+	// Use GetConfig() so machines on non-ok hosts (where the real config lives
+	// in IncompleteConfig and Config is nil) are handled, mirroring
+	// launchInputForUpdate. See issue #4190.
+	mConfig := machine.CloneConfig(origMachineRaw.GetConfig())
+	if mConfig == nil {
+		return nil, fmt.Errorf("machine %s has no config", origMachineRaw.ID)
+	}
 	md.setMachineReleaseData(mConfig)
 
 	return &fly.LaunchMachineInput{

--- a/internal/command/deploy/machines_launchinput_test.go
+++ b/internal/command/deploy/machines_launchinput_test.go
@@ -167,6 +167,33 @@ func testLaunchInputForUpdateHostStatusUnreachable(t *testing.T) {
 	require.Equal(t, li.Config.Mounts, []fly.MachineMount{{Path: "/data", Volume: "vol_10001", Name: "data"}})
 }
 
+// Restarting a machine on an unreachable host must not panic: its real config
+// lives in IncompleteConfig (Config is nil). Regression test for issue #4190.
+func TestLaunchInputForRestartHostStatusUnreachable(t *testing.T) {
+	makeTerminalLoggerQuiet(t)
+
+	md, err := stabMachineDeployment(&appconfig.Config{
+		AppName:       "my-cool-app",
+		PrimaryRegion: "scl",
+	})
+	assert.NoError(t, err)
+	md.releaseId = "new_release_id"
+
+	li, err := md.launchInputForRestart(&fly.Machine{
+		ID:     "ab1234567890",
+		Region: "ord",
+		Config: nil,
+		IncompleteConfig: &fly.MachineConfig{
+			Metadata: map[string]string{"fly_process_group": "app"},
+		},
+		HostStatus: fly.HostStatusUnreachable,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, li.Config)
+	require.Equal(t, "ord", li.Region)
+	require.Equal(t, "new_release_id", li.Config.Metadata[fly.MachineConfigMetadataKeyFlyReleaseId])
+}
+
 // Test Mounts
 func testLaunchInputForOnMounts(t *testing.T) {
 	md, err := stabMachineDeployment(&appconfig.Config{


### PR DESCRIPTION
Fixes #4190.

`fly secrets set` (and the restart path) could panic with a nil-pointer dereference in `setMachineReleaseData` when a machine returned a nil `Config` — e.g. a machine on an unreachable host.

This guards the nil `Config` before dereferencing it, so the deploy/secrets path no longer crashes.

**Testing:** added `TestLaunchInputForRestartHostStatusUnreachable` — it fails on `master` (nil-pointer dereference) and passes with the fix. `go test ./internal/command/deploy/...` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
