### PR TITLE
fix(mpg): clarify restore command help text

### DIFF
--- a/internal/command/mpg/restore.go
+++ b/internal/command/mpg/restore.go
@@ -14,14 +14,11 @@ import (
 
 func newRestore() *cobra.Command {
 	const (
-		long = `Restore a backup of a Managed Postgres cluster into a new, separate cluster.
-The source cluster is not modified. The restored cluster is provisioned in the
-same organization and billed as a separate cluster. Provisioning happens
-asynchronously; the new cluster ID and generated name are printed when the
-restore is initiated.
+		long = `Restore a Managed Postgres backup into a new cluster, leaving the source
+cluster unchanged. The restored cluster is provisioned asynchronously in the
+same organization and billed separately.
 
-Find backup IDs with 'fly mpg backup list <CLUSTER_ID>', or
-'fly mpg backup list <CLUSTER_ID> --all' for backups older than 24 hours.`
+Find backup IDs with 'fly mpg backup list'.`
 		short = "Restore MPG cluster from backup into a new cluster."
 		usage = "restore <CLUSTER_ID>"
 	)

--- a/internal/command/mpg/restore.go
+++ b/internal/command/mpg/restore.go
@@ -14,8 +14,15 @@ import (
 
 func newRestore() *cobra.Command {
 	const (
-		long  = `Restore a Managed Postgres cluster from a backup.`
-		short = "Restore MPG cluster from backup."
+		long = `Restore a backup of a Managed Postgres cluster into a new, separate cluster.
+The source cluster is not modified. The restored cluster is provisioned in the
+same organization and billed as a separate cluster. Provisioning happens
+asynchronously; the new cluster ID and generated name are printed when the
+restore is initiated.
+
+Find backup IDs with 'fly mpg backup list <CLUSTER_ID>', or
+'fly mpg backup list <CLUSTER_ID> --all' for backups older than 24 hours.`
+		short = "Restore MPG cluster from backup into a new cluster."
 		usage = "restore <CLUSTER_ID>"
 	)
 


### PR DESCRIPTION
### Change Summary

What and Why:

`fly mpg restore` provisions a new, separately-billed cluster from the backup and leaves the source cluster untouched. The help text didn't say that, and gave no pointer to where `--backup-id` values come from. A customer reported the command as confusing.

How:

Update the command's short/long help text to state that restore creates a new cluster (billed separately, same organization, provisioned asynchronously) rather than restoring in place, and to point at `fly mpg backup list` for backup IDs. Help text only — no behavior change, `--backup-id` description left as-is.

Verified by:

- `go build`, `gofmt`, `go vet`, `go test ./internal/command/mpg/...` — all clean;
- inspecting the rendered `fly mpg restore --help` from a built binary;
- confirming each claim against both the v1 and v2 code paths, since `mpg restore` dispatches on cluster version — the wording is deliberately version-agnostic because the two differ (e.g. generated-name format is `<source> restored <timestamp>` on v1 vs `<source> restored <backup_id>` on v2).

Open question for reviewers: this is now on the long side for flyctl help text (~70 words vs a ~10-word median). Happy to trim if it reads as too much — the facts were added in response to the reported confusion, but which of them earn their place is a fair thing to push back on.

Related to:

- [superfly/mpg#285](https://github.com/superfly/mpg/issues/285)

Follow-ups tracked in that issue and intentionally out of scope here: `--name` to set the restored cluster's name, and `--pitr-time` for point-in-time restore.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a