### PR TITLE
chore(deps): bump fly-go to client-signals commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/fly-go v0.5.5
+	github.com/superfly/fly-go v0.5.7-0.20260701221816-1af567b34693
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/fly-go v0.5.7-0.20260702162410-3e7727a436b2
+	github.com/superfly/fly-go v0.5.7-0.20260702180251-91357982435f
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/fly-go v0.5.7-0.20260701221816-1af567b34693
+	github.com/superfly/fly-go v0.5.7-0.20260702162410-3e7727a436b2
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/fly-go v0.5.7-0.20260702202221-8e02b35e367b
+	github.com/superfly/fly-go v0.6.0
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/fly-go v0.5.7-0.20260702180251-91357982435f
+	github.com/superfly/fly-go v0.5.7-0.20260702181749-44716203f698
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/fly-go v0.5.7-0.20260702181749-44716203f698
+	github.com/superfly/fly-go v0.5.7-0.20260702202221-8e02b35e367b
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.5.7-0.20260702180251-91357982435f h1:uVTT1Anj9wTP+SaisWbWCB6ZLlIPQu7+haOlmMnX7j8=
-github.com/superfly/fly-go v0.5.7-0.20260702180251-91357982435f/go.mod h1:T94X0HGD7+W65/n7PgseJWRIU7O+qRCTqpzqofd28VE=
+github.com/superfly/fly-go v0.5.7-0.20260702181749-44716203f698 h1:6j6yR8PcBM3HghQj+3yxrHUhmt8gANtV3lTMDa5ysDU=
+github.com/superfly/fly-go v0.5.7-0.20260702181749-44716203f698/go.mod h1:T94X0HGD7+W65/n7PgseJWRIU7O+qRCTqpzqofd28VE=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.5.7-0.20260702181749-44716203f698 h1:6j6yR8PcBM3HghQj+3yxrHUhmt8gANtV3lTMDa5ysDU=
-github.com/superfly/fly-go v0.5.7-0.20260702181749-44716203f698/go.mod h1:T94X0HGD7+W65/n7PgseJWRIU7O+qRCTqpzqofd28VE=
+github.com/superfly/fly-go v0.5.7-0.20260702202221-8e02b35e367b h1:eEx+RYn0LushAUjwS+1FxnuhYYTPvKPsUUBCFkSLbVA=
+github.com/superfly/fly-go v0.5.7-0.20260702202221-8e02b35e367b/go.mod h1:T94X0HGD7+W65/n7PgseJWRIU7O+qRCTqpzqofd28VE=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.5.5 h1:BWn7xjSPKIviNI0TOhlvJ17s0Ke+MNNtarOTZvfv2og=
-github.com/superfly/fly-go v0.5.5/go.mod h1:RYus6RQFZ5iXjAqo1G8w8imIkbfp3KW8czMRyDlMgCY=
+github.com/superfly/fly-go v0.5.7-0.20260701221816-1af567b34693 h1:nSIzytRUyaYa6bPVuO9rrxhqghki9RqU4ny6QkGCl4U=
+github.com/superfly/fly-go v0.5.7-0.20260701221816-1af567b34693/go.mod h1:T94X0HGD7+W65/n7PgseJWRIU7O+qRCTqpzqofd28VE=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.5.7-0.20260702202221-8e02b35e367b h1:eEx+RYn0LushAUjwS+1FxnuhYYTPvKPsUUBCFkSLbVA=
-github.com/superfly/fly-go v0.5.7-0.20260702202221-8e02b35e367b/go.mod h1:T94X0HGD7+W65/n7PgseJWRIU7O+qRCTqpzqofd28VE=
+github.com/superfly/fly-go v0.6.0 h1:2TD4ZeOqJOzG+y00AXqIkIliI+kag1H9naYTKy4GPEU=
+github.com/superfly/fly-go v0.6.0/go.mod h1:AXHKj/tDjLocH/3c8IIgdv0o1Dg2m+Mabj76xxkdIM4=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.5.7-0.20260701221816-1af567b34693 h1:nSIzytRUyaYa6bPVuO9rrxhqghki9RqU4ny6QkGCl4U=
-github.com/superfly/fly-go v0.5.7-0.20260701221816-1af567b34693/go.mod h1:T94X0HGD7+W65/n7PgseJWRIU7O+qRCTqpzqofd28VE=
+github.com/superfly/fly-go v0.5.7-0.20260702162410-3e7727a436b2 h1:vhDdZBNLkHK4rhK/6ndfrvZT3KepFHVzhv9TwVcov5E=
+github.com/superfly/fly-go v0.5.7-0.20260702162410-3e7727a436b2/go.mod h1:T94X0HGD7+W65/n7PgseJWRIU7O+qRCTqpzqofd28VE=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.5.7-0.20260702162410-3e7727a436b2 h1:vhDdZBNLkHK4rhK/6ndfrvZT3KepFHVzhv9TwVcov5E=
-github.com/superfly/fly-go v0.5.7-0.20260702162410-3e7727a436b2/go.mod h1:T94X0HGD7+W65/n7PgseJWRIU7O+qRCTqpzqofd28VE=
+github.com/superfly/fly-go v0.5.7-0.20260702180251-91357982435f h1:uVTT1Anj9wTP+SaisWbWCB6ZLlIPQu7+haOlmMnX7j8=
+github.com/superfly/fly-go v0.5.7-0.20260702180251-91357982435f/go.mod h1:T94X0HGD7+W65/n7PgseJWRIU7O+qRCTqpzqofd28VE=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -83,8 +83,9 @@ func InitClient(ctx context.Context) (context.Context, error) {
 
 	if uiexutil.ClientFromContext(ctx) == nil {
 		client, err := uiexutil.NewClientWithOptions(ctx, uiex.NewClientOpts{
-			Logger: logger,
-			Tokens: cfg.Tokens,
+			Logger:        logger,
+			Tokens:        cfg.Tokens,
+			ClientSignals: signals,
 		})
 		if err != nil {
 			return nil, err
@@ -94,8 +95,9 @@ func InitClient(ctx context.Context) (context.Context, error) {
 
 	if mpgv1.ClientFromContext(ctx) == nil {
 		mpgClient, err := mpgv1.NewClientWithOptions(ctx, uiex.NewClientOpts{
-			Logger: logger,
-			Tokens: cfg.Tokens,
+			Logger:        logger,
+			Tokens:        cfg.Tokens,
+			ClientSignals: signals,
 		})
 		if err != nil {
 			return nil, err
@@ -104,8 +106,9 @@ func InitClient(ctx context.Context) (context.Context, error) {
 	}
 	if mpgv2.ClientFromContext(ctx) == nil {
 		mpgClient, err := mpgv2.NewClientWithOptions(ctx, uiex.NewClientOpts{
-			Logger: logger,
-			Tokens: cfg.Tokens,
+			Logger:        logger,
+			Tokens:        cfg.Tokens,
+			ClientSignals: signals,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -63,10 +63,14 @@ func InitClient(ctx context.Context) (context.Context, error) {
 	} else {
 		clientSignalsEnabled = ldClient.ClientSignalsEnabled()
 	}
+	logger.Debugf("client-signals-enabled feature flag is: %v", clientSignalsEnabled)
 	disableClientSignals := !clientSignalsEnabled
 
 	if flyutil.ClientFromContext(ctx) == nil {
-		client := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{Tokens: cfg.Tokens, DisableClientSignals: &disableClientSignals})
+		client := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{
+			Tokens:               cfg.Tokens,
+			DisableClientSignals: &disableClientSignals,
+		})
 		logger.Debug("client initialized.")
 		ctx = flyutil.NewContextWithClient(ctx, client)
 	}
@@ -104,7 +108,9 @@ func InitClient(ctx context.Context) (context.Context, error) {
 	}
 
 	if flapsutil.ClientFromContext(ctx) == nil {
-		flapsClient, err := flapsutil.NewClientWithOptions(ctx, flaps.NewClientOpts{DisableClientSignals: disableClientSignals})
+		flapsClient, err := flapsutil.NewClientWithOptions(ctx, flaps.NewClientOpts{
+			DisableClientSignals: disableClientSignals,
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -64,12 +64,11 @@ func InitClient(ctx context.Context) (context.Context, error) {
 		clientSignalsEnabled = ldClient.ClientSignalsEnabled()
 	}
 	logger.Debugf("client-signals-enabled feature flag is: %v", clientSignalsEnabled)
-	disableClientSignals := !clientSignalsEnabled
 
 	if flyutil.ClientFromContext(ctx) == nil {
 		client := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{
-			Tokens:               cfg.Tokens,
-			DisableClientSignals: &disableClientSignals,
+			Tokens:              cfg.Tokens,
+			EnableClientSignals: &clientSignalsEnabled,
 		})
 		logger.Debug("client initialized.")
 		ctx = flyutil.NewContextWithClient(ctx, client)
@@ -109,7 +108,7 @@ func InitClient(ctx context.Context) (context.Context, error) {
 
 	if flapsutil.ClientFromContext(ctx) == nil {
 		flapsClient, err := flapsutil.NewClientWithOptions(ctx, flaps.NewClientOpts{
-			DisableClientSignals: disableClientSignals,
+			EnableClientSignals: clientSignalsEnabled,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/instrument"
+	"github.com/superfly/flyctl/internal/launchdarkly"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/state"
 	"github.com/superfly/flyctl/internal/uiex"
@@ -56,8 +57,16 @@ func InitClient(ctx context.Context) (context.Context, error) {
 	fly.SetInstrumenter(instrument.ApiAdapter)
 	fly.SetTransport(otelhttp.NewTransport(http.DefaultTransport))
 
+	clientSignalsEnabled := false
+	if ldClient, err := launchdarkly.NewServiceClient(); err != nil {
+		logger.Debugf("could not create feature flag client: %v", err)
+	} else {
+		clientSignalsEnabled = ldClient.ClientSignalsEnabled()
+	}
+	disableClientSignals := !clientSignalsEnabled
+
 	if flyutil.ClientFromContext(ctx) == nil {
-		client := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{Tokens: cfg.Tokens})
+		client := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{Tokens: cfg.Tokens, DisableClientSignals: &disableClientSignals})
 		logger.Debug("client initialized.")
 		ctx = flyutil.NewContextWithClient(ctx, client)
 	}
@@ -95,7 +104,7 @@ func InitClient(ctx context.Context) (context.Context, error) {
 	}
 
 	if flapsutil.ClientFromContext(ctx) == nil {
-		flapsClient, err := flapsutil.NewClientWithOptions(ctx, flaps.NewClientOpts{})
+		flapsClient, err := flapsutil.NewClientWithOptions(ctx, flaps.NewClientOpts{DisableClientSignals: disableClientSignals})
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/pflag"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/fly-go/pkg/clientsignals"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag/flagctx"
@@ -65,10 +66,16 @@ func InitClient(ctx context.Context) (context.Context, error) {
 	}
 	logger.Debugf("client-signals-enabled feature flag is: %v", clientSignalsEnabled)
 
+	var signals *clientsignals.Signals
+	if clientSignalsEnabled {
+		s := clientsignals.DetectOnce()
+		signals = &s
+	}
+
 	if flyutil.ClientFromContext(ctx) == nil {
 		client := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{
-			Tokens:              cfg.Tokens,
-			EnableClientSignals: &clientSignalsEnabled,
+			Tokens:        cfg.Tokens,
+			ClientSignals: signals,
 		})
 		logger.Debug("client initialized.")
 		ctx = flyutil.NewContextWithClient(ctx, client)
@@ -108,7 +115,7 @@ func InitClient(ctx context.Context) (context.Context, error) {
 
 	if flapsutil.ClientFromContext(ctx) == nil {
 		flapsClient, err := flapsutil.NewClientWithOptions(ctx, flaps.NewClientOpts{
-			EnableClientSignals: clientSignalsEnabled,
+			ClientSignals: signals,
 		})
 		if err != nil {
 			return nil, err

--- a/internal/launchdarkly/launchdarkly.go
+++ b/internal/launchdarkly/launchdarkly.go
@@ -74,7 +74,7 @@ func NewClient(ctx context.Context, userInfo UserInfo) (*Client, error) {
 	defer cancel()
 	// we don't really care if this errors or not, but it's good to at least try
 	if err := ldClient.updateFeatureFlags(timeoutCtx); err != nil {
-		logger.Debug("update feature flags failed: %s", err)
+		logger.Debugf("update feature flags failed: %s", err)
 	}
 
 	go ldClient.monitor(ctx)
@@ -95,7 +95,7 @@ func NewServiceClient() (*Client, error) {
 	defer cancel()
 	// we don't really care if this errors or not, but it's good to at least try
 	if err := ldClient.updateFeatureFlags(timeoutCtx); err != nil {
-		logger.Debug("update feature flags failed: %s", err)
+		logger.Debugf("update feature flags failed: %s", err)
 	}
 
 	go ldClient.monitor(ctx)

--- a/internal/launchdarkly/launchdarkly.go
+++ b/internal/launchdarkly/launchdarkly.go
@@ -237,3 +237,7 @@ func (ldClient *Client) UseZstdEnabled() bool {
 func (ldClient *Client) GetCompressionStrength() any {
 	return ldClient.GetFeatureFlagValue("flyctl-compression-strength", 7)
 }
+
+func (ldClient *Client) ClientSignalsEnabled() bool {
+	return ldClient.GetFeatureFlagValue("flyctl-client-signals-enabled", false).(bool)
+}

--- a/internal/launchdarkly/launchdarkly.go
+++ b/internal/launchdarkly/launchdarkly.go
@@ -47,6 +47,8 @@ type UserInfo struct {
 }
 
 func NewClient(ctx context.Context, userInfo UserInfo) (*Client, error) {
+	logger := logger.MaybeFromContext(ctx)
+
 	_, span := tracing.GetTracer().Start(ctx, "new_feature_flag_client")
 	defer span.End()
 
@@ -71,7 +73,9 @@ func NewClient(ctx context.Context, userInfo UserInfo) (*Client, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	// we don't really care if this errors or not, but it's good to at least try
-	_ = ldClient.updateFeatureFlags(timeoutCtx)
+	if err := ldClient.updateFeatureFlags(timeoutCtx); err != nil {
+		logger.Debug("update feature flags failed: %s", err)
+	}
 
 	go ldClient.monitor(ctx)
 
@@ -80,6 +84,8 @@ func NewClient(ctx context.Context, userInfo UserInfo) (*Client, error) {
 
 func NewServiceClient() (*Client, error) {
 	ctx := context.Background()
+	logger := logger.MaybeFromContext(ctx)
+
 	_, span := tracing.GetTracer().Start(ctx, "new_flyctl_feature_flag_client")
 	defer span.End()
 
@@ -88,7 +94,9 @@ func NewServiceClient() (*Client, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	// we don't really care if this errors or not, but it's good to at least try
-	_ = ldClient.updateFeatureFlags(timeoutCtx)
+	if err := ldClient.updateFeatureFlags(timeoutCtx); err != nil {
+		logger.Debug("update feature flags failed: %s", err)
+	}
 
 	go ldClient.monitor(ctx)
 
@@ -124,7 +132,6 @@ func (ldClient *Client) GetFeatureFlagValue(key string, defaultValue any) any {
 	span.SetAttributes(attribute.Bool("default_flag", true))
 
 	return defaultValue
-
 }
 
 type FeatureFlag struct {
@@ -190,7 +197,6 @@ func (ldClient *Client) updateFeatureFlags(ctx context.Context) error {
 
 			return nil
 		}
-
 	})
 
 	for _, flagAttribute := range flagAttributes {

--- a/internal/launchdarkly/launchdarkly.go
+++ b/internal/launchdarkly/launchdarkly.go
@@ -89,7 +89,9 @@ func NewServiceClient() (*Client, error) {
 	_, span := tracing.GetTracer().Start(ctx, "new_flyctl_feature_flag_client")
 	defer span.End()
 
-	ldClient := &Client{ldContext: ldcontext.NewWithKind(ldcontext.Kind("service"), "flyctl"), flagsMutex: sync.Mutex{}}
+	ldClient := &Client{
+		ldContext: ldcontext.NewWithKind(ldcontext.Kind("service"), "flyctl"),
+	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()

--- a/internal/uiex/client.go
+++ b/internal/uiex/client.go
@@ -59,7 +59,7 @@ func NewWithOptions(ctx context.Context, opts NewClientOpts) (*Client, error) {
 		baseUrl = uiexUrl
 	}
 
-	var transport http.RoundTripper = httptracing.NewTransport(http.DefaultTransport)
+	var transport = httptracing.NewTransport(http.DefaultTransport)
 	if opts.ClientSignals != nil {
 		transport = opts.ClientSignals.WrapTransport(transport)
 	}

--- a/internal/uiex/client.go
+++ b/internal/uiex/client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/pkg/clientsignals"
 	"github.com/superfly/fly-go/tokens"
 	"github.com/superfly/flyctl/internal/httptracing"
 	"github.com/superfly/flyctl/internal/logger"
@@ -34,6 +35,10 @@ type NewClientOpts struct {
 
 	// optional, used to construct the underlying HTTP client
 	Transport http.RoundTripper
+
+	// optional; if non-nil, attaches the Fly-Client-* headers/UA suffix
+	// derived from these signals
+	ClientSignals *clientsignals.Signals
 }
 
 func NewWithOptions(ctx context.Context, opts NewClientOpts) (*Client, error) {
@@ -54,7 +59,12 @@ func NewWithOptions(ctx context.Context, opts NewClientOpts) (*Client, error) {
 		baseUrl = uiexUrl
 	}
 
-	httpClient, err := fly.NewHTTPClient(logger.MaybeFromContext(ctx), httptracing.NewTransport(http.DefaultTransport))
+	var transport http.RoundTripper = httptracing.NewTransport(http.DefaultTransport)
+	if opts.ClientSignals != nil {
+		transport = opts.ClientSignals.WrapTransport(transport)
+	}
+
+	httpClient, err := fly.NewHTTPClient(logger.MaybeFromContext(ctx), transport)
 	if err != nil {
 		return nil, fmt.Errorf("uiex: can't setup HTTP client to %s: %w", baseUrl.String(), err)
 	}


### PR DESCRIPTION
Bumps the `fly-go` dependency to v0.6.0, pulling in `Fly-Client-*` headers and a matching User-Agent suffix that flyctl now emits on outbound GraphQL, Machines API, and uiex requests. These headers are gated behind a LaunchDarkly flag (`flyctl-client-signals-enabled`, default off) rather than shipping enabled unconditionally.

## Context

These headers attach coarse, privacy-safe signals (terminal attachment, bucketed parent-process type, cooperative agent marker, CI detection) so Fly can estimate the human-vs-agent split of API traffic for capacity planning and abuse policy, without any per-request certainty or gating. fly-go computes the signals once via `clientsignals.DetectOnce()` and exposes a `*clientsignals.Signals` option on `fly.ClientOptions`, `flaps.NewClientOpts`, and now (via this PR) `uiex.NewClientOpts` — a `nil` value disables the headers entirely, so the wrapping `http.RoundTripper` only gets attached when the flag is on.

Gating behind LaunchDarkly, rather than shipping this on unconditionally, lets Fly turn it on gradually or kill it centrally without a flyctl release. `InitClient` builds all the shared clients before any org or user is known, so this uses the anonymous `launchdarkly.NewServiceClient()` (a global, non-targeted flag) rather than the org-scoped client used elsewhere — that adds one LaunchDarkly network round-trip to every command's startup, which is a real (if typically fast) cost worth calling out in review.

## Details

- `internal/launchdarkly/launchdarkly.go`: adds `ClientSignalsEnabled()`, reading the `flyctl-client-signals-enabled` flag, defaulting to `false`.
- `internal/cmdutil/preparers/preparers.go`: `InitClient` fetches the flag via `launchdarkly.NewServiceClient()`, computes `clientsignals.DetectOnce()` once when enabled, and threads the resulting `*clientsignals.Signals` through to the fly-go, flaps, uiex, and mpg (v1/v2) client constructors.
- `internal/uiex/client.go`: adds a `ClientSignals` option to `uiex.NewClientOpts`, wrapping the outbound transport the same way fly-go's own client does. `mpgv1`/`mpgv2` inherit this for free since they wrap `uiex.Client` with the same options struct.