### PR TITLE
Populate launch metrics on early region-determination failures

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -417,6 +417,7 @@ func run(ctx context.Context) (err error) {
 					status.FlyctlVersion = launchManifest.Plan.FlyctlVersion.String()
 					status.ScannerFamily = launchManifest.Plan.ScannerFamily
 				}
+
 				return err
 			}
 		}

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -408,6 +408,15 @@ func run(ctx context.Context) (err error) {
 		if err != nil {
 			var recoverableErr recoverableInUiError
 			if !errors.As(err, &recoverableErr) || !canEnterUi {
+				// Populate status from partial manifest so metrics
+				// events carry org/app context even on early failures.
+				if launchManifest != nil && launchManifest.Plan != nil {
+					status.AppName = launchManifest.Plan.AppName
+					status.OrgSlug = launchManifest.Plan.OrgSlug
+					status.Region = launchManifest.Plan.RegionCode
+					status.FlyctlVersion = launchManifest.Plan.FlyctlVersion.String()
+					status.ScannerFamily = launchManifest.Plan.ScannerFamily
+				}
 				return err
 			}
 		}

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -179,7 +179,19 @@ func buildManifest(ctx context.Context, parentConfig *appconfig.Config, recovera
 	regionCode, regionExplanation, err := determineRegion(ctx, appConfig, org.Slug, guest, flapsClient)
 	if err != nil {
 		if err := recoverableErrors.tryRecover(err); err != nil {
-			return nil, nil, err
+			// Return a partial manifest so that metrics events
+			// carry org/app context even on early failures.
+			partial := &LaunchManifest{
+				Plan: &plan.LaunchPlan{
+					AppName:       appName,
+					OrgSlug:       org.Slug,
+					FlyctlVersion: buildinfo.Info().Version,
+				},
+			}
+			if srcInfo != nil {
+				partial.Plan.ScannerFamily = srcInfo.Family
+			}
+			return partial, nil, err
 		}
 	}
 

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -185,6 +185,7 @@ func buildManifest(ctx context.Context, parentConfig *appconfig.Config, recovera
 				Plan: &plan.LaunchPlan{
 					AppName:       appName,
 					OrgSlug:       org.Slug,
+					RegionCode:    regionCode,
 					FlyctlVersion: buildinfo.Info().Version,
 				},
 			}

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -191,6 +191,7 @@ func buildManifest(ctx context.Context, parentConfig *appconfig.Config, recovera
 			if srcInfo != nil {
 				partial.Plan.ScannerFamily = srcInfo.Family
 			}
+
 			return partial, nil, err
 		}
 	}


### PR DESCRIPTION
## Summary
- When `determineRegion` fails in non-interactive mode (e.g. org suspended, machine count exceeded), `buildManifest` returned `nil`, causing the deferred metrics event to have empty `org=""`, `app=""`, `region=""`, `flyctl=""` fields — making it impossible to identify who was generating the failures.
- `buildManifest` now returns a partial `LaunchManifest` with the org/app/flyctl-version info that was already determined before the region error.
- `run()` populates the metrics status from this partial manifest before the early return.

## Context
After #4830 switched region determination to the placements API, org-level errors (suspension, machine limits) started surfacing during `determineRegion` instead of later during deploy. Because `determineRegion` runs after org and app name are already known but before the `LaunchPlan` is constructed, the metrics event was losing all identifying context.

## Test plan
- [ ] `fly launch` with a suspended org in non-interactive mode → metrics event should now carry `org=` and `app=` values
- [ ] `fly launch` with an org at machine limit in non-interactive mode → same
- [ ] `fly launch` happy path (interactive and non-interactive) → no change in behavior
- [ ] `fly launch` with `--manifest` flag → no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)