### PR TITLE
Bump client-signals to v0.4.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/superfly/client-signals/go v0.4.2
+	github.com/superfly/client-signals/go v0.4.4
 	github.com/superfly/fly-go v0.9.2
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -662,8 +662,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/superfly/client-signals/go v0.4.2 h1:8UH1s+jgCz/goOMdy2d8Wx4XDIDXqq70zStrimMaFIM=
-github.com/superfly/client-signals/go v0.4.2/go.mod h1:v/FQ2fZ4zOkOxKmue+bYh96awuh9Qh1ImcdxzRYcHFA=
+github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVuwVJGWndfmc8=
+github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
 github.com/superfly/fly-go v0.9.2 h1:eGleZZi3FeRt1CcG/qVbWnKoh+AbF9ut7dSr0AuiUxs=
 github.com/superfly/fly-go v0.9.2/go.mod h1:TOdS0mlGgPUvOlISm2SyaJPt3nWfCQwO8lD45DBvPbE=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=


### PR DESCRIPTION
## What changed

- bump `github.com/superfly/client-signals/go` from `v0.4.2` to `v0.4.4`

## Why

flyctl is two releases behind, so it never detects Grok Build. Verified against the module in a clean environment (`env -i GROK_AGENT=1`):

| client-signals | detection |
| --- | --- |
| `v0.4.2` | `agent=""` — no agent header sent |
| `v0.4.3` | `agent=""` — no agent header sent |
| `v0.4.4` | `agent="grok"`, `operator="agent"` |

So Grok-driven flyctl traffic is currently not attributed at all: with no `Fly-Client-Agent` header, servers classify it as `agent="none"` and it never appears as agentic in `fly_client_signals_requests_total`. This is the client-side half of the same gap being closed for flaps.

`v0.4.2..v0.4.4` adds the `grok` marker ([superfly/client-signals#11](https://github.com/superfly/client-signals/pull/11)) on top of the server-side helpers and operator classification; the marker table gains no other entries, so no other agent changes behavior.

## Coordinated rollout

- [superfly/nomad-firecracker#4664](https://github.com/superfly/nomad-firecracker/pull/4664) — same bump for flaps, from `v0.4.3`

## Validation

- `go get github.com/superfly/client-signals/go@v0.4.4 && go mod tidy`
- `go build ./...`
- `go test ./internal/cmdutil/preparers ./internal/metrics ./internal/uiex -count=1` — no test files in these packages
- `go mod verify` — all modules verified
- `git diff --check`
