### PR TITLE
Reject bluegreen deploys with detached process-group machines

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -355,65 +355,54 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 		return err
 	}
 
-	nMachines := len(machines)
-	if nMachines == 0 {
-		terminal.Debug("Found no machines that are part of Fly Apps Platform. Checking for active machines...")
-		activeMachines, err := md.flapsClient.ListActive(ctx, md.app.Name)
+	var activeMachines []*fly.Machine
+	activeMachinesLoaded := false
+	loadActiveMachines := func() error {
+		if activeMachinesLoaded {
+			return nil
+		}
+
+		var err error
+		activeMachines, err = md.flapsClient.ListActive(ctx, md.app.Name)
 		if err != nil {
 			tracing.RecordError(span, err, "failed to list machines")
 
 			return err
 		}
-		if len(activeMachines) > 0 {
-			fmt.Fprintf(md.io.ErrOut, "%s Your app doesn't have any Fly Launch machines, so we'll create one now. Learn more at \nhttps://fly.io/docs/launch/\n\n", aurora.Yellow("[WARNING]"))
-			md.isFirstDeploy = true
+		activeMachinesLoaded = true
+
+		return nil
+	}
+
+	nMachines := len(machines)
+	if nMachines == 0 {
+		terminal.Debug("Found no machines that are part of Fly Apps Platform. Checking for active machines...")
+		if err := loadActiveMachines(); err != nil {
+			return err
 		}
 	}
 
 	filtersApplied := map[string]struct{}{}
 	machines = slices.DeleteFunc(machines, func(m *fly.Machine) bool {
-		if len(md.onlyRegions) > 0 {
-			filtersApplied["--regions"] = struct{}{}
-
-			if !md.onlyRegions[m.Region] {
-				return true
-			}
-		}
-
-		if len(md.excludeRegions) > 0 {
-			filtersApplied["--exclude-regions"] = struct{}{}
-
-			if md.excludeRegions[m.Region] {
-				return true
-			}
-		}
-
-		if len(md.onlyMachines) > 0 {
-			filtersApplied["--only-machines"] = struct{}{}
-
-			if !md.onlyMachines[m.ID] {
-				return true
-			}
-		}
-
-		if len(md.excludeMachines) > 0 {
-			filtersApplied["--exclude-machines"] = struct{}{}
-
-			if md.excludeMachines[m.ID] {
-				return true
-			}
-		}
-
-		if len(md.processGroups) > 0 {
-			filtersApplied["--process-groups"] = struct{}{}
-
-			if !md.processGroups[m.ProcessGroup()] {
-				return true
-			}
-		}
-
-		return false
+		return md.machineFilteredFromDeployment(m, filtersApplied)
 	})
+
+	if md.strategy == "bluegreen" && len(machines) == 0 {
+		if err := loadActiveMachines(); err != nil {
+			return err
+		}
+
+		if err := md.validateNoDetachedBluegreenMachines(activeMachines); err != nil {
+			tracing.RecordError(span, err, "failed to validate bluegreen machines")
+
+			return err
+		}
+	}
+
+	if nMachines == 0 && len(activeMachines) > 0 {
+		fmt.Fprintf(md.io.ErrOut, "%s Your app doesn't have any Fly Launch machines, so we'll create one now. Learn more at \nhttps://fly.io/docs/launch/\n\n", aurora.Yellow("[WARNING]"))
+		md.isFirstDeploy = true
+	}
 
 	if len(filtersApplied) > 0 {
 		s := ""
@@ -446,6 +435,98 @@ func (md *machineDeployment) setMachinesForDeployment(ctx context.Context) error
 	md.releaseCommandMachine = machine.NewMachineSet(md.flapsClient, md.io, md.app.Name, releaseCmdSet, true)
 
 	return nil
+}
+
+func (md *machineDeployment) machineFilteredFromDeployment(m *fly.Machine, filtersApplied map[string]struct{}) bool {
+	return md.machineFilteredFromDeploymentByProcessGroup(m, filtersApplied, m.ProcessGroup())
+}
+
+func (md *machineDeployment) machineFilteredFromDeploymentByProcessGroup(m *fly.Machine, filtersApplied map[string]struct{}, processGroup string) bool {
+	if len(md.onlyRegions) > 0 {
+		filtersApplied["--regions"] = struct{}{}
+
+		if !md.onlyRegions[m.Region] {
+			return true
+		}
+	}
+
+	if len(md.excludeRegions) > 0 {
+		filtersApplied["--exclude-regions"] = struct{}{}
+
+		if md.excludeRegions[m.Region] {
+			return true
+		}
+	}
+
+	if len(md.onlyMachines) > 0 {
+		filtersApplied["--only-machines"] = struct{}{}
+
+		if !md.onlyMachines[m.ID] {
+			return true
+		}
+	}
+
+	if len(md.excludeMachines) > 0 {
+		filtersApplied["--exclude-machines"] = struct{}{}
+
+		if md.excludeMachines[m.ID] {
+			return true
+		}
+	}
+
+	if len(md.processGroups) > 0 {
+		filtersApplied["--process-groups"] = struct{}{}
+
+		if !md.processGroups[processGroup] {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (md *machineDeployment) machineProcessGroup(m *fly.Machine) string {
+	group := m.ProcessGroup()
+	if group != "" {
+		return group
+	}
+
+	return md.appConfig.DefaultProcessName()
+}
+
+func (md *machineDeployment) validateNoDetachedBluegreenMachines(activeMachines []*fly.Machine) error {
+	groupsInConfig := md.ProcessNames()
+	ignoredFilters := map[string]struct{}{}
+	var detachedMachines []string
+	for _, m := range activeMachines {
+		if m.IsFlyAppsPlatform() {
+			continue
+		}
+		group := md.machineProcessGroup(m)
+		if md.machineFilteredFromDeploymentByProcessGroup(m, ignoredFilters, group) {
+			continue
+		}
+
+		if !slices.Contains(groupsInConfig, group) {
+			continue
+		}
+
+		detachedMachines = append(detachedMachines, fmt.Sprintf("%s (%s)", m.ID, group))
+	}
+	if len(detachedMachines) == 0 {
+		return nil
+	}
+
+	slices.Sort(detachedMachines)
+
+	return fmt.Errorf(
+		"bluegreen deployment can't safely continue because active Machines outside Fly Launch management belong to configured process groups: %s. "+
+			"If these Machines should be managed by deploys, make sure they have %s=%s and the correct %s metadata; otherwise destroy or move them before using bluegreen",
+		strings.Join(detachedMachines, ", "),
+		fly.MachineConfigMetadataKeyFlyPlatformVersion,
+		fly.MachineFlyPlatformVersion2,
+		fly.MachineConfigMetadataKeyFlyProcessGroup,
+	)
 }
 
 func (md *machineDeployment) setVolumes(ctx context.Context) error {

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +11,8 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/machine"
+	"github.com/superfly/flyctl/internal/mock"
+	"github.com/superfly/flyctl/iostreams"
 )
 
 func stabMachineDeployment(appConfig *appconfig.Config) (*machineDeployment, error) {
@@ -58,6 +61,131 @@ func Test_resolveUpdatedMachineConfig_Basic(t *testing.T) {
 		},
 		MinSecretsVersion: nil,
 	}, li)
+}
+
+func TestSetMachinesForDeploymentRejectsDetachedProcessGroupMachinesForBluegreen(t *testing.T) {
+	detachedMachine := testProcessGroupMachine("detached-app", "", map[string]string{
+		fly.MachineConfigMetadataKeyFlyProcessGroup: fly.MachineProcessGroupApp,
+	})
+	md := testMachineDeploymentForSetMachines(t, "bluegreen", nil, []*fly.Machine{detachedMachine})
+
+	err := md.setMachinesForDeployment(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "detached-app")
+	assert.Contains(t, err.Error(), fly.MachineConfigMetadataKeyFlyPlatformVersion)
+}
+
+func TestSetMachinesForDeploymentRejectsDetachedDefaultProcessGroupMachinesForBluegreen(t *testing.T) {
+	detachedMachine := testProcessGroupMachine("detached-app", "", nil)
+	md := testMachineDeploymentForSetMachines(t, "bluegreen", nil, []*fly.Machine{detachedMachine})
+
+	err := md.setMachinesForDeployment(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "detached-app")
+	assert.Contains(t, err.Error(), fly.MachineConfigMetadataKeyFlyProcessGroup)
+}
+
+func TestSetMachinesForDeploymentAllowsDetachedProcessGroupMachinesForBluegreenWithManagedMachines(t *testing.T) {
+	managedMachine := testFlyLaunchMachine("managed-app")
+	detachedMachine := testProcessGroupMachine("detached-app", "", map[string]string{
+		fly.MachineConfigMetadataKeyFlyProcessGroup: fly.MachineProcessGroupApp,
+	})
+	md := testMachineDeploymentForSetMachines(t, "bluegreen", []*fly.Machine{managedMachine}, []*fly.Machine{managedMachine, detachedMachine})
+
+	err := md.setMachinesForDeployment(context.Background())
+
+	require.NoError(t, err)
+	machines := md.machineSet.GetMachines()
+	require.Len(t, machines, 1)
+	assert.Equal(t, "managed-app", machines[0].Machine().ID)
+}
+
+func TestSetMachinesForDeploymentAllowsDetachedProcessGroupMachinesForRolling(t *testing.T) {
+	detachedMachine := testProcessGroupMachine("detached-app", "", map[string]string{
+		fly.MachineConfigMetadataKeyFlyProcessGroup: fly.MachineProcessGroupApp,
+	})
+	md := testMachineDeploymentForSetMachines(t, "rolling", nil, []*fly.Machine{detachedMachine})
+
+	err := md.setMachinesForDeployment(context.Background())
+
+	require.NoError(t, err)
+	assert.True(t, md.isFirstDeploy)
+}
+
+func TestSetMachinesForDeploymentDoesNotReportFilteredFlyLaunchMachinesAsDetached(t *testing.T) {
+	managedMachine := testFlyLaunchMachine("managed-app")
+	managedMachine.Region = "ord"
+	detachedMachine := testProcessGroupMachine("detached-app", "iad", map[string]string{
+		fly.MachineConfigMetadataKeyFlyProcessGroup: fly.MachineProcessGroupApp,
+	})
+	md := testMachineDeploymentForSetMachines(t, "bluegreen", []*fly.Machine{managedMachine}, []*fly.Machine{managedMachine, detachedMachine})
+	md.onlyRegions = map[string]bool{"iad": true}
+
+	err := md.setMachinesForDeployment(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "detached-app")
+	assert.NotContains(t, err.Error(), "managed-app")
+}
+
+func TestSetMachinesForDeploymentIgnoresDetachedProcessGroupMachinesOutsideBluegreenFilters(t *testing.T) {
+	detachedMachine := testProcessGroupMachine("detached-app", "lax", map[string]string{
+		fly.MachineConfigMetadataKeyFlyProcessGroup: fly.MachineProcessGroupApp,
+	})
+	md := testMachineDeploymentForSetMachines(t, "bluegreen", nil, []*fly.Machine{detachedMachine})
+	md.onlyRegions = map[string]bool{"iad": true}
+
+	err := md.setMachinesForDeployment(context.Background())
+
+	require.NoError(t, err)
+	assert.True(t, md.isFirstDeploy)
+}
+
+func testFlyLaunchMachine(id string) *fly.Machine {
+	return testProcessGroupMachine(id, "", map[string]string{
+		fly.MachineConfigMetadataKeyFlyPlatformVersion: fly.MachineFlyPlatformVersion2,
+		fly.MachineConfigMetadataKeyFlyProcessGroup:    fly.MachineProcessGroupApp,
+	})
+}
+
+func testProcessGroupMachine(id, region string, metadata map[string]string) *fly.Machine {
+	return &fly.Machine{
+		ID:     id,
+		Region: region,
+		State:  fly.MachineStateStarted,
+		Config: &fly.MachineConfig{
+			Metadata: metadata,
+		},
+	}
+}
+
+func testMachineDeploymentForSetMachines(t *testing.T, strategy string, flyLaunchMachines, activeMachines []*fly.Machine) *machineDeployment {
+	t.Helper()
+
+	ios, _, _, _ := iostreams.Test()
+	client := &mock.FlapsClient{
+		ListFlyAppsMachinesFunc: func(ctx context.Context, appName string) ([]*fly.Machine, *fly.Machine, error) {
+			return flyLaunchMachines, nil, nil
+		},
+		ListActiveFunc: func(ctx context.Context, appName string) ([]*fly.Machine, error) {
+			return activeMachines, nil
+		},
+	}
+
+	return &machineDeployment{
+		app:         &flaps.App{Name: "my-cool-app"},
+		io:          ios,
+		colorize:    ios.ColorScheme(),
+		flapsClient: client,
+		strategy:    strategy,
+		appConfig: &appconfig.Config{
+			HTTPService: &appconfig.HTTPService{
+				Processes: []string{fly.MachineProcessGroupApp},
+			},
+		},
+	}
 }
 
 // Test any LaunchMachineInput field that must not be set on a machine

--- a/test/preflight/fly_deploy_bluegreen_test.go
+++ b/test/preflight/fly_deploy_bluegreen_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+// +build integration
+
+package preflight
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/test/preflight/testlib"
+)
+
+func TestFlyDeployBluegreenImplicitAppProcessGroup(t *testing.T) {
+	f := testlib.NewTestEnvFromEnv(t)
+	appName := f.CreateRandomAppMachines()
+
+	writeImplicitAppProcessFlyToml(f, appName, "one")
+
+	runDetachedAppProcessMachine(f, appName)
+
+	_, detachedMachines := requireMachineCounts(f, appName, 0, 1)
+	require.Equal(f, fly.MachineProcessGroupApp, detachedMachines[0].ProcessGroup())
+
+	res := f.FlyAllowExitFailure("deploy --buildkit --remote-only --now --image nginx --ha=false --strategy bluegreen")
+	require.NotZero(f, res.ExitCode())
+	require.Contains(f, res.StdErrString(), "outside Fly Launch management")
+	require.Contains(f, res.StdErrString(), detachedMachines[0].ID)
+}
+
+func runDetachedAppProcessMachine(f *testlib.FlyctlTestEnv, appName string) {
+	f.Fly(
+		"m run -a %s -r %s --metadata %s=%s --env ENV=preflight -- nginx",
+		appName,
+		f.PrimaryRegion(),
+		fly.MachineConfigMetadataKeyFlyProcessGroup,
+		fly.MachineProcessGroupApp,
+	)
+}
+
+func requireMachineCounts(f *testlib.FlyctlTestEnv, appName string, managedCount, detachedCount int) ([]*fly.Machine, []*fly.Machine) {
+	var managedMachines, detachedMachines []*fly.Machine
+	require.EventuallyWithT(f, func(c *assert.CollectT) {
+		managedMachines, detachedMachines = splitFlyLaunchMachines(f.MachinesList(appName))
+		assert.Len(c, managedMachines, managedCount)
+		assert.Len(c, detachedMachines, detachedCount)
+	}, 2*time.Minute, 3*time.Second)
+
+	return managedMachines, detachedMachines
+}
+
+func splitFlyLaunchMachines(machines []*fly.Machine) (managedMachines, detachedMachines []*fly.Machine) {
+	for _, m := range machines {
+		if m.Config != nil && m.Config.Metadata[fly.MachineConfigMetadataKeyFlyPlatformVersion] == fly.MachineFlyPlatformVersion2 {
+			managedMachines = append(managedMachines, m)
+			continue
+		}
+
+		detachedMachines = append(detachedMachines, m)
+	}
+
+	return managedMachines, detachedMachines
+}
+
+func writeImplicitAppProcessFlyToml(f *testlib.FlyctlTestEnv, appName, generation string) {
+	f.WriteFlyToml(`app = "%s"
+primary_region = "%s"
+
+[env]
+  PREFLIGHT_GENERATION = "%s"
+
+[http_service]
+  internal_port = 80
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [[http_service.checks]]
+    grace_period = "5s"
+    interval = "10s"
+    method = "GET"
+    timeout = "2s"
+    path = "/"
+`, appName, f.PrimaryRegion(), generation)
+}


### PR DESCRIPTION
Refs #4886.

## What

Reject bluegreen deploys when the selected deploy target has no managed Fly
Launch Machines, but does have active detached Machines in the same process
group.

## Why

Bluegreen deploys can create or update a managed Fly Launch fleet while active
Machines outside Fly Launch management keep serving old traffic. In that shape,
flyctl cannot safely cordon or replace those detached Machines as part of the
bluegreen handoff.

## How

- Reuse the existing deploy filters so region-, machine-, and process-group-scoped deploys only consider detached Machines in the selected target.
- Fail before release creation in the zero-managed-target case, with an error that lists the detached Machine IDs and the metadata needed for Fly Launch management.
- Treat detached Machines with no process-group metadata as the app's default process group for this safety check.

## Testing

- `go test ./internal/command/deploy -run 'TestSetMachinesForDeployment|Test_resolveUpdatedMachineConfig_Basic' -count=1 -v`
- `go test ./internal/command/deploy -count=1`
- `go test -tags=integration ./test/preflight -list 'TestFlyDeployBluegreenImplicitAppProcessGroup'`
- `go test -tags=integration ./test/preflight -run TestFlyDeployBluegreenImplicitAppProcessGroup -count=0`
- `make preflight-test T=TestFlyDeployBluegreenImplicitAppProcessGroup`