### PR TITLE
chore(deps): bump fly-go to v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,8 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/fly-go v0.6.0
+	github.com/superfly/client-signals v0.2.0
+	github.com/superfly/fly-go v0.7.0
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -666,8 +666,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/fly-go v0.6.0 h1:2TD4ZeOqJOzG+y00AXqIkIliI+kag1H9naYTKy4GPEU=
-github.com/superfly/fly-go v0.6.0/go.mod h1:AXHKj/tDjLocH/3c8IIgdv0o1Dg2m+Mabj76xxkdIM4=
+github.com/superfly/client-signals v0.2.0 h1:ecwb3sCWwZ55+gpinSi/3yl4/OSBAsqYpmMUxsbbNaU=
+github.com/superfly/client-signals v0.2.0/go.mod h1:YeQnlJ3sh9ptDyq1QZMKYv+AUW9Xuh77lRS9ULj+m2I=
+github.com/superfly/fly-go v0.7.0 h1:ZywZhHtBCWCH1YQpi1lrbnlbDvkvs/S36FOk2Q3Bri4=
+github.com/superfly/fly-go v0.7.0/go.mod h1:eQjT7h4mTrEjeH2YVLu7ID6jffxJM/pggdQgyZRpQmo=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/spf13/pflag"
+	"github.com/superfly/client-signals"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
-	"github.com/superfly/fly-go/pkg/clientsignals"
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag/flagctx"

--- a/internal/uiex/client.go
+++ b/internal/uiex/client.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 	"os"
 
+	"github.com/superfly/client-signals"
 	"github.com/superfly/fly-go"
-	"github.com/superfly/fly-go/pkg/clientsignals"
 	"github.com/superfly/fly-go/tokens"
 	"github.com/superfly/flyctl/internal/httptracing"
 	"github.com/superfly/flyctl/internal/logger"


### PR DESCRIPTION
Bumps the `fly-go` dependency to v0.7.0.

## Context

fly-go extracted its `clientsignals` package (the AI-agent-vs-human client signal detection added in superfly/fly-go#249, wired into flyctl's `InitClient` in #4964) into a standalone module, [superfly/client-signals](https://github.com/superfly/client-signals) v0.2.0. The package name and API (`Signals`, `DetectOnce`, `Signals.WrapTransport`) are unchanged, only the import path moves.

## Details

- `internal/cmdutil/preparers/preparers.go` and `internal/uiex/client.go`: swap the import from `github.com/superfly/fly-go/pkg/clientsignals` to `github.com/superfly/client-signals`.