### PR TITLE
Return region code in case of error.

### DIFF
--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -783,13 +783,13 @@ func determineRegion(ctx context.Context, config *appconfig.Config, orgSlug stri
 		Org:                 orgSlug,
 	})
 	if err != nil {
-		return "", recoverableSpecifyInUi, recoverableInUiError{
+		return regionCode, recoverableSpecifyInUi, recoverableInUiError{
 			fmt.Errorf("failed to determine region: %w", err),
 		}
 	}
 
 	if len(placements) == 0 {
-		return "", recoverableSpecifyInUi, recoverableInUiError{
+		return regionCode, recoverableSpecifyInUi, recoverableInUiError{
 			fmt.Errorf("no regions with capacity for the requested configuration"),
 		}
 	}


### PR DESCRIPTION
### Change Summary

What and Why:

So far, when launching an app in an invalid region, we would end up with a broken error message:

    Error: region  not found. Is this a valid region according to `fly platform regions`?

Note the two spaces: A format string was not set correctly. 

How:

To fix that, this PR returns the region code in case there's a (recoverable) error. This will result in flyctl asking the user to fix the error in the UI, as intended:

    The following problems must be fixed in the Launch UI:
     * failed to determine region: failed to get placements: no capacity

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [X] n/a
