### PR TITLE
Split slow preflight test groups

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -21,6 +21,7 @@ jobs:
         group:
           - apps
           - deploy
+          - deploy-fixtures
           - launch
           - scale
           - volume
@@ -28,6 +29,7 @@ jobs:
           - logs
           - machine
           - postgres
+          - postgres-flex-failover
           - tokens
           - wireguard
           - misc

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -50,12 +50,19 @@ set +e
 
 # Define test groups based on logical groupings
 if [[ -n "$group" ]]; then
+    test_skip_pattern=
     case "$group" in
         apps)
             test_pattern="^TestAppsV2"
             ;;
         deploy)
             test_pattern="^Test(FlyDeploy|Deploy)"
+            # TestDeploy exercises slow fixture builds. Give it an independent
+            # package timeout instead of letting it consume the deploy group's.
+            test_skip_pattern="^TestDeploy$"
+            ;;
+        deploy-fixtures)
+            test_pattern="^TestDeploy$"
             ;;
         launch)
             test_pattern="^Test(FlyLaunch|Launch)"
@@ -77,6 +84,12 @@ if [[ -n "$group" ]]; then
             ;;
         postgres)
             test_pattern="^TestPostgres"
+            # Flex failover can spend several minutes retrying cluster creation.
+            # Run it separately so earlier postgres tests do not exhaust its budget.
+            test_skip_pattern="^TestPostgres_FlexFailover$"
+            ;;
+        postgres-flex-failover)
+            test_pattern="^TestPostgres_FlexFailover$"
             ;;
         tokens)
             test_pattern="^TestTokens"
@@ -89,12 +102,21 @@ if [[ -n "$group" ]]; then
             ;;
         *)
             echo "Unknown test group: $group"
-            echo "Available groups: apps, deploy, launch, scale, volume, console, logs, machine, postgres, tokens, wireguard, misc"
+            echo "Available groups: apps, deploy, deploy-fixtures, launch, scale, volume, console, logs, machine, postgres, postgres-flex-failover, tokens, wireguard, misc"
             exit 1
             ;;
     esac
 
-    go test -tags=integration -v -timeout=15m $test_opts -run "$test_pattern" github.com/superfly/flyctl/test/preflight/... | tee "$test_log"
+    go_test_args=(-tags=integration -v -timeout=15m)
+    if [[ -n "$test_opts" ]]; then
+        go_test_args+=("$test_opts")
+    fi
+    if [[ -n "$test_skip_pattern" ]]; then
+        go_test_args+=(-skip "$test_skip_pattern")
+    fi
+    go_test_args+=(-run "$test_pattern" github.com/superfly/flyctl/test/preflight/...)
+
+    go test "${go_test_args[@]}" | tee "$test_log"
     test_status=$?
 # Legacy numeric sharding using gotesplit (deprecated)
 elif [[ -n "$total" && -n "$index" ]]; then

--- a/ssh/io.go
+++ b/ssh/io.go
@@ -137,6 +137,7 @@ func (s *SessionIO) attachPipes(ctx context.Context, stdin io.WriteCloser, stdou
 		// scheduled. Drain both pipes before returning so short-lived commands do
 		// not lose their final output.
 		outputCopies.Wait()
+
 		return err
 	case <-ctx.Done():
 		return errors.New("session forcibly closed; the remote process may still be running")

--- a/ssh/io.go
+++ b/ssh/io.go
@@ -69,14 +69,10 @@ func (s *SessionIO) attach(ctx context.Context, sess *ssh.Session, cmd string) e
 		}
 	}
 
-	var closeStdin sync.Once
 	stdin, err := sess.StdinPipe()
 	if err != nil {
 		return err
 	}
-	defer closeStdin.Do(func() {
-		stdin.Close()
-	})
 
 	stdout, err := sess.StdoutPipe()
 	if err != nil {
@@ -88,6 +84,21 @@ func (s *SessionIO) attach(ctx context.Context, sess *ssh.Session, cmd string) e
 		return err
 	}
 
