### PR TITLE
Always send client signals

### DIFF
--- a/internal/cmdutil/preparers/preparers.go
+++ b/internal/cmdutil/preparers/preparers.go
@@ -17,7 +17,6 @@ import (
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/instrument"
-	"github.com/superfly/flyctl/internal/launchdarkly"
 	"github.com/superfly/flyctl/internal/logger"
 	"github.com/superfly/flyctl/internal/state"
 	"github.com/superfly/flyctl/internal/uiex"
@@ -58,19 +57,8 @@ func InitClient(ctx context.Context) (context.Context, error) {
 	fly.SetInstrumenter(instrument.ApiAdapter)
 	fly.SetTransport(otelhttp.NewTransport(http.DefaultTransport))
 
-	clientSignalsEnabled := false
-	if ldClient, err := launchdarkly.NewServiceClient(); err != nil {
-		logger.Debugf("could not create feature flag client: %v", err)
-	} else {
-		clientSignalsEnabled = ldClient.ClientSignalsEnabled()
-	}
-	logger.Debugf("client-signals-enabled feature flag is: %v", clientSignalsEnabled)
-
-	var signals *clientsignals.Signals
-	if clientSignalsEnabled {
-		s := clientsignals.DetectOnce()
-		signals = &s
-	}
+	s := clientsignals.DetectOnce()
+	signals := &s
 
 	if flyutil.ClientFromContext(ctx) == nil {
 		client := flyutil.NewClientFromOptions(ctx, fly.ClientOptions{

--- a/internal/launchdarkly/launchdarkly.go
+++ b/internal/launchdarkly/launchdarkly.go
@@ -245,7 +245,3 @@ func (ldClient *Client) UseZstdEnabled() bool {
 func (ldClient *Client) GetCompressionStrength() any {
 	return ldClient.GetFeatureFlagValue("flyctl-compression-strength", 7)
 }
-
-func (ldClient *Client) ClientSignalsEnabled() bool {
-	return ldClient.GetFeatureFlagValue("flyctl-client-signals-enabled", false).(bool)
-}


### PR DESCRIPTION
## What changed

- remove evaluation of the fully enabled `flyctl-client-signals-enabled` LaunchDarkly flag
- detect client signals once during client initialization
- always pass the resulting signals to the Fly, Flaps, and UIEX clients
- remove the now-unused feature-flag accessor

## Why

Agentic API traffic metrics need consistent client-signal headers. The rollout flag is already enabled for all users, so retaining the runtime evaluation adds failure modes where signals disappear when LaunchDarkly cannot be reached.

## Coordinated rollout

Public companion change:

- [superfly/client-signals#7](https://github.com/superfly/client-signals/pull/7) — shared server-side classification and route-label helpers

Additional service integrations live in non-public repositories and are intentionally not linked here.

## Validation

- `go test ./internal/cmdutil/preparers ./internal/launchdarkly`
- `gofmt`
- `git diff --check`

Unrelated local files were left out of this PR.