### PR TITLE
chore(deps): bump github.com/superfly/fly-go from 0.7.0 to 0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/superfly/client-signals v0.2.0
-	github.com/superfly/fly-go v0.7.0
+	github.com/superfly/fly-go v0.8.0
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals v0.2.0 h1:ecwb3sCWwZ55+gpinSi/3yl4/OSBAsqYpmMUxsbbNaU=
 github.com/superfly/client-signals v0.2.0/go.mod h1:YeQnlJ3sh9ptDyq1QZMKYv+AUW9Xuh77lRS9ULj+m2I=
-github.com/superfly/fly-go v0.7.0 h1:ZywZhHtBCWCH1YQpi1lrbnlbDvkvs/S36FOk2Q3Bri4=
-github.com/superfly/fly-go v0.7.0/go.mod h1:eQjT7h4mTrEjeH2YVLu7ID6jffxJM/pggdQgyZRpQmo=
+github.com/superfly/fly-go v0.8.0 h1:U7cZ2ZzT5F+euzeNnwi0H4by2dUCfykwWrQ3dbrT48Q=
+github.com/superfly/fly-go v0.8.0/go.mod h1:eQjT7h4mTrEjeH2YVLu7ID6jffxJM/pggdQgyZRpQmo=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=


### PR DESCRIPTION
Picks up fly-go v0.8.0, which gives the GraphQL and flaps clients a sane default User-Agent (identifying the consumer via build info, with fly-go's own version as a suffix) when a caller doesn't supply a name/version. See superfly/fly-go#254.

## Context

flyctl already sets its own name/version explicitly on both clients (`internal/flyutil`, `internal/flapsutil`), so this new default doesn't change flyctl's own request behavior — this is purely a dependency version bump, no other code changes needed.