### PR TITLE
Add MPG extension management commands

### DIFF
--- a/internal/command/mpg/databases.go
+++ b/internal/command/mpg/databases.go
@@ -23,6 +23,7 @@ func newDatabases() *cobra.Command {
 	cmd.AddCommand(
 		newDatabasesList(),
 		newDatabasesCreate(),
+		newExtensions(),
 	)
 
 	return cmd

--- a/internal/command/mpg/extensions.go
+++ b/internal/command/mpg/extensions.go
@@ -1,0 +1,184 @@
+package mpg
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/command"
+	cmdv1 "github.com/superfly/flyctl/internal/command/mpg/v1"
+	cmdv2 "github.com/superfly/flyctl/internal/command/mpg/v2"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/uiex/mpg"
+)
+
+func newExtensions() *cobra.Command {
+	const (
+		short = "Manage Postgres extensions in a managed postgres cluster database"
+		long  = short + "\n"
+	)
+
+	cmd := command.New("extensions", short, long, nil)
+	cmd.Aliases = []string{"extension", "ext"}
+
+	cmd.AddCommand(
+		newExtensionsList(),
+		newExtensionsEnable(),
+		newExtensionsDisable(),
+	)
+
+	return cmd
+}
+
+func newExtensionsList() *cobra.Command {
+	const (
+		long  = `List Postgres extensions in a database, showing which are currently installed.`
+		short = "List Postgres extensions for a database in an MPG cluster."
+		usage = "list <CLUSTER_ID>"
+	)
+
+	cmd := command.New(usage, short, long, runExtensionsList,
+		command.RequireSession,
+		requireMacaroonToken,
+	)
+
+	cmd.Args = cobra.MaximumNArgs(1)
+	cmd.Aliases = []string{"ls"}
+
+	flag.Add(cmd,
+		flag.String{
+			Name:        "database",
+			Shorthand:   "d",
+			Description: "Target database within the cluster",
+		},
+		flag.JSONOutput(),
+	)
+
+	return cmd
+}
+
+func runExtensionsList(ctx context.Context) error {
+	clusterID := flag.FirstArg(ctx)
+	cluster, _, err := ClusterFromArgOrSelect(ctx, clusterID, "")
+	if err != nil {
+		return err
+	}
+
+	database := flag.GetString(ctx, "database")
+
+	if cluster.Version == mpg.VersionV1 {
+		return cmdv1.RunExtensionsList(ctx, cluster.Id, database)
+	}
+
+	return cmdv2.RunExtensionsList(ctx, cluster.Id, database)
+}
+
+func newExtensionsEnable() *cobra.Command {
+	const (
+		long  = `Enable a Postgres extension on a database in a Managed Postgres cluster.`
+		short = "Enable a Postgres extension on a database."
+		usage = "enable <EXTENSION>"
+	)
+
+	cmd := command.New(usage, short, long, runExtensionsEnable,
+		command.RequireSession,
+		requireMacaroonToken,
+	)
+
+	cmd.Args = cobra.ExactArgs(1)
+
+	flag.Add(cmd,
+		flag.String{
+			Name:        "cluster",
+			Shorthand:   "c",
+			Description: "Target cluster ID",
+		},
+		flag.String{
+			Name:        "database",
+			Shorthand:   "d",
+			Description: "Target database within the cluster",
+		},
+		flag.String{
+			Name:        "schema",
+			Description: "Schema in which to create the extension (default: public)",
+		},
+		flag.Bool{
+			Name:        "create-schema",
+			Description: "Create the schema if it does not exist",
+			Default:     false,
+		},
+	)
+
+	return cmd
+}
+
+func runExtensionsEnable(ctx context.Context) error {
+	extensionName := flag.FirstArg(ctx)
+	clusterID := flag.GetString(ctx, "cluster")
+	cluster, _, err := ClusterFromArgOrSelect(ctx, clusterID, "")
+	if err != nil {
+		return err
+	}
+
+	database := flag.GetString(ctx, "database")
+	schema := flag.GetString(ctx, "schema")
+	createSchema := flag.GetBool(ctx, "create-schema")
+
+	if cluster.Version == mpg.VersionV1 {
+		return cmdv1.RunExtensionsEnable(ctx, cluster.Id, database, extensionName, schema, createSchema)
+	}
+
+	return cmdv2.RunExtensionsEnable(ctx, cluster.Id, database, extensionName, schema, createSchema)
+}
+
+func newExtensionsDisable() *cobra.Command {
+	const (
+		long  = `Disable a Postgres extension on a database in a Managed Postgres cluster.`
+		short = "Disable a Postgres extension on a database."
+		usage = "disable <EXTENSION>"
+	)
+
+	cmd := command.New(usage, short, long, runExtensionsDisable,
+		command.RequireSession,
+		requireMacaroonToken,
+	)
+
+	cmd.Args = cobra.ExactArgs(1)
+
+	flag.Add(cmd,
+		flag.String{
+			Name:        "cluster",
+			Shorthand:   "c",
+			Description: "Target cluster ID",
+		},
+		flag.String{
+			Name:        "database",
+			Shorthand:   "d",
+			Description: "Target database within the cluster",
+		},
+		flag.Bool{
+			Name:        "force",
+			Description: "Drop dependent objects as well (CASCADE)",
+			Default:     false,
+		},
+	)
+
+	return cmd
+}
+
+func runExtensionsDisable(ctx context.Context) error {
+	extensionName := flag.FirstArg(ctx)
+	clusterID := flag.GetString(ctx, "cluster")
+	cluster, _, err := ClusterFromArgOrSelect(ctx, clusterID, "")
+	if err != nil {
+		return err
+	}
+
+	database := flag.GetString(ctx, "database")
+	force := flag.GetBool(ctx, "force")
+
+	if cluster.Version == mpg.VersionV1 {
+		return cmdv1.RunExtensionsDisable(ctx, cluster.Id, database, extensionName, force)
+	}
+
+	return cmdv2.RunExtensionsDisable(ctx, cluster.Id, database, extensionName, force)
+}

