### PR TITLE
fix(deploy): retry transient failures when setting release status

### DIFF
--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -741,6 +741,7 @@ func (md *machineDeployment) updateReleaseInBackend(ctx context.Context, status 
 		func() error {
 			attempts++
 			_, err := md.uiexClient.UpdateRelease(ctx, md.releaseId, status, metadata)
+
 			return err
 		},
 		retry.Context(ctx),

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -10,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/google/shlex"
 	"github.com/logrusorgru/aurora"
 	"github.com/morikuni/aec"
@@ -714,6 +716,15 @@ func (md *machineDeployment) createReleaseInBackend(ctx context.Context) error {
 	return nil
 }
 
+const (
+	// releaseStatusRetryAttempts bounds how many times a release status update is
+	// attempted before the deploy gives up.
+	releaseStatusRetryAttempts = 3
+	// releaseStatusRetryDelay is the delay before the first retry; it doubles on
+	// each subsequent attempt.
+	releaseStatusRetryDelay = 500 * time.Millisecond
+)
+
 func (md *machineDeployment) updateReleaseInBackend(ctx context.Context, status string, metadata *fly.ReleaseMetadata) error {
 	ctx, span := tracing.GetTracer().Start(ctx, "update_release_in_backend", trace.WithAttributes(
 		attribute.String("release_id", md.releaseId),
@@ -721,7 +732,29 @@ func (md *machineDeployment) updateReleaseInBackend(ctx context.Context, status 
 	))
 	defer span.End()
 
-	_, err := md.uiexClient.UpdateRelease(ctx, md.releaseId, status, metadata)
+	// Setting a release's status is idempotent, so a transient failure is safe to
+	// retry. Without this, a single blip anywhere between flyctl and api.fly.io
+	// aborts an otherwise healthy deploy after the image has already been built
+	// and pushed -- the user's only recourse being to run the whole deploy again.
+	attempts := 0
+	err := retry.Do(
+		func() error {
+			attempts++
+			_, err := md.uiexClient.UpdateRelease(ctx, md.releaseId, status, metadata)
+			return err
+		},
+		retry.Context(ctx),
+		retry.Attempts(releaseStatusRetryAttempts),
+		retry.Delay(releaseStatusRetryDelay),
+		retry.DelayType(retry.BackOffDelay),
+		retry.RetryIf(isRetryableReleaseStatusError),
+		retry.LastErrorOnly(true),
+		retry.OnRetry(func(n uint, err error) {
+			terminal.Debugf("retrying release status update to %q (attempt %d/%d): %v\n",
+				status, n+2, releaseStatusRetryAttempts, err)
+		}),
+	)
+	span.SetAttributes(attribute.Int("attempts", attempts))
 
 	if err != nil {
 		tracing.RecordError(span, err, "failed to update machine release")
@@ -730,6 +763,32 @@ func (md *machineDeployment) updateReleaseInBackend(ctx context.Context, status 
 	}
 
 	return nil
+}
+
+// isRetryableReleaseStatusError reports whether a failed release status update is
+// worth another attempt.
+//
+// A 5xx from api.fly.io is transient, and notably includes the 504 served by the
+// proxy in front of it when it gives up waiting on the backend. A 4xx means the
+// request itself is wrong and will fail the same way next time. Errors that never
+// produced a response at all (connection reset, TLS handshake failure, timeout)
+// are transport-level and worth retrying.
+func isRetryableReleaseStatusError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// The user interrupted us, or a deadline expired. Retrying would ignore that.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var statusErr *uiex.StatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.Retryable()
+	}
+
+	return true
 }
 
 func (md *machineDeployment) logClearLinesAbove(count int) {

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -769,11 +769,18 @@ func (md *machineDeployment) updateReleaseInBackend(ctx context.Context, status 
 // isRetryableReleaseStatusError reports whether a failed release status update is
 // worth another attempt.
 //
-// A 5xx from api.fly.io is transient, and notably includes the 504 served by the
-// proxy in front of it when it gives up waiting on the backend. A 4xx means the
-// request itself is wrong and will fail the same way next time. Errors that never
-// produced a response at all (connection reset, TLS handshake failure, timeout)
-// are transport-level and worth retrying.
+// A *uiex.StatusError means the server did answer, so the status code decides:
+// 5xx is transient, and notably includes the 504 served by the proxy in front of
+// api.fly.io when it gives up waiting on the backend, while 4xx means the request
+// itself is wrong and will fail the same way next time.
+//
+// Any other error -- a connection reset, a TLS handshake failure, a response body
+// that could not be read or decoded -- carries no status code to judge, so we
+// cannot tell a transient fault from a permanent one. Setting a release status is
+// idempotent and the retry budget is small and bounded, so the default is to try
+// again rather than fail a deploy that might well have succeeded. Context
+// cancellation and deadline expiry are the exceptions: both are explicit
+// instructions to stop.
 func isRetryableReleaseStatusError(err error) bool {
 	if err == nil {
 		return false

--- a/internal/command/deploy/machines_releasestatus_test.go
+++ b/internal/command/deploy/machines_releasestatus_test.go
@@ -1,0 +1,107 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/superfly/flyctl/internal/uiex"
+)
+
+func TestIsRetryableReleaseStatusError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error is not retried",
+			err:  nil,
+			want: false,
+		},
+		{
+			// The failure that motivated this retry: HAProxy in front of api.fly.io
+			// gives up on the backend and serves its own 504 page.
+			name: "504 from the proxy is retried",
+			err:  &uiex.StatusError{Op: "update release", StatusCode: 502, Body: "<html>502 Bad Gateway</html>"},
+			want: true,
+		},
+		{
+			name: "gateway timeout is retried",
+			err:  &uiex.StatusError{Op: "update release", StatusCode: 504, Body: "<html>504 Gateway Time-out</html>"},
+			want: true,
+		},
+		{
+			name: "500 is retried",
+			err:  &uiex.StatusError{Op: "update release", StatusCode: 500, Body: "boom"},
+			want: true,
+		},
+		{
+			name: "wrapped 5xx is still retried",
+			err:  fmt.Errorf("updating release: %w", &uiex.StatusError{Op: "update release", StatusCode: 503, Body: "unavailable"}),
+			want: true,
+		},
+		{
+			name: "401 is not retried",
+			err:  &uiex.StatusError{Op: "update release", StatusCode: 401, Body: "unauthorized"},
+			want: false,
+		},
+		{
+			name: "404 is not retried",
+			err:  &uiex.StatusError{Op: "update release", StatusCode: 404, Body: "not found"},
+			want: false,
+		},
+		{
+			name: "422 is not retried",
+			err:  &uiex.StatusError{Op: "update release", StatusCode: 422, Body: "the release has already finished"},
+			want: false,
+		},
+		{
+			name: "user interrupt is not retried",
+			err:  context.Canceled,
+			want: false,
+		},
+		{
+			name: "deadline exceeded is not retried",
+			err:  context.DeadlineExceeded,
+			want: false,
+		},
+		{
+			// No response was ever produced, so there is nothing to inspect a status
+			// code on. These are transport-level and worth another attempt.
+			name: "connection failure is retried",
+			err:  &net.OpError{Op: "dial", Err: errors.New("connection reset by peer")},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isRetryableReleaseStatusError(tc.err))
+		})
+	}
+}
+
+func TestStatusErrorMessageIsUnchanged(t *testing.T) {
+	// The message must keep matching what callers and users saw before StatusError
+	// was introduced, so error output and any log scraping stay stable.
+	err := &uiex.StatusError{
+		Op:         "update release",
+		StatusCode: 504,
+		Body:       "<html><body><h1>504 Gateway Time-out</h1>\nThe server didn't respond in time.\n</body></html>",
+	}
+
+	assert.Equal(t,
+		"failed to update release (status 504): <html><body><h1>504 Gateway Time-out</h1>\nThe server didn't respond in time.\n</body></html>",
+		err.Error(),
+	)
+}
+
+func TestStatusErrorRetryable(t *testing.T) {
+	assert.False(t, (&uiex.StatusError{StatusCode: 499}).Retryable())
+	assert.True(t, (&uiex.StatusError{StatusCode: 500}).Retryable())
+	assert.True(t, (&uiex.StatusError{StatusCode: 599}).Retryable())
+}

