### PR TITLE
Show Managed Postgres availability in `fly platform regions`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/superfly/client-signals/go v0.4.4
-	github.com/superfly/fly-go v0.9.2
+	github.com/superfly/fly-go v0.9.3
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -662,8 +662,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVuwVJGWndfmc8=
 github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
-github.com/superfly/fly-go v0.9.2 h1:eGleZZi3FeRt1CcG/qVbWnKoh+AbF9ut7dSr0AuiUxs=
-github.com/superfly/fly-go v0.9.2/go.mod h1:TOdS0mlGgPUvOlISm2SyaJPt3nWfCQwO8lD45DBvPbE=
+github.com/superfly/fly-go v0.9.3 h1:+ndPRF0q4m7UanKT0SA8f89XLtkKyo3OurRfbSEEW7g=
+github.com/superfly/fly-go v0.9.3/go.mod h1:XwR9oVL8t2N/0gVWkgA+SIw46hWIt79I+bLP2WXDmFI=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/command/platform/regions.go
+++ b/internal/command/platform/regions.go
@@ -70,9 +70,10 @@ func runRegions(ctx context.Context) error {
 			rows = append(rows, []string{
 				region.Name,
 				region.Code,
+				lo.Ternary(region.MPGAvailable, io.ColorScheme().SuccessIcon(), ""),
 			})
 		}
 	}
 
-	return render.Table(out, "", rows, "Name", "Code")
+	return render.Table(out, "", rows, "Name", "Code", "MPG")
 }

--- a/internal/command/platform/regions_test.go
+++ b/internal/command/platform/regions_test.go
@@ -76,7 +76,7 @@ func TestRunRegionsJSON(t *testing.T) {
 	require.NoError(t, runRegions(ctx))
 
 	var regions []map[string]any
-	require.NoError(t, json.Unmarshal([]byte(out.String()), &regions))
+	require.NoError(t, json.Unmarshal(out.Bytes(), &regions))
 	require.Len(t, regions, 2)
 
 	byCode := map[string]map[string]any{}

--- a/internal/command/platform/regions_test.go
+++ b/internal/command/platform/regions_test.go
@@ -1,0 +1,89 @@
+package platform
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/mock"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func regionsTestContext(jsonOutput bool) (context.Context, *bytes.Buffer) {
+	ios, _, out, _ := iostreams.Test()
+
+	ctx := context.Background()
+	ctx = iostreams.NewContext(ctx, ios)
+	ctx = config.NewContext(ctx, &config.Config{JSONOutput: jsonOutput})
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+		GetRegionsFunc: func(ctx context.Context) (*flaps.RegionData, error) {
+			return &flaps.RegionData{
+				Regions: []fly.Region{
+					{
+						Code:         "iad",
+						Name:         "Ashburn, Virginia (US)",
+						GeoRegion:    "north_america",
+						MPGAvailable: true,
+					},
+					{
+						Code:      "arn",
+						Name:      "Stockholm, Sweden",
+						GeoRegion: "europe",
+					},
+					{
+						Code:       "atl",
+						Name:       "Atlanta, Georgia (US)",
+						GeoRegion:  "north_america",
+						Deprecated: true,
+					},
+				},
+			}, nil
+		},
+	})
+
+	return ctx, out
+}
+
+func TestRunRegionsTable(t *testing.T) {
+	ctx, out := regionsTestContext(false)
+
+	require.NoError(t, runRegions(ctx))
+
+	output := out.String()
+	require.Contains(t, output, "MPG")
+	require.NotContains(t, output, "Atlanta")
+
+	for _, line := range strings.Split(output, "\n") {
+		switch {
+		case strings.Contains(line, "iad"):
+			require.Contains(t, line, "✓")
+		case strings.Contains(line, "arn"):
+			require.NotContains(t, line, "✓")
+		}
+	}
+}
+
+func TestRunRegionsJSON(t *testing.T) {
+	ctx, out := regionsTestContext(true)
+
+	require.NoError(t, runRegions(ctx))
+
+	var regions []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out.String()), &regions))
+	require.Len(t, regions, 2)
+
+	byCode := map[string]map[string]any{}
+	for _, r := range regions {
+		byCode[r["code"].(string)] = r
+	}
+
+	require.Equal(t, true, byCode["iad"]["mpg_available"])
+	require.Equal(t, false, byCode["arn"]["mpg_available"])
+}


### PR DESCRIPTION
# Note
I'll keep this PR as draft while I prepare a PR for superfly/docs

### Change Summary

What and Why:
`/v1/platform/regions` now reports where Managed Postgres is available, and through this PR I'm making sure that `fly platform regions` shows it too. The table gets an MPG column with a checkmark on the regions that have it, and `--json` gains a `mpg_available` field per region. Nothing else in the output changes.

<img width="471" height="652" alt="Screenshot 2026-08-10 at 10 14 07 PM" src="https://github.com/user-attachments/assets/8deee0de-7a9b-48ec-aa48-503598c47e41" />

How:
Adding the column requires the `fly-go` bump to v0.9.3, included here.

---

### Documentation

- [ ] Fresh Produce
- [x] In superfly/docs, or asked for help from docs team
- [ ] n/a

### Related PRs
- https://github.com/superfly/docs/pull/2459