### PR TITLE
Add listen address check timeout with grace period support

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -1260,6 +1260,59 @@ func (md *machineDeployment) warnAboutProcessGroupChanges(diff ProcessGroupsDiff
 	fmt.Fprint(md.io.Out, "\n")
 }
 
+// defaultListenAddressCheckTimeout is the minimum time we'll wait for an app
+// to expose its expected listen addresses before warning that it isn't
+// listening. This exists because some frameworks (e.g. Rails/Puma,
+// NodeJS+puppeteer) take several seconds to bind after the machine is
+// considered started, especially on first boot. Warning immediately produces
+// false positives such as the one reported in
+// https://github.com/superfly/flyctl/issues/3358.
+//
+// When the user has configured any check with a longer `grace_period` (in
+// `[checks]`, `[[services.tcp_checks]]`, `[[services.http_checks]]`, or
+// `[[http_service.checks]]`) we honour that instead, on the theory that the
+// grace period is the user's own declaration of "my app can take this long to
+// come up." See listenAddressCheckTimeoutFor.
+var defaultListenAddressCheckTimeout = 15 * time.Second
+
+// listenAddressCheckTimeoutFor returns how long warnAboutIncorrectListenAddress
+// should poll before giving up and printing the warning. It takes the max of
+// defaultListenAddressCheckTimeout and the largest configured grace_period on
+// any check (top-level, service TCP/HTTP, or http_service) so that users who
+// explicitly opt into a long startup window aren't warned prematurely.
+func listenAddressCheckTimeoutFor(cfg *appconfig.Config) time.Duration {
+	timeout := defaultListenAddressCheckTimeout
+	if cfg == nil {
+		return timeout
+	}
+
+	consider := func(d *fly.Duration) {
+		if d != nil && d.Duration > timeout {
+			timeout = d.Duration
+		}
+	}
+
+	for _, chk := range cfg.Checks {
+		if chk != nil {
+			consider(chk.GracePeriod)
+		}
+	}
+	for _, svc := range cfg.AllServices() {
+		for _, c := range svc.TCPChecks {
+			if c != nil {
+				consider(c.GracePeriod)
+			}
+		}
+		for _, c := range svc.HTTPChecks {
+			if c != nil {
+				consider(c.GracePeriod)
+			}
+		}
+	}
+
+	return timeout
+}
+
 func (md *machineDeployment) warnAboutIncorrectListenAddress(ctx context.Context, lm machine.LeasableMachine) {
 	group := lm.Machine().ProcessGroup()
 
@@ -1273,42 +1326,25 @@ func (md *machineDeployment) warnAboutIncorrectListenAddress(ctx context.Context
 	}
 	services := groupConfig.AllServices()
 
-	tcpServices := make(map[int]struct{})
+	expectedTCPPorts := make(map[int]struct{})
 	for _, s := range services {
 		if s.Protocol == "tcp" {
-			tcpServices[s.InternalPort] = struct{}{}
+			expectedTCPPorts[s.InternalPort] = struct{}{}
 		}
 	}
 
-	processes, err := md.flapsClient.GetProcesses(ctx, md.app.Name, lm.Machine().ID)
-	// Let's not fail the whole deployment because of this, as listen address check is just a warning
-	if err != nil {
+	// If there are no TCP services expected, there's nothing to warn about.
+	if len(expectedTCPPorts) == 0 {
 		return
 	}
 
-	var foundSockets int
-	for _, proc := range processes {
-		for _, ls := range proc.ListenSockets {
-			foundSockets += 1
-
-			host, portStr, err := net.SplitHostPort(ls.Address)
-			if err != nil {
-				continue
-			}
-			port, err := strconv.Atoi(portStr)
-			if err != nil {
-				continue
-			}
-
-			ip := net.ParseIP(host)
-
-			// We don't know VM's internal ipv4 which is also a valid address to bind to.
-			// Let's assume that whoever binds to a non-loopback address knows what they are doing.
-			// If we expose this address to flyctl later, we can revisit this logic.
-			if !ip.IsLoopback() {
-				delete(tcpServices, port)
-			}
-		}
+	// Poll for a while to give the app a chance to bind before warning.
+	// Slow-starting apps (Rails/Puma, Node/puppeteer, JVM apps) may take several
+	// seconds to open their listening sockets after the machine reports started.
+	timeout := listenAddressCheckTimeoutFor(groupConfig)
+	processes, uncoveredPorts, foundSockets, ok := md.waitForExpectedListenAddresses(ctx, lm, expectedTCPPorts, timeout)
+	if !ok {
+		return
 	}
 
 	// This can either mean that nothing is listening or that VM is running old init that doesn't expose
@@ -1319,13 +1355,13 @@ func (md *machineDeployment) warnAboutIncorrectListenAddress(ctx context.Context
 	}
 
 	// All services are covered
-	if len(tcpServices) == 0 {
+	if len(uncoveredPorts) == 0 {
 		return
 	}
 
 	fmt.Fprintf(md.io.ErrOut, "\n%s The app is not listening on the expected address and will not be reachable by fly-proxy.\n", md.colorize.Yellow("WARNING"))
 	fmt.Fprintf(md.io.ErrOut, "You can fix this by configuring your app to listen on the following addresses:\n")
-	for port := range tcpServices {
+	for port := range uncoveredPorts {
 		fmt.Fprintf(md.io.ErrOut, "  - %s\n", md.colorize.Green("0.0.0.0:"+strconv.Itoa(port)))
 	}
 	fmt.Fprintf(md.io.ErrOut, "Found these processes inside the machine with open listening sockets:\n")
@@ -1344,6 +1380,101 @@ func (md *machineDeployment) warnAboutIncorrectListenAddress(ctx context.Context
 	}
 	table.Render() //nolint:errcheck
 	fmt.Fprintf(md.io.ErrOut, "\n")
+}
+
+// waitForExpectedListenAddresses polls the machine's process list and returns
+// once every expected TCP port has an open non-loopback listener, or the
+// caller-provided timeout elapses. It returns the final process snapshot,
+// the set of expected ports that are still uncovered, the total number of
+// listening sockets observed on the machine, and whether the check completed
+// successfully (false only when GetProcesses failed and we should stay silent).
+func (md *machineDeployment) waitForExpectedListenAddresses(
+	ctx context.Context,
+	lm machine.LeasableMachine,
+	expectedTCPPorts map[int]struct{},
+	timeout time.Duration,
+) (fly.MachinePsResponse, map[int]struct{}, int, bool) {
+	b := &backoff.ExponentialBackOff{
+		InitialInterval:     500 * time.Millisecond,
+		RandomizationFactor: 0.2,
+		Multiplier:          1.5,
+		MaxInterval:         2 * time.Second,
+	}
+	b.Reset()
+
+	deadline := time.Now().Add(timeout)
+
+	var (
+		processes      fly.MachinePsResponse
+		uncoveredPorts map[int]struct{}
+		foundSockets   int
+	)
+
+	for {
+		var err error
+		processes, err = md.flapsClient.GetProcesses(ctx, md.app.Name, lm.Machine().ID)
+		// Let's not fail the whole deployment because of this, as listen address check is just a warning
+		if err != nil {
+			return nil, nil, 0, false
+		}
+
+		uncoveredPorts = make(map[int]struct{}, len(expectedTCPPorts))
+		for port := range expectedTCPPorts {
+			uncoveredPorts[port] = struct{}{}
+		}
+
+		foundSockets = 0
+		for _, proc := range processes {
+			for _, ls := range proc.ListenSockets {
+				foundSockets++
+
+				host, portStr, err := net.SplitHostPort(ls.Address)
+				if err != nil {
+					continue
+				}
+				port, err := strconv.Atoi(portStr)
+				if err != nil {
+					continue
+				}
+
+				ip := net.ParseIP(host)
+
+				// We don't know VM's internal ipv4 which is also a valid address to bind to.
+				// Let's assume that whoever binds to a non-loopback address knows what they are doing.
+				// If we expose this address to flyctl later, we can revisit this logic.
+				if !ip.IsLoopback() {
+					delete(uncoveredPorts, port)
+				}
+			}
+		}
+
+		// Success: every expected TCP port is covered by a non-loopback listener.
+		if len(uncoveredPorts) == 0 {
+			return processes, uncoveredPorts, foundSockets, true
+		}
+
+		// If we're out of time, return the last snapshot so the caller can warn.
+		if !time.Now().Before(deadline) {
+			return processes, uncoveredPorts, foundSockets, true
+		}
+
+		wait := b.NextBackOff()
+		if wait <= 0 {
+			wait = 500 * time.Millisecond
+		}
+		if remaining := time.Until(deadline); remaining < wait {
+			wait = remaining
+		}
+		if wait <= 0 {
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return processes, uncoveredPorts, foundSockets, false
+		case <-time.After(wait):
+		}
+	}
 }
 
 type smokeChecksError struct {

--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -39,6 +39,11 @@ type mockFlapsClient struct {
 	// an unreachable host returning an empty ImageRef).
 	GetFunc func(ctx context.Context, appName, machineID string) (*fly.Machine, error)
 
+	// GetProcessesFunc, when set, overrides the default GetProcesses behaviour.
+	// Useful for tests that simulate an app slowly binding to its listening
+	// sockets (see warnAboutIncorrectListenAddress).
+	GetProcessesFunc func(ctx context.Context, appName, machineID string) (fly.MachinePsResponse, error)
+
 	// uncordonTransientFailures causes Uncordon to fail this many times before
 	// succeeding, simulating transient API errors for retry tests.
 	uncordonTransientFailures int
@@ -222,6 +227,13 @@ func (m *mockFlapsClient) GetPlacements(ctx context.Context, req *flaps.GetPlace
 }
 
 func (m *mockFlapsClient) GetProcesses(ctx context.Context, appName, machineID string) (fly.MachinePsResponse, error) {
+	m.mu.Lock()
+	fn := m.GetProcessesFunc
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, appName, machineID)
+	}
+
 	return nil, fmt.Errorf("failed to get processes for %s", machineID)
 }
 

--- a/internal/command/deploy/warn_listen_address_test.go
+++ b/internal/command/deploy/warn_listen_address_test.go
@@ -1,0 +1,372 @@
+package deploy
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/machine"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+// newListenAddressDeployment builds a machineDeployment sized down for testing
+// warnAboutIncorrectListenAddress. The app is configured with a single TCP
+// service on port 3000 (the same shape as the fly.toml in
+// https://github.com/superfly/flyctl/issues/3358).
+func newListenAddressDeployment(t *testing.T, client *mockFlapsClient) (*machineDeployment, *iostreams.IOStreams, func() string) {
+	t.Helper()
+
+	ios, _, _, stderr := iostreams.Test()
+
+	cfg := appconfig.NewConfig()
+	cfg.AppName = "test-app"
+	cfg.HTTPService = &appconfig.HTTPService{InternalPort: 3000}
+	require.NoError(t, cfg.SetMachinesPlatform())
+
+	md := &machineDeployment{
+		app:         &flaps.App{Name: "test-app"},
+		io:          ios,
+		colorize:    ios.ColorScheme(),
+		flapsClient: client,
+		appConfig:   cfg,
+	}
+
+	return md, ios, func() string { return stderr.String() }
+}
+
+func processesWithListener(port int) fly.MachinePsResponse {
+	return fly.MachinePsResponse{
+		{
+			Pid:     1,
+			Command: "puma",
+			ListenSockets: []fly.ListenSocket{
+				{Proto: "tcp", Address: "0.0.0.0:" + strconv.Itoa(port)},
+			},
+		},
+	}
+}
+
+func processesWithoutListener() fly.MachinePsResponse {
+	return fly.MachinePsResponse{
+		{
+			Pid:     1,
+			Command: "puma",
+			// The init still reports SSH etc. so we get a non-zero foundSockets
+			// value, otherwise the old-init fallback path would kick in and hide
+			// the warning entirely.
+			ListenSockets: []fly.ListenSocket{
+				{Proto: "tcp", Address: "127.0.0.1:22"},
+			},
+		},
+	}
+}
+
+// TestWarnAboutIncorrectListenAddress_WaitsForSlowBind is the regression test
+// for https://github.com/superfly/flyctl/issues/3358. Apps like Rails/Puma or
+// NodeJS+puppeteer can take several seconds to bind after the machine is
+// considered started. flyctl used to warn "The app is not listening on the
+// expected address" the first time it looked, before the app had a chance to
+// bind. This test simulates a slow bind and asserts that no warning is emitted.
+func TestWarnAboutIncorrectListenAddress_WaitsForSlowBind(t *testing.T) {
+	// Give the polling loop enough time to observe the delayed bind.
+	prev := defaultListenAddressCheckTimeout
+	defaultListenAddressCheckTimeout = 5 * time.Second
+	t.Cleanup(func() { defaultListenAddressCheckTimeout = prev })
+
+	var calls atomic.Int32
+	// Simulate an app that hasn't bound to its port yet for the first few
+	// polls, then binds to 0.0.0.0:3000.
+	client := &mockFlapsClient{
+		GetProcessesFunc: func(ctx context.Context, appName, machineID string) (fly.MachinePsResponse, error) {
+			n := calls.Add(1)
+			if n < 3 {
+				return processesWithoutListener(), nil
+			}
+
+			return processesWithListener(3000), nil
+		},
+	}
+
+	md, ios, stderr := newListenAddressDeployment(t, client)
+	lm := machine.NewLeasableMachine(client, ios, "test-app", &fly.Machine{ID: "m1"}, false)
+
+	md.warnAboutIncorrectListenAddress(context.Background(), lm)
+
+	assert.NotContains(t, stderr(), "not listening on the expected address",
+		"warning should be suppressed once the app binds; got: %s", stderr())
+	assert.GreaterOrEqual(t, calls.Load(), int32(3),
+		"polling should retry until the expected address appears")
+}
+
+// TestWarnAboutIncorrectListenAddress_SucceedsImmediately covers the fast
+// path where the app is already listening on the expected address by the time
+// we check. We should not spend any time polling in this case.
+func TestWarnAboutIncorrectListenAddress_SucceedsImmediately(t *testing.T) {
+	prev := defaultListenAddressCheckTimeout
+	defaultListenAddressCheckTimeout = 5 * time.Second
+	t.Cleanup(func() { defaultListenAddressCheckTimeout = prev })
+
+	var calls atomic.Int32
+	client := &mockFlapsClient{
+		GetProcessesFunc: func(ctx context.Context, appName, machineID string) (fly.MachinePsResponse, error) {
+			calls.Add(1)
+
+			return processesWithListener(3000), nil
+		},
+	}
+
+	md, ios, stderr := newListenAddressDeployment(t, client)
+	lm := machine.NewLeasableMachine(client, ios, "test-app", &fly.Machine{ID: "m1"}, false)
+
+	start := time.Now()
+	md.warnAboutIncorrectListenAddress(context.Background(), lm)
+	elapsed := time.Since(start)
+
+	assert.NotContains(t, stderr(), "not listening on the expected address")
+	assert.Equal(t, int32(1), calls.Load(),
+		"should only poll once when the address is already listening")
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"the happy path should return quickly, took %s", elapsed)
+}
+
+// TestWarnAboutIncorrectListenAddress_WarnsAfterTimeout ensures that if the
+// app truly never binds to the expected address, we still emit the warning
+// with the port that is missing.
+func TestWarnAboutIncorrectListenAddress_WarnsAfterTimeout(t *testing.T) {
+	prev := defaultListenAddressCheckTimeout
+	// Keep the timeout small so the test runs quickly but still exercises the
+	// polling loop.
+	defaultListenAddressCheckTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { defaultListenAddressCheckTimeout = prev })
+
+	client := &mockFlapsClient{
+		GetProcessesFunc: func(ctx context.Context, appName, machineID string) (fly.MachinePsResponse, error) {
+			return processesWithoutListener(), nil
+		},
+	}
+
+	md, ios, stderr := newListenAddressDeployment(t, client)
+	lm := machine.NewLeasableMachine(client, ios, "test-app", &fly.Machine{ID: "m1"}, false)
+
+	md.warnAboutIncorrectListenAddress(context.Background(), lm)
+
+	assert.Contains(t, stderr(), "not listening on the expected address")
+	assert.Contains(t, stderr(), "0.0.0.0:3000",
+		"the missing port should be reported in the warning")
+}
+
+// TestWarnAboutIncorrectListenAddress_OnlyChecksOncePerGroup verifies that
+// the sync.Map-based caching still works: a second call for the same process
+// group should be a no-op even if we would otherwise poll.
+func TestWarnAboutIncorrectListenAddress_OnlyChecksOncePerGroup(t *testing.T) {
+	prev := defaultListenAddressCheckTimeout
+	defaultListenAddressCheckTimeout = 5 * time.Second
+	t.Cleanup(func() { defaultListenAddressCheckTimeout = prev })
+
+	var calls atomic.Int32
+	client := &mockFlapsClient{
+		GetProcessesFunc: func(ctx context.Context, appName, machineID string) (fly.MachinePsResponse, error) {
+			calls.Add(1)
+
+			return processesWithListener(3000), nil
+		},
+	}
+
+	md, ios, _ := newListenAddressDeployment(t, client)
+	lm := machine.NewLeasableMachine(client, ios, "test-app", &fly.Machine{ID: "m1"}, false)
+
+	md.warnAboutIncorrectListenAddress(context.Background(), lm)
+	md.warnAboutIncorrectListenAddress(context.Background(), lm)
+
+	assert.Equal(t, int32(1), calls.Load(),
+		"the second call for the same process group should short-circuit")
+}
+
+// TestListenAddressCheckTimeoutFor_UsesLongestGracePeriod verifies that when
+// the user has configured a check with a `grace_period` larger than the
+// default polling window, we honour it. This matters for apps that legitimately
+// take a long time to boot: the user has already told us how long, so we
+// should trust that value rather than fire a spurious "not listening" warning.
+func TestListenAddressCheckTimeoutFor_UsesLongestGracePeriod(t *testing.T) {
+	prev := defaultListenAddressCheckTimeout
+	defaultListenAddressCheckTimeout = 5 * time.Second
+	t.Cleanup(func() { defaultListenAddressCheckTimeout = prev })
+
+	t.Run("nil config falls back to default", func(t *testing.T) {
+		assert.Equal(t, defaultListenAddressCheckTimeout, listenAddressCheckTimeoutFor(nil))
+	})
+
+	t.Run("no checks configured falls back to default", func(t *testing.T) {
+		cfg := appconfig.NewConfig()
+		cfg.HTTPService = &appconfig.HTTPService{InternalPort: 3000}
+		require.NoError(t, cfg.SetMachinesPlatform())
+
+		assert.Equal(t, defaultListenAddressCheckTimeout, listenAddressCheckTimeoutFor(cfg))
+	})
+
+	t.Run("shorter grace period does not lower the default", func(t *testing.T) {
+		cfg := appconfig.NewConfig()
+		cfg.HTTPService = &appconfig.HTTPService{
+			InternalPort: 3000,
+			HTTPChecks: []*appconfig.ServiceHTTPCheck{
+				{GracePeriod: fly.MustParseDuration("2s")},
+			},
+		}
+		require.NoError(t, cfg.SetMachinesPlatform())
+
+		assert.Equal(t, defaultListenAddressCheckTimeout, listenAddressCheckTimeoutFor(cfg))
+	})
+
+	t.Run("http_service check grace period is honoured", func(t *testing.T) {
+		cfg := appconfig.NewConfig()
+		cfg.HTTPService = &appconfig.HTTPService{
+			InternalPort: 3000,
+			HTTPChecks: []*appconfig.ServiceHTTPCheck{
+				{GracePeriod: fly.MustParseDuration("45s")},
+			},
+		}
+		require.NoError(t, cfg.SetMachinesPlatform())
+
+		assert.Equal(t, 45*time.Second, listenAddressCheckTimeoutFor(cfg))
+	})
+
+	t.Run("top-level [checks] grace period is honoured", func(t *testing.T) {
+		cfg := appconfig.NewConfig()
+		cfg.HTTPService = &appconfig.HTTPService{InternalPort: 3000}
+		cfg.Checks = map[string]*appconfig.ToplevelCheck{
+			"alive": {GracePeriod: fly.MustParseDuration("90s")},
+		}
+		require.NoError(t, cfg.SetMachinesPlatform())
+
+		assert.Equal(t, 90*time.Second, listenAddressCheckTimeoutFor(cfg))
+	})
+
+	t.Run("service tcp_checks grace period is honoured", func(t *testing.T) {
+		cfg := appconfig.NewConfig()
+		cfg.Services = []appconfig.Service{{
+			Protocol:     "tcp",
+			InternalPort: 5432,
+			TCPChecks: []*appconfig.ServiceTCPCheck{
+				{GracePeriod: fly.MustParseDuration("30s")},
+			},
+		}}
+		require.NoError(t, cfg.SetMachinesPlatform())
+
+		assert.Equal(t, 30*time.Second, listenAddressCheckTimeoutFor(cfg))
+	})
+
+	t.Run("largest grace period across checks wins", func(t *testing.T) {
+		cfg := appconfig.NewConfig()
+		cfg.HTTPService = &appconfig.HTTPService{
+			InternalPort: 3000,
+			HTTPChecks: []*appconfig.ServiceHTTPCheck{
+				{GracePeriod: fly.MustParseDuration("20s")},
+				{GracePeriod: fly.MustParseDuration("60s")},
+			},
+		}
+		cfg.Checks = map[string]*appconfig.ToplevelCheck{
+			"alive": {GracePeriod: fly.MustParseDuration("40s")},
+		}
+		require.NoError(t, cfg.SetMachinesPlatform())
+
+		assert.Equal(t, 60*time.Second, listenAddressCheckTimeoutFor(cfg))
+	})
+}
+
+// TestWarnAboutIncorrectListenAddress_HonorsGracePeriod is an end-to-end check
+// that ties the grace-period plumbing to the polling loop. It configures a
+// grace_period of 2s, then feeds a mock that only reports a bound listener
+// after ~1s. With the default 5ms timeout in this test, the poll would give
+// up long before the bind; with grace_period honoured, it should wait and
+// suppress the warning.
+func TestWarnAboutIncorrectListenAddress_HonorsGracePeriod(t *testing.T) {
+	prev := defaultListenAddressCheckTimeout
+	// Set the default extremely low so the test only passes if grace_period is
+	// actually being consulted.
+	defaultListenAddressCheckTimeout = 5 * time.Millisecond
+	t.Cleanup(func() { defaultListenAddressCheckTimeout = prev })
+
+	start := time.Now()
+	client := &mockFlapsClient{
+		GetProcessesFunc: func(ctx context.Context, appName, machineID string) (fly.MachinePsResponse, error) {
+			if time.Since(start) < 1*time.Second {
+				return processesWithoutListener(), nil
+			}
+
+			return processesWithListener(3000), nil
+		},
+	}
+
+	ios, _, _, stderr := iostreams.Test()
+	cfg := appconfig.NewConfig()
+	cfg.AppName = "test-app"
+	cfg.HTTPService = &appconfig.HTTPService{
+		InternalPort: 3000,
+		HTTPChecks: []*appconfig.ServiceHTTPCheck{
+			{GracePeriod: fly.MustParseDuration("2s")},
+		},
+	}
+	require.NoError(t, cfg.SetMachinesPlatform())
+
+	md := &machineDeployment{
+		app:         &flaps.App{Name: "test-app"},
+		io:          ios,
+		colorize:    ios.ColorScheme(),
+		flapsClient: client,
+		appConfig:   cfg,
+	}
+	lm := machine.NewLeasableMachine(client, ios, "test-app", &fly.Machine{ID: "m1"}, false)
+
+	md.warnAboutIncorrectListenAddress(context.Background(), lm)
+
+	assert.NotContains(t, stderr.String(), "not listening on the expected address",
+		"grace_period should extend the polling window so slow-binding apps aren't flagged; got: %s", stderr.String())
+}
+
+// TestWarnAboutIncorrectListenAddress_HonorsContextCancellation asserts that
+// the polling loop bails out promptly if the caller's context is cancelled
+// (e.g. the user hit Ctrl-C during deploy).
+func TestWarnAboutIncorrectListenAddress_HonorsContextCancellation(t *testing.T) {
+	prev := defaultListenAddressCheckTimeout
+	defaultListenAddressCheckTimeout = 30 * time.Second
+	t.Cleanup(func() { defaultListenAddressCheckTimeout = prev })
+
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	client := &mockFlapsClient{
+		GetProcessesFunc: func(ctx context.Context, appName, machineID string) (fly.MachinePsResponse, error) {
+			mu.Lock()
+			calls++
+			mu.Unlock()
+
+			return processesWithoutListener(), nil
+		},
+	}
+
+	md, ios, _ := newListenAddressDeployment(t, client)
+	lm := machine.NewLeasableMachine(client, ios, "test-app", &fly.Machine{ID: "m1"}, false)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel shortly after we start to interrupt the polling loop.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	md.warnAboutIncorrectListenAddress(ctx, lm)
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 5*time.Second,
+		"cancelled context should cut the polling short, took %s", elapsed)
+}

--- a/test/preflight/fly_deploy_test.go
+++ b/test/preflight/fly_deploy_test.go
@@ -159,6 +159,56 @@ ENV PREFLIGHT_TEST=true`)
 	}, 30*time.Second, 2*time.Second)
 }
 
+// TestFlyDeploy_SlowBind_NoFalseListenWarning is the regression test for
+// https://github.com/superfly/flyctl/issues/3358. Apps that take several
+// seconds to bind after boot (Rails/Puma, Node/puppeteer, JVM apps, ...) used
+// to trip flyctl's "The app is not listening on the expected address" warning
+// because the check ran the moment the machine reported "started", before
+// the user's process had a chance to open its listening socket.
+//
+// This test builds an image whose entrypoint sleeps for a few seconds before
+// starting nginx, deploys it without any explicit http_service checks (so the
+// health-check gate returns immediately), and asserts that no false positive
+// warning is emitted while the app is still binding.
+func TestFlyDeploy_SlowBind_NoFalseListenWarning(t *testing.T) {
+	f := testlib.NewTestEnvFromEnv(t)
+	appName := f.CreateRandomAppName()
+
+	// The sleep is chosen to be well within listenAddressCheckTimeout (15s) so
+	// the polling loop has a chance to observe the bind. It's also long enough
+	// to reliably reproduce the race on machines that would otherwise be fast
+	// enough to hide it.
+	f.WriteFile("Dockerfile", `FROM nginx
+RUN printf '#!/bin/sh\nsleep 8\nexec nginx -g "daemon off;"\n' > /start.sh && chmod +x /start.sh
+CMD ["/start.sh"]
+`)
+
+	// Launch without --now: we want to write a fly.toml with no http_service
+	// checks (matching the issue reporter's config) before the first deploy.
+	f.Fly("launch --org %s --name %s --region %s --internal-port 80 --ha=false --no-deploy", f.OrgSlug(), appName, f.PrimaryRegion())
+
+	f.WriteFlyToml(`app = %q
+primary_region = %q
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 80
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+`, appName, f.PrimaryRegion())
+
+	deployRes := f.Fly("deploy --buildkit --remote-only")
+	output := deployRes.StdErrString() + deployRes.StdOutString()
+
+	require.NotContains(f, output, "not listening on the expected address",
+		"deploy should not emit a false 'not listening' warning for slow-binding apps")
+}
+
 // If this test passes at all, that means that a slow metrics server isn't affecting flyctl
 func TestFlyDeploySlowMetrics(t *testing.T) {
 	env := make(map[string]string)


### PR DESCRIPTION
### Change Summary

What and Why: Add configurable polling timeout for listen address checks that respects user-configured grace periods This prevents false warnings for apps that take several seconds to bind after the machine starts.

How: The polling loop now waits up to the longest configured grace_period across all checks, or a 15-second default if none are set. Includes comprehensive unit tests and a regression test.

Related to: #3358

---

### Documentation

- [x] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