--- a/internal/command/mpg/v1/run_extensions.go
+++ b/internal/command/mpg/v1/run_extensions.go
@@ -80,6 +80,7 @@ func RunExtensionsEnable(ctx context.Context, clusterID, database, name, schema 
 	}
 
 	fmt.Fprintf(out, "Extension %s enabled on database %s.\n", name, database)
+	
 	return nil
 }
 
@@ -97,6 +98,7 @@ func RunExtensionsDisable(ctx context.Context, clusterID, database, name string,
 	}
 
 	fmt.Fprintf(out, "Extension %s disabled on database %s.\n", name, database)
+	
 	return nil
 }
 
@@ -137,5 +139,6 @@ func resolveDatabase(ctx context.Context, clusterID, database string) (string, e
 	if err := prompt.Select(ctx, &idx, "Select database:", "", options...); err != nil {
 		return "", err
 	}
+	
 	return dbs.Data[idx].Name, nil
 }

--- a/internal/command/mpg/v1/run_extensions.go
+++ b/internal/command/mpg/v1/run_extensions.go
@@ -139,6 +139,6 @@ func resolveDatabase(ctx context.Context, clusterID, database string) (string, e
 	if err := prompt.Select(ctx, &idx, "Select database:", "", options...); err != nil {
 		return "", err
 	}
-	
+
 	return dbs.Data[idx].Name, nil
 }

