### PR TITLE
feat(mpg): add --name to restore

### DIFF
--- a/internal/command/mpg/restore.go
+++ b/internal/command/mpg/restore.go
@@ -35,6 +35,11 @@ Find backup IDs with 'fly mpg backup list'.`
 			Name:        "backup-id",
 			Description: "The backup ID to restore from",
 		},
+		flag.String{
+			Name:        "name",
+			Shorthand:   "n",
+			Description: "The name of the restored cluster (defaults to a generated name)",
+		},
 	)
 
 	return cmd
@@ -52,10 +57,12 @@ func runRestore(ctx context.Context) error {
 		return fmt.Errorf("--backup-id flag is required")
 	}
 
+	name := flag.GetString(ctx, "name")
+
 	if cluster.Version == mpg.VersionV1 {
-		return cmdv1.RunRestore(ctx, cluster.Id, backupID)
+		return cmdv1.RunRestore(ctx, cluster.Id, backupID, name)
 
 	}
 
-	return cmdv2.RunRestore(ctx, cluster.Id, backupID)
+	return cmdv2.RunRestore(ctx, cluster.Id, backupID, name)
 }

--- a/internal/command/mpg/v1/run_restore.go
+++ b/internal/command/mpg/v1/run_restore.go
@@ -8,7 +8,7 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 )
 
-func RunRestore(ctx context.Context, clusterID string, backupID string) error {
+func RunRestore(ctx context.Context, clusterID string, backupID string, name string) error {
 	out := iostreams.FromContext(ctx).Out
 	mpgClient := mpgv1.ClientFromContext(ctx)
 
@@ -16,6 +16,7 @@ func RunRestore(ctx context.Context, clusterID string, backupID string) error {
 
 	input := mpgv1.RestoreManagedClusterBackupInput{
 		BackupId: backupID,
+		Name:     name,
 	}
 
 	response, err := mpgClient.RestoreManagedClusterBackup(ctx, clusterID, input)

--- a/internal/command/mpg/v2/run_restore.go
+++ b/internal/command/mpg/v2/run_restore.go
@@ -8,7 +8,7 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 )
 
-func RunRestore(ctx context.Context, clusterID string, backupID string) error {
+func RunRestore(ctx context.Context, clusterID string, backupID string, name string) error {
 	out := iostreams.FromContext(ctx).Out
 	mpgClient := mpgv2.ClientFromContext(ctx)
 
@@ -16,6 +16,7 @@ func RunRestore(ctx context.Context, clusterID string, backupID string) error {
 
 	input := mpgv2.RestoreClusterBackupInput{
 		BackupId: backupID,
+		Name:     name,
 	}
 
 	response, err := mpgClient.RestoreClusterBackup(ctx, clusterID, input)

--- a/internal/uiex/mpg/v1/client.go
+++ b/internal/uiex/mpg/v1/client.go
@@ -139,6 +139,7 @@ type CreateManagedClusterBackupResponse struct {
 
 type RestoreManagedClusterBackupInput struct {
 	BackupId string `json:"backup_id"`
+	Name     string `json:"name,omitempty"`
 }
 
 type RestoreManagedClusterBackupResponse struct {

--- a/internal/uiex/mpg/v1/managed_postgres_test.go
+++ b/internal/uiex/mpg/v1/managed_postgres_test.go
@@ -254,3 +254,66 @@ func TestCreateDatabase_EmptyName(t *testing.T) {
 		t.Fatal("expected error for empty database name")
 	}
 }
+
+// TestRestoreManagedClusterBackup_NamePayload asserts the wire format of the
+// optional destination name: omitted entirely when unset, so an older ui-ex
+// deployment sees exactly the payload it saw before this flag existed.
+func TestRestoreManagedClusterBackup_NamePayload(t *testing.T) {
+	tests := []struct {
+		desc     string
+		name     string
+		wantName any
+	}{
+		{desc: "unset name is omitted", name: "", wantName: nil},
+		{desc: "explicit name is sent", name: "my-restore", wantName: "my-restore"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var body map[string]any
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST request, got %s", r.Method)
+				}
+				if r.URL.Path != "/api/v1/postgres/test-cluster-id/restore" {
+					t.Errorf("expected path /api/v1/postgres/test-cluster-id/restore, got %s", r.URL.Path)
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("failed to decode request body: %v", err)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(RestoreManagedClusterBackupResponse{})
+			}))
+			defer server.Close()
+
+			client, ctx, err := setupTestClient(server)
+			if err != nil {
+				t.Fatalf("failed to setup test client: %v", err)
+			}
+
+			_, err = client.RestoreManagedClusterBackup(ctx, "test-cluster-id", RestoreManagedClusterBackupInput{
+				BackupId: "backup-1",
+				Name:     tt.name,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got := body["backup_id"]; got != "backup-1" {
+				t.Errorf("expected backup_id backup-1, got %v", got)
+			}
+
+			got, present := body["name"]
+			if tt.wantName == nil {
+				if present {
+					t.Errorf("expected name to be omitted, got %v", got)
+				}
+			} else if got != tt.wantName {
+				t.Errorf("expected name %v, got %v", tt.wantName, got)
+			}
+		})
+	}
+}

--- a/internal/uiex/mpg/v2/client.go
+++ b/internal/uiex/mpg/v2/client.go
@@ -198,6 +198,7 @@ type CreateClusterBackupInput struct {
 
 type RestoreClusterBackupInput struct {
 	BackupId string `json:"backup_id"`
+	Name     string `json:"name,omitempty"`
 }
 
 type RestoreClusterBackupResponse struct {

--- a/internal/uiex/mpg/v2/managed_postgres_test.go
+++ b/internal/uiex/mpg/v2/managed_postgres_test.go
@@ -1,0 +1,100 @@
+package v2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/superfly/fly-go/tokens"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func setupTestClient(server *httptest.Server) (*Client, context.Context, error) {
+	baseURL, err := url.Parse(server.URL)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctx := context.Background()
+	ios, _, _, _ := iostreams.Test()
+	ctx = iostreams.NewContext(ctx, ios)
+
+	ctx = config.NewContext(ctx, &config.Config{
+		Tokens: &tokens.Tokens{},
+	})
+
+	client, err := NewClientWithOptions(ctx, uiex.NewClientOpts{BaseURL: baseURL})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return client, ctx, nil
+}
+
+// TestRestoreClusterBackup_NamePayload asserts the wire format of the optional
+// destination name: omitted entirely when unset, so an older ui-ex deployment
+// sees exactly the payload it saw before this flag existed.
+func TestRestoreClusterBackup_NamePayload(t *testing.T) {
+	tests := []struct {
+		desc     string
+		name     string
+		wantName any
+	}{
+		{desc: "unset name is omitted", name: "", wantName: nil},
+		{desc: "explicit name is sent", name: "my-restore", wantName: "my-restore"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			var body map[string]any
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST request, got %s", r.Method)
+				}
+				if r.URL.Path != "/api/v1/postgresv2/test-cluster-id/restore" {
+					t.Errorf("expected path /api/v1/postgresv2/test-cluster-id/restore, got %s", r.URL.Path)
+				}
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("failed to decode request body: %v", err)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(RestoreClusterBackupResponse{})
+			}))
+			defer server.Close()
+
+			client, ctx, err := setupTestClient(server)
+			if err != nil {
+				t.Fatalf("failed to setup test client: %v", err)
+			}
+
+			_, err = client.RestoreClusterBackup(ctx, "test-cluster-id", RestoreClusterBackupInput{
+				BackupId: "backup-1",
+				Name:     tt.name,
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got := body["backup_id"]; got != "backup-1" {
+				t.Errorf("expected backup_id backup-1, got %v", got)
+			}
+
+			got, present := body["name"]
+			if tt.wantName == nil {
+				if present {
+					t.Errorf("expected name to be omitted, got %v", got)
+				}
+			} else if got != tt.wantName {
+				t.Errorf("expected name %v, got %v", tt.wantName, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Change Summary

Adds an optional `--name` / `-n` flag to `fly mpg restore`.

The server support in [superfly/ui-ex#5070](https://github.com/superfly/ui-ex/pull/5070) is deployed.

### How

The flag is passed through both v1 and v2 restore paths. When unset, `omitempty` leaves the existing generated-name behavior unchanged. Name validation remains server-side.

### Verification

- `go test ./internal/command/mpg/... ./internal/uiex/mpg/...`
- Payload tests cover v1 and v2 with the name set and omitted
- Verified on staging that valid names are applied and a 256-character name returns 422 without creating a cluster
- Rebased onto the help-text change from #5043

Related to [superfly/mpg#285](https://github.com/superfly/mpg/issues/285).

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a