### PR TITLE
Send Fly-Client-Agent header with metrics requests

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -417,6 +417,7 @@ func run(ctx context.Context) (err error) {
 					status.FlyctlVersion = launchManifest.Plan.FlyctlVersion.String()
 					status.ScannerFamily = launchManifest.Plan.ScannerFamily
 				}
+
 				return err
 			}
 		}

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -408,6 +408,15 @@ func run(ctx context.Context) (err error) {
 		if err != nil {
 			var recoverableErr recoverableInUiError
 			if !errors.As(err, &recoverableErr) || !canEnterUi {
+				// Populate status from partial manifest so metrics
+				// events carry org/app context even on early failures.
+				if launchManifest != nil && launchManifest.Plan != nil {
+					status.AppName = launchManifest.Plan.AppName
+					status.OrgSlug = launchManifest.Plan.OrgSlug
+					status.Region = launchManifest.Plan.RegionCode
+					status.FlyctlVersion = launchManifest.Plan.FlyctlVersion.String()
+					status.ScannerFamily = launchManifest.Plan.ScannerFamily
+				}
 				return err
 			}
 		}

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -179,7 +179,19 @@ func buildManifest(ctx context.Context, parentConfig *appconfig.Config, recovera
 	regionCode, regionExplanation, err := determineRegion(ctx, appConfig, org.Slug, guest, flapsClient)
 	if err != nil {
 		if err := recoverableErrors.tryRecover(err); err != nil {
-			return nil, nil, err
+			// Return a partial manifest so that metrics events
+			// carry org/app context even on early failures.
+			partial := &LaunchManifest{
+				Plan: &plan.LaunchPlan{
+					AppName:       appName,
+					OrgSlug:       org.Slug,
+					FlyctlVersion: buildinfo.Info().Version,
+				},
+			}
+			if srcInfo != nil {
+				partial.Plan.ScannerFamily = srcInfo.Family
+			}
+			return partial, nil, err
 		}
 	}
 

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -185,6 +185,7 @@ func buildManifest(ctx context.Context, parentConfig *appconfig.Config, recovera
 				Plan: &plan.LaunchPlan{
 					AppName:       appName,
 					OrgSlug:       org.Slug,
+					RegionCode:    regionCode,
 					FlyctlVersion: buildinfo.Info().Version,
 				},
 			}

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -191,6 +191,7 @@ func buildManifest(ctx context.Context, parentConfig *appconfig.Config, recovera
 			if srcInfo != nil {
 				partial.Plan.ScannerFamily = srcInfo.Family
 			}
+
 			return partial, nil, err
 		}
 	}

--- a/internal/metrics/db.go
+++ b/internal/metrics/db.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/rehttp"
+	clientsignals "github.com/superfly/client-signals/go"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/cmdutil"
 	"github.com/superfly/flyctl/internal/config"
@@ -111,6 +112,11 @@ func sendMetricsRequest(ctx context.Context, endpoint, token, userAgent string, 
 
 	request.Header.Set("Authorization", "Bearer "+token)
 	request.Header.Set("User-Agent", userAgent)
+
+	signals := clientsignals.DetectOnce()
+	if signals.Agent != "" {
+		request.Header.Set("Fly-Client-Agent", signals.Agent)
+	}
 
 	client := createHTTPClient()
 


### PR DESCRIPTION
## Summary
- Adds `Fly-Client-Agent` header to metrics POST requests sent to flyctl-metrics
- Uses `clientsignals.DetectOnce()` which is already a dependency — detection is cached and cheap
- Works in both interactive (forked subprocess inherits env vars) and non-interactive paths
- No feature flag gating — this is internal metrics, we control both sides

## Companion PR
- superfly/flyctl-metrics#67 — reads the header and adds it as a `client_agent` Prometheus label

## Test plan
- [x] `go build ./internal/metrics/...` passes
- [ ] Verify header appears in metrics POST requests when running under an agent environment
- [ ] Verify no header sent for normal human CLI usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)