--- a/internal/command/mpg/v1/run_extensions.go
+++ b/internal/command/mpg/v1/run_extensions.go
@@ -1,0 +1,141 @@
+package cmdv1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/internal/render"
+	mpgv1 "github.com/superfly/flyctl/internal/uiex/mpg/v1"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func RunExtensionsList(ctx context.Context, clusterID, database string) error {
+	cfg := config.FromContext(ctx)
+	out := iostreams.FromContext(ctx).Out
+	mpgClient := mpgv1.ClientFromContext(ctx)
+
+	database, err := resolveDatabase(ctx, clusterID, database)
+	if err != nil {
+		return err
+	}
+
+	resp, err := mpgClient.ListExtensions(ctx, clusterID, database)
+	if err != nil {
+		return fmt.Errorf("failed to list extensions for database %s: %w", database, err)
+	}
+
+	if cfg.JSONOutput {
+		return render.JSON(out, resp.Data)
+	}
+
+	rows := make([][]string, 0, len(resp.Data))
+	for _, ext := range resp.Data {
+		installed := "no"
+		version := ""
+		schema := ""
+		if ext.Installed != nil {
+			installed = "yes"
+			version = ext.Installed.Version
+			schema = ext.Installed.Schema
+		}
+		rows = append(rows, []string{
+			ext.Name,
+			installed,
+			version,
+			schema,
+			ext.Description,
+		})
+	}
+
+	return render.Table(out, fmt.Sprintf("Extensions in database %s", database), rows,
+		"Name", "Installed", "Version", "Schema", "Description")
+}
+
+func RunExtensionsEnable(ctx context.Context, clusterID, database, name, schema string, createSchema bool) error {
+	out := iostreams.FromContext(ctx).Out
+	mpgClient := mpgv1.ClientFromContext(ctx)
+
+	database, err := resolveDatabase(ctx, clusterID, database)
+	if err != nil {
+		return err
+	}
+
+	// postgis_topology must live in the "topology" schema. Default to that when
+	// the user didn't explicitly pick a schema so the command works out of the box.
+	if name == "postgis_topology" && schema == "" {
+		schema = "topology"
+		createSchema = true
+	}
+
+	input := mpgv1.EnableExtensionInput{
+		Name:                 name,
+		Schema:               schema,
+		CreateSchemaIfNeeded: createSchema,
+	}
+
+	if err := mpgClient.EnableExtension(ctx, clusterID, database, input); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Extension %s enabled on database %s.\n", name, database)
+	return nil
+}
+
+func RunExtensionsDisable(ctx context.Context, clusterID, database, name string, force bool) error {
+	out := iostreams.FromContext(ctx).Out
+	mpgClient := mpgv1.ClientFromContext(ctx)
+
+	database, err := resolveDatabase(ctx, clusterID, database)
+	if err != nil {
+		return err
+	}
+
+	if err := mpgClient.DisableExtension(ctx, clusterID, database, name, force); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Extension %s disabled on database %s.\n", name, database)
+	return nil
+}
+
+// resolveDatabase returns the database to target: the explicit flag value if
+// given, the cluster's only database if there's exactly one, or an interactive
+// pick from the list. Returns an error if running non-interactively without a
+// flag and the cluster has multiple databases.
+func resolveDatabase(ctx context.Context, clusterID, database string) (string, error) {
+	if database != "" {
+		return database, nil
+	}
+
+	mpgClient := mpgv1.ClientFromContext(ctx)
+	dbs, err := mpgClient.ListDatabases(ctx, clusterID)
+	if err != nil {
+		return "", fmt.Errorf("failed to list databases: %w", err)
+	}
+
+	if len(dbs.Data) == 0 {
+		return "", fmt.Errorf("no databases found in cluster %s", clusterID)
+	}
+
+	if len(dbs.Data) == 1 {
+		return dbs.Data[0].Name, nil
+	}
+
+	io := iostreams.FromContext(ctx)
+	if !io.IsInteractive() {
+		return "", prompt.NonInteractiveError("the cluster has multiple databases; pass --database to choose one")
+	}
+
+	options := make([]string, 0, len(dbs.Data))
+	for _, db := range dbs.Data {
+		options = append(options, db.Name)
+	}
+
+	var idx int
+	if err := prompt.Select(ctx, &idx, "Select database:", "", options...); err != nil {
+		return "", err
+	}
+	return dbs.Data[idx].Name, nil
+}

--- a/internal/command/mpg/v1/run_extensions.go
+++ b/internal/command/mpg/v1/run_extensions.go
@@ -80,7 +80,7 @@ func RunExtensionsEnable(ctx context.Context, clusterID, database, name, schema 
 	}
 
 	fmt.Fprintf(out, "Extension %s enabled on database %s.\n", name, database)
-	
+
 	return nil
 }
 
@@ -98,7 +98,7 @@ func RunExtensionsDisable(ctx context.Context, clusterID, database, name string,
 	}
 
 	fmt.Fprintf(out, "Extension %s disabled on database %s.\n", name, database)
-	
+
 	return nil
 }
 

