### PR TITLE
Serve `fly sftp` from the container it selected

### DIFF
--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -67,6 +67,10 @@ func stdArgsSSH(cmd *cobra.Command) {
 			Description: "Container to connect to",
 		},
 		flag.Bool{
+			Name:        "no-container",
+			Description: "Connect to the machine itself rather than to one of its containers",
+		},
+		flag.Bool{
 			Name:        "pty",
 			Description: "Allocate a pseudo-terminal (default: on when no command is provided)",
 		},
@@ -131,13 +135,6 @@ func newConsole() *cobra.Command {
 	cmd.Args = cobra.MaximumNArgs(1)
 
 	stdArgsSSH(cmd)
-
-	flag.Add(cmd,
-		flag.Bool{
-			Name:        "no-container",
-			Description: "Connect to the machine itself rather than to one of its containers",
-		},
-	)
 
 	return cmd
 }

--- a/internal/command/ssh/sftp.go
+++ b/internal/command/ssh/sftp.go
@@ -185,6 +185,7 @@ func runLs(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer ftp.Close()
 
 	root := "/"
 	args := flag.Args(ctx)
@@ -235,6 +236,7 @@ func runGet(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer ftp.Close()
 
 	// Check if remote is a directory
 	remoteInfo, err := ftp.Stat(remote)
@@ -460,6 +462,7 @@ func runPut(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer ftp.Close()
 
 	if localInfo.IsDir() {
 		recursive := flag.GetBool(ctx, "recursive")
@@ -947,6 +950,7 @@ func runShell(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer ftp.Close()
 
 	l, err := readline.NewEx(&readline.Config{
 		Prompt:          "\033[31m»\033[0m ",

--- a/internal/command/ssh/sftp.go
+++ b/internal/command/ssh/sftp.go
@@ -159,6 +159,7 @@ func newSFTPConnection(ctx context.Context) (*sftp.Client, error) {
 		Username:       DefaultSshUsername,
 		DisableSpinner: true,
 		Container:      container,
+		Machine:        flag.GetBool(ctx, "no-container"),
 		AppNames:       []string{app.Name},
 	}
 
@@ -169,7 +170,11 @@ func newSFTPConnection(ctx context.Context) (*sftp.Client, error) {
 		return nil, err
 	}
 
-	return sftp.NewClient(conn.Client,
+	// The target has to reach the subsystem the transfers run over, which is
+	// why this asks the connection for the SFTP client rather than handing the
+	// connection to sftp.NewClient: a session opened without it lands in the
+	// machine's namespace, whatever container was selected above.
+	return conn.SFTP(ctx, SessionTarget{Container: params.Container, Machine: params.Machine},
 		sftp.UseConcurrentReads(true),
 		sftp.UseConcurrentWrites(true),
 	)

--- a/ssh/client.go
+++ b/ssh/client.go
@@ -244,13 +244,24 @@ type sessionWriteCloser struct {
 	sess *ssh.Session
 }
 
+// Close closes both halves, reporting the first thing that actually went
+// wrong. A session the server has already finished with closes as EOF on
+// either half -- it hangs up as soon as it is done serving, which it may well
+// do before the client gets here -- and that is the ordinary end of a transfer
+// rather than a failure the caller can act on.
 func (w sessionWriteCloser) Close() error {
-	err := w.WriteCloser.Close()
+	err := ignoreEOF(w.WriteCloser.Close())
 
-	// A session the server has already finished with closes as EOF, which is
-	// the ordinary end of a transfer rather than a failure to report.
-	if cerr := w.sess.Close(); err == nil && !errors.Is(cerr, io.EOF) {
+	if cerr := ignoreEOF(w.sess.Close()); err == nil {
 		err = cerr
+	}
+
+	return err
+}
+
+func ignoreEOF(err error) error {
+	if errors.Is(err, io.EOF) {
+		return nil
 	}
 
 	return err

--- a/ssh/client.go
+++ b/ssh/client.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
+	"strings"
+	"sync"
 
+	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -145,16 +149,135 @@ func (c *Client) Shell(ctx context.Context, sessIO *SessionIO, cmd string, targe
 
 	defer sess.Close()
 
-	switch {
-	case target.Machine:
-		if err := sess.Setenv("FLY_SSH_MACHINE", "1"); err != nil {
-			return err
-		}
-	case target.Container != "":
-		if err := sess.Setenv("FLY_SSH_CONTAINER", target.Container); err != nil {
-			return err
-		}
+	if err := setTarget(sess, target); err != nil {
+		return err
 	}
 
 	return sessIO.attach(ctx, sess, cmd)
+}
+
+// setTarget tells the server where the session should run, which it reads as
+// env on the session. Every kind of session says it the same way, so this is
+// the one place that names the variables.
+func setTarget(sess *ssh.Session, target SessionTarget) error {
+	switch {
+	case target.Machine:
+		return sess.Setenv("FLY_SSH_MACHINE", "1")
+	case target.Container != "":
+		return sess.Setenv("FLY_SSH_CONTAINER", target.Container)
+	}
+
+	return nil
+}
+
+// SFTP opens an SFTP client against the session target: a container's
+// filesystem, or the machine's own. The target has to be set on the session
+// carrying the subsystem, and sftp.NewClient opens a session of its own with
+// nothing set on it -- so the session is built here, where the target already
+// gets set for shells.
+//
+// Closing the returned client closes that session with it.
+func (c *Client) SFTP(ctx context.Context, target SessionTarget, opts ...sftp.ClientOption) (*sftp.Client, error) {
+	if err := target.validate(); err != nil {
+		return nil, err
+	}
+
+	if c.Client == nil {
+		if err := c.Connect(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	sess, err := c.Client.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := setTarget(sess, target); err != nil {
+		sess.Close()
+
+		return nil, err
+	}
+
+	// Whatever the server has to say about a subsystem that never starts, it
+	// says on stderr; the SFTP client would only report the silence that
+	// follows.
+	var stderr sessionStderr
+	sess.Stderr = &stderr
+
+	stdin, err := sess.StdinPipe()
+	if err != nil {
+		sess.Close()
+
+		return nil, err
+	}
+
+	stdout, err := sess.StdoutPipe()
+	if err != nil {
+		sess.Close()
+
+		return nil, err
+	}
+
+	if err := sess.RequestSubsystem("sftp"); err != nil {
+		sess.Close()
+
+		return nil, fmt.Errorf("request sftp subsystem: %w%s", err, stderr.reason())
+	}
+
+	client, err := sftp.NewClientPipe(stdout, sessionWriteCloser{stdin, sess}, opts...)
+	if err != nil {
+		sess.Close()
+
+		return nil, fmt.Errorf("start sftp: %w%s", err, stderr.reason())
+	}
+
+	return client, nil
+}
+
+// sessionWriteCloser ties the session's life to the SFTP client's: pkg/sftp
+// closes the stream it writes to when the client is closed, and the session
+// that stream runs over has nothing left to do at that point.
+type sessionWriteCloser struct {
+	io.WriteCloser
+
+	sess *ssh.Session
+}
+
+func (w sessionWriteCloser) Close() error {
+	err := w.WriteCloser.Close()
+
+	// A session the server has already finished with closes as EOF, which is
+	// the ordinary end of a transfer rather than a failure to report.
+	if cerr := w.sess.Close(); err == nil && !errors.Is(cerr, io.EOF) {
+		err = cerr
+	}
+
+	return err
+}
+
+// sessionStderr collects a session's stderr, which the SSH library writes from
+// its own goroutine while this one reads it.
+type sessionStderr struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (s *sessionStderr) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.buf.Write(p)
+}
+
+// reason renders what the server said, ready to append to an error message.
+func (s *sessionStderr) reason() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if said := strings.TrimSpace(s.buf.String()); said != "" {
+		return ": " + said
+	}
+
+	return ""
 }

--- a/ssh/sftp_test.go
+++ b/ssh/sftp_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -181,15 +182,23 @@ func TestSFTPSetsTarget(t *testing.T) {
 				t.Fatalf("write file: %v", err)
 			}
 
-			f, err := ftp.Open(path)
+			// SFTP paths are POSIX wherever the file is: a local path reaches
+			// the server spelled "/C:/..." on Windows, and unchanged anywhere
+			// this test would otherwise be running.
+			remote := filepath.ToSlash(path)
+			if !strings.HasPrefix(remote, "/") {
+				remote = "/" + remote
+			}
+
+			f, err := ftp.Open(remote)
 			if err != nil {
-				t.Fatalf("open %s: %v", path, err)
+				t.Fatalf("open %s: %v", remote, err)
 			}
 			defer f.Close()
 
 			content, err := io.ReadAll(f)
 			if err != nil {
-				t.Fatalf("read %s: %v", path, err)
+				t.Fatalf("read %s: %v", remote, err)
 			}
 
 			if string(content) != "hello world" {

--- a/ssh/sftp_test.go
+++ b/ssh/sftp_test.go
@@ -1,0 +1,222 @@
+package ssh
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	"maps"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
+)
+
+// sftpTestServer runs a stand-in for the SSH server on a machine: it serves
+// the SFTP subsystem, and records the env the session carried, which is how a
+// client says which container the session should be served from.
+//
+// It returns a connected Client, the env recorded so far, and a channel closed
+// once the session the subsystem ran over is done.
+func sftpTestServer(t *testing.T) (client *Client, recorded func() map[string]string, sessionDone <-chan struct{}) {
+	t.Helper()
+
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate host key: %v", err)
+	}
+
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		t.Fatalf("sign with host key: %v", err)
+	}
+
+	config := &ssh.ServerConfig{NoClientAuth: true}
+	config.AddHostKey(signer)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { listener.Close() })
+
+	var (
+		mu   sync.Mutex
+		env  = map[string]string{}
+		done = make(chan struct{})
+	)
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+
+		_, chans, reqs, err := ssh.NewServerConn(conn, config)
+		if err != nil {
+			return
+		}
+
+		go ssh.DiscardRequests(reqs)
+
+		for newChan := range chans {
+			channel, requests, err := newChan.Accept()
+			if err != nil {
+				return
+			}
+
+			go func() {
+				defer close(done)
+				defer channel.Close()
+
+				for req := range requests {
+					switch req.Type {
+					case "env":
+						var kv struct{ Name, Value string }
+						if err := ssh.Unmarshal(req.Payload, &kv); err != nil {
+							req.Reply(false, nil)
+
+							continue
+						}
+
+						mu.Lock()
+						env[kv.Name] = kv.Value
+						mu.Unlock()
+
+						req.Reply(true, nil)
+
+					case "subsystem":
+						server, err := sftp.NewServer(channel)
+						if err != nil {
+							req.Reply(false, nil)
+
+							return
+						}
+
+						req.Reply(true, nil)
+						server.Serve()
+
+						return
+
+					default:
+						req.Reply(false, nil)
+					}
+				}
+			}()
+		}
+	}()
+
+	conn, err := ssh.Dial("tcp", listener.Addr().String(), &ssh.ClientConfig{
+		User:            "root",
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	return &Client{Client: conn}, func() map[string]string {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return maps.Clone(env)
+	}, done
+}
+
+// TestSFTPSetsTarget covers what an SFTP session has to carry to be served
+// from the right place: the same env a shell session carries, on the session
+// the subsystem runs over. Without it the transfers land in the machine's
+// namespace no matter which container was selected.
+func TestSFTPSetsTarget(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		target SessionTarget
+		want   map[string]string
+	}{
+		{
+			// Nothing set: the machine decides, as it always has.
+			name: "neither",
+			want: map[string]string{},
+		},
+		{
+			name:   "container",
+			target: SessionTarget{Container: "worker"},
+			want:   map[string]string{"FLY_SSH_CONTAINER": "worker"},
+		},
+		{
+			name:   "machine",
+			target: SessionTarget{Machine: true},
+			want:   map[string]string{"FLY_SSH_MACHINE": "1"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, recorded, _ := sftpTestServer(t)
+
+			ftp, err := client.SFTP(context.Background(), tc.target)
+			if err != nil {
+				t.Fatalf("open sftp: %v", err)
+			}
+			defer ftp.Close()
+
+			env := recorded()
+			for name, want := range tc.want {
+				if env[name] != want {
+					t.Errorf("session env %s = %q, want %q", name, env[name], want)
+				}
+			}
+
+			if len(env) != len(tc.want) {
+				t.Errorf("session env is %v, want %v", env, tc.want)
+			}
+
+			// The env is only worth anything if the subsystem it was set on is
+			// the one carrying the transfers.
+			path := filepath.Join(t.TempDir(), "hello")
+			if err := os.WriteFile(path, []byte("hello world"), 0o600); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+
+			f, err := ftp.Open(path)
+			if err != nil {
+				t.Fatalf("open %s: %v", path, err)
+			}
+			defer f.Close()
+
+			content, err := io.ReadAll(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+
+			if string(content) != "hello world" {
+				t.Errorf("read %q, want %q", content, "hello world")
+			}
+		})
+	}
+}
+
+// TestSFTPCloseEndsSession covers the session opened on the caller's behalf:
+// nothing else holds a reference to it, so closing the SFTP client has to be
+// what closes it.
+func TestSFTPCloseEndsSession(t *testing.T) {
+	client, _, sessionDone := sftpTestServer(t)
+
+	ftp, err := client.SFTP(context.Background(), SessionTarget{Container: "worker"})
+	if err != nil {
+		t.Fatalf("open sftp: %v", err)
+	}
+
+	if err := ftp.Close(); err != nil {
+		t.Fatalf("close sftp: %v", err)
+	}
+
+	select {
+	case <-sessionDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("closing the SFTP client left its session open")
+	}
+}

--- a/ssh/sftp_test.go
+++ b/ssh/sftp_test.go
@@ -22,9 +22,10 @@ import (
 // the SFTP subsystem, and records the env the session carried, which is how a
 // client says which container the session should be served from.
 //
-// It returns a connected Client, the env recorded so far, and a channel closed
-// once the session the subsystem ran over is done.
-func sftpTestServer(t *testing.T) (client *Client, recorded func() map[string]string, sessionDone <-chan struct{}) {
+// It returns a connected Client, the env recorded so far, a channel closed
+// once the session the subsystem ran over is done, and a hangup that drops the
+// session from the server's end.
+func sftpTestServer(t *testing.T) (client *Client, recorded func() map[string]string, sessionDone <-chan struct{}, hangup func()) {
 	t.Helper()
 
 	_, key, err := ed25519.GenerateKey(rand.Reader)
@@ -47,9 +48,10 @@ func sftpTestServer(t *testing.T) (client *Client, recorded func() map[string]st
 	t.Cleanup(func() { listener.Close() })
 
 	var (
-		mu   sync.Mutex
-		env  = map[string]string{}
-		done = make(chan struct{})
+		mu      sync.Mutex
+		env     = map[string]string{}
+		done    = make(chan struct{})
+		serving = make(chan ssh.Channel, 1)
 	)
 
 	go func() {
@@ -70,6 +72,8 @@ func sftpTestServer(t *testing.T) (client *Client, recorded func() map[string]st
 			if err != nil {
 				return
 			}
+
+			serving <- channel
 
 			go func() {
 				defer close(done)
@@ -122,11 +126,13 @@ func sftpTestServer(t *testing.T) (client *Client, recorded func() map[string]st
 	t.Cleanup(func() { conn.Close() })
 
 	return &Client{Client: conn}, func() map[string]string {
-		mu.Lock()
-		defer mu.Unlock()
+			mu.Lock()
+			defer mu.Unlock()
 
-		return maps.Clone(env)
-	}, done
+			return maps.Clone(env)
+		}, done, func() {
+			(<-serving).Close()
+		}
 }
 
 // TestSFTPSetsTarget covers what an SFTP session has to carry to be served
@@ -156,7 +162,7 @@ func TestSFTPSetsTarget(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			client, recorded, _ := sftpTestServer(t)
+			client, recorded, _, _ := sftpTestServer(t)
 
 			ftp, err := client.SFTP(context.Background(), tc.target)
 			if err != nil {
@@ -212,7 +218,7 @@ func TestSFTPSetsTarget(t *testing.T) {
 // nothing else holds a reference to it, so closing the SFTP client has to be
 // what closes it.
 func TestSFTPCloseEndsSession(t *testing.T) {
-	client, _, sessionDone := sftpTestServer(t)
+	client, _, sessionDone, _ := sftpTestServer(t)
 
 	ftp, err := client.SFTP(context.Background(), SessionTarget{Container: "worker"})
 	if err != nil {
@@ -227,5 +233,26 @@ func TestSFTPCloseEndsSession(t *testing.T) {
 	case <-sessionDone:
 	case <-time.After(10 * time.Second):
 		t.Fatal("closing the SFTP client left its session open")
+	}
+}
+
+// TestSFTPCloseAfterServerHangup covers the other order these end in: the
+// server drops the session first -- an early failure on its side, or a
+// container server that exits on its own -- and the client closes afterwards.
+// The session is already gone by then, and saying so is not an error the
+// caller can do anything with.
+func TestSFTPCloseAfterServerHangup(t *testing.T) {
+	client, _, sessionDone, hangup := sftpTestServer(t)
+
+	ftp, err := client.SFTP(context.Background(), SessionTarget{Container: "worker"})
+	if err != nil {
+		t.Fatalf("open sftp: %v", err)
+	}
+
+	hangup()
+	<-sessionDone
+
+	if err := ftp.Close(); err != nil {
+		t.Fatalf("close after the server hung up: %v", err)
 	}
 }


### PR DESCRIPTION
`fly sftp get/put/find/shell` now serve the container they selected, instead of the machine around it, and gain `--no-container` for asking after the machine on purpose.

## Context

`fly sftp` has taken `--container` for a while, and prompts for one on a multi-container machine — but the answer went no further than the prompt. The SFTP subsystem was requested over a session opened by the SFTP client itself, which carries none of the env that tells a machine where a session should run, so every transfer landed in the machine's namespace whatever was selected. A file `fly ssh console --container worker` reads fine came back from `fly sftp get --container worker` as "file does not exist", leaving `fly ssh console -C 'cat ...'` as the only way to get at it.

Reported in #5080.

## Details

The session is now opened here rather than by `sftp.NewClient`, with the target set on it the way `Shell` already sets it for consoles, and its streams handed to the SFTP client. That keeps the `FLY_SSH_*` knowledge in `ssh/client.go` next to the other place that has it, rather than spreading it into the command package.

Two things fall out of having a target to plumb:

- `--no-container` joins the shared SSH flags, so `fly sftp` can ask for the machine itself the way `fly ssh console` (#5075) and `fly machine exec` (#5077) can. It moved out of `newConsole` into `stdArgsSSH`; console is unaffected.
- The session is closed when the SFTP client is, which nothing was doing before — `sftp.Client.Close` does not close a session it did not open.

A machine serves this once it picks up the matching server-side change; until then it answers in its own namespace, exactly as it does today, so this is inert rather than wrong on machines that are behind. Worth releasing ahead of that rollout for the same reason: clients that already send a target are the ones the new server behaviour is for.

`ssh/sftp_test.go` runs a small SSH server that serves the subsystem and records what the session carried, covering both the target env and the session lifetime.