### PR TITLE
fix(apps): open app URL without config

### DIFF
--- a/internal/command/apps/open.go
+++ b/internal/command/apps/open.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 
 	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
@@ -11,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -40,16 +42,33 @@ to the root URL of the deployed application.
 	return
 }
 
+var (
+	openBrowser         = open.Run
+	loadRemoteAppConfig = appconfig.FromRemoteApp
+)
+
 func runOpen(ctx context.Context) error {
-	iostream := iostreams.FromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
+	if appName == "" {
+		return command.ErrRequireAppName
+	}
 
 	appConfig := appconfig.ConfigFromContext(ctx)
+	if appConfig != nil && appConfig.AppName != appName {
+		appConfig = nil
+	}
 	if appConfig == nil {
 		var err error
-		appConfig, err = appconfig.FromRemoteApp(ctx, appName)
-		if err != nil {
-			return errors.New("The app config could not be found")
+		appConfig, err = loadRemoteAppConfig(ctx, appName)
+		if err != nil || appConfig == nil {
+			if log := logger.MaybeFromContext(ctx); log != nil && err != nil {
+				log.Debugf("failed loading remote app config for %s: %v", appName, err)
+			}
+
+			appURL := defaultAppURL(appName)
+			fmt.Fprintf(iostreams.FromContext(ctx).ErrOut, "Warning: couldn't load app config for %s, falling back to the default app URL\n", appName)
+
+			return openAppURL(ctx, appURL)
 		}
 	}
 
@@ -57,6 +76,20 @@ func runOpen(ctx context.Context) error {
 	if appURL == nil {
 		return errors.New("The app doesn't expose a public http service")
 	}
+
+	return openAppURL(ctx, appURL)
+}
+
+func defaultAppURL(appName string) *url.URL {
+	return &url.URL{
+		Scheme: "https",
+		Host:   appName + ".fly.dev",
+		Path:   "/",
+	}
+}
+
+func openAppURL(ctx context.Context, appURL *url.URL) error {
+	iostream := iostreams.FromContext(ctx)
 
 	if relURI := flag.FirstArg(ctx); relURI != "" {
 		newURL, err := appURL.Parse(relURI)
@@ -67,7 +100,7 @@ func runOpen(ctx context.Context) error {
 	}
 
 	fmt.Fprintf(iostream.Out, "opening %s ...\n", appURL)
-	if err := open.Run(appURL.String()); err != nil {
+	if err := openBrowser(appURL.String()); err != nil {
 		return fmt.Errorf("failed opening %s: %w", appURL, err)
 	}
 

--- a/internal/command/apps/open_test.go
+++ b/internal/command/apps/open_test.go
@@ -1,0 +1,176 @@
+package apps
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func TestRunOpenRequiresAppName(t *testing.T) {
+	ctx, _ := testOpenContext(t)
+
+	err := runOpen(ctx)
+	require.ErrorIs(t, err, command.ErrRequireAppName)
+}
+
+func TestRunOpenFallsBackToDefaultAppURLWhenRemoteConfigIsUnavailable(t *testing.T) {
+	ctx, out := testOpenContext(t)
+	ctx = appconfig.WithName(ctx, "test-app")
+
+	restore := stubOpenDependencies(t)
+	defer restore()
+
+	loadRemoteAppConfig = func(context.Context, string) (*appconfig.Config, error) {
+		return nil, errors.New("missing remote config")
+	}
+
+	require.NoError(t, runOpen(ctx))
+	assert.Equal(t, "https://test-app.fly.dev/", openedURL)
+	assert.Contains(t, out.String(), "Warning: couldn't load app config for test-app, falling back to the default app URL")
+	assert.Contains(t, out.String(), "opening https://test-app.fly.dev/ ...")
+}
+
+func TestRunOpenAppliesRelativeURIToDefaultAppURL(t *testing.T) {
+	ctx, out := testOpenContext(t, "dashboard")
+	ctx = appconfig.WithName(ctx, "test-app")
+
+	restore := stubOpenDependencies(t)
+	defer restore()
+
+	loadRemoteAppConfig = func(context.Context, string) (*appconfig.Config, error) {
+		return nil, errors.New("missing remote config")
+	}
+
+	require.NoError(t, runOpen(ctx))
+	assert.Equal(t, "https://test-app.fly.dev/dashboard", openedURL)
+	assert.Contains(t, out.String(), "Warning: couldn't load app config for test-app, falling back to the default app URL")
+	assert.Contains(t, out.String(), "opening https://test-app.fly.dev/dashboard ...")
+}
+
+func TestRunOpenUsesLocalConfigURLWhenPresent(t *testing.T) {
+	ctx, out := testOpenContext(t, "dashboard")
+	ctx = appconfig.WithName(ctx, "test-app")
+	ctx = appconfig.WithConfig(ctx, &appconfig.Config{
+		AppName:     "test-app",
+		HTTPService: &appconfig.HTTPService{InternalPort: 8080},
+	})
+
+	restore := stubOpenDependencies(t)
+	defer restore()
+
+	loadRemoteAppConfig = func(context.Context, string) (*appconfig.Config, error) {
+		t.Fatal("should not load remote app config when local config exists")
+
+		return nil, nil
+	}
+
+	require.NoError(t, runOpen(ctx))
+	assert.Equal(t, "https://test-app.fly.dev/dashboard", openedURL)
+	assert.Contains(t, out.String(), "opening https://test-app.fly.dev/dashboard ...")
+}
+
+func TestRunOpenFallsBackToSelectedAppWhenLocalConfigIsForAnotherApp(t *testing.T) {
+	ctx, out := testOpenContext(t)
+	ctx = appconfig.WithName(ctx, "flag-app")
+	ctx = appconfig.WithConfig(ctx, &appconfig.Config{
+		AppName:     "local-app",
+		HTTPService: &appconfig.HTTPService{InternalPort: 8080},
+	})
+
+	restore := stubOpenDependencies(t)
+	defer restore()
+
+	var remoteAppName string
+	loadRemoteAppConfig = func(_ context.Context, appName string) (*appconfig.Config, error) {
+		remoteAppName = appName
+
+		return nil, errors.New("missing remote config")
+	}
+
+	require.NoError(t, runOpen(ctx))
+	assert.Equal(t, "flag-app", remoteAppName)
+	assert.Equal(t, "https://flag-app.fly.dev/", openedURL)
+	assert.Contains(t, out.String(), "Warning: couldn't load app config for flag-app, falling back to the default app URL")
+	assert.Contains(t, out.String(), "opening https://flag-app.fly.dev/ ...")
+}
+
+func TestRunOpenUsesRemoteConfigURLWhenAvailable(t *testing.T) {
+	ctx, out := testOpenContext(t, "status")
+	ctx = appconfig.WithName(ctx, "test-app")
+
+	restore := stubOpenDependencies(t)
+	defer restore()
+
+	loadRemoteAppConfig = func(context.Context, string) (*appconfig.Config, error) {
+		return &appconfig.Config{
+			AppName:     "test-app",
+			HTTPService: &appconfig.HTTPService{InternalPort: 8080},
+		}, nil
+	}
+
+	require.NoError(t, runOpen(ctx))
+	assert.Equal(t, "https://test-app.fly.dev/status", openedURL)
+	assert.Contains(t, out.String(), "opening https://test-app.fly.dev/status ...")
+}
+
+func TestRunOpenDoesNotFallbackWhenRemoteConfigHasNoPublicService(t *testing.T) {
+	ctx, _ := testOpenContext(t)
+	ctx = appconfig.WithName(ctx, "test-app")
+
+	restore := stubOpenDependencies(t)
+	defer restore()
+
+	loadRemoteAppConfig = func(context.Context, string) (*appconfig.Config, error) {
+		return &appconfig.Config{AppName: "test-app"}, nil
+	}
+
+	err := runOpen(ctx)
+	require.EqualError(t, err, "The app doesn't expose a public http service")
+	assert.Empty(t, openedURL)
+}
+
+var openedURL string
+
+func stubOpenDependencies(t *testing.T) func() {
+	t.Helper()
+
+	openedURL = ""
+	originalOpenBrowser := openBrowser
+	originalLoadRemoteAppConfig := loadRemoteAppConfig
+
+	openBrowser = func(url string) error {
+		openedURL = url
+
+		return nil
+	}
+
+	return func() {
+		openBrowser = originalOpenBrowser
+		loadRemoteAppConfig = originalLoadRemoteAppConfig
+	}
+}
+
+func testOpenContext(t *testing.T, args ...string) (context.Context, *bytes.Buffer) {
+	t.Helper()
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	require.NoError(t, flags.Parse(args))
+
+	out := &bytes.Buffer{}
+	ctx := flag.NewContext(context.Background(), flags)
+	ctx = iostreams.NewContext(ctx, &iostreams.IOStreams{
+		Out:    out,
+		ErrOut: out,
+	})
+
+	return ctx, out
+}


### PR DESCRIPTION
## What

Allow `fly apps open -a <app>` to open the default `https://<app>.fly.dev/` URL when flyctl cannot load app config.

## Why

Supplying `-a` currently still fails if no local/remote app config can be loaded, which makes the app flag feel ignored for a command whose main job is to open the app URL.

## How

- Keep using config-derived URLs when local or remote app config is available
- Ignore local config that belongs to a different app than the selected app
- Fall back to the default Fly app hostname only when app config is unavailable
- Print a warning before falling back, while keeping the raw remote-load error in debug logs
- Share relative-URI handling across both paths
- Add focused tests for fallback, warning output, relative URI handling, local config, mismatched local config, remote config, missing app name, and no-public-service behavior

## Tests

```text
go test ./internal/command/apps -run TestRunOpen -count=1 -v
go test ./internal/command/apps -count=1
go test ./internal/command/... -count=1
go test ./... -run '^$' -count=1
go test ./... -count=1
```

Fixes #4215