--- a/internal/command/mpg/v2/run_extensions.go
+++ b/internal/command/mpg/v2/run_extensions.go
@@ -1,0 +1,141 @@
+package cmdv2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/internal/render"
+	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func RunExtensionsList(ctx context.Context, clusterID, database string) error {
+	cfg := config.FromContext(ctx)
+	out := iostreams.FromContext(ctx).Out
+	mpgClient := mpgv2.ClientFromContext(ctx)
+
+	database, err := resolveDatabase(ctx, clusterID, database)
+	if err != nil {
+		return err
+	}
+
+	resp, err := mpgClient.ListExtensions(ctx, clusterID, database)
+	if err != nil {
+		return fmt.Errorf("failed to list extensions for database %s: %w", database, err)
+	}
+
+	if cfg.JSONOutput {
+		return render.JSON(out, resp.Data)
+	}
+
+	rows := make([][]string, 0, len(resp.Data))
+	for _, ext := range resp.Data {
+		installed := "no"
+		version := ""
+		schema := ""
+		if ext.Installed != nil {
+			installed = "yes"
+			version = ext.Installed.Version
+			schema = ext.Installed.Schema
+		}
+		rows = append(rows, []string{
+			ext.Name,
+			installed,
+			version,
+			schema,
+			ext.Description,
+		})
+	}
+
+	return render.Table(out, fmt.Sprintf("Extensions in database %s", database), rows,
+		"Name", "Installed", "Version", "Schema", "Description")
+}
+
+func RunExtensionsEnable(ctx context.Context, clusterID, database, name, schema string, createSchema bool) error {
+	out := iostreams.FromContext(ctx).Out
+	mpgClient := mpgv2.ClientFromContext(ctx)
+
+	database, err := resolveDatabase(ctx, clusterID, database)
+	if err != nil {
+		return err
+	}
+
+	// postgis_topology must live in the "topology" schema. Default to that when
+	// the user didn't explicitly pick a schema so the command works out of the box.
+	if name == "postgis_topology" && schema == "" {
+		schema = "topology"
+		createSchema = true
+	}
+
+	input := mpgv2.EnableExtensionInput{
+		Name:                 name,
+		Schema:               schema,
+		CreateSchemaIfNeeded: createSchema,
+	}
+
+	if err := mpgClient.EnableExtension(ctx, clusterID, database, input); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Extension %s enabled on database %s.\n", name, database)
+	return nil
+}
+
+func RunExtensionsDisable(ctx context.Context, clusterID, database, name string, force bool) error {
+	out := iostreams.FromContext(ctx).Out
+	mpgClient := mpgv2.ClientFromContext(ctx)
+
+	database, err := resolveDatabase(ctx, clusterID, database)
+	if err != nil {
+		return err
+	}
+
+	if err := mpgClient.DisableExtension(ctx, clusterID, database, name, force); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Extension %s disabled on database %s.\n", name, database)
+	return nil
+}
+
+// resolveDatabase returns the database to target: the explicit flag value if
+// given, the cluster's only database if there's exactly one, or an interactive
+// pick from the list. Returns an error if running non-interactively without a
+// flag and the cluster has multiple databases.
+func resolveDatabase(ctx context.Context, clusterID, database string) (string, error) {
+	if database != "" {
+		return database, nil
+	}
+
+	mpgClient := mpgv2.ClientFromContext(ctx)
+	dbs, err := mpgClient.ListDatabases(ctx, clusterID)
+	if err != nil {
+		return "", fmt.Errorf("failed to list databases: %w", err)
+	}
+
+	if len(dbs.Data) == 0 {
+		return "", fmt.Errorf("no databases found in cluster %s", clusterID)
+	}
+
+	if len(dbs.Data) == 1 {
+		return dbs.Data[0].Name, nil
+	}
+
+	io := iostreams.FromContext(ctx)
+	if !io.IsInteractive() {
+		return "", prompt.NonInteractiveError("the cluster has multiple databases; pass --database to choose one")
+	}
+
+	options := make([]string, 0, len(dbs.Data))
+	for _, db := range dbs.Data {
+		options = append(options, db.Name)
+	}
+
+	var idx int
+	if err := prompt.Select(ctx, &idx, "Select database:", "", options...); err != nil {
+		return "", err
+	}
+	return dbs.Data[idx].Name, nil
+}

--- a/internal/command/mpg/v2/run_extensions.go
+++ b/internal/command/mpg/v2/run_extensions.go
@@ -80,6 +80,7 @@ func RunExtensionsEnable(ctx context.Context, clusterID, database, name, schema 
 	}
 
 	fmt.Fprintf(out, "Extension %s enabled on database %s.\n", name, database)
+
 	return nil
 }
 
@@ -97,6 +98,7 @@ func RunExtensionsDisable(ctx context.Context, clusterID, database, name string,
 	}
 
 	fmt.Fprintf(out, "Extension %s disabled on database %s.\n", name, database)
+
 	return nil
 }
 
@@ -137,5 +139,6 @@ func resolveDatabase(ctx context.Context, clusterID, database string) (string, e
 	if err := prompt.Select(ctx, &idx, "Select database:", "", options...); err != nil {
 		return "", err
 	}
+
 	return dbs.Data[idx].Name, nil
 }

