### PR TITLE
[wip]  feature flag to change depot builder region from src to dest

### DIFF
--- a/internal/build/imgsrc/depot.go
+++ b/internal/build/imgsrc/depot.go
@@ -20,6 +20,7 @@ import (
 	"github.com/superfly/flyctl/helpers"
 	"github.com/superfly/flyctl/internal/cmdfmt"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/launchdarkly"
 	"github.com/superfly/flyctl/internal/metrics"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/internal/tracing"
@@ -194,6 +195,21 @@ func depotBuild(ctx context.Context, streams *iostreams.IOStreams, opts ImageOpt
 // initBuilder returns a Depot machine to build a container image.
 // Note that the caller is responsible for passing a context with a resonable timeout.
 // Otherwise, the function cloud block indefinitely.
+// depotBuilderRegion picks the region hint sent to the depot builder API: the
+// FLY_REMOTE_BUILDER_REGION env var wins over the LaunchDarkly-served alt
+// region, and an empty result leaves placement to the server.
+func depotBuilderRegion(envRegion, altRegion string) string {
+	region := envRegion
+	if region == "" {
+		region = altRegion
+	}
+	if region != "" {
+		region = "fly-" + region
+	}
+
+	return region
+}
+
 func initBuilder(ctx context.Context, buildState *build, appName string, streams *iostreams.IOStreams, builderScope depotBuilderScope) (m *depotmachine.Machine, b *depotbuild.Build, retErr error) {
 	ctx, span := tracing.GetTracer().Start(ctx, "init_depot_build")
 
@@ -207,10 +223,10 @@ func initBuilder(ctx context.Context, buildState *build, appName string, streams
 	}()
 
 	uiexClient := uiexutil.ClientFromContext(ctx)
-	region := os.Getenv("FLY_REMOTE_BUILDER_REGION")
-	if region != "" {
-		region = "fly-" + region
-	}
+	region := depotBuilderRegion(
+		os.Getenv("FLY_REMOTE_BUILDER_REGION"),
+		launchdarkly.ClientFromContext(ctx).AltBuildRegion(),
+	)
 	span.SetAttributes(attribute.String("depot_builder_region", region))
 
 	buildInfo, err := uiexClient.EnsureDepotBuilder(ctx, uiex.EnsureDepotBuilderRequest{

--- a/internal/build/imgsrc/depot_test.go
+++ b/internal/build/imgsrc/depot_test.go
@@ -32,3 +32,24 @@ func TestInitBuilder(t *testing.T) {
 	_, _, err := initBuilder(ctx, build, "app1", ios, DepotBuilderScopeOrganization)
 	require.ErrorContains(t, err, `unsupported protocol scheme "invalid"`)
 }
+
+func TestDepotBuilderRegion(t *testing.T) {
+	cases := []struct {
+		name      string
+		envRegion string
+		altRegion string
+		want      string
+	}{
+		{name: "no region", envRegion: "", altRegion: "", want: ""},
+		{name: "env only", envRegion: "iad", altRegion: "", want: "fly-iad"},
+		{name: "alt only", envRegion: "", altRegion: "ord", want: "fly-ord"},
+		{name: "env wins over alt", envRegion: "iad", altRegion: "ord", want: "fly-iad"},
+		{name: "alias alt region", envRegion: "", altRegion: "eu", want: "fly-eu"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, depotBuilderRegion(tc.envRegion, tc.altRegion))
+		})
+	}
+}

--- a/internal/launchdarkly/launchdarkly.go
+++ b/internal/launchdarkly/launchdarkly.go
@@ -238,6 +238,14 @@ func (ldClient *Client) ManagedBuilderEnabled() bool {
 	return ldClient.getManagedBuilderEnabled()
 }
 
+func (ldClient *Client) AltBuildRegion() string {
+	if ldClient == nil {
+		return ""
+	}
+
+	return ldClient.GetFeatureFlagValue("alt-build-region", "").(string)
+}
+
 func (ldClient *Client) UseZstdEnabled() bool {
 	return ldClient.GetFeatureFlagValue("use-zstd-for-docker-images", false).(bool)
 }


### PR DESCRIPTION

### Change Summary

FLY_REMOTE_BUILDER_REGION still takes precedence

What and Why:

How:

Related to:

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x ] n/a
