### PR TITLE
feat(mpg): default cluster creation to v2

### DIFF
--- a/internal/command/mpg/create.go
+++ b/internal/command/mpg/create.go
@@ -44,7 +44,8 @@ func newCreate() *cobra.Command {
 		flag.Bool{
 			Name:        "v2",
 			Description: "Create a Postgres cluster deployed on the V2 platform",
-			Default:     false,
+			Default:     true,
+			Hidden:      true,
 		},
 		flag.String{
 			Name:        "plan",


### PR DESCRIPTION
We don't want people creating V1 clusters anymore. `fly mpg create`
now defaults `--v2` to true. We keep the flag as an escape hatch but
hide it from `--help` so V1 isn't advertised.

Signed-off-by: Juliana Oliveira <juliana@fly.io>
