### PR TITLE
Fix launch command help typo

### DIFF
--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -167,7 +167,7 @@ func New() (cmd *cobra.Command) {
 		},
 		flag.String{
 			Name:        "command",
-			Description: "The command to override the Docker CND.",
+			Description: "The command to override the Docker CMD.",
 		},
 		flag.StringSlice{
 			Name:        "volume",


### PR DESCRIPTION
### Change Summary

What and Why:

There is a typo in the `--command` help description of the `launch` command.

How:

```
flyctl launch --help | grep -B1 CND
      --command string       The command to override the Docker CND.
```

It's also in the docs superfly/docs#2458