### PR TITLE
Use client-signals Operator() for metrics classification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/client-signals/go v0.3.0
+	github.com/superfly/client-signals/go v0.4.2
 	github.com/superfly/fly-go v0.9.0
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -668,6 +668,10 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals/go v0.3.0 h1:UegKdBgPCYn5FqSGdxHUIeyLTAGWnd0kYxlioARw4LY=
 github.com/superfly/client-signals/go v0.3.0/go.mod h1:v/FQ2fZ4zOkOxKmue+bYh96awuh9Qh1ImcdxzRYcHFA=
+github.com/superfly/client-signals/go v0.4.0 h1:nuzq8vUZivaQ5rEHCUp1CsnrRdvWiNAkuOhokSfyxoA=
+github.com/superfly/client-signals/go v0.4.0/go.mod h1:v/FQ2fZ4zOkOxKmue+bYh96awuh9Qh1ImcdxzRYcHFA=
+github.com/superfly/client-signals/go v0.4.2 h1:8UH1s+jgCz/goOMdy2d8Wx4XDIDXqq70zStrimMaFIM=
+github.com/superfly/client-signals/go v0.4.2/go.mod h1:v/FQ2fZ4zOkOxKmue+bYh96awuh9Qh1ImcdxzRYcHFA=
 github.com/superfly/fly-go v0.9.0 h1:aYPEv8LPm61O22iAY+2kfZScaXJU0szuZfYc54qvWko=
 github.com/superfly/fly-go v0.9.0/go.mod h1:fRCFpiasmGrkifFFgQy+3AUd+On2BvSsrh/zV/mvX7s=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=

--- a/go.sum
+++ b/go.sum
@@ -666,10 +666,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/client-signals/go v0.3.0 h1:UegKdBgPCYn5FqSGdxHUIeyLTAGWnd0kYxlioARw4LY=
-github.com/superfly/client-signals/go v0.3.0/go.mod h1:v/FQ2fZ4zOkOxKmue+bYh96awuh9Qh1ImcdxzRYcHFA=
-github.com/superfly/client-signals/go v0.4.0 h1:nuzq8vUZivaQ5rEHCUp1CsnrRdvWiNAkuOhokSfyxoA=
-github.com/superfly/client-signals/go v0.4.0/go.mod h1:v/FQ2fZ4zOkOxKmue+bYh96awuh9Qh1ImcdxzRYcHFA=
 github.com/superfly/client-signals/go v0.4.2 h1:8UH1s+jgCz/goOMdy2d8Wx4XDIDXqq70zStrimMaFIM=
 github.com/superfly/client-signals/go v0.4.2/go.mod h1:v/FQ2fZ4zOkOxKmue+bYh96awuh9Qh1ImcdxzRYcHFA=
 github.com/superfly/fly-go v0.9.0 h1:aYPEv8LPm61O22iAY+2kfZScaXJU0szuZfYc54qvWko=

--- a/internal/metrics/helpers.go
+++ b/internal/metrics/helpers.go
@@ -165,19 +165,10 @@ func StartTiming(ctx context.Context, metricSlug string) func() {
 }
 
 // OperatorFromSignals returns an operator classification and, when the
-// operator is "agent", the agent name. Precedence: ci > agent > interactive.
-// Falls back to "unknown" when none of the signals match.
+// operator is "agent", the agent name. Precedence is defined by
+// clientsignals.Signals.Operator(): ci > agent > interactive > unknown.
 func OperatorFromSignals(s clientsignals.Signals) (operator, agentName string) {
-	switch {
-	case s.CI:
-		return "ci", ""
-	case s.Agent != "":
-		return "agent", s.Agent
-	case s.Interactive:
-		return "interactive", ""
-	default:
-		return "unknown", ""
-	}
+	return s.Operator(), s.Agent
 }
 
 type disableFlushMetricsKey struct{}


### PR DESCRIPTION
## Summary
- Bumps `client-signals` to v0.4.2
- Simplifies `OperatorFromSignals` to use the library's new `Operator()` method instead of reimplementing the precedence logic

## Related PRs
- superfly/client-signals#5 — added `Operator()` method (merged)
- superfly/flyctl#4995 — original operator/agent_name metrics work (merged)

## Test plan
- [x] `go build` passes
- [ ] Verify deploy/launch metrics still emit correct `operator` and `agentName` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)