### PR TITLE
Support Dockerfile URLs in [build]

### DIFF
--- a/internal/appconfig/config.go
+++ b/internal/appconfig/config.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/dockerfileurl"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/launchdarkly"
 )
@@ -360,7 +361,7 @@ func (c *Config) BuildStrategies() []string {
 	}
 	if c.Build.Dockerfile != "" || c.Build.DockerBuildTarget != "" {
 		if c.Build.Dockerfile != "" {
-			strategies = append(strategies, fmt.Sprintf("the \"%s\" dockerfile", c.Build.Dockerfile))
+			strategies = append(strategies, fmt.Sprintf("the \"%s\" dockerfile", dockerfileurl.ForDisplay(c.Build.Dockerfile)))
 		} else {
 			strategies = append(strategies, "a dockerfile")
 		}

--- a/internal/appconfig/config_test.go
+++ b/internal/appconfig/config_test.go
@@ -77,6 +77,17 @@ func TestManyBuildStrategies(t *testing.T) {
 	assert.Equal(t, 4, len(cfg.BuildStrategies()))
 }
 
+func TestDockerfileURLBuildStrategy(t *testing.T) {
+	dockerfileURL := "https://" + "user:password@" + "example.com/Dockerfile?token=secret#fragment"
+	cfg := Config{Build: &Build{Dockerfile: dockerfileURL}}
+
+	assert.Equal(t, dockerfileURL, cfg.Dockerfile())
+	assert.Equal(t,
+		[]string{`the "https://example.com/Dockerfile" dockerfile`},
+		cfg.BuildStrategies(),
+	)
+}
+
 func TestConfigPortGetter(t *testing.T) {
 	type testcase struct {
 		name         string

--- a/internal/appconfig/validation_test.go
+++ b/internal/appconfig/validation_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/superfly/flyctl/internal/logger"
 )
 
-func TestConfigValidateRedactsDockerfileURL(t *testing.T) {
-	dockerfileURL := "https://" + "user:password@" + "example.com/Dockerfile?token=secret#fragment"
+func TestConfigValidateRedactsMalformedDockerfileURL(t *testing.T) {
+	dockerfileURL := "https://" + "user:pass@" + "example.com/%zz?token=secret#fragment"
 	cfg := &Config{Build: &Build{
 		Builder:    "example.com/builder",
 		Dockerfile: dockerfileURL,
@@ -38,14 +38,14 @@ func TestConfigValidateRedactsDockerfileURL(t *testing.T) {
 	err, output := cfg.Validate(context.Background())
 
 	require.NoError(t, err)
-	assert.Contains(t, output, `the "https://example.com/Dockerfile" dockerfile`)
-	assert.NotContains(t, output, "user:password@")
+	assert.Contains(t, output, `the "invalid URL" dockerfile`)
+	assert.NotContains(t, output, "user:pass@")
 	assert.NotContains(t, output, "token=secret")
 	assert.NotContains(t, output, "#fragment")
 	require.NotNil(t, captured)
 	require.NotEmpty(t, captured.Exception)
-	assert.Contains(t, captured.Exception[0].Value, "https://example.com/Dockerfile")
-	assert.NotContains(t, captured.Exception[0].Value, "user:password@")
+	assert.Contains(t, captured.Exception[0].Value, "invalid URL")
+	assert.NotContains(t, captured.Exception[0].Value, "user:pass@")
 	assert.NotContains(t, captured.Exception[0].Value, "token=secret")
 	assert.NotContains(t, captured.Exception[0].Value, "#fragment")
 }

--- a/internal/appconfig/validation_test.go
+++ b/internal/appconfig/validation_test.go
@@ -5,12 +5,50 @@ import (
 	"os"
 	"testing"
 
+	getsentry "github.com/getsentry/sentry-go"
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superfly/flyctl/internal/cmdutil/preparers"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/logger"
 )
+
+func TestConfigValidateRedactsDockerfileURL(t *testing.T) {
+	dockerfileURL := "https://" + "user:password@" + "example.com/Dockerfile?token=secret#fragment"
+	cfg := &Config{Build: &Build{
+		Builder:    "example.com/builder",
+		Dockerfile: dockerfileURL,
+	}}
+
+	var captured *getsentry.Event
+	client, err := getsentry.NewClient(getsentry.ClientOptions{
+		BeforeSend: func(event *getsentry.Event, _ *getsentry.EventHint) *getsentry.Event {
+			captured = event
+
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	hub := getsentry.CurrentHub()
+	previousClient := hub.Client()
+	hub.BindClient(client)
+	t.Cleanup(func() { hub.BindClient(previousClient) })
+
+	err, output := cfg.Validate(context.Background())
+
+	require.NoError(t, err)
+	assert.Contains(t, output, `the "https://example.com/Dockerfile" dockerfile`)
+	assert.NotContains(t, output, "user:password@")
+	assert.NotContains(t, output, "token=secret")
+	assert.NotContains(t, output, "#fragment")
+	require.NotNil(t, captured)
+	require.NotEmpty(t, captured.Exception)
+	assert.Contains(t, captured.Exception[0].Value, "https://example.com/Dockerfile")
+	assert.NotContains(t, captured.Exception[0].Value, "user:password@")
+	assert.NotContains(t, captured.Exception[0].Value, "token=secret")
+	assert.NotContains(t, captured.Exception[0].Value, "#fragment")
+}
 
 func _getValidationContext(t *testing.T) context.Context {
 	ctx := logger.NewContext(context.Background(), logger.New(os.Stderr, logger.Info, false))

--- a/internal/build/imgsrc/buildkit_builder.go
+++ b/internal/build/imgsrc/buildkit_builder.go
@@ -45,6 +45,8 @@ func NewBuildkitBuilder(addr string, provisioner *Provisioner) *BuildkitBuilder 
 
 func (r *BuildkitBuilder) Name() string { return "Buildkit" }
 
+func (*BuildkitBuilder) usesDockerfile() {}
+
 func (r *BuildkitBuilder) Run(ctx context.Context, _ *dockerClientFactory, streams *iostreams.IOStreams, opts ImageOptions, build *build) (*DeploymentImage, string, error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "buildkit_builder", trace.WithAttributes(opts.ToSpanAttributes()...))
 	defer span.End()

--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -59,6 +59,8 @@ type DepotBuilder struct {
 
 func (d *DepotBuilder) Name() string { return "depot.dev" }
 
+func (*DepotBuilder) usesDockerfile() {}
+
 func (d *DepotBuilder) Run(ctx context.Context, _ *dockerClientFactory, streams *iostreams.IOStreams, opts ImageOptions, build *build) (*DeploymentImage, string, error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "depot_builder", trace.WithAttributes(opts.ToSpanAttributes()...))
 	defer span.End()

--- a/internal/build/imgsrc/dockerfile_builder.go
+++ b/internal/build/imgsrc/dockerfile_builder.go
@@ -41,6 +41,8 @@ func (*dockerfileBuilder) Name() string {
 	return "Dockerfile"
 }
 
+func (*dockerfileBuilder) usesDockerfile() {}
+
 // lastProgressOutput is the same as progress.Output except
 // that it only output with the last update. It is used in
 // non terminal scenarios to suppress verbose messages

--- a/internal/build/imgsrc/dockerfile_url.go
+++ b/internal/build/imgsrc/dockerfile_url.go
@@ -46,6 +46,12 @@ func redactDockerfileURL(path string) string {
 	return u.String()
 }
 
+// DockerfilePathForDisplay removes sensitive URL components from HTTP(S)
+// Dockerfile paths and leaves local paths unchanged.
+func DockerfilePathForDisplay(path string) string {
+	return redactDockerfileURL(path)
+}
+
 func redactDockerfileRequestError(err error) error {
 	var urlErr *url.Error
 	if !errors.As(err, &urlErr) {

--- a/internal/build/imgsrc/dockerfile_url.go
+++ b/internal/build/imgsrc/dockerfile_url.go
@@ -2,11 +2,13 @@ package imgsrc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -26,6 +28,36 @@ func IsDockerfileURL(path string) bool {
 	return strings.EqualFold(u.Scheme, "http") || strings.EqualFold(u.Scheme, "https")
 }
 
+func redactDockerfileURL(path string) string {
+	if !IsDockerfileURL(path) {
+		return path
+	}
+
+	u, err := url.Parse(path)
+	if err != nil {
+		return path
+	}
+
+	u.User = nil
+	u.RawQuery = ""
+	u.ForceQuery = false
+	u.Fragment = ""
+
+	return u.String()
+}
+
+func redactDockerfileRequestError(err error) error {
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		return err
+	}
+
+	redacted := *urlErr
+	redacted.URL = redactDockerfileURL(urlErr.URL)
+
+	return &redacted
+}
+
 func materializeDockerfile(ctx context.Context, path string) (localPath string, cleanup func(), err error) {
 	if !IsDockerfileURL(path) {
 		return path, func() {}, nil
@@ -40,12 +72,12 @@ func downloadDockerfile(ctx context.Context, dockerfileURL string, timeout time.
 
 	req, err := http.NewRequestWithContext(downloadCtx, http.MethodGet, dockerfileURL, http.NoBody)
 	if err != nil {
-		return "", nil, fmt.Errorf("creating Dockerfile request: %w", err)
+		return "", nil, fmt.Errorf("creating Dockerfile request: %w", redactDockerfileRequestError(err))
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", nil, fmt.Errorf("downloading Dockerfile: %w", err)
+		return "", nil, fmt.Errorf("downloading Dockerfile: %w", redactDockerfileRequestError(err))
 	}
 	defer resp.Body.Close()
 
@@ -56,13 +88,19 @@ func downloadDockerfile(ctx context.Context, dockerfileURL string, timeout time.
 		return "", nil, fmt.Errorf("downloading Dockerfile: response exceeds %d-byte limit", maxBytes)
 	}
 
-	f, err := os.CreateTemp("", "flyctl-dockerfile-*")
+	tempDir, err := os.MkdirTemp("", "flyctl-dockerfile-*")
 	if err != nil {
+		return "", nil, fmt.Errorf("creating temporary Dockerfile directory: %w", err)
+	}
+	cleanup = func() { _ = os.RemoveAll(tempDir) }
+
+	path = filepath.Join(tempDir, "Dockerfile")
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		cleanup()
 		return "", nil, fmt.Errorf("creating temporary Dockerfile: %w", err)
 	}
 
-	path = f.Name()
-	cleanup = func() { _ = os.Remove(path) }
 	defer func() {
 		if closeErr := f.Close(); err == nil && closeErr != nil {
 			err = fmt.Errorf("closing temporary Dockerfile: %w", closeErr)

--- a/internal/build/imgsrc/dockerfile_url.go
+++ b/internal/build/imgsrc/dockerfile_url.go
@@ -9,48 +9,15 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
+
+	"github.com/superfly/flyctl/internal/dockerfileurl"
 )
 
 const (
 	dockerfileDownloadTimeout = 30 * time.Second
 	maxDockerfileSizeBytes    = 10 << 20
 )
-
-// IsDockerfileURL reports whether path is an HTTP(S) URL.
-func IsDockerfileURL(path string) bool {
-	u, err := url.Parse(path)
-	if err != nil || u.Host == "" {
-		return false
-	}
-
-	return strings.EqualFold(u.Scheme, "http") || strings.EqualFold(u.Scheme, "https")
-}
-
-func redactDockerfileURL(path string) string {
-	if !IsDockerfileURL(path) {
-		return path
-	}
-
-	u, err := url.Parse(path)
-	if err != nil {
-		return path
-	}
-
-	u.User = nil
-	u.RawQuery = ""
-	u.ForceQuery = false
-	u.Fragment = ""
-
-	return u.String()
-}
-
-// DockerfilePathForDisplay removes sensitive URL components from HTTP(S)
-// Dockerfile paths and leaves local paths unchanged.
-func DockerfilePathForDisplay(path string) string {
-	return redactDockerfileURL(path)
-}
 
 func redactDockerfileRequestError(err error) error {
 	var urlErr *url.Error
@@ -59,13 +26,13 @@ func redactDockerfileRequestError(err error) error {
 	}
 
 	redacted := *urlErr
-	redacted.URL = redactDockerfileURL(urlErr.URL)
+	redacted.URL = dockerfileurl.ForDisplay(urlErr.URL)
 
 	return &redacted
 }
 
 func materializeDockerfile(ctx context.Context, path string) (localPath string, cleanup func(), err error) {
-	if !IsDockerfileURL(path) {
+	if !dockerfileurl.IsURL(path) {
 		return path, func() {}, nil
 	}
 

--- a/internal/build/imgsrc/dockerfile_url.go
+++ b/internal/build/imgsrc/dockerfile_url.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/superfly/flyctl/internal/dockerfileurl"
@@ -19,6 +20,22 @@ const (
 	maxDockerfileSizeBytes    = 10 << 20
 )
 
+// DockerfileMaterializer lazily resolves one remote Dockerfile and keeps that
+// exact snapshot available across builder connection failover.
+type DockerfileMaterializer struct {
+	attempted bool
+	closed    bool
+	source    string
+	path      string
+	cleanup   func() error
+	err       error
+}
+
+// NewDockerfileMaterializer returns an empty lazy materializer.
+func NewDockerfileMaterializer() *DockerfileMaterializer {
+	return new(DockerfileMaterializer)
+}
+
 func redactDockerfileRequestError(err error) error {
 	var urlErr *url.Error
 	if !errors.As(err, &urlErr) {
@@ -26,20 +43,57 @@ func redactDockerfileRequestError(err error) error {
 	}
 
 	redacted := *urlErr
-	redacted.URL = dockerfileurl.ForDisplay(urlErr.URL)
+	redacted.URL = dockerfileurl.ForRequestError(urlErr.URL)
+	if strings.HasPrefix(urlErr.Err.Error(), "failed to parse Location header ") {
+		redacted.Err = errors.New("failed to parse redirect Location header")
+	}
 
 	return &redacted
 }
 
-func materializeDockerfile(ctx context.Context, path string) (localPath string, cleanup func(), err error) {
+func (m *DockerfileMaterializer) materialize(ctx context.Context, path string) (string, error) {
 	if !dockerfileurl.IsURL(path) {
-		return path, func() {}, nil
+		return path, nil
+	}
+	if m.closed {
+		return "", errors.New("Dockerfile materializer is closed")
+	}
+	if m.attempted {
+		if path != m.source {
+			return "", errors.New("Dockerfile materializer cannot resolve multiple sources")
+		}
+
+		return m.path, m.err
 	}
 
-	return downloadDockerfile(ctx, path, dockerfileDownloadTimeout, maxDockerfileSizeBytes)
+	m.attempted = true
+	m.source = path
+	m.path, m.cleanup, m.err = downloadDockerfile(ctx, path, dockerfileDownloadTimeout, maxDockerfileSizeBytes)
+
+	return m.path, m.err
 }
 
-func downloadDockerfile(ctx context.Context, dockerfileURL string, timeout time.Duration, maxBytes int64) (path string, cleanup func(), err error) {
+func (m *DockerfileMaterializer) Close() error {
+	if m.closed {
+		return nil
+	}
+	if m.cleanup == nil {
+		m.closed = true
+
+		return nil
+	}
+
+	err := m.cleanup()
+	if err != nil {
+		return fmt.Errorf("removing temporary Dockerfile directory: %w", err)
+	}
+	m.cleanup = nil
+	m.closed = true
+
+	return nil
+}
+
+func downloadDockerfile(ctx context.Context, dockerfileURL string, timeout time.Duration, maxBytes int64) (path string, cleanup func() error, err error) {
 	downloadCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -47,6 +101,7 @@ func downloadDockerfile(ctx context.Context, dockerfileURL string, timeout time.
 	if err != nil {
 		return "", nil, fmt.Errorf("creating Dockerfile request: %w", redactDockerfileRequestError(err))
 	}
+	req.URL.Scheme = strings.ToLower(req.URL.Scheme)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -55,7 +110,7 @@ func downloadDockerfile(ctx context.Context, dockerfileURL string, timeout time.
 	defer resp.Body.Close()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return "", nil, fmt.Errorf("downloading Dockerfile: unexpected HTTP status %s", resp.Status)
+		return "", nil, fmt.Errorf("downloading Dockerfile: unexpected HTTP status %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 	if resp.ContentLength > maxBytes {
 		return "", nil, fmt.Errorf("downloading Dockerfile: response exceeds %d-byte limit", maxBytes)
@@ -65,12 +120,14 @@ func downloadDockerfile(ctx context.Context, dockerfileURL string, timeout time.
 	if err != nil {
 		return "", nil, fmt.Errorf("creating temporary Dockerfile directory: %w", err)
 	}
-	cleanup = func() { _ = os.RemoveAll(tempDir) }
+	cleanup = func() error { return os.RemoveAll(tempDir) }
 
 	path = filepath.Join(tempDir, "Dockerfile")
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
-		cleanup()
+		if cleanupErr := cleanup(); cleanupErr != nil {
+			err = errors.Join(err, cleanupErr)
+		}
 
 		return "", nil, fmt.Errorf("creating temporary Dockerfile: %w", err)
 	}
@@ -80,7 +137,9 @@ func downloadDockerfile(ctx context.Context, dockerfileURL string, timeout time.
 			err = fmt.Errorf("closing temporary Dockerfile: %w", closeErr)
 		}
 		if err != nil {
-			cleanup()
+			if cleanupErr := cleanup(); cleanupErr != nil {
+				err = errors.Join(err, fmt.Errorf("removing temporary Dockerfile directory: %w", cleanupErr))
+			}
 			path = ""
 			cleanup = nil
 		}

--- a/internal/build/imgsrc/dockerfile_url.go
+++ b/internal/build/imgsrc/dockerfile_url.go
@@ -51,6 +51,34 @@ func redactDockerfileRequestError(err error) error {
 	return &redacted
 }
 
+func dockerfileHTTPClient() *http.Client {
+	client := *http.DefaultClient
+	client.CheckRedirect = dockerfileCheckRedirect(client.CheckRedirect)
+
+	return &client
+}
+
+func dockerfileCheckRedirect(checkRedirect func(*http.Request, []*http.Request) error) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		if checkRedirect != nil {
+			if err := checkRedirect(req, via); err != nil {
+				return err
+			}
+		} else if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		if len(via) > 0 && strings.EqualFold(via[len(via)-1].URL.Scheme, "https") && strings.EqualFold(req.URL.Scheme, "http") {
+			return errors.New("refusing Dockerfile redirect from HTTPS to HTTP")
+		}
+
+		// net/http derives Referer from the previous URL, including its query.
+		// Do this after any inherited hook so it cannot restore signed parameters.
+		req.Header.Del("Referer")
+
+		return nil
+	}
+}
+
 func (m *DockerfileMaterializer) materialize(ctx context.Context, path string) (string, error) {
 	if !dockerfileurl.IsURL(path) {
 		return path, nil
@@ -103,7 +131,7 @@ func downloadDockerfile(ctx context.Context, dockerfileURL string, timeout time.
 	}
 	req.URL.Scheme = strings.ToLower(req.URL.Scheme)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := dockerfileHTTPClient().Do(req)
 	if err != nil {
 		return "", nil, fmt.Errorf("downloading Dockerfile: %w", redactDockerfileRequestError(err))
 	}

--- a/internal/build/imgsrc/dockerfile_url.go
+++ b/internal/build/imgsrc/dockerfile_url.go
@@ -98,6 +98,7 @@ func downloadDockerfile(ctx context.Context, dockerfileURL string, timeout time.
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		cleanup()
+
 		return "", nil, fmt.Errorf("creating temporary Dockerfile: %w", err)
 	}
 

--- a/internal/build/imgsrc/dockerfile_url.go
+++ b/internal/build/imgsrc/dockerfile_url.go
@@ -1,0 +1,85 @@
+package imgsrc
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	dockerfileDownloadTimeout = 30 * time.Second
+	maxDockerfileSizeBytes    = 10 << 20
+)
+
+// IsDockerfileURL reports whether path is an HTTP(S) URL.
+func IsDockerfileURL(path string) bool {
+	u, err := url.Parse(path)
+	if err != nil || u.Host == "" {
+		return false
+	}
+
+	return strings.EqualFold(u.Scheme, "http") || strings.EqualFold(u.Scheme, "https")
+}
+
+func materializeDockerfile(ctx context.Context, path string) (localPath string, cleanup func(), err error) {
+	if !IsDockerfileURL(path) {
+		return path, func() {}, nil
+	}
+
+	return downloadDockerfile(ctx, path, dockerfileDownloadTimeout, maxDockerfileSizeBytes)
+}
+
+func downloadDockerfile(ctx context.Context, dockerfileURL string, timeout time.Duration, maxBytes int64) (path string, cleanup func(), err error) {
+	downloadCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(downloadCtx, http.MethodGet, dockerfileURL, http.NoBody)
+	if err != nil {
+		return "", nil, fmt.Errorf("creating Dockerfile request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", nil, fmt.Errorf("downloading Dockerfile: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", nil, fmt.Errorf("downloading Dockerfile: unexpected HTTP status %s", resp.Status)
+	}
+	if resp.ContentLength > maxBytes {
+		return "", nil, fmt.Errorf("downloading Dockerfile: response exceeds %d-byte limit", maxBytes)
+	}
+
+	f, err := os.CreateTemp("", "flyctl-dockerfile-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("creating temporary Dockerfile: %w", err)
+	}
+
+	path = f.Name()
+	cleanup = func() { _ = os.Remove(path) }
+	defer func() {
+		if closeErr := f.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("closing temporary Dockerfile: %w", closeErr)
+		}
+		if err != nil {
+			cleanup()
+			path = ""
+			cleanup = nil
+		}
+	}()
+
+	written, copyErr := io.Copy(f, io.LimitReader(resp.Body, maxBytes+1))
+	if copyErr != nil {
+		err = fmt.Errorf("writing temporary Dockerfile: %w", copyErr)
+	} else if written > maxBytes {
+		err = fmt.Errorf("downloading Dockerfile: response exceeds %d-byte limit", maxBytes)
+	}
+
+	return
+}

--- a/internal/build/imgsrc/dockerfile_url_test.go
+++ b/internal/build/imgsrc/dockerfile_url_test.go
@@ -1,0 +1,148 @@
+package imgsrc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+type imageBuilderFunc func(context.Context, *dockerClientFactory, *iostreams.IOStreams, ImageOptions, *build) (*DeploymentImage, string, error)
+
+func (f imageBuilderFunc) Name() string { return "test" }
+
+func (f imageBuilderFunc) Run(ctx context.Context, dockerFactory *dockerClientFactory, streams *iostreams.IOStreams, opts ImageOptions, build *build) (*DeploymentImage, string, error) {
+	return f(ctx, dockerFactory, streams, opts, build)
+}
+
+type dockerfileBuilderFunc struct {
+	imageBuilderFunc
+}
+
+func (*dockerfileBuilderFunc) usesDockerfile() {}
+
+func TestRunImageBuilderDoesNotFetchUnusedDockerfileURL(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	t.Cleanup(server.Close)
+
+	expected := &DeploymentImage{Tag: "buildpack-image"}
+	strategy := imageBuilderFunc(func(_ context.Context, _ *dockerClientFactory, _ *iostreams.IOStreams, opts ImageOptions, _ *build) (*DeploymentImage, string, error) {
+		assert.Equal(t, server.URL+"/Dockerfile", opts.DockerfilePath)
+
+		return expected, "", nil
+	})
+
+	image, _, err := runImageBuilder(context.Background(), strategy, nil, nil, ImageOptions{
+		Builder:        "paketobuildpacks/builder-jammy-base",
+		DockerfilePath: server.URL + "/Dockerfile",
+	}, nil)
+
+	require.NoError(t, err)
+	assert.Same(t, expected, image)
+	assert.Zero(t, requests.Load())
+	assert.NotImplements(t, (*dockerfileConsumer)(nil), &buildpacksBuilder{})
+	assert.Implements(t, (*dockerfileConsumer)(nil), &dockerfileBuilder{})
+	assert.Implements(t, (*dockerfileConsumer)(nil), &BuildkitBuilder{})
+	assert.Implements(t, (*dockerfileConsumer)(nil), &DepotBuilder{})
+}
+
+func TestRunImageBuilderMaterializesDockerfileURLAndCleansUp(t *testing.T) {
+	const content = "FROM alpine:latest\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, content)
+	}))
+	t.Cleanup(server.Close)
+
+	var materializedPath string
+	strategy := &dockerfileBuilderFunc{imageBuilderFunc: func(_ context.Context, _ *dockerClientFactory, _ *iostreams.IOStreams, opts ImageOptions, _ *build) (*DeploymentImage, string, error) {
+		materializedPath = opts.DockerfilePath
+		got, err := os.ReadFile(materializedPath)
+		require.NoError(t, err)
+		assert.Equal(t, content, string(got))
+
+		return &DeploymentImage{Tag: "dockerfile-image"}, "", nil
+	}}
+
+	_, _, err := runImageBuilder(context.Background(), strategy, nil, nil, ImageOptions{
+		DockerfilePath: server.URL + "/Dockerfile",
+	}, nil)
+
+	require.NoError(t, err)
+	_, err = os.Stat(materializedPath)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestDownloadDockerfile(t *testing.T) {
+	const content = "FROM alpine:latest\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, content)
+	}))
+	t.Cleanup(server.Close)
+
+	path, cleanup, err := downloadDockerfile(context.Background(), server.URL+"/Dockerfile", time.Second, int64(len(content)))
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(got))
+
+	cleanup()
+	_, err = os.Stat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestDownloadDockerfileRejectsHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+
+	path, cleanup, err := downloadDockerfile(context.Background(), server.URL+"/Dockerfile", time.Second, 1024)
+
+	assert.Empty(t, path)
+	assert.Nil(t, cleanup)
+	assert.ErrorContains(t, err, "404 Not Found")
+}
+
+func TestDownloadDockerfileRejectsOversizedStreamAndCleansUp(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.(http.Flusher).Flush()
+		fmt.Fprint(w, "123456789")
+	}))
+	t.Cleanup(server.Close)
+
+	path, cleanup, err := downloadDockerfile(context.Background(), server.URL+"/Dockerfile", time.Second, 8)
+
+	assert.Empty(t, path)
+	assert.Nil(t, cleanup)
+	assert.ErrorContains(t, err, "response exceeds 8-byte limit")
+	entries, readErr := os.ReadDir(tempDir)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries)
+}
+
+func TestDownloadDockerfileTimesOut(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	path, cleanup, err := downloadDockerfile(context.Background(), server.URL+"/Dockerfile", 50*time.Millisecond, 1024)
+
+	assert.Empty(t, path)
+	assert.Nil(t, cleanup)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/internal/build/imgsrc/dockerfile_url_test.go
+++ b/internal/build/imgsrc/dockerfile_url_test.go
@@ -212,6 +212,58 @@ func TestDownloadDockerfileAcceptsUppercaseScheme(t *testing.T) {
 	assert.NotEmpty(t, path)
 }
 
+func TestDownloadDockerfileDoesNotForwardSensitiveRefererOnRedirect(t *testing.T) {
+	var referer string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirect" {
+			w.Header().Set("Location", "/Dockerfile")
+			w.WriteHeader(http.StatusFound)
+
+			return
+		}
+
+		referer = r.Referer()
+		fmt.Fprint(w, "FROM scratch\n")
+	}))
+	t.Cleanup(server.Close)
+
+	path, cleanup, err := downloadDockerfile(context.Background(), server.URL+"/redirect?token=secret", time.Second, 1024)
+
+	require.NoError(t, err)
+	require.NoError(t, cleanup())
+	assert.NotEmpty(t, path)
+	assert.Empty(t, referer)
+}
+
+func TestDockerfileCheckRedirectSanitizesAfterInheritedHook(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/Dockerfile", http.NoBody)
+	require.NoError(t, err)
+	previous, err := http.NewRequest(http.MethodGet, "https://example.com/redirect?token=secret", http.NoBody)
+	require.NoError(t, err)
+
+	checkRedirect := dockerfileCheckRedirect(func(req *http.Request, _ []*http.Request) error {
+		req.Header.Set("Referer", "https://example.com/redirect?token=secret")
+
+		return nil
+	})
+
+	require.NoError(t, checkRedirect(req, []*http.Request{previous}))
+	assert.Empty(t, req.Referer())
+}
+
+func TestDockerfileCheckRedirectRejectsHTTPSDowngrade(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/Dockerfile", http.NoBody)
+	require.NoError(t, err)
+	previous, err := http.NewRequest(http.MethodGet, "https://user:password@example.com/redirect", http.NoBody)
+	require.NoError(t, err)
+
+	err = dockerfileCheckRedirect(nil)(req, []*http.Request{previous})
+
+	assert.ErrorContains(t, err, "refusing Dockerfile redirect from HTTPS to HTTP")
+	assert.NotContains(t, err.Error(), "user")
+	assert.NotContains(t, err.Error(), "password")
+}
+
 func TestDockerfileMaterializerReportsCleanupFailure(t *testing.T) {
 	expectedErr := errors.New("remove failed")
 	materializer := &DockerfileMaterializer{

--- a/internal/build/imgsrc/dockerfile_url_test.go
+++ b/internal/build/imgsrc/dockerfile_url_test.go
@@ -31,6 +31,13 @@ type dockerfileBuilderFunc struct {
 
 func (*dockerfileBuilderFunc) usesDockerfile() {}
 
+func setTempDir(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("TMPDIR", dir)
+	t.Setenv("TMP", dir)
+	t.Setenv("TEMP", dir)
+}
+
 func TestRunImageBuilderDoesNotFetchUnusedDockerfileURL(t *testing.T) {
 	var requests atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
@@ -61,7 +68,7 @@ func TestRunImageBuilderDoesNotFetchUnusedDockerfileURL(t *testing.T) {
 
 func TestRunImageBuilderMaterializesDockerfileURLAndCleansUp(t *testing.T) {
 	tempRoot := t.TempDir()
-	t.Setenv("TMPDIR", tempRoot)
+	setTempDir(t, tempRoot)
 
 	const content = "FROM alpine:latest\n"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -98,7 +105,7 @@ func TestRunImageBuilderMaterializesDockerfileURLAndCleansUp(t *testing.T) {
 
 func TestRunImageBuilderCleansUpAfterBuilderError(t *testing.T) {
 	tempRoot := t.TempDir()
-	t.Setenv("TMPDIR", tempRoot)
+	setTempDir(t, tempRoot)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, "FROM alpine:latest\n")
@@ -109,6 +116,7 @@ func TestRunImageBuilderCleansUpAfterBuilderError(t *testing.T) {
 	var materializedDir string
 	strategy := &dockerfileBuilderFunc{imageBuilderFunc: func(_ context.Context, _ *dockerClientFactory, _ *iostreams.IOStreams, opts ImageOptions, _ *build) (*DeploymentImage, string, error) {
 		materializedDir = filepath.Dir(opts.DockerfilePath)
+
 		return nil, "", expectedErr
 	}}
 
@@ -154,7 +162,7 @@ func TestDownloadDockerfileRejectsHTTPError(t *testing.T) {
 
 func TestDownloadDockerfileRejectsOversizedStreamAndCleansUp(t *testing.T) {
 	tempDir := t.TempDir()
-	t.Setenv("TMPDIR", tempDir)
+	setTempDir(t, tempDir)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.(http.Flusher).Flush()

--- a/internal/build/imgsrc/dockerfile_url_test.go
+++ b/internal/build/imgsrc/dockerfile_url_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -55,7 +56,7 @@ func TestRunImageBuilderDoesNotFetchUnusedDockerfileURL(t *testing.T) {
 	image, _, err := runImageBuilder(context.Background(), strategy, nil, nil, ImageOptions{
 		Builder:        "paketobuildpacks/builder-jammy-base",
 		DockerfilePath: server.URL + "/Dockerfile",
-	}, nil)
+	}, nil, NewDockerfileMaterializer())
 
 	require.NoError(t, err)
 	assert.Same(t, expected, image)
@@ -64,6 +65,18 @@ func TestRunImageBuilderDoesNotFetchUnusedDockerfileURL(t *testing.T) {
 	assert.Implements(t, (*dockerfileConsumer)(nil), &dockerfileBuilder{})
 	assert.Implements(t, (*dockerfileConsumer)(nil), &BuildkitBuilder{})
 	assert.Implements(t, (*dockerfileConsumer)(nil), &DepotBuilder{})
+}
+
+func TestImageOptionsRedactsMalformedDockerfileURL(t *testing.T) {
+	const dockerfileURL = "https://" + "user:pass@" + "example.com/%zz?token=secret#fragment"
+	var got string
+	for _, attr := range (ImageOptions{DockerfilePath: dockerfileURL}).ToSpanAttributes() {
+		if string(attr.Key) == "imageoptions.dockerfile_path" {
+			got = attr.Value.AsString()
+		}
+	}
+
+	assert.Equal(t, "invalid URL", got)
 }
 
 func TestRunImageBuilderMaterializesDockerfileURLAndCleansUp(t *testing.T) {
@@ -77,6 +90,7 @@ func TestRunImageBuilderMaterializesDockerfileURLAndCleansUp(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	var materializedPath string
+	materializer := NewDockerfileMaterializer()
 	strategy := &dockerfileBuilderFunc{imageBuilderFunc: func(_ context.Context, _ *dockerClientFactory, _ *iostreams.IOStreams, opts ImageOptions, _ *build) (*DeploymentImage, string, error) {
 		materializedPath = opts.DockerfilePath
 		assert.Equal(t, filepath.Join(filepath.Dir(materializedPath), "Dockerfile"), materializedPath)
@@ -96,9 +110,10 @@ func TestRunImageBuilderMaterializesDockerfileURLAndCleansUp(t *testing.T) {
 
 	_, _, err := runImageBuilder(context.Background(), strategy, nil, nil, ImageOptions{
 		DockerfilePath: server.URL + "/Dockerfile",
-	}, nil)
+	}, nil, materializer)
 
 	require.NoError(t, err)
+	require.NoError(t, materializer.Close())
 	_, err = os.Stat(filepath.Dir(materializedPath))
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }
@@ -114,6 +129,7 @@ func TestRunImageBuilderCleansUpAfterBuilderError(t *testing.T) {
 
 	expectedErr := errors.New("builder failed")
 	var materializedDir string
+	materializer := NewDockerfileMaterializer()
 	strategy := &dockerfileBuilderFunc{imageBuilderFunc: func(_ context.Context, _ *dockerClientFactory, _ *iostreams.IOStreams, opts ImageOptions, _ *build) (*DeploymentImage, string, error) {
 		materializedDir = filepath.Dir(opts.DockerfilePath)
 
@@ -122,11 +138,44 @@ func TestRunImageBuilderCleansUpAfterBuilderError(t *testing.T) {
 
 	_, _, err := runImageBuilder(context.Background(), strategy, nil, nil, ImageOptions{
 		DockerfilePath: server.URL + "/Dockerfile",
-	}, nil)
+	}, nil, materializer)
 
 	assert.ErrorIs(t, err, expectedErr)
+	require.NoError(t, materializer.Close())
 	_, err = os.Stat(materializedDir)
 	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestRunImageBuilderReusesDockerfileAcrossFailover(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		fmt.Fprint(w, "FROM alpine:latest\n")
+	}))
+	t.Cleanup(server.Close)
+
+	materializer := NewDockerfileMaterializer()
+	var paths []string
+	expectedErr := errors.New("builder connection failed")
+	strategy := &dockerfileBuilderFunc{imageBuilderFunc: func(_ context.Context, _ *dockerClientFactory, _ *iostreams.IOStreams, opts ImageOptions, _ *build) (*DeploymentImage, string, error) {
+		paths = append(paths, opts.DockerfilePath)
+		if len(paths) == 1 {
+			return nil, "", expectedErr
+		}
+
+		return &DeploymentImage{Tag: "dockerfile-image"}, "", nil
+	}}
+	opts := ImageOptions{DockerfilePath: server.URL + "/Dockerfile"}
+
+	_, _, err := runImageBuilder(context.Background(), strategy, nil, nil, opts, nil, materializer)
+	require.ErrorIs(t, err, expectedErr)
+	_, _, err = runImageBuilder(context.Background(), strategy, nil, nil, opts, nil, materializer)
+
+	require.NoError(t, err)
+	require.NoError(t, materializer.Close())
+	assert.Equal(t, int32(1), requests.Load())
+	require.Len(t, paths, 2)
+	assert.Equal(t, paths[0], paths[1])
 }
 
 func TestDownloadDockerfile(t *testing.T) {
@@ -144,9 +193,35 @@ func TestDownloadDockerfile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, content, string(got))
 
-	cleanup()
+	require.NoError(t, cleanup())
 	_, err = os.Stat(path)
 	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestDownloadDockerfileAcceptsUppercaseScheme(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "FROM alpine:latest\n")
+	}))
+	t.Cleanup(server.Close)
+	dockerfileURL := strings.Replace(server.URL, "http://", "HTTP://", 1) + "/Dockerfile"
+
+	path, cleanup, err := downloadDockerfile(context.Background(), dockerfileURL, time.Second, 1024)
+
+	require.NoError(t, err)
+	require.NoError(t, cleanup())
+	assert.NotEmpty(t, path)
+}
+
+func TestDockerfileMaterializerReportsCleanupFailure(t *testing.T) {
+	expectedErr := errors.New("remove failed")
+	materializer := &DockerfileMaterializer{
+		cleanup: func() error { return expectedErr },
+	}
+
+	err := materializer.Close()
+
+	assert.ErrorIs(t, err, expectedErr)
+	assert.ErrorIs(t, materializer.Close(), expectedErr)
 }
 
 func TestDownloadDockerfileRejectsHTTPError(t *testing.T) {
@@ -220,6 +295,42 @@ func TestDownloadDockerfileRedactsURLFromRequestError(t *testing.T) {
 	assert.ErrorContains(t, err, "https://example.com/Dockerfile")
 	assert.NotContains(t, err.Error(), "user")
 	assert.NotContains(t, err.Error(), "password")
+	assert.NotContains(t, err.Error(), "token")
+	assert.NotContains(t, err.Error(), "secret")
+	assert.NotContains(t, err.Error(), "fragment")
+}
+
+func TestDownloadDockerfileRedactsMalformedRedirectURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "https://"+"user:pass@"+"example.com/%zz?token=secret#fragment")
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+
+	path, cleanup, err := downloadDockerfile(context.Background(), server.URL+"/Dockerfile", time.Second, 1024)
+
+	assert.Empty(t, path)
+	assert.Nil(t, cleanup)
+	assert.ErrorContains(t, err, "failed to parse redirect Location header")
+	assert.NotContains(t, err.Error(), "user")
+	assert.NotContains(t, err.Error(), "pass")
+	assert.NotContains(t, err.Error(), "token")
+	assert.NotContains(t, err.Error(), "secret")
+	assert.NotContains(t, err.Error(), "fragment")
+}
+
+func TestDownloadDockerfileRedactsRelativeRedirectURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "/Dockerfile?token=secret#fragment")
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+
+	path, cleanup, err := downloadDockerfile(context.Background(), server.URL+"/Dockerfile", time.Second, 1024)
+
+	assert.Empty(t, path)
+	assert.Nil(t, cleanup)
+	assert.ErrorContains(t, err, "/Dockerfile")
 	assert.NotContains(t, err.Error(), "token")
 	assert.NotContains(t, err.Error(), "secret")
 	assert.NotContains(t, err.Error(), "fragment")

--- a/internal/build/imgsrc/dockerfile_url_test.go
+++ b/internal/build/imgsrc/dockerfile_url_test.go
@@ -210,8 +210,9 @@ func TestDownloadDockerfileTimesOut(t *testing.T) {
 func TestDownloadDockerfileRedactsURLFromRequestError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
+	dockerfileURL := "https://" + "user:password@" + "example.com/Dockerfile?token=secret#fragment"
 
-	path, cleanup, err := downloadDockerfile(ctx, "https://user:password@example.com/Dockerfile?token=secret#fragment", time.Second, 1024)
+	path, cleanup, err := downloadDockerfile(ctx, dockerfileURL, time.Second, 1024)
 
 	assert.Empty(t, path)
 	assert.Nil(t, cleanup)
@@ -225,9 +226,11 @@ func TestDownloadDockerfileRedactsURLFromRequestError(t *testing.T) {
 }
 
 func TestRedactDockerfileURL(t *testing.T) {
+	dockerfileURL := "https://" + "user:password@" + "example.com/path/Dockerfile?token=secret#fragment"
+
 	assert.Equal(t, "Dockerfile.custom", redactDockerfileURL("Dockerfile.custom"))
 	assert.Equal(t,
 		"https://example.com/path/Dockerfile",
-		redactDockerfileURL("https://user:password@example.com/path/Dockerfile?token=secret#fragment"),
+		redactDockerfileURL(dockerfileURL),
 	)
 }

--- a/internal/build/imgsrc/dockerfile_url_test.go
+++ b/internal/build/imgsrc/dockerfile_url_test.go
@@ -224,13 +224,3 @@ func TestDownloadDockerfileRedactsURLFromRequestError(t *testing.T) {
 	assert.NotContains(t, err.Error(), "secret")
 	assert.NotContains(t, err.Error(), "fragment")
 }
-
-func TestRedactDockerfileURL(t *testing.T) {
-	dockerfileURL := "https://" + "user:password@" + "example.com/path/Dockerfile?token=secret#fragment"
-
-	assert.Equal(t, "Dockerfile.custom", redactDockerfileURL("Dockerfile.custom"))
-	assert.Equal(t,
-		"https://example.com/path/Dockerfile",
-		redactDockerfileURL(dockerfileURL),
-	)
-}

--- a/internal/build/imgsrc/dockerfile_url_test.go
+++ b/internal/build/imgsrc/dockerfile_url_test.go
@@ -2,10 +2,12 @@ package imgsrc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -58,6 +60,9 @@ func TestRunImageBuilderDoesNotFetchUnusedDockerfileURL(t *testing.T) {
 }
 
 func TestRunImageBuilderMaterializesDockerfileURLAndCleansUp(t *testing.T) {
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+
 	const content = "FROM alpine:latest\n"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, content)
@@ -67,6 +72,14 @@ func TestRunImageBuilderMaterializesDockerfileURLAndCleansUp(t *testing.T) {
 	var materializedPath string
 	strategy := &dockerfileBuilderFunc{imageBuilderFunc: func(_ context.Context, _ *dockerClientFactory, _ *iostreams.IOStreams, opts ImageOptions, _ *build) (*DeploymentImage, string, error) {
 		materializedPath = opts.DockerfilePath
+		assert.Equal(t, filepath.Join(filepath.Dir(materializedPath), "Dockerfile"), materializedPath)
+		assert.Equal(t, tempRoot, filepath.Dir(filepath.Dir(materializedPath)))
+
+		entries, err := os.ReadDir(filepath.Dir(materializedPath))
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "Dockerfile", entries[0].Name())
+
 		got, err := os.ReadFile(materializedPath)
 		require.NoError(t, err)
 		assert.Equal(t, content, string(got))
@@ -79,7 +92,32 @@ func TestRunImageBuilderMaterializesDockerfileURLAndCleansUp(t *testing.T) {
 	}, nil)
 
 	require.NoError(t, err)
-	_, err = os.Stat(materializedPath)
+	_, err = os.Stat(filepath.Dir(materializedPath))
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestRunImageBuilderCleansUpAfterBuilderError(t *testing.T) {
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, "FROM alpine:latest\n")
+	}))
+	t.Cleanup(server.Close)
+
+	expectedErr := errors.New("builder failed")
+	var materializedDir string
+	strategy := &dockerfileBuilderFunc{imageBuilderFunc: func(_ context.Context, _ *dockerClientFactory, _ *iostreams.IOStreams, opts ImageOptions, _ *build) (*DeploymentImage, string, error) {
+		materializedDir = filepath.Dir(opts.DockerfilePath)
+		return nil, "", expectedErr
+	}}
+
+	_, _, err := runImageBuilder(context.Background(), strategy, nil, nil, ImageOptions{
+		DockerfilePath: server.URL + "/Dockerfile",
+	}, nil)
+
+	assert.ErrorIs(t, err, expectedErr)
+	_, err = os.Stat(materializedDir)
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }
 
@@ -134,6 +172,20 @@ func TestDownloadDockerfileRejectsOversizedStreamAndCleansUp(t *testing.T) {
 	assert.Empty(t, entries)
 }
 
+func TestDownloadDockerfileRejectsDeclaredOversize(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", "9")
+		fmt.Fprint(w, "123456789")
+	}))
+	t.Cleanup(server.Close)
+
+	path, cleanup, err := downloadDockerfile(context.Background(), server.URL+"/Dockerfile", time.Second, 8)
+
+	assert.Empty(t, path)
+	assert.Nil(t, cleanup)
+	assert.ErrorContains(t, err, "response exceeds 8-byte limit")
+}
+
 func TestDownloadDockerfileTimesOut(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		<-r.Context().Done()
@@ -145,4 +197,29 @@ func TestDownloadDockerfileTimesOut(t *testing.T) {
 	assert.Empty(t, path)
 	assert.Nil(t, cleanup)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestDownloadDockerfileRedactsURLFromRequestError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	path, cleanup, err := downloadDockerfile(ctx, "https://user:password@example.com/Dockerfile?token=secret#fragment", time.Second, 1024)
+
+	assert.Empty(t, path)
+	assert.Nil(t, cleanup)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.ErrorContains(t, err, "https://example.com/Dockerfile")
+	assert.NotContains(t, err.Error(), "user")
+	assert.NotContains(t, err.Error(), "password")
+	assert.NotContains(t, err.Error(), "token")
+	assert.NotContains(t, err.Error(), "secret")
+	assert.NotContains(t, err.Error(), "fragment")
+}
+
+func TestRedactDockerfileURL(t *testing.T) {
+	assert.Equal(t, "Dockerfile.custom", redactDockerfileURL("Dockerfile.custom"))
+	assert.Equal(t,
+		"https://example.com/path/Dockerfile",
+		redactDockerfileURL("https://user:password@example.com/path/Dockerfile?token=secret#fragment"),
+	)
 }

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -3,6 +3,7 @@ package imgsrc
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -168,6 +169,9 @@ type Resolver struct {
 	// dockerFactory is a factory for creating docker clients.
 	// Some strategies don't need it, but it won't be nil.
 	dockerFactory *dockerClientFactory
+	// dockerfileMaterializer is shared by deploy retries so a remote Dockerfile
+	// is fetched once and reused across builder connection failover.
+	dockerfileMaterializer *DockerfileMaterializer
 }
 
 type StopSignal struct {
@@ -236,6 +240,17 @@ func (r *Resolver) ResolveReference(ctx context.Context, streams *iostreams.IOSt
 func (r *Resolver) BuildImage(ctx context.Context, streams *iostreams.IOStreams, opts ImageOptions) (img *DeploymentImage, err error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "build_image", trace.WithAttributes(opts.ToSpanAttributes()...))
 	defer span.End()
+
+	materializer := r.dockerfileMaterializer
+	if materializer == nil {
+		materializer = NewDockerfileMaterializer()
+		defer func() {
+			if cleanupErr := materializer.Close(); cleanupErr != nil {
+				img = nil
+				err = stderrors.Join(err, cleanupErr)
+			}
+		}()
+	}
 
 	if !r.dockerFactory.mode.IsAvailable() {
 		err := errors.New("docker is unavailable to build the deployment image")
@@ -309,7 +324,7 @@ func (r *Resolver) BuildImage(ctx context.Context, streams *iostreams.IOStreams,
 		bld.ResetTimings()
 		bld.BuildAndPushStart()
 		var note string
-		img, note, err = runImageBuilder(ctx, s, r.dockerFactory, streams, opts, bld)
+		img, note, err = runImageBuilder(ctx, s, r.dockerFactory, streams, opts, bld, materializer)
 		terminal.Debugf("result image:%+v error:%v\n", img, err)
 		if err != nil {
 			bld.BuildAndPushFinish()
@@ -816,6 +831,13 @@ func WithProvisioner(provisioner *Provisioner) func(resolver *Resolver) {
 	}
 }
 
+// WithDockerfileMaterializer shares one lazy remote Dockerfile snapshot across resolvers.
+func WithDockerfileMaterializer(materializer *DockerfileMaterializer) func(resolver *Resolver) {
+	return func(resolver *Resolver) {
+		resolver.dockerfileMaterializer = materializer
+	}
+}
+
 func NewResolver(
 	daemonType DockerDaemonType, apiClient flyutil.Client, appName string, iostreams *iostreams.IOStreams,
 	connectOverWireguard, recreateBuilder bool,
@@ -846,13 +868,12 @@ type dockerfileConsumer interface {
 	usesDockerfile()
 }
 
-func runImageBuilder(ctx context.Context, strategy imageBuilder, dockerFactory *dockerClientFactory, streams *iostreams.IOStreams, opts ImageOptions, build *build) (*DeploymentImage, string, error) {
+func runImageBuilder(ctx context.Context, strategy imageBuilder, dockerFactory *dockerClientFactory, streams *iostreams.IOStreams, opts ImageOptions, build *build, materializer *DockerfileMaterializer) (*DeploymentImage, string, error) {
 	if _, ok := strategy.(dockerfileConsumer); ok {
-		path, cleanup, err := materializeDockerfile(ctx, opts.DockerfilePath)
+		path, err := materializer.materialize(ctx, opts.DockerfilePath)
 		if err != nil {
 			return nil, "", err
 		}
-		defer cleanup()
 
 		opts.DockerfilePath = path
 	}

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/buildinfo"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/dockerfileurl"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
@@ -62,7 +63,7 @@ func (io ImageOptions) ToSpanAttributes() []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attribute.String("imageoptions.app_name", io.AppName),
 		attribute.String("imageoptions.work_dir", io.WorkingDir),
-		attribute.String("imageoptions.dockerfile_path", redactDockerfileURL(io.DockerfilePath)),
+		attribute.String("imageoptions.dockerfile_path", dockerfileurl.ForDisplay(io.DockerfilePath)),
 		attribute.String("imageoptions.ignorefile_path", io.IgnorefilePath),
 		attribute.String("imageoptions.image.ref", io.ImageRef),
 		attribute.String("imageoptions.image.label", io.ImageLabel),
@@ -364,7 +365,7 @@ func (r *Resolver) createBuild(ctx context.Context, strategies []imageBuilder, o
 		Builder:         opts.Builder,
 		BuiltIn:         opts.BuiltIn,
 		BuiltInSettings: opts.BuiltInSettings,
-		DockerfilePath:  redactDockerfileURL(opts.DockerfilePath),
+		DockerfilePath:  dockerfileurl.ForDisplay(opts.DockerfilePath),
 		ExtraBuildArgs:  opts.ExtraBuildArgs,
 		ImageLabel:      opts.ImageLabel,
 		ImageRef:        opts.ImageRef,

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -62,7 +62,7 @@ func (io ImageOptions) ToSpanAttributes() []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attribute.String("imageoptions.app_name", io.AppName),
 		attribute.String("imageoptions.work_dir", io.WorkingDir),
-		attribute.String("imageoptions.dockerfile_path", io.DockerfilePath),
+		attribute.String("imageoptions.dockerfile_path", redactDockerfileURL(io.DockerfilePath)),
 		attribute.String("imageoptions.ignorefile_path", io.IgnorefilePath),
 		attribute.String("imageoptions.image.ref", io.ImageRef),
 		attribute.String("imageoptions.image.label", io.ImageLabel),
@@ -364,7 +364,7 @@ func (r *Resolver) createBuild(ctx context.Context, strategies []imageBuilder, o
 		Builder:         opts.Builder,
 		BuiltIn:         opts.BuiltIn,
 		BuiltInSettings: opts.BuiltInSettings,
-		DockerfilePath:  opts.DockerfilePath,
+		DockerfilePath:  redactDockerfileURL(opts.DockerfilePath),
 		ExtraBuildArgs:  opts.ExtraBuildArgs,
 		ImageLabel:      opts.ImageLabel,
 		ImageRef:        opts.ImageRef,

--- a/internal/build/imgsrc/resolver.go
+++ b/internal/build/imgsrc/resolver.go
@@ -308,7 +308,7 @@ func (r *Resolver) BuildImage(ctx context.Context, streams *iostreams.IOStreams,
 		bld.ResetTimings()
 		bld.BuildAndPushStart()
 		var note string
-		img, note, err = s.Run(ctx, r.dockerFactory, streams, opts, bld)
+		img, note, err = runImageBuilder(ctx, s, r.dockerFactory, streams, opts, bld)
 		terminal.Debugf("result image:%+v error:%v\n", img, err)
 		if err != nil {
 			bld.BuildAndPushFinish()
@@ -839,6 +839,24 @@ func NewResolver(
 type imageBuilder interface {
 	Name() string
 	Run(ctx context.Context, dockerFactory *dockerClientFactory, streams *iostreams.IOStreams, opts ImageOptions, build *build) (*DeploymentImage, string, error)
+}
+
+type dockerfileConsumer interface {
+	usesDockerfile()
+}
+
+func runImageBuilder(ctx context.Context, strategy imageBuilder, dockerFactory *dockerClientFactory, streams *iostreams.IOStreams, opts ImageOptions, build *build) (*DeploymentImage, string, error) {
+	if _, ok := strategy.(dockerfileConsumer); ok {
+		path, cleanup, err := materializeDockerfile(ctx, opts.DockerfilePath)
+		if err != nil {
+			return nil, "", err
+		}
+		defer cleanup()
+
+		opts.DockerfilePath = path
+	}
+
+	return strategy.Run(ctx, dockerFactory, streams, opts, build)
 }
 
 type imageResolver interface {

--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -2,6 +2,7 @@ package deploy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -365,15 +366,19 @@ func DeployWithConfig(ctx context.Context, appConfig *appconfig.Config, userID i
 	recreateBuilder := flag.GetRecreateBuilder(ctx)
 
 	// Fetch an image ref or build from source to get the final image reference to deploy
-	img, err := determineImage(ctx, app, appConfig, usingWireguard, recreateBuilder)
+	dockerfileMaterializer := imgsrc.NewDockerfileMaterializer()
+	img, err := determineImage(ctx, app, appConfig, usingWireguard, recreateBuilder, dockerfileMaterializer)
 	if err != nil {
 		noBuilder := strings.Contains(err.Error(), "Could not find App")
 		recreateBuilder = recreateBuilder || noBuilder
 		if noBuilder || (usingWireguard && httpFailover) {
 			span.SetAttributes(attribute.String("builder.failover_error", err.Error()))
 			span.AddEvent("using http failover")
-			img, err = determineImage(ctx, app, appConfig, false, recreateBuilder)
+			img, err = determineImage(ctx, app, appConfig, false, recreateBuilder, dockerfileMaterializer)
 		}
+	}
+	if cleanupErr := dockerfileMaterializer.Close(); cleanupErr != nil {
+		err = errors.Join(err, cleanupErr)
 	}
 
 	if err != nil {

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -46,7 +46,7 @@ func multipleDockerfile(ctx context.Context, appConfig *appconfig.Config) error 
 	}
 
 	if found != config {
-		return fmt.Errorf("ignoring %s, and using %s (from %s)", found, config, appConfig.ConfigFilePath())
+		return fmt.Errorf("ignoring %s, and using %s (from %s)", found, imgsrc.DockerfilePathForDisplay(config), appConfig.ConfigFilePath())
 	}
 
 	return nil

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -285,22 +285,22 @@ func determineImage(ctx context.Context, app *flaps.App, appConfig *appconfig.Co
 	return
 }
 
-// resolveDockerfilePath returns the absolute path to the Dockerfile
-// if one was specified in the app config or a command line argument
+// resolveDockerfilePath returns HTTP(S) URLs unchanged and makes local
+// Dockerfile paths absolute.
 func resolveDockerfilePath(ctx context.Context, appConfig *appconfig.Config) (path string, err error) {
-	defer func() {
-		if err == nil && path != "" {
-			path, err = filepath.Abs(path)
-		}
-	}()
-
 	if path = appConfig.Dockerfile(); path != "" {
-		path = filepath.Join(filepath.Dir(appConfig.ConfigFilePath()), path)
+		if !imgsrc.IsDockerfileURL(path) {
+			path = filepath.Join(filepath.Dir(appConfig.ConfigFilePath()), path)
+		}
 	} else {
 		path = flag.GetString(ctx, "dockerfile")
 	}
 
-	return
+	if path == "" || imgsrc.IsDockerfileURL(path) {
+		return path, nil
+	}
+
+	return filepath.Abs(path)
 }
 
 // resolveIgnorefilePath returns the absolute path to the Dockerfile

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -55,7 +55,7 @@ func multipleDockerfile(ctx context.Context, appConfig *appconfig.Config) error 
 
 // determineImage picks the deployment strategy, builds the image and returns a
 // DeploymentImage struct
-func determineImage(ctx context.Context, app *flaps.App, appConfig *appconfig.Config, useWG, recreateBuilder bool) (img *imgsrc.DeploymentImage, err error) {
+func determineImage(ctx context.Context, app *flaps.App, appConfig *appconfig.Config, useWG, recreateBuilder bool, dockerfileMaterializer *imgsrc.DockerfileMaterializer) (img *imgsrc.DeploymentImage, err error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "determine_image")
 	defer span.End()
 
@@ -128,6 +128,7 @@ func determineImage(ctx context.Context, app *flaps.App, appConfig *appconfig.Co
 		daemonType, client, appConfig.AppName, io,
 		useWG, recreateBuilder,
 		imgsrc.WithProvisioner(provisioner),
+		imgsrc.WithDockerfileMaterializer(dockerfileMaterializer),
 	)
 
 	var imageRef string
@@ -292,6 +293,9 @@ func resolveDockerfilePath(ctx context.Context, appConfig *appconfig.Config) (pa
 	if path = appConfig.Dockerfile(); path != "" {
 		if dockerfileurl.IsURL(path) {
 			return path, nil
+		}
+		if dockerfileurl.LooksLikeURL(path) {
+			return "", errors.New("invalid Dockerfile URL")
 		}
 
 		path = filepath.Join(filepath.Dir(appConfig.ConfigFilePath()), path)

--- a/internal/command/deploy/deploy_build.go
+++ b/internal/command/deploy/deploy_build.go
@@ -13,6 +13,7 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/build/imgsrc"
 	"github.com/superfly/flyctl/internal/cmdutil"
+	"github.com/superfly/flyctl/internal/dockerfileurl"
 	"github.com/superfly/flyctl/internal/env"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flyutil"
@@ -46,7 +47,7 @@ func multipleDockerfile(ctx context.Context, appConfig *appconfig.Config) error 
 	}
 
 	if found != config {
-		return fmt.Errorf("ignoring %s, and using %s (from %s)", found, imgsrc.DockerfilePathForDisplay(config), appConfig.ConfigFilePath())
+		return fmt.Errorf("ignoring %s, and using %s (from %s)", found, dockerfileurl.ForDisplay(config), appConfig.ConfigFilePath())
 	}
 
 	return nil
@@ -285,18 +286,21 @@ func determineImage(ctx context.Context, app *flaps.App, appConfig *appconfig.Co
 	return
 }
 
-// resolveDockerfilePath returns HTTP(S) URLs unchanged and makes local
-// Dockerfile paths absolute.
+// resolveDockerfilePath returns HTTP(S) URLs from app config unchanged and
+// makes local Dockerfile paths absolute.
 func resolveDockerfilePath(ctx context.Context, appConfig *appconfig.Config) (path string, err error) {
 	if path = appConfig.Dockerfile(); path != "" {
-		if !imgsrc.IsDockerfileURL(path) {
-			path = filepath.Join(filepath.Dir(appConfig.ConfigFilePath()), path)
+		if dockerfileurl.IsURL(path) {
+			return path, nil
 		}
-	} else {
-		path = flag.GetString(ctx, "dockerfile")
+
+		path = filepath.Join(filepath.Dir(appConfig.ConfigFilePath()), path)
+
+		return filepath.Abs(path)
 	}
 
-	if path == "" || imgsrc.IsDockerfileURL(path) {
+	path = flag.GetString(ctx, "dockerfile")
+	if path == "" {
 		return path, nil
 	}
 

--- a/internal/command/deploy/deploy_build_test.go
+++ b/internal/command/deploy/deploy_build_test.go
@@ -37,3 +37,30 @@ func TestMultipleDockerfile(t *testing.T) {
 	err = multipleDockerfile(ctx, cfg)
 	assert.ErrorContains(t, err, "fly.production.toml")
 }
+
+func TestResolveDockerfilePath(t *testing.T) {
+	t.Run("relative config path", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg := &appconfig.Config{
+			Build: &appconfig.Build{Dockerfile: "Dockerfile.custom"},
+		}
+		cfg.SetConfigFilePath(filepath.Join(dir, "fly.toml"))
+
+		got, err := resolveDockerfilePath(context.Background(), cfg)
+
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(dir, "Dockerfile.custom"), got)
+	})
+
+	t.Run("URL remains unchanged", func(t *testing.T) {
+		const dockerfileURL = "https://example.com/Dockerfile"
+		cfg := &appconfig.Config{
+			Build: &appconfig.Build{Dockerfile: dockerfileURL},
+		}
+
+		got, err := resolveDockerfilePath(context.Background(), cfg)
+
+		require.NoError(t, err)
+		assert.Equal(t, dockerfileURL, got)
+	})
+}

--- a/internal/command/deploy/deploy_build_test.go
+++ b/internal/command/deploy/deploy_build_test.go
@@ -6,11 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superfly/flyctl/internal/appconfig"
-	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/state"
 )
 
@@ -80,16 +78,4 @@ func TestResolveDockerfilePath(t *testing.T) {
 		assert.Equal(t, dockerfileURL, got)
 	})
 
-	t.Run("URL flag remains unchanged", func(t *testing.T) {
-		const dockerfileURL = "https://example.com/Dockerfile?token=secret"
-		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
-		fs.String("dockerfile", "", "")
-		require.NoError(t, fs.Set("dockerfile", dockerfileURL))
-		ctx := flag.NewContext(context.Background(), fs)
-
-		got, err := resolveDockerfilePath(ctx, &appconfig.Config{})
-
-		require.NoError(t, err)
-		assert.Equal(t, dockerfileURL, got)
-	})
 }

--- a/internal/command/deploy/deploy_build_test.go
+++ b/internal/command/deploy/deploy_build_test.go
@@ -78,4 +78,22 @@ func TestResolveDockerfilePath(t *testing.T) {
 		assert.Equal(t, dockerfileURL, got)
 	})
 
+	for name, dockerfileURL := range map[string]string{
+		"invalid escape": "https://" + "user:pass@" + "example.com/%zz?token=secret#fragment",
+		"missing slash":  "https:/" + "user:pass@" + "example.com/Dockerfile?token=secret",
+		"backslash form": `https:\user:pass@example.com\Dockerfile?token=secret`,
+	} {
+		t.Run("malformed URL fails closed: "+name, func(t *testing.T) {
+			cfg := &appconfig.Config{
+				Build: &appconfig.Build{Dockerfile: dockerfileURL},
+			}
+
+			got, err := resolveDockerfilePath(context.Background(), cfg)
+
+			assert.Empty(t, got)
+			require.Error(t, err)
+			assert.EqualError(t, err, "invalid Dockerfile URL")
+			assert.NotContains(t, err.Error(), dockerfileURL)
+		})
+	}
 }

--- a/internal/command/deploy/deploy_build_test.go
+++ b/internal/command/deploy/deploy_build_test.go
@@ -6,9 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/state"
 )
 
@@ -53,12 +55,25 @@ func TestResolveDockerfilePath(t *testing.T) {
 	})
 
 	t.Run("URL remains unchanged", func(t *testing.T) {
-		const dockerfileURL = "https://example.com/Dockerfile"
+		const dockerfileURL = "https://example.com/Dockerfile?token=secret"
 		cfg := &appconfig.Config{
 			Build: &appconfig.Build{Dockerfile: dockerfileURL},
 		}
 
 		got, err := resolveDockerfilePath(context.Background(), cfg)
+
+		require.NoError(t, err)
+		assert.Equal(t, dockerfileURL, got)
+	})
+
+	t.Run("URL flag remains unchanged", func(t *testing.T) {
+		const dockerfileURL = "https://example.com/Dockerfile?token=secret"
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.String("dockerfile", "", "")
+		require.NoError(t, fs.Set("dockerfile", dockerfileURL))
+		ctx := flag.NewContext(context.Background(), fs)
+
+		got, err := resolveDockerfilePath(ctx, &appconfig.Config{})
 
 		require.NoError(t, err)
 		assert.Equal(t, dockerfileURL, got)

--- a/internal/command/deploy/deploy_build_test.go
+++ b/internal/command/deploy/deploy_build_test.go
@@ -38,6 +38,20 @@ func TestMultipleDockerfile(t *testing.T) {
 
 	err = multipleDockerfile(ctx, cfg)
 	assert.ErrorContains(t, err, "fly.production.toml")
+
+	t.Run("redacts credentials in URL warning", func(t *testing.T) {
+		cfg.Build.Dockerfile = "https://" + "user:password@" + "example.com/Dockerfile?token=secret#fragment"
+
+		err := multipleDockerfile(ctx, cfg)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "https://example.com/Dockerfile")
+		assert.NotContains(t, err.Error(), "user")
+		assert.NotContains(t, err.Error(), "password")
+		assert.NotContains(t, err.Error(), "token")
+		assert.NotContains(t, err.Error(), "secret")
+		assert.NotContains(t, err.Error(), "fragment")
+	})
 }
 
 func TestResolveDockerfilePath(t *testing.T) {

--- a/internal/dockerfileurl/dockerfileurl.go
+++ b/internal/dockerfileurl/dockerfileurl.go
@@ -1,0 +1,43 @@
+// Package dockerfileurl classifies Dockerfile URLs and makes them safe to display.
+package dockerfileurl
+
+import (
+	"net/url"
+	"strings"
+)
+
+func parse(value string) (*url.URL, bool) {
+	u, err := url.Parse(value)
+	if err != nil || u.Host == "" {
+		return nil, false
+	}
+
+	if !strings.EqualFold(u.Scheme, "http") && !strings.EqualFold(u.Scheme, "https") {
+		return nil, false
+	}
+
+	return u, true
+}
+
+// IsURL reports whether value is an HTTP(S) URL.
+func IsURL(value string) bool {
+	_, ok := parse(value)
+
+	return ok
+}
+
+// ForDisplay removes sensitive URL components from HTTP(S) Dockerfile values
+// and leaves local paths unchanged.
+func ForDisplay(value string) string {
+	u, ok := parse(value)
+	if !ok {
+		return value
+	}
+
+	u.User = nil
+	u.RawQuery = ""
+	u.ForceQuery = false
+	u.Fragment = ""
+
+	return u.String()
+}

--- a/internal/dockerfileurl/dockerfileurl.go
+++ b/internal/dockerfileurl/dockerfileurl.go
@@ -19,6 +19,14 @@ func parse(value string) (*url.URL, bool) {
 	return u, true
 }
 
+// LooksLikeURL reports whether value starts with an HTTP(S) scheme, including
+// malformed values that should fail closed instead of being treated as paths.
+func LooksLikeURL(value string) bool {
+	value = strings.ToLower(strings.TrimSpace(value))
+
+	return strings.HasPrefix(value, "http:") || strings.HasPrefix(value, "https:")
+}
+
 // IsURL reports whether value is an HTTP(S) URL.
 func IsURL(value string) bool {
 	_, ok := parse(value)
@@ -31,9 +39,28 @@ func IsURL(value string) bool {
 func ForDisplay(value string) string {
 	u, ok := parse(value)
 	if !ok {
+		if LooksLikeURL(value) {
+			return "invalid URL"
+		}
+
 		return value
 	}
 
+	return redact(u)
+}
+
+// ForRequestError removes sensitive components from an absolute or relative
+// URL reference returned by net/http.
+func ForRequestError(value string) string {
+	u, err := url.Parse(value)
+	if err != nil {
+		return "invalid URL"
+	}
+
+	return redact(u)
+}
+
+func redact(u *url.URL) string {
 	u.User = nil
 	u.RawQuery = ""
 	u.ForceQuery = false

--- a/internal/dockerfileurl/dockerfileurl_test.go
+++ b/internal/dockerfileurl/dockerfileurl_test.go
@@ -13,9 +13,25 @@ func TestIsURL(t *testing.T) {
 	assert.False(t, IsURL("ftp://example.com/Dockerfile"))
 }
 
+func TestLooksLikeURL(t *testing.T) {
+	assert.True(t, LooksLikeURL("https://example.com/%zz"))
+	assert.True(t, LooksLikeURL("HTTPS://example.com/%zz"))
+	assert.True(t, LooksLikeURL("https:/example.com/%zz"))
+	assert.True(t, LooksLikeURL(`https:\example.com\Dockerfile`))
+	assert.False(t, LooksLikeURL("Dockerfile.custom"))
+}
+
 func TestForDisplay(t *testing.T) {
 	dockerfileURL := "https://" + "user:password@" + "example.com/path/Dockerfile?token=secret#fragment"
 
 	assert.Equal(t, "Dockerfile.custom", ForDisplay("Dockerfile.custom"))
 	assert.Equal(t, "https://example.com/path/Dockerfile", ForDisplay(dockerfileURL))
+	assert.Equal(t, "invalid URL", ForDisplay("https://example.com/%zz?token=secret"))
+	assert.Equal(t, "invalid URL", ForDisplay("https:/example.com/%zz?token=secret"))
+	assert.Equal(t, "invalid URL", ForDisplay(`https:\example.com\Dockerfile?token=secret`))
+}
+
+func TestForRequestError(t *testing.T) {
+	assert.Equal(t, "/Dockerfile", ForRequestError("/Dockerfile?token=secret#fragment"))
+	assert.Equal(t, "invalid URL", ForRequestError("https://example.com/%zz?token=secret"))
 }

--- a/internal/dockerfileurl/dockerfileurl_test.go
+++ b/internal/dockerfileurl/dockerfileurl_test.go
@@ -1,0 +1,21 @@
+package dockerfileurl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsURL(t *testing.T) {
+	assert.True(t, IsURL("https://example.com/Dockerfile"))
+	assert.True(t, IsURL("HTTPS://example.com/Dockerfile"))
+	assert.False(t, IsURL("Dockerfile.custom"))
+	assert.False(t, IsURL("ftp://example.com/Dockerfile"))
+}
+
+func TestForDisplay(t *testing.T) {
+	dockerfileURL := "https://" + "user:password@" + "example.com/path/Dockerfile?token=secret#fragment"
+
+	assert.Equal(t, "Dockerfile.custom", ForDisplay("Dockerfile.custom"))
+	assert.Equal(t, "https://example.com/path/Dockerfile", ForDisplay(dockerfileURL))
+}


### PR DESCRIPTION
Fixes #4464.

`[build] dockerfile` accepts URLs, but flyctl currently turns every value into a local path.

This grew a bit from the first version because deploy has a few different Dockerfile build paths and can retry over HTTP if the WireGuard builder connection fails. Downloading the file during config parsing would also fetch it for image and buildpack deploys that never use it. So the URL stays untouched until a Dockerfile builder actually needs it, and the same downloaded copy is reused for the whole deploy.

The rest is mostly keeping that safe: a 30 second timeout and 10 MiB limit, a private temp directory that gets cleaned up before deploy continues, and redaction keeping credentials and query strings out of errors and build metadata. Redirects also drop query-bearing Referer headers and refuse HTTPS-to-HTTP downgrades. Local Dockerfiles and non-Dockerfile builds are unchanged.

Validation: affected package tests, Windows cross-compile, focused race and repeat tests, full compile, generation, and changed-code lint.

Live smoke: exact commit `eecada886` fetched the remote Dockerfile through BuildKit, preserved the local context, started the Machine, and left no temporary Dockerfile directory.