### PR TITLE
Fix nil-dereference when Docker is not installed

### DIFF
--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -130,6 +130,10 @@ type DeploymentImage struct {
 }
 
 func (di *DeploymentImage) String() string {
+	if di == nil {
+		return "<nil>"
+	}
+
 	if di.Digest == "" {
 		return di.Tag
 	}


### PR DESCRIPTION
During a deploy, if Docker isn't installed, `localImageResolver` returns
a nil `*DeploymentImage`. Later, `ResolveReference` tries debug print it
as `%+v`. This invokes the `String` method on the image pointer, which
then crashes.