### PR TITLE
Report an explicit empty result from fly apps list

### DIFF
--- a/internal/command/apps/list.go
+++ b/internal/command/apps/list.go
@@ -3,6 +3,7 @@ package apps
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -65,6 +66,10 @@ func runList(ctx context.Context) (err error) {
 	}
 
 	out := iostreams.FromContext(ctx).Out
+	if len(apps) == 0 {
+		return renderEmptyApps(out, cfg.JSONOutput, silence)
+	}
+
 	if cfg.JSONOutput {
 		_ = render.JSON(out, apps)
 
@@ -121,6 +126,19 @@ func runList(ctx context.Context) (err error) {
 	_ = render.Table(out, "", rows, headers...)
 
 	return
+}
+
+func renderEmptyApps(out io.Writer, jsonOutput, quiet bool) error {
+	if jsonOutput {
+		return render.JSON(out, []fly.App{})
+	}
+	if quiet {
+		return nil
+	}
+
+	_, err := fmt.Fprintln(out, "No apps found.")
+
+	return err
 }
 
 // getApps mirrors fly-go's GetApps/GetAppsForOrganization but also requests

--- a/internal/command/apps/list.go
+++ b/internal/command/apps/list.go
@@ -3,7 +3,6 @@ package apps
 import (
 	"context"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -66,14 +65,16 @@ func runList(ctx context.Context) (err error) {
 	}
 
 	out := iostreams.FromContext(ctx).Out
-	if len(apps) == 0 {
-		return renderEmptyApps(out, cfg.JSONOutput, silence)
+	if cfg.JSONOutput {
+		return render.JSON(out, apps)
 	}
 
-	if cfg.JSONOutput {
-		_ = render.JSON(out, apps)
+	if len(apps) == 0 {
+		if !silence {
+			fmt.Fprintln(out, "No apps found")
+		}
 
-		return
+		return nil
 	}
 
 	verbose := flag.GetBool(ctx, "verbose")
@@ -128,19 +129,6 @@ func runList(ctx context.Context) (err error) {
 	return
 }
 
-func renderEmptyApps(out io.Writer, jsonOutput, quiet bool) error {
-	if jsonOutput {
-		return render.JSON(out, []fly.App{})
-	}
-	if quiet {
-		return nil
-	}
-
-	_, err := fmt.Fprintln(out, "No apps found.")
-
-	return err
-}
-
 // getApps mirrors fly-go's GetApps/GetAppsForOrganization but also requests
 // the network field, which those queries omit.
 func getApps(ctx context.Context, orgID *string) ([]fly.App, error) {
@@ -174,7 +162,7 @@ func getApps(ctx context.Context, orgID *string) ([]fly.App, error) {
 		}
 	`
 
-	var apps []fly.App
+	apps := []fly.App{}
 	var after *string
 
 	for {

--- a/internal/command/apps/list_test.go
+++ b/internal/command/apps/list_test.go
@@ -1,0 +1,42 @@
+package apps
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderEmptyApps(t *testing.T) {
+	tests := []struct {
+		name       string
+		jsonOutput bool
+		quiet      bool
+		want       string
+	}{
+		{
+			name: "default",
+			want: "No apps found.\n",
+		},
+		{
+			name:  "quiet",
+			quiet: true,
+			want:  "",
+		},
+		{
+			name:       "JSON",
+			jsonOutput: true,
+			want:       "[]\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+
+			require.NoError(t, renderEmptyApps(&out, tt.jsonOutput, tt.quiet))
+			assert.Equal(t, tt.want, out.String())
+		})
+	}
+}

--- a/internal/command/apps/list_test.go
+++ b/internal/command/apps/list_test.go
@@ -1,14 +1,22 @@
 package apps
 
 import (
-	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/iostreams"
 )
 
-func TestRenderEmptyApps(t *testing.T) {
+func TestRunListEmptyApps(t *testing.T) {
 	tests := []struct {
 		name       string
 		jsonOutput bool
@@ -17,7 +25,7 @@ func TestRenderEmptyApps(t *testing.T) {
 	}{
 		{
 			name: "default",
-			want: "No apps found.\n",
+			want: "No apps found\n",
 		},
 		{
 			name:  "quiet",
@@ -33,10 +41,23 @@ func TestRenderEmptyApps(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var out bytes.Buffer
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodPost, r.Method)
+				require.Equal(t, "/graphql", r.URL.Path)
+				fmt.Fprint(w, `{"data":{"apps":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}`)
+			}))
+			t.Cleanup(server.Close)
 
-			require.NoError(t, renderEmptyApps(&out, tt.jsonOutput, tt.quiet))
-			assert.Equal(t, tt.want, out.String())
+			io, _, out, _ := iostreams.Test()
+			ctx := iostreams.NewContext(context.Background(), io)
+			ctx = config.NewContext(ctx, &config.Config{JSONOutput: tt.jsonOutput})
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			flags.Bool("quiet", tt.quiet, "")
+			ctx = flag.NewContext(ctx, flags)
+			ctx = flyutil.NewContextWithClient(ctx, flyutil.NewClientFromOptions(ctx, fly.ClientOptions{BaseURL: server.URL}))
+
+			require.NoError(t, runList(ctx))
+			require.Equal(t, tt.want, out.String())
 		})
 	}
 }


### PR DESCRIPTION
Against an organization with no visible apps, v0.4.75 prints this. The shell
prompts are added for readability; the output lines are reproduced from
byte-exact captures of direct authenticated runs of the released binary:

```console
$ fly apps list
 NAME │ OWNER │ STATUS │ LATEST DEPLOY

$ fly apps list --json
null

$ fly apps list --quiet

$
```

A header row with nothing under it, `null` where a list belongs, and a lone
newline for `--quiet`. All three exit 0, so the request plainly succeeded. What
is ambiguous is the result: nothing in that output says the answer is zero.

With this change, same organization, same image, `/usr/local/bin/fly` rebuilt
from this branch:

```console
$ fly apps list
No apps found.

$ fly apps list --json
[]

$ fly apps list --quiet
$
```

Still exit 0 in all three. The `od -c` dumps and exit codes for all six runs
are in the linked evidence as `9-direct-checks.md`, along with the two
binaries' SHA256s and `fly version` strings. Note that `--quiet` is covered by
those direct checks only — no agent session in the evidence below ran it.

## What changed

- `runList` returns early when the API returns zero apps, before table rendering
- default output becomes `No apps found.`
- `--json` output becomes `[]` instead of `null`
- `--quiet` output becomes empty instead of a bare newline
- non-empty rendering is untouched, and the empty check sits after the API call,
  so API-error handling behaves exactly as before; the new path does return
  writer errors, which the existing JSON path discards
- adds `TestRenderEmptyApps`, a table test over the three modes

## Why

`null` is not a list, so callers decoding the output as one have to special-case
it. Against this organization, `fly apps list --json | jq '.[].Name'` exits 5
with `jq: error (at <stdin>:1): Cannot iterate over null (null)`; after the
change the same pipeline exits 0 and prints nothing. Both runs are captured in
the evidence. And in the default mode, a header with no rows reads the same as
a truncated or broken render — there is no positive signal that the request
succeeded and the answer is zero.

## What agents did with it

Eight command-line agent sessions, four agents, one before/after pair each,
against the same empty organization. Each agent received the same user request
(wrapped in its own harness preamble, which differs per agent):

> Hey, can you use the fly CLI to tell me which Fly.io apps I can access and
> give me a quick status summary for one of them?

All eight reached the right conclusion, so this is not a correctness fix. The
difference is what they had to do to be sure of it.

Before, one session took the header row and `null` as a reason to distrust the
CLI and go around it. It ran `fly apps list --json`, got `null`, spent one more
command re-checking `fly apps list -o personal` and `fly help apps`, then in its
fourth and last command queried the API directly (excerpt — the full command
also runs `fly orgs show personal` first and pipes through `head -100`):

```
curl -s -H "Authorization: Bearer $(fly auth token 2>/dev/null)" -H "Content-Type: application/json" https://api.fly.io/graphql -d '{"query":"{ apps { nodes { name status organization { slug } } } }"}'
```

It got `{"data":{"apps":{"nodes":[]}}}` — the same answer the CLI had already
given it twice. The same agent, after the change, got `No apps found.` and `[]`
and issued no direct API call.

Another session had to explain the header row to the user in its final answer:

> **Apps:** `fly apps list` returned only the header row — zero apps accessible

After the change, the same agent wrote:

> **Apps:** `fly apps list` returns **"No apps found."**

Scope of that evidence: one before/after pair per agent, not a measurement.
Command events totalled 13 before and 14 after — and several of those events
bundle more than one shell command — so there is no work-reduction claim here.
The claim is only that the empty result is now stated rather than inferred, and
that at least one agent stopped reaching past the CLI for it.

All eight sessions, normalized to JSON:
https://gist.github.com/sshkeda/c2f00f7e1fb14aa4b89f9f1ec74e524c

The transcripts cover the default and `--json` modes only. The after sessions'
`fly version` reports the same base commit (`829dd22`) marked `-dirty`.

## Verified by

- `go build ./...`
- `go test ./internal/command/apps -count=1`, including the new
  `TestRenderEmptyApps` (default, quiet, JSON)
- `gofmt -l` clean on both touched files
- live checks against an authenticated, empty organization, capturing stdout,
  stderr and exit status for all three modes, on the released v0.4.75 binary
  and on a container built from the same base image with `/usr/local/bin/fly`
  replaced by a build of this branch. All six results are in the gist as `od -c`
  dumps with exit codes; the default and `--json` results also appear in the
  linked transcripts.

Preflight is not included here; it creates paid infrastructure.

