### PR TITLE
Fix --file-local on Windows

### DIFF
--- a/internal/command/command_run.go
+++ b/internal/command/command_run.go
@@ -351,7 +351,7 @@ func parseFiles(ctx context.Context, flagName string, cb func(value string, file
 		switch {
 		case !ok:
 			return nil, fmt.Errorf("invalid %s argument %s", flagName, f)
-		case !filepath.IsAbs(guestPath):
+		case !path.IsAbs(guestPath):
 			return nil, fmt.Errorf("guest path, %s, must be absolute", guestPath)
 		case fileRef == "":
 			// empty value is allowed to remove file from machine

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -2,12 +2,45 @@ package command
 
 import (
 	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/pflag"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flag/flagnames"
 )
+
+func TestFilesFromCommandUsesPOSIXGuestPath(t *testing.T) {
+	content := []byte("hello from windows")
+	localPath := filepath.Join(t.TempDir(), "config.txt")
+	if err := os.WriteFile(localPath, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.StringArray("file-local", []string{"/etc/config.txt=" + localPath}, "")
+	ctx := flag.NewContext(context.Background(), fs)
+
+	files, err := FilesFromCommand(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+
+	if got, want := files[0].GuestPath, "/etc/config.txt"; got != want {
+		t.Errorf("GuestPath = %q, want %q", got, want)
+	}
+	if files[0].RawValue == nil {
+		t.Fatal("RawValue is nil")
+	}
+	if got, want := *files[0].RawValue, base64.StdEncoding.EncodeToString(content); got != want {
+		t.Errorf("RawValue = %q, want %q", got, want)
+	}
+}
 
 func TestHasExternallySuppliedToken(t *testing.T) {
 	t.Run("env var set", func(t *testing.T) {


### PR DESCRIPTION
### Change Summary

What and Why:

Fix `--file-local` on Windows. Guest paths point inside a Linux Machine, but flyctl was checking them with the local OS's path rules, so paths like `/etc/config.txt` were rejected on Windows.

How:

Validate guest paths with slash-separated path semantics while leaving native local-file reads unchanged. Add a regression test with a POSIX guest path and a host-native temporary file.

Related to:

Fixes #4061

### Testing

- `go test ./internal/command -run '^TestFilesFromCommandUsesPOSIXGuestPath$' -count=1`
- `make test`
- Windows cross-compile of `internal/command`
- changed-lines `golangci-lint`

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a