### PR TITLE
Remove the GPU surface

### DIFF
--- a/internal/command/mcp/launch.go
+++ b/internal/command/mcp/launch.go
@@ -287,6 +287,8 @@ func runLaunch(ctx context.Context) error {
 		args = append(args, "--vm-cpus", fmt.Sprintf("%d", vmCpus))
 	}
 
+	// Forwarded so that `fly launch` rejects them, rather than dropping a
+	// GPU request on the floor and quietly launching a CPU machine.
 	if vmGpuKind := flag.GetString(ctx, "vm-gpu-kind"); vmGpuKind != "" {
 		args = append(args, "--vm-gpu-kind", vmGpuKind)
 	}

--- a/internal/command/mcp/server/machine.go
+++ b/internal/command/mcp/server/machine.go
@@ -76,17 +76,6 @@ var MachineCommands = []FlyCommand{
 				Required:    false,
 				Type:        "number",
 			},
-			"vm-gpu-kind": {
-				Description: "If set, the GPU model to attach",
-				Required:    false,
-				Type:        "enum",
-				Enum:        []string{"a100-pcie-40gb", "a100-sxm4-80gb", "l40s", "a10", "none"},
-			},
-			"vm-gpus": {
-				Description: "The number of GPUs to use for the new machine",
-				Required:    false,
-				Type:        "number",
-			},
 			"vm-memory": {
 				Description: "The amount of memory (in megabytes) to use for the new machine",
 				Required:    false,
@@ -170,14 +159,6 @@ var MachineCommands = []FlyCommand{
 
 			if vmCpus, ok := args["vm-cpus"]; ok {
 				cmdArgs = append(cmdArgs, "--vm-cpus", vmCpus)
-			}
-
-			if vmGpuKind, ok := args["vm-gpu-kind"]; ok {
-				cmdArgs = append(cmdArgs, "--vm-gpu-kind", vmGpuKind)
-			}
-
-			if vmGpus, ok := args["vm-gpus"]; ok {
-				cmdArgs = append(cmdArgs, "--vm-gpus", vmGpus)
 			}
 
 			if vmMemory, ok := args["vm-memory"]; ok {
@@ -348,17 +329,6 @@ var MachineCommands = []FlyCommand{
 				Required:    false,
 				Type:        "number",
 			},
-			"vm-gpu-kind": {
-				Description: "If set, the GPU model to attach",
-				Required:    false,
-				Type:        "enum",
-				Enum:        []string{"a100-pcie-40gb", "a100-sxm4-80gb", "l40s", "a10", "none"},
-			},
-			"vm-gpus": {
-				Description: "The number of GPUs to use for the new machine",
-				Required:    false,
-				Type:        "number",
-			},
 			"vm-memory": {
 				Description: "The amount of memory (in megabytes) to use for the new machine",
 				Required:    false,
@@ -481,14 +451,6 @@ var MachineCommands = []FlyCommand{
 
 			if vmCpus, ok := args["vm-cpus"]; ok {
 				cmdArgs = append(cmdArgs, "--vm-cpus", vmCpus)
-			}
-
-			if vmGpuKind, ok := args["vm-gpu-kind"]; ok {
-				cmdArgs = append(cmdArgs, "--vm-gpu-kind", vmGpuKind)
-			}
-
-			if vmGpus, ok := args["vm-gpus"]; ok {
-				cmdArgs = append(cmdArgs, "--vm-gpus", vmGpus)
 			}
 
 			if vmMemory, ok := args["vm-memory"]; ok {
@@ -1030,17 +992,6 @@ var MachineCommands = []FlyCommand{
 				Required:    false,
 				Type:        "number",
 			},
-			"vm-gpu-kind": {
-				Description: "If set, the GPU model to attach",
-				Required:    false,
-				Type:        "enum",
-				Enum:        []string{"a100-pcie-40gb", "a100-sxm4-80gb", "l40s", "a10", "none"},
-			},
-			"vm-gpus": {
-				Description: "The number of GPUs to use for the new machine",
-				Required:    false,
-				Type:        "number",
-			},
 			"vm-memory": {
 				Description: "The amount of memory (in megabytes) to use for the new machine",
 				Required:    false,
@@ -1173,14 +1124,6 @@ var MachineCommands = []FlyCommand{
 
 			if vmCpus, ok := args["vm-cpus"]; ok {
 				cmdArgs = append(cmdArgs, "--vm-cpus", vmCpus)
-			}
-
-			if vmGpuKind, ok := args["vm-gpu-kind"]; ok {
-				cmdArgs = append(cmdArgs, "--vm-gpu-kind", vmGpuKind)
-			}
-
-			if vmGpus, ok := args["vm-gpus"]; ok {
-				cmdArgs = append(cmdArgs, "--vm-gpus", vmGpus)
 			}
 
 			if vmMemory, ok := args["vm-memory"]; ok {
@@ -1516,17 +1459,6 @@ var MachineCommands = []FlyCommand{
 				Required:    false,
 				Type:        "number",
 			},
-			"vm-gpu-kind": {
-				Description: "If set, the GPU model to attach",
-				Required:    false,
-				Type:        "enum",
-				Enum:        []string{"a100-pcie-40gb", "a100-sxm4-80gb", "l40s", "a10", "none"},
-			},
-			"vm-gpus": {
-				Description: "The number of GPUs to use for the new machine",
-				Required:    false,
-				Type:        "number",
-			},
 			"vm-memory": {
 				Description: "The amount of memory (in megabytes) to use for the new machine",
 				Required:    false,
@@ -1641,14 +1573,6 @@ var MachineCommands = []FlyCommand{
 
 			if vmCpus, ok := args["vm-cpus"]; ok {
 				cmdArgs = append(cmdArgs, "--vm-cpus", vmCpus)
-			}
-
-			if vmGpuKind, ok := args["vm-gpu-kind"]; ok {
-				cmdArgs = append(cmdArgs, "--vm-gpu-kind", vmGpuKind)
-			}
-
-			if vmGpus, ok := args["vm-gpus"]; ok {
-				cmdArgs = append(cmdArgs, "--vm-gpus", vmGpus)
 			}
 
 			if vmMemory, ok := args["vm-memory"]; ok {

--- a/internal/command/platform/vmsizes.go
+++ b/internal/command/platform/vmsizes.go
@@ -43,15 +43,19 @@ func runMachineVMSizes(ctx context.Context) error {
 		strings []string
 	}
 
-	sortedPresets := lo.MapToSlice(fly.MachinePresets, func(key string, value *fly.MachineGuest) preset {
-		arr := []string{
-			key,
-			cores(value.CPUs),
-			memory(value.MemoryMB),
-			value.GPUKind,
+	// GPU presets are still in fly-go, but GPU machines are no longer offered.
+	sortedPresets := lo.FilterMap(lo.Entries(fly.MachinePresets), func(e lo.Entry[string, *fly.MachineGuest], _ int) (preset, bool) {
+		if e.Value.GPUKind != "" {
+			return preset{}, false
 		}
 
-		return preset{value, arr}
+		arr := []string{
+			e.Key,
+			cores(e.Value.CPUs),
+			memory(e.Value.MemoryMB),
+		}
+
+		return preset{e.Value, arr}, true
 	})
 
 	sort.Slice(sortedPresets, func(i, j int) bool {
@@ -60,10 +64,8 @@ func runMachineVMSizes(ctx context.Context) error {
 		switch {
 		case a.CPUs != b.CPUs:
 			return a.CPUs < b.CPUs
-		case a.MemoryMB != b.MemoryMB:
-			return a.MemoryMB < b.MemoryMB
 		default:
-			return a.GPUKind < b.GPUKind
+			return a.MemoryMB < b.MemoryMB
 		}
 	})
 
@@ -78,7 +80,7 @@ func runMachineVMSizes(ctx context.Context) error {
 
 	// Filter and display shared cpu sizes.
 	shared := lo.FilterMap(sortedPresets, func(p preset, _ int) ([]string, bool) {
-		return p.strings, p.guest.CPUKind == "shared" && p.guest.GPUKind == ""
+		return p.strings, p.guest.CPUKind == "shared"
 	})
 	if err := render.Table(out, "Machines platform", shared, "Name", "CPU Cores", "Memory"); err != nil {
 		return err
@@ -86,18 +88,10 @@ func runMachineVMSizes(ctx context.Context) error {
 
 	// Filter and display performance cpu sizes.
 	performance := lo.FilterMap(sortedPresets, func(p preset, _ int) ([]string, bool) {
-		return p.strings, p.guest.CPUKind == "performance" && p.guest.GPUKind == ""
-	})
-	if err := render.Table(out, "", performance, "Name", "CPU Cores", "Memory"); err != nil {
-		return err
-	}
-
-	// Filter and display gpu sizes.
-	gpus := lo.FilterMap(sortedPresets, func(p preset, _ int) ([]string, bool) {
-		return p.strings, p.guest.GPUKind != ""
+		return p.strings, p.guest.CPUKind == "performance"
 	})
 
-	return render.Table(out, "", gpus, "Name", "CPU Cores", "Memory", "GPU model")
+	return render.Table(out, "", performance, "Name", "CPU Cores", "Memory")
 }
 
 func cores(cores int) string {

--- a/internal/flag/machines.go
+++ b/internal/flag/machines.go
@@ -2,34 +2,19 @@ package flag
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"slices"
-	"strings"
 
 	"github.com/docker/go-units"
-	"github.com/samber/lo"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/helpers"
 )
 
-var (
-	validGPUKinds  = []string{"a100-pcie-40gb", "a100-sxm4-80gb", "l40s", "a10", "none"}
-	gpuKindAliases = map[string]string{
-		"a100-40gb": "a100-pcie-40gb",
-		"a100-80gb": "a100-sxm4-80gb",
-	}
-)
-
 // Returns a MachineGuest based on the flags provided overwriting a default VM
 func GetMachineGuest(ctx context.Context, guest *fly.MachineGuest) (*fly.MachineGuest, error) {
-	defaultVMSize := fly.DefaultVMSize
-	if IsSpecified(ctx, "vm-gpu-kind") {
-		defaultVMSize = fly.DefaultGPUVMSize
-	}
-
 	if guest == nil {
 		guest = &fly.MachineGuest{}
-		guest.SetSize(defaultVMSize)
+		guest.SetSize(fly.DefaultVMSize)
 	}
 
 	if IsSpecified(ctx, "vm-size") {
@@ -78,33 +63,8 @@ func GetMachineGuest(ctx context.Context, guest *fly.MachineGuest) (*fly.Machine
 		}
 	}
 
-	if IsSpecified(ctx, "vm-gpu-kind") {
-		m := GetString(ctx, "vm-gpu-kind")
-		m = lo.ValueOr(gpuKindAliases, m, m)
-		if !slices.Contains(validGPUKinds, m) {
-			return nil, fmt.Errorf("--vm-gpu-kind must be set to one of: %v", strings.Join(validGPUKinds, ", "))
-		}
-		if m == "none" {
-			guest.GPUs = 0
-			guest.GPUKind = ""
-		} else {
-			guest.GPUKind = m
-			if guest.GPUs == 0 {
-				guest.GPUs = 1
-			}
-		}
-	}
-
-	if IsSpecified(ctx, "vm-gpus") {
-		guest.GPUs = GetInt(ctx, "vm-gpus")
-		switch {
-		case guest.GPUKind != "" && guest.GPUs == 0:
-			return nil, fmt.Errorf("--vm-gpus must be greater than zero, got: %d", guest.GPUs)
-		case guest.GPUKind == "" && guest.GPUs > 0:
-			return nil, fmt.Errorf("--vm-gpus requires a GPU Model to be set, pass --vm-gpu-kind=X where X is one of: %v", strings.Join(validGPUKinds, ", "))
-		case guest.GPUs < 0:
-			return nil, fmt.Errorf("--vm-gpus must be greater than or equal to zero, got: %d", guest.GPUs)
-		}
+	if IsSpecified(ctx, "vm-gpu-kind") || IsSpecified(ctx, "vm-gpus") {
+		return nil, errors.New("GPU machines are no longer supported: --vm-gpu-kind and --vm-gpus are no longer accepted")
 	}
 
 	if IsSpecified(ctx, "host-dedication-id") {
@@ -139,14 +99,18 @@ var VMSizeFlags = Set{
 		Description: "Maximum memory (in megabytes) to allow for the VM",
 		Hidden:      true,
 	},
+	// GPU machines are no longer supported. Both flags are kept so that
+	// passing one fails with an explanation rather than "unknown flag".
 	Int{
 		Name:        "vm-gpus",
-		Description: "Number of GPUs. Must also choose the GPU model with --vm-gpu-kind flag",
+		Description: "GPU machines are no longer supported",
+		Hidden:      true,
 	},
 	String{
 		Name:        "vm-gpu-kind",
-		Description: fmt.Sprintf("If set, the GPU model to attach (%v) (also --vm-gpukind)", strings.Join(validGPUKinds, ", ")),
+		Description: "GPU machines are no longer supported",
 		Aliases:     []string{"vm-gpukind"},
+		Hidden:      true,
 	},
 	String{
 		Name:        "host-dedication-id",

--- a/internal/flag/machines_test.go
+++ b/internal/flag/machines_test.go
@@ -1,0 +1,44 @@
+package flag
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/flyctl/internal/cmdutil/preparers"
+)
+
+func ctxWithFlags(t *testing.T, args ...string) context.Context {
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "test"}
+	VMSizeFlags.addTo(cmd)
+
+	fs := cmd.Flags()
+	require.NoError(t, fs.Parse(args))
+
+	// Aliases only resolve onto their main flag once this preparer has run.
+	ctx, err := preparers.ApplyAliases(NewContext(context.Background(), fs))
+	require.NoError(t, err)
+
+	return ctx
+}
+
+func TestGetMachineGuestRejectsGPUFlags(t *testing.T) {
+	for _, args := range [][]string{
+		{"--vm-gpu-kind", "l40s"},
+		{"--vm-gpukind", "l40s"},
+		{"--vm-gpus", "1"},
+	} {
+		_, err := GetMachineGuest(ctxWithFlags(t, args...), nil)
+		assert.ErrorContains(t, err, "GPU machines are no longer supported", "for %v", args)
+	}
+}
+
+func TestGetMachineGuestWithoutGPUFlags(t *testing.T) {
+	guest, err := GetMachineGuest(ctxWithFlags(t, "--vm-cpus", "2"), nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, guest.CPUs)
+}

--- a/test/preflight/apps_v2_integration_test.go
+++ b/test/preflight/apps_v2_integration_test.go
@@ -502,27 +502,16 @@ func TestErrOutput(t *testing.T) {
 	res = f.FlyAllowExitFailure("machine update --vm-memory 10 %s --yes", firstMachine.ID)
 	require.Contains(f, res.StdErrString(), "invalid memory size")
 
-	// This should fail on GPU machines because they're performance VMs.
-	if f.IsGpuMachine() {
-		res = f.FlyAllowExitFailure("machine update --vm-cpus 4 %s --vm-memory 2048 --yes", firstMachine.ID)
-		require.Contains(f, res.StdErrString(), "memory size for config is too low")
-	} else {
-		f.Fly("machine update --vm-cpus 4 %s --vm-memory 2048 --yes", firstMachine.ID)
-	}
+	f.Fly("machine update --vm-cpus 4 %s --vm-memory 2048 --yes", firstMachine.ID)
 
-	// Not applicable for GPU machines since this size is too small.
-	if !f.IsGpuMachine() {
-		res = f.FlyAllowExitFailure("machine update --vm-memory 256 %s --yes", firstMachine.ID)
-		require.Contains(f, res.StdErrString(), "memory size for config is too low")
-	}
+	res = f.FlyAllowExitFailure("machine update --vm-memory 256 %s --yes", firstMachine.ID)
+	require.Contains(f, res.StdErrString(), "memory size for config is too low")
 
-	if !f.IsGpuMachine() {
-		res = f.FlyAllowExitFailure("machine update --vm-memory 16384 %s --yes", firstMachine.ID)
-		require.Contains(f, res.StdErrString(), "memory size for config is too high")
+	res = f.FlyAllowExitFailure("machine update --vm-memory 16384 %s --yes", firstMachine.ID)
+	require.Contains(f, res.StdErrString(), "memory size for config is too high")
 
-		res = f.FlyAllowExitFailure("machine update -a %s %s -y --wait-timeout 1 --vm-size performance-1x", appName, firstMachine.ID)
-		require.Contains(f, res.StdErrString(), "timeout reached waiting for machine's state to change")
-	}
+	res = f.FlyAllowExitFailure("machine update -a %s %s -y --wait-timeout 1 --vm-size performance-1x", appName, firstMachine.ID)
+	require.Contains(f, res.StdErrString(), "timeout reached waiting for machine's state to change")
 }
 
 func TestImageLabel(t *testing.T) {

--- a/test/preflight/testlib/test_env.go
+++ b/test/preflight/testlib/test_env.go
@@ -473,7 +473,3 @@ func (f *FlyctlTestEnv) Skipped() bool {
 func (f *FlyctlTestEnv) TempDir() string {
 	return f.t.TempDir()
 }
-
-func (f *FlyctlTestEnv) IsGpuMachine() bool {
-	return strings.Contains(f.VMSize, "a10") || strings.Contains(f.VMSize, "l40s")
-}


### PR DESCRIPTION
Removes the GPU surface from the CLI: the GPU validation, the MCP tool arguments that advertised GPUs, and the GPU table in `fly platform vm-sizes`. `--vm-gpus` and `--vm-gpu-kind` stay as hidden flags that now error out.

## Context

Fly no longer offers GPU machines. There are no GPU hosts left, and the Machines API now rejects any request whose guest carries `gpu_kind` or `gpus` with an HTTP 400, so anything flyctl advertised here could only ever end in a rejection from the API.

## Details

`--vm-gpus` and `--vm-gpu-kind` (and its `--vm-gpukind` alias) are kept rather than deleted, hidden from help and erroring in `GetMachineGuest` with a message matching the one the API returns. A script still passing one gets an explanation instead of `unknown flag`. `fly mcp launch` keeps forwarding both for the same reason — dropping them there would quietly launch a CPU machine instead of failing.

The MCP server tool definitions do lose their `vm-gpu-kind` / `vm-gpus` arguments, since there is no reason to keep offering them to a model.

The four GPU size presets (`a100-40gb`, `a100-80gb`, `l40s`, `a10`) live in fly-go's `MachinePresets`, which is out of scope for this change, so `fly platform vm-sizes` filters them out rather than deleting them. `--vm-size a100-40gb` still resolves to a guest and gets rejected by the API, which is the intended degradation.

Also drops the `IsGpuMachine()` branches in preflight, which only fired when the suite was pointed at a GPU VM size.