--- a/internal/mock/mpgv1_client.go
+++ b/internal/mock/mpgv1_client.go
@@ -29,6 +29,9 @@ type MpgV1Client struct {
 	RestoreManagedClusterBackupFunc func(ctx context.Context, clusterID string, input mpgv1.RestoreManagedClusterBackupInput) (mpgv1.RestoreManagedClusterBackupResponse, error)
 	CreateAttachmentFunc            func(ctx context.Context, clusterId string, input mpgv1.CreateAttachmentInput) (mpgv1.CreateAttachmentResponse, error)
 	DeleteAttachmentFunc            func(ctx context.Context, clusterId string, appName string) (mpgv1.DeleteAttachmentResponse, error)
+	ListExtensionsFunc              func(ctx context.Context, id, database string) (mpgv1.ListExtensionsResponse, error)
+	EnableExtensionFunc             func(ctx context.Context, id, database string, input mpgv1.EnableExtensionInput) error
+	DisableExtensionFunc            func(ctx context.Context, id, database, name string, force bool) error
 }
 
 func (m *MpgV1Client) ListMPGRegions(ctx context.Context, orgSlug string) (mpgv1.ListMPGRegionsResponse, error) {
@@ -181,4 +184,28 @@ func (m *MpgV1Client) DeleteAttachment(ctx context.Context, clusterId string, ap
 	}
 
 	return mpgv1.DeleteAttachmentResponse{}, nil
+}
+
+func (m *MpgV1Client) ListExtensions(ctx context.Context, id, database string) (mpgv1.ListExtensionsResponse, error) {
+	if m.ListExtensionsFunc != nil {
+		return m.ListExtensionsFunc(ctx, id, database)
+	}
+
+	return mpgv1.ListExtensionsResponse{}, nil
+}
+
+func (m *MpgV1Client) EnableExtension(ctx context.Context, id, database string, input mpgv1.EnableExtensionInput) error {
+	if m.EnableExtensionFunc != nil {
+		return m.EnableExtensionFunc(ctx, id, database, input)
+	}
+
+	return nil
+}
+
+func (m *MpgV1Client) DisableExtension(ctx context.Context, id, database, name string, force bool) error {
+	if m.DisableExtensionFunc != nil {
+		return m.DisableExtensionFunc(ctx, id, database, name, force)
+	}
+
+	return nil
 }

--- a/internal/mock/mpgv2_client.go
+++ b/internal/mock/mpgv2_client.go
@@ -27,6 +27,9 @@ type MpgV2Client struct {
 	RestoreClusterBackupFunc func(ctx context.Context, clusterID string, input mpgv2.RestoreClusterBackupInput) (mpgv2.RestoreClusterBackupResponse, error)
 	CreateAttachmentFunc     func(ctx context.Context, clusterId string, input mpgv2.CreateAttachmentInput) (mpgv2.CreateAttachmentResponse, error)
 	DeleteAttachmentFunc     func(ctx context.Context, clusterId string, appName string) (mpgv2.DeleteAttachmentResponse, error)
+	ListExtensionsFunc       func(ctx context.Context, id, database string) (mpgv2.ListExtensionsResponse, error)
+	EnableExtensionFunc      func(ctx context.Context, id, database string, input mpgv2.EnableExtensionInput) error
+	DisableExtensionFunc     func(ctx context.Context, id, database, name string, force bool) error
 }
 
 func (m *MpgV2Client) ListRegions(ctx context.Context, orgSlug string) (mpgv2.ListRegionsResponse, error) {
@@ -163,4 +166,28 @@ func (m *MpgV2Client) DeleteAttachment(ctx context.Context, clusterId string, ap
 	}
 
 	return mpgv2.DeleteAttachmentResponse{}, nil
+}
+
+func (m *MpgV2Client) ListExtensions(ctx context.Context, id, database string) (mpgv2.ListExtensionsResponse, error) {
+	if m.ListExtensionsFunc != nil {
+		return m.ListExtensionsFunc(ctx, id, database)
+	}
+
+	return mpgv2.ListExtensionsResponse{}, nil
+}
+
+func (m *MpgV2Client) EnableExtension(ctx context.Context, id, database string, input mpgv2.EnableExtensionInput) error {
+	if m.EnableExtensionFunc != nil {
+		return m.EnableExtensionFunc(ctx, id, database, input)
+	}
+
+	return nil
+}
+
+func (m *MpgV2Client) DisableExtension(ctx context.Context, id, database, name string, force bool) error {
+	if m.DisableExtensionFunc != nil {
+		return m.DisableExtensionFunc(ctx, id, database, name, force)
+	}
+
+	return nil
 }

