### PR TITLE
[WIP] Add hidden `fly ticket` command for support-ticket submission

### DIFF
--- a/internal/command/root/root.go
+++ b/internal/command/root/root.go
@@ -65,6 +65,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/storage"
 	"github.com/superfly/flyctl/internal/command/suspend"
 	"github.com/superfly/flyctl/internal/command/synthetics"
+	"github.com/superfly/flyctl/internal/command/ticket"
 	"github.com/superfly/flyctl/internal/command/tokens"
 	"github.com/superfly/flyctl/internal/command/version"
 	"github.com/superfly/flyctl/internal/command/volumes"
@@ -117,6 +118,7 @@ func New() *cobra.Command {
 		group(status.New(), "deploy"),
 		group(logs.New(), "upkeep"),
 		group(doctor.New(), "more_help"),
+		group(ticket.New(), "more_help"),
 		group(dig.New(), "upkeep"),
 		group(volumes.New(), "configuring"),
 		group(lfsc.New(), "dbs_and_extensions"),

--- a/internal/command/ticket/create.go
+++ b/internal/command/ticket/create.go
@@ -1,0 +1,233 @@
+package ticket
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/internal/render"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+// CreateTicketRequest is the body of the proposed
+// POST /api/v1/organizations/:org_slug/support/tickets endpoint. The
+// organization is the path parameter rather than a body field.
+type CreateTicketRequest struct {
+	Subject      string `json:"subject,omitempty"`
+	Message      string `json:"message"`
+	Priority     string `json:"priority"` // low|high|emergency
+	Category     string `json:"category,omitempty"`
+	Product      string `json:"product,omitempty"`
+	AppName      string `json:"app_name,omitempty"`
+	MPGClusterID string `json:"mpg_cluster_id,omitempty"`
+}
+
+const (
+	messageMinLen = 10
+	messageMaxLen = 5000
+
+	defaultChoice = "Something else"
+)
+
+var (
+	priorities = []string{"low", "high", "emergency"}
+
+	categories = []string{
+		"Deployment", "Account Settings", "DNS", "Machines API", "Networking",
+		"Performance", "Security", "Sprites", "Proxy", defaultChoice,
+	}
+
+	products = []string{
+		"Fly Launch", "Fly Apps", "Fly Machines", "Fly GPUs", "Fly Volumes",
+		"Sprites", "Managed Postgres", "Fly Postgres (Legacy)",
+		"Tigris Object Storage", "Extensions", defaultChoice,
+	}
+)
+
+func completeStatic(choices []string) func(ctx context.Context, cmd *cobra.Command, args []string, partial string) ([]string, error) {
+	return func(ctx context.Context, cmd *cobra.Command, args []string, partial string) ([]string, error) {
+		var out []string
+		for _, choice := range choices {
+			if strings.HasPrefix(strings.ToLower(choice), strings.ToLower(partial)) {
+				out = append(out, choice)
+			}
+		}
+		return out, nil
+	}
+}
+
+func newCreate() *cobra.Command {
+	const (
+		short = "Open a new support ticket"
+		long  = `Open a new support ticket with the Fly.io support team. The ticket body
+comes from --message, from stdin when piped, or from an interactive prompt.
+Requires an organization with a support plan.`
+	)
+	cmd := command.New("create", short, long, runCreate,
+		command.RequireSession,
+		command.LoadAppNameIfPresent,
+	)
+	cmd.Args = cobra.NoArgs
+
+	flag.Add(cmd,
+		flag.App(),
+		flag.AppConfig(),
+		flag.Org(),
+		flag.JSONOutput(),
+		flag.String{
+			Name:        "subject",
+			Description: "Short summary used as the ticket title",
+		},
+		flag.String{
+			Name:        "message",
+			Shorthand:   "m",
+			Description: "Ticket body; reads stdin if piped, prompts otherwise",
+		},
+		flag.String{
+			Name:        "priority",
+			Default:     "low",
+			Description: "Ticket priority: low, high, or emergency",
+		},
+		flag.String{
+			Name:         "category",
+			Default:      defaultChoice,
+			Description:  "Issue category, e.g. Deployment, Networking, Performance",
+			CompletionFn: completeStatic(categories),
+		},
+		flag.String{
+			Name:         "product",
+			Default:      defaultChoice,
+			Description:  "Product the ticket concerns, e.g. Fly Machines, Managed Postgres",
+			CompletionFn: completeStatic(products),
+		},
+		flag.String{
+			Name:        "mpg-cluster-id",
+			Description: "Managed Postgres cluster the ticket concerns",
+		},
+	)
+
+	return cmd
+}
+
+func runCreate(ctx context.Context) error {
+	message, err := resolveMessage(ctx)
+	if err != nil {
+		return err
+	}
+
+	priority := flag.GetString(ctx, "priority")
+	if err := validateTicket(message, priority); err != nil {
+		return err
+	}
+
+	org, err := prompt.Org(ctx)
+	if err != nil {
+		return err
+	}
+
+	req := CreateTicketRequest{
+		Subject:      flag.GetString(ctx, "subject"),
+		Message:      message,
+		Priority:     priority,
+		Category:     flag.GetString(ctx, "category"),
+		Product:      flag.GetString(ctx, "product"),
+		AppName:      appconfig.NameFromContext(ctx),
+		MPGClusterID: flag.GetString(ctx, "mpg-cluster-id"),
+	}
+
+	ios := iostreams.FromContext(ctx)
+
+	if config.FromContext(ctx).JSONOutput {
+		return render.JSON(ios.Out, struct {
+			DryRun bool                `json:"dry_run"`
+			Org    string              `json:"org"`
+			Ticket CreateTicketRequest `json:"ticket"`
+		}{
+			DryRun: true,
+			Org:    org.Slug,
+			Ticket: req,
+		})
+	}
+
+	cs := ios.ColorScheme()
+
+	fmt.Fprintf(ios.Out, "%s %s\n", cs.Bold("Organization:"), org.Slug)
+	if req.AppName != "" {
+		fmt.Fprintf(ios.Out, "%s %s\n", cs.Bold("App:"), req.AppName)
+	}
+	if req.Subject != "" {
+		fmt.Fprintf(ios.Out, "%s %s\n", cs.Bold("Subject:"), req.Subject)
+	}
+	fmt.Fprintf(ios.Out, "%s %s\n", cs.Bold("Priority:"), req.Priority)
+	fmt.Fprintf(ios.Out, "%s %s\n", cs.Bold("Category:"), req.Category)
+	fmt.Fprintf(ios.Out, "%s %s\n", cs.Bold("Product:"), req.Product)
+	if req.MPGClusterID != "" {
+		fmt.Fprintf(ios.Out, "%s %s\n", cs.Bold("MPG cluster:"), req.MPGClusterID)
+	}
+	fmt.Fprintf(ios.Out, "%s\n%s\n", cs.Bold("Message:"), messagePreview(req.Message))
+
+	fmt.Fprintf(ios.Out, "\n%s Ticket submission isn't wired up yet; this is a preview of what will be sent.\n", cs.WarningIcon())
+
+	return nil
+}
+
+// resolveMessage picks the ticket body from --message, piped stdin, or an
+// interactive prompt, in that order.
+func resolveMessage(ctx context.Context) (string, error) {
+	if flag.IsSpecified(ctx, "message") {
+		return flag.GetString(ctx, "message"), nil
+	}
+
+	ios := iostreams.FromContext(ctx)
+
+	if !ios.IsStdinTTY() {
+		b, err := io.ReadAll(ios.In)
+		if err != nil {
+			return "", fmt.Errorf("failed reading message from stdin: %w", err)
+		}
+		if msg := strings.TrimRight(string(b), "\n"); msg != "" {
+			return msg, nil
+		}
+	}
+
+	if ios.IsInteractive() {
+		var msg string
+		if err := prompt.String(ctx, &msg, "Describe the problem:", "", true); err != nil {
+			return "", err
+		}
+		return msg, nil
+	}
+
+	return "", prompt.NonInteractiveError("supply a message with --message or pipe it on stdin")
+}
+
+func validateTicket(message, priority string) error {
+	switch n := len(strings.TrimSpace(message)); {
+	case n < messageMinLen:
+		return fmt.Errorf("message must be at least %d characters; describe the problem in more detail", messageMinLen)
+	case n > messageMaxLen:
+		return fmt.Errorf("message must be at most %d characters; trim it down or leave out large logs", messageMaxLen)
+	}
+
+	for _, p := range priorities {
+		if priority == p {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid priority %q; must be one of: %s", priority, strings.Join(priorities, ", "))
+}
+
+func messagePreview(message string) string {
+	const maxPreview = 500
+	if len(message) > maxPreview {
+		return message[:maxPreview] + "…"
+	}
+	return message
+}

--- a/internal/command/ticket/create_test.go
+++ b/internal/command/ticket/create_test.go
@@ -1,0 +1,44 @@
+package ticket
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateTicket(t *testing.T) {
+	cases := []struct {
+		name     string
+		message  string
+		priority string
+		wantErr  string
+	}{
+		{"valid low", "my app will not deploy", "low", ""},
+		{"valid high", "my app will not deploy", "high", ""},
+		{"valid emergency", "my app will not deploy", "emergency", ""},
+		{"message too short", "too short", "low", "at least 10 characters"},
+		{"message all whitespace", strings.Repeat(" ", 20), "low", "at least 10 characters"},
+		{"message too long", strings.Repeat("x", 5001), "low", "at most 5000 characters"},
+		{"message at max", strings.Repeat("x", 5000), "low", ""},
+		{"message at min", strings.Repeat("x", 10), "low", ""},
+		{"invalid priority", "my app will not deploy", "urgent", "invalid priority"},
+		{"empty priority", "my app will not deploy", "", "invalid priority"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTicket(tc.message, tc.priority)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}

--- a/internal/command/ticket/ticket.go
+++ b/internal/command/ticket/ticket.go
@@ -1,0 +1,24 @@
+// Package ticket implements the ticket command chain.
+package ticket
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/superfly/flyctl/internal/command"
+)
+
+func New() *cobra.Command {
+	const (
+		short = "Open support tickets with Fly.io"
+		long  = `Open support tickets with the Fly.io support team from the command line.
+Requires an organization with a support plan.`
+	)
+	cmd := command.New("ticket", short, long, nil)
+	cmd.Aliases = []string{"mayday"}
+	cmd.Hidden = true // TODO: unhide when the support API endpoint ships
+
+	cmd.AddCommand(
+		newCreate(),
+	)
+
+	return cmd
+}


### PR DESCRIPTION
### Change Summary

What and Why:

Support tickets can currently only be filed through the dashboard's LiveView form. This PR stakes out the CLI side of a `fly ticket` command so tickets can be filed from the terminal by humans and by agents (error contextualization) alike. This first commit is a **CLI mockup only**: a hidden `fly ticket` namespace (aliased `fly mayday`) whose `create` subcommand runs the full UX — flags, stdin body, prompts, validation — and then dry-run prints the composed request payload with a "not wired up yet" notice. The command stays hidden until the backing endpoint ships (prior art: hidden `secrets keys`).

How:

- New `internal/command/ticket` package following the `internal/command/incidents` shape: parent group command with nil runner, `create` subcommand with `RequireSession` + `LoadAppNameIfPresent`.
- Fully flag-drivable for agent use: `--subject`, `--message/-m`, `--priority low|high|emergency`, `--category`, `--product`, `--mpg-cluster-id`, plus standard `--app/--org/--json`. Category/product have shell completions matching the dashboard enums.
- Body resolution order: `--message` → piped stdin → interactive prompt → `NonInteractiveError`.
- Validation mirrors the dashboard form: message 10–5000 chars, priority enum.
- `CreateTicketRequest` in `create.go` is the proposed body for `POST /api/v1/organizations/:org_slug/support/tickets`; org is deliberately a path param (so the API's macaroon org authorization resolves it) rather than a body field. `--json` emits `{dry_run: true, org, ticket}`.
- Registered in root under `more_help`; hidden commands register normally.
- Known/accepted `cmd/audit lint` hit: `inconsistent-aliases` flags the `mayday` alias because `fly tokens 3p ticket` shares the name `ticket` (lint is not CI-enforced; no other new findings).

Follow-ups (not in this PR):

1. **API endpoint**: `POST /api/v1/organizations/:org_slug/support/tickets` — thin controller that validates into the existing support-request form, maps priority → Plain impact/emergency (emergency→P0, high→degraded_performance/P1, low→general_issue/P2), enqueues the existing `SupportFormWorker`, and responds `{ticket_ref, url}`; non-entitled orgs get a structured "no support plan" response with community/upgrade URLs. Tier gating stays server-side.
2. **Identity** (open question): the worker needs `user_email`/`full_name`; the macaroon API pipeline resolves org, not user, and agents hold org/deploy tokens.
3. **flyctl wiring**: new `internal/uiex` method, replace the dry run with the real call, unhide the command.
4. **Diagnostics**: opt-in `--attach-diagnostics` (candidates: latest `~/.fly/logs/flyctl-*.log`, the `fly doctor diag` zip flow, Plain attachment uploads); `$EDITOR` body authoring.

Related to:

Design discussion with Eli on CLI support-ticket submission.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a (command is hidden until the endpoint ships)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzNAbdQJfbjEeTTbQBmcwy

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzNAbdQJfbjEeTTbQBmcwy)_