--- a/internal/command/deploy/machines_releasestatus_test.go
+++ b/internal/command/deploy/machines_releasestatus_test.go
@@ -23,14 +23,14 @@ func TestIsRetryableReleaseStatusError(t *testing.T) {
 			want: false,
 		},
 		{
-			// The failure that motivated this retry: HAProxy in front of api.fly.io
-			// gives up on the backend and serves its own 504 page.
-			name: "504 from the proxy is retried",
+			name: "502 from the proxy is retried",
 			err:  &uiex.StatusError{Op: "update release", StatusCode: 502, Body: "<html>502 Bad Gateway</html>"},
 			want: true,
 		},
 		{
-			name: "gateway timeout is retried",
+			// The failure that motivated this retry: HAProxy in front of api.fly.io
+			// gives up on the backend and serves its own 504 page.
+			name: "504 from the proxy is retried",
 			err:  &uiex.StatusError{Op: "update release", StatusCode: 504, Body: "<html>504 Gateway Time-out</html>"},
 			want: true,
 		},

--- a/internal/uiex/releases.go
+++ b/internal/uiex/releases.go
@@ -12,6 +12,32 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 )
 
+// StatusError is returned when api.fly.io answers with an unexpected status
+// code. It carries the code so callers can tell a transient server-side failure
+// apart from a request that will never succeed.
+type StatusError struct {
+	// Op describes the attempted operation, e.g. "update release".
+	Op string
+	// StatusCode is the HTTP status returned by api.fly.io.
+	StatusCode int
+	// Body is the raw response body, included in the error message.
+	Body string
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("failed to %s (status %d): %s", e.Op, e.StatusCode, e.Body)
+}
+
+// Retryable reports whether the failure is worth another attempt. 5xx responses
+// are transient by definition, and include the 504s served by the proxy in front
+// of api.fly.io when it gives up waiting on the backend. 4xx responses mean the
+// request itself is wrong and will fail identically on a retry.
+//
+// Callers must only retry when the request is idempotent.
+func (e *StatusError) Retryable() bool {
+	return e.StatusCode >= 500
+}
+
 type DeploymentStrategy string
 
 const (
@@ -253,6 +279,6 @@ func (c *Client) UpdateRelease(ctx context.Context, releaseID, status string, me
 
 		return response, nil
 	default:
-		return nil, fmt.Errorf("failed to update release (status %d): %s", res.StatusCode, string(body))
+		return nil, &StatusError{Op: "update release", StatusCode: res.StatusCode, Body: string(body)}
 	}
 }


