### PR TITLE
fix(mpg): remove nonexistent --cluster flag from connect hint

### DIFF
--- a/internal/command/mpg/v1/run_create.go
+++ b/internal/command/mpg/v1/run_create.go
@@ -107,7 +107,7 @@ func RunCreate(ctx context.Context, orgRawSlug string, params *CreateClusterPara
 	fmt.Fprintf(io.Out, "Waiting for cluster %s (%s) to be ready...\n", params.Name, clusterID)
 	fmt.Fprintf(io.Out, "You can view the cluster in the UI at: https://fly.io/dashboard/%s/managed_postgres/%s\n", params.OrgSlug, clusterID)
 	fmt.Fprintf(io.Out, "You can cancel this wait with Ctrl+C - the cluster will continue provisioning in the background.\n")
-	fmt.Fprintf(io.Out, "Once ready, you can connect to the database with: fly mpg connect --cluster %s\n\n", clusterID)
+	fmt.Fprintf(io.Out, "Once ready, you can connect to the database with: fly mpg connect %s\n\n", clusterID)
 	for {
 		res, err := mpgClient.GetManagedClusterById(ctx, clusterID)
 		if err != nil {

--- a/internal/command/mpg/v2/run_create.go
+++ b/internal/command/mpg/v2/run_create.go
@@ -106,7 +106,7 @@ func RunCreate(ctx context.Context, orgRawSlug string, params *CreateClusterPara
 	fmt.Fprintf(io.Out, "Waiting for cluster %s (%s) to be ready...\n", params.Name, clusterID)
 	fmt.Fprintf(io.Out, "You can view the cluster in the UI at: https://fly.io/dashboard/%s/managed_postgres/%s\n", params.OrgSlug, clusterID)
 	fmt.Fprintf(io.Out, "You can cancel this wait with Ctrl+C - the cluster will continue provisioning in the background.\n")
-	fmt.Fprintf(io.Out, "Once ready, you can connect to the database with: fly mpg connect --cluster %s\n\n", clusterID)
+	fmt.Fprintf(io.Out, "Once ready, you can connect to the database with: fly mpg connect %s\n\n", clusterID)
 	for {
 		res, err := mpgClient.GetClusterById(ctx, clusterID)
 		if err != nil {


### PR DESCRIPTION
### Change Summary

What and Why:

Changes in this PR delete the `--cluster` flag from a post-create hint printed in both v1 and v2 create flows.

Both `fly mpg connect` and `fly mpg proxy` take the cluster ID as a positional argument, not a `--cluster` flag.

Fixes superfly/mpg#256

Related to:
- https://github.com/superfly/mpg/issues/256

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
