### PR TITLE
Add --no-container to fly ssh console

### DIFF
--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -233,7 +233,7 @@ func runConsole(ctx context.Context) error {
 		consoleCommand = flag.GetString(ctx, "command")
 	}
 
-	return ssh.Console(ctx, sshClient, consoleCommand, true, params.Container)
+	return ssh.Console(ctx, sshClient, consoleCommand, true, ssh.SessionTarget{Container: params.Container})
 }
 
 func selectMachine(ctx context.Context, app *fly.AppCompact, appConfig *appconfig.Config) (*fly.Machine, func(), error) {

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -502,7 +502,7 @@ func runMachineRun(ctx context.Context) error {
 			return err
 		}
 
-		err = ssh.Console(ctx, sshClient, flag.GetString(ctx, "command"), true, "")
+		err = ssh.Console(ctx, sshClient, flag.GetString(ctx, "command"), true, ssh.SessionTarget{})
 		if destroy {
 			err = soManyErrors("console", err, "destroy machine", Destroy(ctx, app.Name, machine, true))
 		}

--- a/internal/command/postgres/barman.go
+++ b/internal/command/postgres/barman.go
@@ -498,7 +498,7 @@ func runConsole(ctx context.Context, cmd string) error {
 		return err
 	}
 
-	if err := ssh.Console(ctx, sshc, cmd, false, ""); err != nil {
+	if err := ssh.Console(ctx, sshc, cmd, false, ssh.SessionTarget{}); err != nil {
 		captureError(ctx, err, app)
 
 		return err

--- a/internal/command/ssh/connect.go
+++ b/internal/command/ssh/connect.go
@@ -27,7 +27,10 @@ type ConnectParams struct {
 	Dialer         agent.Dialer
 	DisableSpinner bool
 	Container      string
-	AppNames       []string
+	// Machine connects to the machine itself rather than to one of its
+	// containers. It is mutually exclusive with Container.
+	Machine  bool
+	AppNames []string
 }
 
 type OrganizationImpl interface {

--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -132,8 +132,18 @@ func newConsole() *cobra.Command {
 
 	stdArgsSSH(cmd)
 
+	flag.Add(cmd,
+		flag.Bool{
+			Name:        "no-container",
+			Description: "Connect to the machine itself rather than to one of its containers",
+		},
+	)
+
 	return cmd
 }
+
+// SessionTarget selects where a session runs on the remote machine.
+type SessionTarget = ssh.SessionTarget
 
 func captureError(ctx context.Context, err error, app *fly.AppCompact) {
 	// ignore cancelled errors
@@ -201,6 +211,7 @@ func runConsole(ctx context.Context) error {
 		Username:       flag.GetString(ctx, "user"),
 		DisableSpinner: quiet(ctx),
 		Container:      container,
+		Machine:        flag.GetBool(ctx, "no-container"),
 		AppNames:       []string{app.Name},
 	}
 	sshc, err := Connect(params, addr)
@@ -210,7 +221,9 @@ func runConsole(ctx context.Context) error {
 		return err
 	}
 
-	if err := Console(ctx, sshc, cmd, allocPTY, params.Container); err != nil {
+	target := SessionTarget{Container: params.Container, Machine: params.Machine}
+
+	if err := Console(ctx, sshc, cmd, allocPTY, target); err != nil {
 		captureError(ctx, err, app)
 
 		return err
@@ -219,7 +232,7 @@ func runConsole(ctx context.Context) error {
 	return nil
 }
 
-func Console(ctx context.Context, sshClient *ssh.Client, cmd string, allocPTY bool, container string) error {
+func Console(ctx context.Context, sshClient *ssh.Client, cmd string, allocPTY bool, target SessionTarget) error {
 	currentStdin, currentStdout, currentStderr, err := setupConsole()
 	defer func() error {
 		if err := cleanupConsole(currentStdin, currentStdout, currentStderr); err != nil {
@@ -241,7 +254,7 @@ func Console(ctx context.Context, sshClient *ssh.Client, cmd string, allocPTY bo
 		TermEnv:  determineTermEnv(),
 	}
 
-	if err := sshClient.Shell(ctx, sessIO, cmd, container); err != nil {
+	if err := sshClient.Shell(ctx, sessIO, cmd, target); err != nil {
 		return errors.Wrap(err, "ssh shell")
 	}
 
@@ -372,6 +385,15 @@ func selectMachine(ctx context.Context, app *fly.AppCompact) (machine *fly.Machi
 func selectContainer(ctx context.Context, machine *fly.Machine) (container string, err error) {
 	containers := machine.Config.Containers
 	container = flag.GetString(ctx, "container")
+
+	// --no-container asks for the machine itself, so there is nothing to select.
+	if flag.GetBool(ctx, "no-container") {
+		if container != "" {
+			return "", errors.New("--container and --no-container are mutually exclusive")
+		}
+
+		return "", nil
+	}
 
 	if len(containers) == 0 {
 		if container == "" {

--- a/internal/command/ssh/console_test.go
+++ b/internal/command/ssh/console_test.go
@@ -1,0 +1,101 @@
+package ssh
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/flag"
+)
+
+func sshFlagContext(t *testing.T, args ...string) context.Context {
+	t.Helper()
+
+	fs := pflag.NewFlagSet("ssh", pflag.ContinueOnError)
+	fs.String("container", "", "")
+	fs.Bool("no-container", false, "")
+	fs.Bool("select", false, "")
+
+	require.NoError(t, fs.Parse(args))
+
+	return flag.NewContext(context.Background(), fs)
+}
+
+func TestSelectContainer(t *testing.T) {
+	withContainers := &fly.Machine{
+		ID: "3d8d9d16f14683",
+		Config: &fly.MachineConfig{
+			Containers: []*fly.ContainerConfig{
+				{Name: "app"},
+				{Name: "sidecar"},
+			},
+		},
+	}
+
+	withoutContainers := &fly.Machine{
+		ID:     "9080e6e2f24d83",
+		Config: &fly.MachineConfig{},
+	}
+
+	for _, tc := range []struct {
+		name      string
+		machine   *fly.Machine
+		args      []string
+		expect    string
+		expectErr string
+	}{
+		{
+			name:    "defaults to the first container",
+			machine: withContainers,
+			expect:  "app",
+		},
+		{
+			name:    "named container",
+			machine: withContainers,
+			args:    []string{"--container", "sidecar"},
+			expect:  "sidecar",
+		},
+		{
+			// The machine itself, so there is no container to select.
+			name:    "no container",
+			machine: withContainers,
+			args:    []string{"--no-container"},
+			expect:  "",
+		},
+		{
+			name:      "no container with a named container",
+			machine:   withContainers,
+			args:      []string{"--no-container", "--container", "app"},
+			expectErr: "--container and --no-container are mutually exclusive",
+		},
+		{
+			name:    "no container on a machine without containers",
+			machine: withoutContainers,
+			args:    []string{"--no-container"},
+			expect:  "",
+		},
+		{
+			name:      "unknown container",
+			machine:   withContainers,
+			args:      []string{"--container", "nope"},
+			expectErr: "container named nope is not present in machine 3d8d9d16f14683, try running with --select to see a list",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := sshFlagContext(t, tc.args...)
+
+			container, err := selectContainer(ctx, tc.machine)
+			if tc.expectErr != "" {
+				require.EqualError(t, err, tc.expectErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expect, container)
+		})
+	}
+}

--- a/internal/command/ssh/ssh_terminal.go
+++ b/internal/command/ssh/ssh_terminal.go
@@ -115,7 +115,7 @@ func SSHConnect(p *SSHParams, addr string) error {
 		TermEnv:  "xterm",
 	}
 
-	if err := sshClient.Shell(context.Background(), sessIO, p.Cmd, ""); err != nil {
+	if err := sshClient.Shell(context.Background(), sessIO, p.Cmd, ssh.SessionTarget{}); err != nil {
 		return errors.Wrap(err, "ssh shell")
 	}
 

--- a/ssh/client.go
+++ b/ssh/client.go
@@ -107,7 +107,30 @@ func (c *Client) Connect(ctx context.Context) error {
 	}
 }
 
-func (c *Client) Shell(ctx context.Context, sessIO *SessionIO, cmd string, container string) error {
+// SessionTarget selects where a session runs on the remote machine.
+type SessionTarget struct {
+	// Container names the container to run in. When empty, the machine decides
+	// where the session lands.
+	Container string
+
+	// Machine runs the session in the machine's own namespace instead of in a
+	// container. It is mutually exclusive with Container.
+	Machine bool
+}
+
+func (t SessionTarget) validate() error {
+	if t.Machine && t.Container != "" {
+		return errors.New("session cannot target both a container and the machine")
+	}
+
+	return nil
+}
+
+func (c *Client) Shell(ctx context.Context, sessIO *SessionIO, cmd string, target SessionTarget) error {
+	if err := target.validate(); err != nil {
+		return err
+	}
+
 	if c.Client == nil {
 		if err := c.Connect(ctx); err != nil {
 			return err
@@ -120,14 +143,18 @@ func (c *Client) Shell(ctx context.Context, sessIO *SessionIO, cmd string, conta
 		return err
 	}
 
-	if container != "" {
-		err = sess.Setenv("FLY_SSH_CONTAINER", container)
-		if err != nil {
+	defer sess.Close()
+
+	switch {
+	case target.Machine:
+		if err := sess.Setenv("FLY_SSH_MACHINE", "1"); err != nil {
+			return err
+		}
+	case target.Container != "":
+		if err := sess.Setenv("FLY_SSH_CONTAINER", target.Container); err != nil {
 			return err
 		}
 	}
-
-	defer sess.Close()
 
 	return sessIO.attach(ctx, sess, cmd)
 }

--- a/ssh/client_test.go
+++ b/ssh/client_test.go
@@ -1,0 +1,42 @@
+package ssh
+
+import "testing"
+
+func TestSessionTargetValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		target  SessionTarget
+		wantErr bool
+	}{
+		{
+			// The machine decides where the session lands.
+			name: "neither",
+		},
+		{
+			name:   "container",
+			target: SessionTarget{Container: "app"},
+		},
+		{
+			name:   "machine",
+			target: SessionTarget{Machine: true},
+		},
+		{
+			// Mutually exclusive: rejected rather than silently preferring one.
+			name:    "both",
+			target:  SessionTarget{Container: "app", Machine: true},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.target.validate()
+
+			if tc.wantErr && err == nil {
+				t.Fatal("expected an error, got none")
+			}
+
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
On a machine that has containers, `fly ssh console` always lands you inside one: the only container, the first of several, or one you choose under `--select`. There was no way to ask for the machine itself, which is what you get on a machine without containers.

`--no-container` asks for the machine's own namespace:

```
fly ssh console --no-container
```

Passing it together with `--container` is an error.

### Behaviour

- Without the flag nothing changes.
- The flag sends an explicit opt-in to the machine rather than just omitting the container, so a hand-rolled SSH client using a cert from `fly ssh issue` is unaffected — it sets no environment and keeps landing where it does today.
- Against a machine running an older platform version the session is refused with an error rather than silently dropping you in a container.

### Notes for the reviewer

- `ssh.Console` and `ssh.Client.Shell` take a `SessionTarget` in place of the trailing container name, since the container and the machine-namespace choice are mutually exclusive and belong together. Both are exported; this changes their signatures.
- `SessionTarget` now rejects a target that sets both rather than quietly preferring one, and `Shell` defers `Close()` immediately after opening the session — previously an error from `Setenv` could return without closing it.
- `fly sftp` on a machine with containers already reads the machine's own filesystem rather than a container's. This PR does not change that, but it is worth knowing when comparing the two surfaces.

`fly machine exec` gets the same flag separately in superfly/flyctl#5077.