### PR TITLE
fix(machine): clarify --shell app lifecycle

### DIFF
--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -269,7 +269,7 @@ func newRun() *cobra.Command {
 		},
 		flag.Bool{
 			Name:        "shell",
-			Description: "Open a shell on the Machine once created (implies --it --rm). If no app is specified, a temporary app is created just for this Machine and destroyed when the Machine is destroyed. See also --command and --user.",
+			Description: "Open a shell on the Machine once created (implies --it --rm). If no app is specified, an app for interactive shells is created or reused. The Machine is destroyed when the shell exits; the app is retained for future shells. See also --command and --user.",
 			Hidden:      false,
 		},
 		flag.String{


### PR DESCRIPTION
### Change Summary

What and Why:

`fly machine run --shell` creates or reuses an app for interactive shells when no app is specified. The Machine is destroyed when the shell exits, but the app is retained for future shells. The existing help incorrectly says that the app is destroyed.

How:

Update the `--shell` flag description to reflect the actual lifecycle.

Verified by:

- running `go build`;
- regenerating the command reference and checking the rendered help;
- confirming end to end that exiting destroys the Machine while retaining the generated app;
- confirming that a subsequent shell reuses the app.

Related to:

- [superfly/docs#2436](https://github.com/superfly/docs/pull/2436)

---

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a
