### PR TITLE
Give Postgres preflight tests more time.

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -50,6 +50,8 @@ set +e
 
 # Define test groups based on logical groupings
 if [[ -n "$group" ]]; then
+    test_timeout=15m
+
     case "$group" in
         apps)
             test_pattern="^TestAppsV2"
@@ -77,6 +79,7 @@ if [[ -n "$group" ]]; then
             ;;
         postgres)
             test_pattern="^TestPostgres"
+            test_timeout=30m # Needs more time than other tests.
             ;;
         tokens)
             test_pattern="^TestTokens"
@@ -94,7 +97,7 @@ if [[ -n "$group" ]]; then
             ;;
     esac
 
-    go test -tags=integration -v -timeout=15m $test_opts -run "$test_pattern" github.com/superfly/flyctl/test/preflight/... | tee "$test_log"
+    go test -tags=integration -v -timeout="$test_timeout" $test_opts -run "$test_pattern" github.com/superfly/flyctl/test/preflight/... | tee "$test_log"
     test_status=$?
 # Legacy numeric sharding using gotesplit (deprecated)
 elif [[ -n "$total" && -n "$index" ]]; then

--- a/test/preflight/testlib/test_env.go
+++ b/test/preflight/testlib/test_env.go
@@ -184,6 +184,16 @@ type testingTWrapper interface {
 	TempDir() string
 }
 
+// defaultFlyctlCmdTimeout bounds how long a single flyctl invocation may run
+// when the caller doesn't supply a context with its own deadline. Without
+// this, a flyctl command that hangs (rather than erroring out) blocks
+// cmd.Wait() forever, and the only backstop is the shared `go test -timeout`
+// for the whole test binary. When that fires, it panics the entire binary,
+// failing every test in the group instead of just the one that hung. A
+// per-command timeout turns a hang into an ordinary failed attempt, which
+// callers with retry loops (e.g. pg create) already know how to handle.
+const defaultFlyctlCmdTimeout = 10 * time.Minute
+
 // Fly runs flyctl and returns the result.
 // It fails the test if the command exits with a non-zero status.
 func (f *FlyctlTestEnv) Fly(flyctlCmd string, vals ...interface{}) *FlyctlResult {
@@ -207,6 +217,12 @@ type FlyCmdConfig struct {
 }
 
 func (f *FlyctlTestEnv) FlyContextAndConfig(ctx context.Context, cfg FlyCmdConfig, flyctlCmd string, vals ...interface{}) *FlyctlResult {
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultFlyctlCmdTimeout)
+		defer cancel()
+	}
+
 	argsStr := fmt.Sprintf(flyctlCmd, vals...)
 	args, err := shlex.Split(argsStr)
 	if err != nil {


### PR DESCRIPTION
The Postgres preflight tests are slow and regularly exceed their time limit. This PR begrudgingly gives these tests more time and also limits how much time any given command may take.