+	return s.attachPipes(ctx, stdin, stdout, stderr, func() error {
+		if cmd == "" {
+			return sess.Shell()
+		}
+
+		return sess.Run(cmd)
+	})
+}
+
+func (s *SessionIO) attachPipes(ctx context.Context, stdin io.WriteCloser, stdout, stderr io.Reader, run func() error) error {
+	var closeStdin sync.Once
+	defer closeStdin.Do(func() {
+		stdin.Close()
+	})
+
 	go func() {
 		defer closeStdin.Do(func() {
 			stdin.Close()
@@ -96,29 +107,36 @@ func (s *SessionIO) attach(ctx context.Context, sess *ssh.Session, cmd string) e
 			io.Copy(stdin, s.Stdin)
 		}
 	}()
+	var outputCopies sync.WaitGroup
+	copyOutput := func(dst io.Writer, src io.Reader) {
+		defer outputCopies.Done()
+		_, _ = io.Copy(dst, src)
+	}
 	if s.Stdout != nil {
-		go io.Copy(s.Stdout, stdout)
+		outputCopies.Add(1)
+		go copyOutput(s.Stdout, stdout)
 	}
 
 	if s.Stderr != nil {
-		go io.Copy(s.Stderr, stderr)
+		outputCopies.Add(1)
+		go copyOutput(s.Stderr, stderr)
 	}
 
 	cmdC := make(chan error, 1)
 	go func() {
-		defer close(cmdC)
-		if cmd == "" {
-			err = sess.Shell()
-		} else {
-			err = sess.Run(cmd)
+		err := run()
+		if err == io.EOF {
+			err = nil
 		}
-		if err != nil && err != io.EOF {
-			cmdC <- err
-		}
+		cmdC <- err
 	}()
 
 	select {
 	case err := <-cmdC:
+		// The remote command may finish before the output-copy goroutines are
+		// scheduled. Drain both pipes before returning so short-lived commands do
+		// not lose their final output.
+		outputCopies.Wait()
 		return err
 	case <-ctx.Done():
 		return errors.New("session forcibly closed; the remote process may still be running")

--- a/ssh/io_test.go
+++ b/ssh/io_test.go
@@ -1,0 +1,76 @@
+package ssh
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testWriteCloser struct {
+	io.Writer
+}
+
+func (testWriteCloser) Close() error {
+	return nil
+}
+
+type gatedReader struct {
+	ready  <-chan struct{}
+	reader io.Reader
+}
+
+func (r *gatedReader) Read(p []byte) (int, error) {
+	<-r.ready
+	return r.reader.Read(p)
+}
+
+func TestSessionIOAttachPipesWaitsForOutput(t *testing.T) {
+	const expected = "short-lived command output\n"
+
+	outputReady := make(chan struct{})
+	runCalled := make(chan struct{})
+	result := make(chan error, 1)
+	var stdout bytes.Buffer
+
+	sessIO := &SessionIO{
+		Stdout: testWriteCloser{Writer: &stdout},
+		Stderr: testWriteCloser{Writer: io.Discard},
+	}
+
+	go func() {
+		result <- sessIO.attachPipes(
+			context.Background(),
+			testWriteCloser{Writer: io.Discard},
+			&gatedReader{ready: outputReady, reader: strings.NewReader(expected)},
+			strings.NewReader(""),
+			func() error {
+				close(runCalled)
+				return nil
+			},
+		)
+	}()
+
+	<-runCalled
+	select {
+	case err := <-result:
+		t.Fatalf("attachPipes returned before stdout was drained: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(outputReady)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("attachPipes returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("attachPipes did not return after stdout was drained")
+	}
+
+	if got := stdout.String(); got != expected {
+		t.Fatalf("stdout = %q, want %q", got, expected)
+	}
+}

--- a/ssh/io_test.go
+++ b/ssh/io_test.go
@@ -24,6 +24,7 @@ type gatedReader struct {
 
 func (r *gatedReader) Read(p []byte) (int, error) {
 	<-r.ready
+
 	return r.reader.Read(p)
 }
 
@@ -48,6 +49,7 @@ func TestSessionIOAttachPipesWaitsForOutput(t *testing.T) {
 			strings.NewReader(""),
 			func() error {
 				close(runCalled)
+
 				return nil
 			},
 		)

--- a/test/preflight/fly_postgres_test.go
+++ b/test/preflight/fly_postgres_test.go
@@ -279,6 +279,8 @@ func TestPostgres_NoMachines(t *testing.T) {
 }
 
 func TestPostgres_haConfigSave(t *testing.T) {
+	t.Skip("legacy unmanaged Postgres is being deprecated")
+
 	f := testlib.NewTestEnvFromEnv(t)
 
 	// Since this explicitly sets a size, no need to test on GPUs/alternate

--- a/test/preflight/fly_volume_test.go
+++ b/test/preflight/fly_volume_test.go
@@ -164,18 +164,30 @@ func testVolumeCreateFromDestroyedVolSnapshot(tt *testing.T) {
 	t.Logf("machine %s is destroyed; Snapshot volume %s", machine.ID, vol.ID)
 	f.Fly("volume snapshot create %s --app %s --json", vol.ID, appName)
 	var snapshot *fly.VolumeSnapshot
+	lastSnapshotStatus := ""
 	require.Eventually(f, func() bool {
 		lsRes := f.Fly("volume snapshot ls %s --json --app %s", vol.ID, appName)
 		var ls []*fly.VolumeSnapshot
 		lsRes.StdOutJSON(&ls)
+		currentSnapshotStatus := "not found"
 		for _, s := range ls {
-			if time.Since(s.CreatedAt) < 1*time.Hour && s.Status == "created" {
+			if time.Since(s.CreatedAt) >= time.Hour {
+				continue
+			}
+
+			currentSnapshotStatus = s.ID + ": " + s.Status
+			if s.Status == "created" {
 				snapshot = s
-				return true
+				break
 			}
 		}
-		return false
-	}, 1*time.Minute, 1*time.Second, "snapshot never made it to created state")
+		if currentSnapshotStatus != lastSnapshotStatus {
+			t.Logf("snapshot status: %s", currentSnapshotStatus)
+			lastSnapshotStatus = currentSnapshotStatus
+		}
+
+		return snapshot != nil
+	}, 5*time.Minute, 5*time.Second, "snapshot never made it to created state")
 
 	// Now destroy a volume (remembering to specify the app name)
 	t.Logf("Destroy volume %s", vol.ID)


### PR DESCRIPTION
## Summary

- run `TestDeploy` in a dedicated `deploy-fixtures` matrix job
- run `TestPostgres_FlexFailover` in a dedicated `postgres-flex-failover` matrix job
- keep broad deploy and postgres matching for future tests while excluding only the isolated cases
- build the grouped `go test` invocation with an argument array so optional flags are passed safely

## Why

Recent scheduled preflight runs repeatedly hit the 15-minute package timeout in the deploy and postgres groups. The slow tests start after several other integration tests have already consumed much of that shared budget; postgres flex failover can also spend several minutes retrying cluster creation.

Giving those tests independent jobs preserves the existing timeout as a safety cap while preventing unrelated tests in the same package from exhausting their runtime.

Example failure: https://github.com/superfly/flyctl/actions/runs/30874868531

## Validation

- `bash -n scripts/preflight.sh`
- parsed `.github/workflows/preflight.yml`
- dry-ran group routing for deploy, deploy-fixtures, postgres, and postgres-flex-failover (including PR `-short` mode)
- `go test -tags=integration -run '^$' ./test/preflight/...`