--- a/internal/uiex/mpg/v1/client.go
+++ b/internal/uiex/mpg/v1/client.go
@@ -29,6 +29,9 @@ type ClientV1 interface {
 	ListUsers(ctx context.Context, id string) (ListUsersResponse, error)
 	ListDatabases(ctx context.Context, id string) (ListDatabasesResponse, error)
 	CreateDatabase(ctx context.Context, id string, input CreateDatabaseInput) (CreateDatabaseResponse, error)
+	ListExtensions(ctx context.Context, id, database string) (ListExtensionsResponse, error)
+	EnableExtension(ctx context.Context, id, database string, input EnableExtensionInput) error
+	DisableExtension(ctx context.Context, id, database, name string, force bool) error
 	CreateCluster(ctx context.Context, input CreateClusterInput) (CreateClusterResponse, error)
 	DestroyCluster(ctx context.Context, orgSlug string, id string) error
 	ListManagedClusterBackups(ctx context.Context, clusterID string) (ListManagedClusterBackupsResponse, error)
@@ -200,6 +203,30 @@ type CreateDatabaseInput struct {
 
 type CreateDatabaseResponse struct {
 	Data Database `json:"data"`
+}
+
+type InstalledExtension struct {
+	Version string `json:"version"`
+	Schema  string `json:"schema"`
+}
+
+type Extension struct {
+	Name           string              `json:"name"`
+	Description    string              `json:"description"`
+	DocsURL        string              `json:"docs_url"`
+	DefaultVersion string              `json:"default_version"`
+	IsSystem       bool                `json:"is_system"`
+	Installed      *InstalledExtension `json:"installed"`
+}
+
+type ListExtensionsResponse struct {
+	Data []Extension `json:"data"`
+}
+
+type EnableExtensionInput struct {
+	Name                  string `json:"name"`
+	Schema                string `json:"schema,omitempty"`
+	CreateSchemaIfNeeded  bool   `json:"create_schema_if_needed"`
 }
 
 type CreateClusterInput struct {

--- a/internal/uiex/mpg/v1/client.go
+++ b/internal/uiex/mpg/v1/client.go
@@ -224,9 +224,9 @@ type ListExtensionsResponse struct {
 }
 
 type EnableExtensionInput struct {
-	Name                  string `json:"name"`
-	Schema                string `json:"schema,omitempty"`
-	CreateSchemaIfNeeded  bool   `json:"create_schema_if_needed"`
+	Name                 string `json:"name"`
+	Schema               string `json:"schema,omitempty"`
+	CreateSchemaIfNeeded bool   `json:"create_schema_if_needed"`
 }
 
 type CreateClusterInput struct {

--- a/internal/uiex/mpg/v1/managed_postgres.go
+++ b/internal/uiex/mpg/v1/managed_postgres.go
@@ -775,6 +775,146 @@ func (c *Client) CreateAttachment(ctx context.Context, clusterId string, input C
 	}
 }
 
+// ListExtensions returns the catalog of available Postgres extensions for the
+// given database, along with whether each one is currently installed.
+func (c *Client) ListExtensions(ctx context.Context, id, database string) (ListExtensionsResponse, error) {
+	var response ListExtensionsResponse
+	cfg := config.FromContext(ctx)
+	url := fmt.Sprintf("%s/api/v1/postgres/%s/databases/%s/extensions", c.BaseURL(), id, database)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return response, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Add("Authorization", "Bearer "+cfg.Tokens.GraphQL())
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := c.HTTPClient().Do(req)
+	if err != nil {
+		return response, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return response, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		if err = json.Unmarshal(body, &response); err != nil {
+			return response, fmt.Errorf("failed to decode response: %w", err)
+		}
+
+		return response, nil
+	case http.StatusNotFound:
+		return response, fmt.Errorf("cluster %s or database %s not found", id, database)
+	case http.StatusForbidden:
+		return response, fmt.Errorf("access denied: you don't have permission to list extensions for cluster %s", id)
+	default:
+		return response, fmt.Errorf("failed to list extensions (status %d): %s", res.StatusCode, decodeError(body))
+	}
+}
+
+// EnableExtension installs a Postgres extension in the given database.
+func (c *Client) EnableExtension(ctx context.Context, id, database string, input EnableExtensionInput) error {
+	cfg := config.FromContext(ctx)
+	url := fmt.Sprintf("%s/api/v1/postgres/%s/databases/%s/extensions", c.BaseURL(), id, database)
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(input); err != nil {
+		return fmt.Errorf("failed to encode request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, &buf)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Add("Authorization", "Bearer "+cfg.Tokens.GraphQL())
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := c.HTTPClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+		return nil
+	case http.StatusConflict:
+		return fmt.Errorf("%s", decodeError(body))
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return fmt.Errorf("%s", decodeError(body))
+	case http.StatusNotFound:
+		return fmt.Errorf("cluster %s or database %s not found", id, database)
+	case http.StatusForbidden:
+		return fmt.Errorf("access denied: you don't have permission to enable extensions for cluster %s", id)
+	default:
+		return fmt.Errorf("failed to enable extension (status %d): %s", res.StatusCode, decodeError(body))
+	}
+}
+
+// DisableExtension drops a Postgres extension from the given database.
+func (c *Client) DisableExtension(ctx context.Context, id, database, name string, force bool) error {
+	cfg := config.FromContext(ctx)
+	url := fmt.Sprintf("%s/api/v1/postgres/%s/databases/%s/extensions/%s", c.BaseURL(), id, database, name)
+	if force {
+		url += "?force=true"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Add("Authorization", "Bearer "+cfg.Tokens.GraphQL())
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := c.HTTPClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK, http.StatusNoContent:
+		return nil
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return fmt.Errorf("%s", decodeError(body))
+	case http.StatusNotFound:
+		return fmt.Errorf("cluster %s or database %s not found", id, database)
+	case http.StatusForbidden:
+		return fmt.Errorf("access denied: you don't have permission to disable extensions for cluster %s", id)
+	default:
+		return fmt.Errorf("failed to disable extension (status %d): %s", res.StatusCode, decodeError(body))
+	}
+}
+
+// decodeError extracts the "error" field from a UI-EX error response body, or
+// falls back to the raw body string if the body is not a JSON error envelope.
+func decodeError(body []byte) string {
+	var envelope struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Error != "" {
+		return envelope.Error
+	}
+	return string(body)
+}
+
 // DeleteAttachment removes a ManagedServiceAttachment record linking an app to a managed Postgres cluster
 func (c *Client) DeleteAttachment(ctx context.Context, clusterId string, appName string) (DeleteAttachmentResponse, error) {
 	var response DeleteAttachmentResponse

--- a/internal/uiex/mpg/v1/managed_postgres.go
+++ b/internal/uiex/mpg/v1/managed_postgres.go
@@ -912,6 +912,7 @@ func decodeError(body []byte) string {
 	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Error != "" {
 		return envelope.Error
 	}
+
 	return string(body)
 }
 

--- a/internal/uiex/mpg/v2/client.go
+++ b/internal/uiex/mpg/v2/client.go
@@ -1049,6 +1049,7 @@ func decodeError(body []byte) string {
 	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Error != "" {
 		return envelope.Error
 	}
+
 	return string(body)
 }
 

--- a/internal/uiex/mpg/v2/client.go
+++ b/internal/uiex/mpg/v2/client.go
@@ -1,4 +1,4 @@
-package v2
+fpackage v2
 
 import (
 	"bytes"

--- a/internal/uiex/mpg/v2/client.go
+++ b/internal/uiex/mpg/v2/client.go
@@ -1,4 +1,4 @@
-fpackage v2
+package v2
 
 import (
 	"bytes"

--- a/internal/uiex/mpg/v2/client.go
+++ b/internal/uiex/mpg/v2/client.go
@@ -31,6 +31,9 @@ type ClientV2 interface {
 	ListUsers(ctx context.Context, id string) (ListUsersResponse, error)
 	ListDatabases(ctx context.Context, id string) (ListDatabasesResponse, error)
 	CreateDatabase(ctx context.Context, id string, input CreateDatabaseInput) error
+	ListExtensions(ctx context.Context, id, database string) (ListExtensionsResponse, error)
+	EnableExtension(ctx context.Context, id, database string, input EnableExtensionInput) error
+	DisableExtension(ctx context.Context, id, database, name string, force bool) error
 	CreateCluster(ctx context.Context, input CreateClusterInput) (CreateClusterResponse, error)
 	DestroyCluster(ctx context.Context, orgSlug string, id string) error
 	ListClusterBackups(ctx context.Context, clusterID string) (ListClusterBackupsResponse, error)
@@ -151,6 +154,30 @@ type Database struct {
 
 type CreateDatabaseInput struct {
 	Name string `json:"name"`
+}
+
+type InstalledExtension struct {
+	Version string `json:"version"`
+	Schema  string `json:"schema"`
+}
+
+type Extension struct {
+	Name           string              `json:"name"`
+	Description    string              `json:"description"`
+	DocsURL        string              `json:"docs_url"`
+	DefaultVersion string              `json:"default_version"`
+	IsSystem       bool                `json:"is_system"`
+	Installed      *InstalledExtension `json:"installed"`
+}
+
+type ListExtensionsResponse struct {
+	Data []Extension `json:"data"`
+}
+
+type EnableExtensionInput struct {
+	Name                 string `json:"name"`
+	Schema               string `json:"schema,omitempty"`
+	CreateSchemaIfNeeded bool   `json:"create_schema_if_needed"`
 }
 
 type ClusterBackup struct {
@@ -883,6 +910,146 @@ func (c *Client) CreateAttachment(ctx context.Context, clusterId string, input C
 	default:
 		return response, fmt.Errorf("failed to create attachment (status %d): %s", res.StatusCode, string(body))
 	}
+}
+
+// ListExtensions returns the catalog of available Postgres extensions for the
+// given database, along with whether each one is currently installed.
+func (c *Client) ListExtensions(ctx context.Context, id, database string) (ListExtensionsResponse, error) {
+	var response ListExtensionsResponse
+	cfg := config.FromContext(ctx)
+	url := fmt.Sprintf("%s/api/v1/postgresv2/%s/databases/%s/extensions", c.BaseURL(), id, database)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return response, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Add("Authorization", "Bearer "+cfg.Tokens.GraphQL())
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := c.HTTPClient().Do(req)
+	if err != nil {
+		return response, err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return response, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		if err = json.Unmarshal(body, &response); err != nil {
+			return response, fmt.Errorf("failed to decode response: %w", err)
+		}
+
+		return response, nil
+	case http.StatusNotFound:
+		return response, fmt.Errorf("cluster %s or database %s not found", id, database)
+	case http.StatusForbidden:
+		return response, fmt.Errorf("access denied: you don't have permission to list extensions for cluster %s", id)
+	default:
+		return response, fmt.Errorf("failed to list extensions (status %d): %s", res.StatusCode, decodeError(body))
+	}
+}
+
+// EnableExtension installs a Postgres extension in the given database.
+func (c *Client) EnableExtension(ctx context.Context, id, database string, input EnableExtensionInput) error {
+	cfg := config.FromContext(ctx)
+	url := fmt.Sprintf("%s/api/v1/postgresv2/%s/databases/%s/extensions", c.BaseURL(), id, database)
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(input); err != nil {
+		return fmt.Errorf("failed to encode request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, &buf)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Add("Authorization", "Bearer "+cfg.Tokens.GraphQL())
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := c.HTTPClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+		return nil
+	case http.StatusConflict:
+		return fmt.Errorf("%s", decodeError(body))
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return fmt.Errorf("%s", decodeError(body))
+	case http.StatusNotFound:
+		return fmt.Errorf("cluster %s or database %s not found", id, database)
+	case http.StatusForbidden:
+		return fmt.Errorf("access denied: you don't have permission to enable extensions for cluster %s", id)
+	default:
+		return fmt.Errorf("failed to enable extension (status %d): %s", res.StatusCode, decodeError(body))
+	}
+}
+
+// DisableExtension drops a Postgres extension from the given database.
+func (c *Client) DisableExtension(ctx context.Context, id, database, name string, force bool) error {
+	cfg := config.FromContext(ctx)
+	url := fmt.Sprintf("%s/api/v1/postgresv2/%s/databases/%s/extensions/%s", c.BaseURL(), id, database, name)
+	if force {
+		url += "?force=true"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Add("Authorization", "Bearer "+cfg.Tokens.GraphQL())
+	req.Header.Add("Content-Type", "application/json")
+
+	res, err := c.HTTPClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK, http.StatusNoContent:
+		return nil
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return fmt.Errorf("%s", decodeError(body))
+	case http.StatusNotFound:
+		return fmt.Errorf("cluster %s or database %s not found", id, database)
+	case http.StatusForbidden:
+		return fmt.Errorf("access denied: you don't have permission to disable extensions for cluster %s", id)
+	default:
+		return fmt.Errorf("failed to disable extension (status %d): %s", res.StatusCode, decodeError(body))
+	}
+}
+
+// decodeError extracts the "error" field from a UI-EX error response body, or
+// falls back to the raw body string if the body is not a JSON error envelope.
+func decodeError(body []byte) string {
+	var envelope struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err == nil && envelope.Error != "" {
+		return envelope.Error
+	}
+	return string(body)
 }
 
 func (c *Client) DeleteAttachment(ctx context.Context, clusterId string, appName string) (DeleteAttachmentResponse, error) {


### PR DESCRIPTION
### Change Summary

What and Why:
Adds the `fly mpg database extensions list | enable | disable` family of commands for managing MPG cluster extensions. As schema_admin users don't have permissions to enable extensions, previously extensions could only be enabled via the dashboard. This blocks non-interactive methods of enabling or disabling extensions, preventing cases like CI from being able to use extensions. 

This works for both new V2 clusters and existing V1 clusters. 

How: Along with this change I added an `api/v1/postgres/<cluster>/databases/<database>/extensions` API endpoint which exposes the same methods the dashboard uses for enabling extensions. These new flyctl commands use those new endpoints.

Related to:

---

### Documentation

- [x ] Fresh Produce - drafted
- [ x] In superfly/docs, or asked for help from docs team
- [ ] n/a
