### PR TITLE
Fix volume lookups broken by GraphQL API change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/superfly/client-signals/go v0.4.2
-	github.com/superfly/fly-go v0.9.1
+	github.com/superfly/fly-go v0.9.2
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -668,8 +668,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals/go v0.4.2 h1:8UH1s+jgCz/goOMdy2d8Wx4XDIDXqq70zStrimMaFIM=
 github.com/superfly/client-signals/go v0.4.2/go.mod h1:v/FQ2fZ4zOkOxKmue+bYh96awuh9Qh1ImcdxzRYcHFA=
-github.com/superfly/fly-go v0.9.1 h1:k42zvgZv2vdGANSaFkvW4z4rLtmhDgw9OXpih3Ud0l4=
-github.com/superfly/fly-go v0.9.1/go.mod h1:TOdS0mlGgPUvOlISm2SyaJPt3nWfCQwO8lD45DBvPbE=
+github.com/superfly/fly-go v0.9.2 h1:eGleZZi3FeRt1CcG/qVbWnKoh+AbF9ut7dSr0AuiUxs=
+github.com/superfly/fly-go v0.9.2/go.mod h1:TOdS0mlGgPUvOlISm2SyaJPt3nWfCQwO8lD45DBvPbE=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -205,20 +205,11 @@ func run(ctx context.Context) (err error) {
 
 		flapsClient := flapsutil.ClientFromContext(ctx)
 
-		// Resolve the volume
+		// Resolve the volume. The lookup is scoped to the fork-from app, so it
+		// also confirms the volume is associated with that app.
 		vol, err := flapsClient.GetVolume(ctx, forkApp.Name, params.ForkFrom)
 		if err != nil {
-			return fmt.Errorf("Failed to resolve the specified fork-from volume %s: %w", params.ForkFrom, err)
-		}
-
-		appName, err := client.GetAppNameFromVolume(ctx, vol.ID)
-		if err != nil {
-			return err
-		}
-
-		// Confirm that the volume is associated with the fork-from app
-		if *appName != forkApp.Name {
-			return fmt.Errorf("The volume %q specified must be associated with the fork-from app %q", vol.ID, forkApp.Name)
+			return fmt.Errorf("Failed to resolve the specified fork-from volume %s on app %s: %w", params.ForkFrom, forkApp.Name, err)
 		}
 
 		// If the region isn't specified, set the region of the fork target


### PR DESCRIPTION
The node(id:) GraphQL field was removed, which broke
GetAppNameFromVolume and friends — and with them fly postgres create
--fork-from, fly volumes show/destroy/update, and the snapshot
commands when given a bare volume ID.

- Bump fly-go to v0.9.2, which moves those queries to the volume(id:)
  root query
- Drop the GraphQL lookup from postgres create --fork-from entirely:
  the Machines API volume lookup is already scoped to the fork-from
  app, so it both resolves the volume and validates ownership

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>