### PR TITLE
Add --container and --no-container to fly machine exec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/superfly/client-signals/go v0.4.4
-	github.com/superfly/fly-go v0.9.3
+	github.com/superfly/fly-go v0.9.4
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -662,8 +662,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVuwVJGWndfmc8=
 github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
-github.com/superfly/fly-go v0.9.3 h1:+ndPRF0q4m7UanKT0SA8f89XLtkKyo3OurRfbSEEW7g=
-github.com/superfly/fly-go v0.9.3/go.mod h1:XwR9oVL8t2N/0gVWkgA+SIw46hWIt79I+bLP2WXDmFI=
+github.com/superfly/fly-go v0.9.4 h1:lhIVm6xbEu75mpLiCltcu5wldHybEKpSsj3ULLwJSVo=
+github.com/superfly/fly-go v0.9.4/go.mod h1:hym5J4lJz5MWPodZN2ZjZSjkIWfgbfYgphdTZAm/eV8=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/command/machine/exec.go
+++ b/internal/command/machine/exec.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -37,6 +38,14 @@ func newMachineExec() *cobra.Command {
 			Name:        "timeout",
 			Description: "Timeout in seconds",
 		},
+		flag.String{
+			Name:        "container",
+			Description: "Container to run the command in",
+		},
+		flag.Bool{
+			Name:        "no-container",
+			Description: "Run the command on the machine itself rather than in one of its containers",
+		},
 	)
 
 	cmd.Args = cobra.RangeArgs(1, 2)
@@ -63,6 +72,13 @@ func runMachineExec(ctx context.Context) (err error) {
 		command = args[0]
 	}
 
+	container := flag.GetString(ctx, "container")
+	noContainer := flag.GetBool(ctx, "no-container")
+
+	if container != "" && noContainer {
+		return errors.New("--container and --no-container are mutually exclusive")
+	}
+
 	current, ctx, err := selectOneMachine(ctx, "", machineID, haveMachineID)
 	if err != nil {
 		return err
@@ -75,8 +91,10 @@ func runMachineExec(ctx context.Context) (err error) {
 	timeout := flag.GetInt(ctx, "timeout")
 
 	in := &fly.MachineExecRequest{
-		Cmd:     command,
-		Timeout: timeout,
+		Cmd:       command,
+		Container: container,
+		Machine:   noContainer,
+		Timeout:   timeout,
 	}
 
 	out, err := flapsClient.Exec(ctx, appName, current.ID, in)


### PR DESCRIPTION
`fly machine exec` has never had a way to choose where a command runs. It sets no container on the request, so on a machine with containers it lands in whichever one the platform picks first, and there is no way to reach the machine itself.

This adds both halves of that choice:

```
fly machine exec --container app "ps aux"
fly machine exec --no-container "ps aux"
```

`--container` names one. `--no-container` asks for the machine's own namespace instead — the same flag, meaning the same thing, as on `fly ssh console` (superfly/flyctl#5075). Passing both is an error.

### Behaviour

- Without either flag nothing changes.
- Against a machine running an older platform version, `--no-container` is ignored and the command runs in a container as it does today. That is the one silent case in this change: the request field is simply unknown to the older API, so it cannot report the mismatch. The platform-side support needs to have rolled out before this is relied on.

The `machine` request field comes from superfly/fly-go#276, released in fly-go v0.9.4; the second commit here bumps go.mod to it.