### PR DESCRIPTION
## Problem

`fly deploy` aborts on a single transient blip when it sets the release status, *after* the image has been built and pushed:

```
Error: failed to set release status to 'running': failed to update release (status 504): <html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>
```

Re-running the deploy immediately almost always succeeds. Reported in superfly/ui-ex#5155.

`updateReleaseInBackend` (`internal/command/deploy/machines.go`) was single-shot — any error from `PATCH /api/v1/releases/:id` propagated straight up and killed the deploy.

## Why the request fails

That 504 page is HAProxy's, not the API's. `flyio-web-proxy` sits in front of `api.fly.io` and serves it when it gives up waiting on its backend.

Evidence it never reaches the app: in Honeycomb, `web` records **7,431,550** of these PATCHes over 14 days — 7,429,050× 200, 2,400× 401, 100× 404, and **zero 5xx**. Rails answers this endpoint fast, essentially always. When a user gets a 504, the request died between HAProxy and web and was never logged.

HAProxy's own metrics point at that hop: `haproxy_backend_connection_reuses_total` is **0** against 339M connection attempts in 7 days, and max connect time to `web_on_fly` peaks at **19.1s**. That's being pursued separately in `superfly/web`; this PR makes flyctl resilient to it regardless of the outcome.

Client-side rate is ~0.03% of `status=running` updates (1,376 of 4,817,457 over 60 days, from the `flyctl` dataset), flat over that window — rare, but it costs a full rebuild-and-push each time.

## Change

Retry up to 3 attempts, exponential backoff from 500ms, only for failures that could plausibly succeed:

- **5xx** responses, including proxy-generated 502/503/504
- **transport errors** that never produced a response (connection reset, TLS handshake failure)

Not retried:

- **4xx** — the request is wrong and will fail identically
- **context cancellation / deadline** — Ctrl-C still takes effect immediately

To tell those apart, `uiex.UpdateRelease` now returns a typed `*uiex.StatusError` carrying the status code instead of a bare `fmt.Errorf`. `Error()` output is byte-identical to before, so nothing user-facing changes — there's a test pinning that.

## Scope

Deliberately limited to `UpdateRelease`. `CreateRelease` is a `POST` and is **not** idempotent, so a client retry there risks duplicate releases. The equivalent problem on that path is a 55s server-side retry ladder in `web` (`releases_controller.rb:92`, `[1,2,4,8,10,10,10,10]`) that overruns the proxy's 60s timeout by construction — that needs fixing in `web`, not here.

## Trade-off worth flagging

When the failure *is* a proxy timeout, each attempt costs ~60s before it returns, so a fully-failing update now takes up to ~3 minutes instead of ~1 before giving up. That's a deliberate trade: the alternative is a hard failure that costs the user a full rebuild and re-push. Failures that never connect return immediately and retry fast.

A per-attempt HTTP timeout shorter than the proxy's 60s would make this snappier. Left out to keep the change focused — `#update` has no measurable slow population, so ~30s would be safe if we want it later.

## Tests

`internal/command/deploy/machines_releasestatus_test.go` — 11 cases over the retry predicate (5xx, wrapped 5xx, 401/404/422, cancellation, deadline, transport error, nil), plus one pinning the unchanged error string.

```
go build ./...                       # ok
go vet ./internal/uiex/... ./internal/command/deploy/...   # ok
go test ./internal/command/deploy/... ./internal/uiex/...  # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)