### PR TITLE
auto retry more transient issues

### DIFF
--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -48,6 +48,28 @@ type mockFlapsClient struct {
 	// succeeding, simulating transient API errors for retry tests.
 	uncordonTransientFailures int
 
+	// setMetadataTransientFailures causes SetMetadata to fail this many times
+	// before succeeding, simulating transient flaps 408/5xx errors for retry
+	// tests of the checkpointing step.
+	setMetadataTransientFailures int
+
+	// launchPreRequestTransientFailures causes Launch to fail this many times
+	// with a pre-request network error before succeeding, simulating a
+	// connection reset before the request reaches flaps.
+	launchPreRequestTransientFailures int
+
+	// launchSilentSuccessFailures makes Launch return a 408 while still
+	// registering the machine in the mock's internal state, simulating the
+	// case where flaps' upstream call to flyd committed the create but the
+	// response was lost. This lets tests exercise the client-side
+	// idempotency lookup path in launchGreenMachineWithRetry.
+	launchSilentSuccessFailures int
+
+	// launchTransient408Failures makes Launch return a 408 without
+	// committing anything on the mock side, exercising the retry path where
+	// the lookup finds no matching machine and we must launch again.
+	launchTransient408Failures int
+
 	// mu to protect the members below.
 	mu            sync.Mutex
 	machines      []*fly.Machine
@@ -273,6 +295,22 @@ func (m *mockFlapsClient) Launch(ctx context.Context, appName string, builder fl
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if m.launchPreRequestTransientFailures > 0 {
+		m.launchPreRequestTransientFailures--
+
+		return nil, fmt.Errorf("dial tcp: connection refused")
+	}
+
+	if m.launchTransient408Failures > 0 {
+		m.launchTransient408Failures--
+
+		return nil, &flaps.FlapsError{
+			OriginalError:      fmt.Errorf("upstream timeout launching %s", builder.ID),
+			ResponseStatusCode: http.StatusRequestTimeout,
+			ResponseBody:       []byte("upstream timeout"),
+		}
+	}
+
 	if m.breakLaunch {
 		return nil, fmt.Errorf("failed to launch %s", builder.ID)
 	}
@@ -281,11 +319,22 @@ func (m *mockFlapsClient) Launch(ctx context.Context, appName string, builder fl
 
 	shortDuration := fly.Duration{Duration: 10 * time.Millisecond}
 
-	return &fly.Machine{
+	// Copy the builder's metadata onto the created machine so that
+	// List-based idempotency lookups can find it (matching real flaps
+	// behaviour: the metadata we sent in the launch input is persisted
+	// and returned by subsequent List/Get calls).
+	metadata := map[string]string{}
+	if builder.Config != nil && builder.Config.Metadata != nil {
+		for k, v := range builder.Config.Metadata {
+			metadata[k] = v
+		}
+	}
+
+	created := &fly.Machine{
 		ID:         fmt.Sprintf("%x", m.nextMachineID),
 		LeaseNonce: fmt.Sprintf("%x-launch-lease", m.nextMachineID),
 		Config: &fly.MachineConfig{
-			Metadata: map[string]string{},
+			Metadata: metadata,
 			// Use a near-zero grace period and interval so that health-check
 			// goroutines poll almost immediately in tests without real timing.
 			Checks: map[string]fly.MachineCheck{
@@ -295,15 +344,39 @@ func (m *mockFlapsClient) Launch(ctx context.Context, appName string, builder fl
 				},
 			},
 		},
-	}, nil
+	}
+	m.machines = append(m.machines, created)
+
+	if m.launchSilentSuccessFailures > 0 {
+		m.launchSilentSuccessFailures--
+
+		// Simulate a 408: the machine was committed on the mock side but the
+		// caller sees a transient error. The idempotency lookup should find
+		// this machine by its launch-id metadata on the next attempt.
+		return nil, &flaps.FlapsError{
+			OriginalError:      fmt.Errorf("upstream timeout after commit"),
+			ResponseStatusCode: http.StatusRequestTimeout,
+			ResponseBody:       []byte("upstream timeout after commit"),
+		}
+	}
+
+	return created, nil
 }
 
 func (m *mockFlapsClient) List(ctx context.Context, appName, state string) ([]*fly.Machine, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if m.breakList {
 		return nil, fmt.Errorf("failed to list machines")
 	}
 
-	return m.machines, nil
+	// Defensive copy so callers holding the slice can't race with future
+	// mutations under m.mu.
+	out := make([]*fly.Machine, len(m.machines))
+	copy(out, m.machines)
+
+	return out, nil
 }
 
 func (m *mockFlapsClient) ListActive(ctx context.Context, appName string) ([]*fly.Machine, error) {
@@ -371,6 +444,19 @@ func (m *mockFlapsClient) Restart(ctx context.Context, appName string, in fly.Re
 }
 
 func (m *mockFlapsClient) SetMetadata(ctx context.Context, appName, machineID, key, value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.setMetadataTransientFailures > 0 {
+		m.setMetadataTransientFailures--
+
+		return &flaps.FlapsError{
+			OriginalError:      fmt.Errorf("transient error setting metadata for %s", machineID),
+			ResponseStatusCode: http.StatusRequestTimeout,
+			ResponseBody:       []byte("transient upstream timeout"),
+		}
+	}
+
 	if m.breakSetMetadata {
 		return fmt.Errorf("failed to set metadata for %s", machineID)
 	}

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	"github.com/hashicorp/go-multierror"
+	"github.com/oklog/ulid/v2"
 	"github.com/sourcegraph/conc/pool"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -48,6 +50,15 @@ var (
 	ErrMultipleImageVersions = errors.New("found multiple image versions")
 
 	safeToDestroyValue = "safe_to_destroy"
+
+	// flyctlBGLaunchIDMetadataKey is a per-launch idempotency tag that flyctl
+	// writes into the machine config's metadata before calling flaps.Launch.
+	// Each intended green machine gets a unique value. When Launch fails with
+	// an ambiguous transient error (like a 408 propagated from flyd via flaps),
+	// the retry loop looks the machine up by this key to detect a silent
+	// success and avoid creating a duplicate machine. The key is intentionally
+	// namespaced under "fly_flyctl_" so it can coexist with any user metadata.
+	flyctlBGLaunchIDMetadataKey = "fly_flyctl_bluegreen_launch_id"
 )
 
 type RollbackLog struct {
@@ -88,6 +99,32 @@ type blueGreen struct {
 
 	uncordonRetryAttempts uint
 	uncordonRetryDelay    time.Duration
+
+	// tagRetryAttempts / tagRetryDelay control the back-off used when
+	// TagBlueMachinesAsSafeForDeletion writes the "safe_to_destroy" metadata
+	// tag on blue machines. Flaps' metadata endpoint can return transient 408
+	// (context.DeadlineExceeded talking to flyd) and we don't want a single
+	// transient failure to strand blue and green versions serving traffic
+	// side-by-side (see: the checkpointing step in Deploy).
+	tagRetryAttempts uint
+	tagRetryDelay    time.Duration
+
+	// launchRetryAttempts / launchRetryDelay control the back-off used when
+	// CreateGreenMachines retries a Launch that failed with a transient error.
+	// Retries are safe because each launch input carries a unique per-machine
+	// idempotency tag (flyctlBGLaunchIDMetadataKey) that lets the retry loop
+	// detect a "silent success" (a Launch that hit an ambiguous 408/5xx but
+	// still committed the machine on the flyd side) by listing machines with
+	// that tag before creating a new one.
+	launchRetryAttempts uint
+	launchRetryDelay    time.Duration
+
+	// launchLookupDelay is the pause between a failed Launch attempt and the
+	// idempotency lookup that follows it. It gives flaps' backing store a
+	// moment to reflect a machine that a silent-success Launch just committed,
+	// which reduces (but does not eliminate) the race where a retry could
+	// otherwise create a duplicate.
+	launchLookupDelay time.Duration
 
 	// imageRefRetryAttempts / imageRefRetryDelay control the back-off used when
 	// DetectMultipleImageVersions re-fetches a machine whose ImageRef came back
@@ -160,6 +197,13 @@ func (bg *blueGreen) initialize() {
 
 	bg.uncordonRetryAttempts = 5
 	bg.uncordonRetryDelay = 500 * time.Millisecond
+
+	bg.tagRetryAttempts = 5
+	bg.tagRetryDelay = 500 * time.Millisecond
+
+	bg.launchRetryAttempts = 3
+	bg.launchRetryDelay = 500 * time.Millisecond
+	bg.launchLookupDelay = 500 * time.Millisecond
 
 	bg.imageRefRetryAttempts = 3
 	bg.imageRefRetryDelay = 1 * time.Second
@@ -264,8 +308,15 @@ func (bg *blueGreen) CreateGreenMachines(ctx context.Context) error {
 				launchInput.SkipLaunch = false
 			}
 			launchInput.Config.Metadata[fly.MachineConfigMetadataKeyFlyctlBGTag] = bg.timestamp
+			// A per-machine ULID lets us safely retry Launch on ambiguous
+			// transient errors (e.g. 408 from flaps): the retry loop first
+			// looks up any machine flaps has already committed with this key
+			// before attempting another Launch, so a "silent success" doesn't
+			// turn into a duplicate green machine.
+			launchID := ulid.Make().String()
+			launchInput.Config.Metadata[flyctlBGLaunchIDMetadataKey] = launchID
 
-			newMachineRaw, err := bg.flaps.Launch(ctx, bg.app.Name, *launchInput)
+			newMachineRaw, err := bg.launchGreenMachineWithRetry(ctx, launchInput, launchID)
 			if err != nil {
 				tracing.RecordError(span, err, "failed to launch machine")
 
@@ -1259,16 +1310,235 @@ func (bg *blueGreen) warnUnreachableMachines(unreachableIDs []string) {
 
 // This method tags blue-machines with a safe to destroy value.
 // This way, a user can easily remove blue machines that are hanging around from deployment.
+//
+// The tag is purely informational: it lets operators identify hanging blue
+// machines from a failed previous deployment. The subsequent cordon/stop/
+// destroy stages of the deployment do NOT depend on the tag being set, so a
+// failure here must not abort the deployment. If we returned an error we'd
+// leave the green machines already accepting traffic while the blue machines
+// remain live too — two versions serving traffic side-by-side, exactly what
+// blue-green deploys are supposed to prevent.
+//
+// Every SetMetadata call is retried with exponential back-off on transient
+// errors (408/timeouts from flyd via flaps, 5xx, common network hiccups).
+// SetMetadata is idempotent — writing the same key/value twice is a no-op —
+// so retrying is always safe. Any machine that still can't be tagged after
+// all retries is reported to the user via a warning; the deploy carries on.
 func (bg *blueGreen) TagBlueMachinesAsSafeForDeletion(ctx context.Context) error {
 	ctx, span := tracing.GetTracer().Start(ctx, "tag_blue_machines")
 	defer span.End()
 
-	p := pool.New().WithErrors().WithFirstError().WithMaxGoroutines(bg.maxConcurrent)
+	var (
+		untaggedMu sync.Mutex
+		untagged   []string
+	)
+
+	p := pool.New().WithMaxGoroutines(bg.maxConcurrent)
 	for _, mach := range bg.blueMachines {
-		p.Go(func() error {
-			return mach.leasableMachine.SetMetadata(ctx, fly.MachineConfigMetadataKeyFlyctlBGTag, "safe_to_destroy")
+		p.Go(func() {
+			err := retry.Do(
+				func() error {
+					return mach.leasableMachine.SetMetadata(ctx, fly.MachineConfigMetadataKeyFlyctlBGTag, safeToDestroyValue)
+				},
+				retry.Context(ctx),
+				retry.Attempts(bg.tagRetryAttempts),
+				retry.Delay(bg.tagRetryDelay),
+				retry.MaxDelay(10*time.Second),
+				retry.DelayType(retry.BackOffDelay),
+				retry.RetryIf(isTransientFlapsError),
+				retry.LastErrorOnly(true),
+				retry.OnRetry(func(n uint, err error) {
+					fmt.Fprintf(bg.io.ErrOut, "  Retrying safe-for-deletion tag for machine %s (attempt %d/%d): %v\n",
+						bg.colorize.Bold(mach.leasableMachine.FormattedMachineId()), n+2, bg.tagRetryAttempts, err)
+				}),
+			)
+			if err == nil {
+				return
+			}
+
+			// Failing to tag a machine is non-fatal — the deployment must proceed
+			// so that green machines are the only ones serving traffic. We just
+			// let the user know so they can manually clean up if a later step
+			// also fails.
+			tracing.RecordError(span, err, "failed to tag blue machine as safe for deletion")
+			fmt.Fprintf(bg.io.ErrOut,
+				"  [warn] Could not tag machine %s as safe-for-deletion after %d attempts: %v\n",
+				bg.colorize.Bold(mach.leasableMachine.FormattedMachineId()), bg.tagRetryAttempts, err)
+
+			untaggedMu.Lock()
+			untagged = append(untagged, mach.leasableMachine.Machine().ID)
+			untaggedMu.Unlock()
 		})
 	}
 
-	return p.Wait()
+	p.Wait()
+
+	if len(untagged) > 0 {
+		span.SetAttributes(attribute.Int("untagged_blue_machines", len(untagged)))
+		span.SetAttributes(attribute.StringSlice("untagged_blue_machine_ids", untagged))
+		fmt.Fprintf(bg.io.ErrOut,
+			"  [warn] %d blue machine(s) could not be tagged safe-for-deletion. "+
+				"The deployment will still proceed; if a later step fails you may need to remove them manually with:\n    %s\n",
+			len(untagged), formatDestroyCommand(bg.app.Name, untagged))
+	}
+
+	return nil
+}
+
+// isTransientFlapsError reports whether an error returned by flaps is worth
+// another attempt. It's intentionally strict about "pre-request" transports
+// (connection reset/refused, EOF, etc.) but also includes HTTP status codes
+// that flaps uses for transient upstream conditions:
+//   - 408 Request Timeout: flaps hit a context.DeadlineExceeded talking to flyd
+//   - 429 Too Many Requests: rate-limited
+//   - 5xx Server Error: transient server-side failure
+//
+// This classifier must NOT be used with non-idempotent endpoints (like Launch)
+// unless the caller only relies on the pre-request substrings, since a 408
+// from flaps doesn't tell us whether the upstream side-effect happened.
+func isTransientFlapsError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// User interrupted / deadline elapsed for the whole operation: don't retry.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var flapsErr *flaps.FlapsError
+	if errors.As(err, &flapsErr) {
+		switch {
+		case flapsErr.ResponseStatusCode == http.StatusRequestTimeout,
+			flapsErr.ResponseStatusCode == http.StatusTooManyRequests,
+			flapsErr.ResponseStatusCode >= 500 && flapsErr.ResponseStatusCode < 600:
+			return true
+		}
+	}
+
+	return hasTransientNetworkSubstring(err)
+}
+
+// launchGreenMachineWithRetry launches a single green machine with client-side
+// pseudo-idempotency. flaps' create-machine endpoint doesn't accept an
+// Idempotency-Key header, so we simulate one by writing a unique ULID into
+// the machine's metadata under flyctlBGLaunchIDMetadataKey before every
+// attempt. If a Launch call fails with a transient error we don't know
+// whether the machine was actually committed on the flyd side, so before
+// retrying we list machines and look for one carrying our launch ID. If we
+// find one, we treat the failed Launch as a silent success and return that
+// machine — no duplicate is created.
+//
+// The race we can't fully close is when flaps commits the machine but the
+// list-lookup runs before that write propagates to the read side flaps'
+// list handler queries (Corrosion). launchLookupDelay gives it a brief
+// window to catch up; in the unlikely event a duplicate does slip through,
+// it will be tagged with the same bg.timestamp as the tracked one and get
+// swept by the normal blue→green cycle on the next deployment. That's a
+// strictly better outcome than aborting the deployment mid-flight.
+func (bg *blueGreen) launchGreenMachineWithRetry(ctx context.Context, launchInput *fly.LaunchMachineInput, launchID string) (*fly.Machine, error) {
+	var lastErr error
+	attempts := bg.launchRetryAttempts
+	if attempts == 0 {
+		attempts = 1
+	}
+
+	delay := bg.launchRetryDelay
+	for attempt := uint(0); attempt < attempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		newMachineRaw, err := bg.flaps.Launch(ctx, bg.app.Name, *launchInput)
+		if err == nil {
+			return newMachineRaw, nil
+		}
+		lastErr = err
+
+		// A non-transient failure (400/404/etc.) isn't going to get better
+		// with another attempt.
+		if !isTransientFlapsError(err) {
+			return nil, err
+		}
+
+		// This might have been a silent success. Give flaps' backing store a
+		// moment to reflect the commit, then look for a machine with our
+		// launch ID.
+		if bg.launchLookupDelay > 0 {
+			select {
+			case <-time.After(bg.launchLookupDelay):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		if existing, lookupErr := bg.findGreenMachineByLaunchID(ctx, launchID); lookupErr != nil {
+			// A failed lookup shouldn't mask the original Launch error, but we
+			// still want the user to see it so they can debug if the retry
+			// also fails.
+			fmt.Fprintf(bg.io.ErrOut, "  Idempotency lookup after failed launch returned an error: %v\n", lookupErr)
+		} else if existing != nil {
+			fmt.Fprintf(bg.io.ErrOut,
+				"  Launch reported an error but machine %s was already created (idempotency tag matched); reusing it\n",
+				bg.colorize.Bold(existing.ID))
+
+			return existing, nil
+		}
+
+		// Not the last attempt: back off and try again.
+		if attempt+1 < attempts {
+			fmt.Fprintf(bg.io.ErrOut, "  Retrying green machine launch (attempt %d/%d): %v\n",
+				attempt+2, attempts, err)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			if delay < 5*time.Second {
+				delay *= 2
+			}
+		}
+	}
+
+	return nil, lastErr
+}
+
+// findGreenMachineByLaunchID scans the app's machines and returns the one
+// whose metadata carries the given launch ID, if any. It's a client-side
+// filter because flaps' List does not (yet) expose a metadata query in the
+// fly-go client interface.
+func (bg *blueGreen) findGreenMachineByLaunchID(ctx context.Context, launchID string) (*fly.Machine, error) {
+	machines, err := bg.flaps.List(ctx, bg.app.Name, "")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, m := range machines {
+		if m == nil || m.Config == nil {
+			continue
+		}
+		if m.Config.Metadata[flyctlBGLaunchIDMetadataKey] == launchID {
+			return m, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func hasTransientNetworkSubstring(err error) bool {
+	message := strings.ToLower(err.Error())
+	for _, s := range []string{
+		"connection reset by peer",
+		"connection refused",
+		"network is unreachable",
+		"temporary failure in name resolution",
+		"no such host",
+		"eof",
+	} {
+		if strings.Contains(message, s) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -1345,7 +1344,7 @@ func (bg *blueGreen) TagBlueMachinesAsSafeForDeletion(ctx context.Context) error
 				retry.Delay(bg.tagRetryDelay),
 				retry.MaxDelay(10*time.Second),
 				retry.DelayType(retry.BackOffDelay),
-				retry.RetryIf(isTransientFlapsError),
+				retry.RetryIf(flapsutil.IsTransientFlapsError),
 				retry.LastErrorOnly(true),
 				retry.OnRetry(func(n uint, err error) {
 					fmt.Fprintf(bg.io.ErrOut, "  Retrying safe-for-deletion tag for machine %s (attempt %d/%d): %v\n",
@@ -1383,40 +1382,6 @@ func (bg *blueGreen) TagBlueMachinesAsSafeForDeletion(ctx context.Context) error
 	}
 
 	return nil
-}
-
-// isTransientFlapsError reports whether an error returned by flaps is worth
-// another attempt. It's intentionally strict about "pre-request" transports
-// (connection reset/refused, EOF, etc.) but also includes HTTP status codes
-// that flaps uses for transient upstream conditions:
-//   - 408 Request Timeout: flaps hit a context.DeadlineExceeded talking to flyd
-//   - 429 Too Many Requests: rate-limited
-//   - 5xx Server Error: transient server-side failure
-//
-// This classifier must NOT be used with non-idempotent endpoints (like Launch)
-// unless the caller only relies on the pre-request substrings, since a 408
-// from flaps doesn't tell us whether the upstream side-effect happened.
-func isTransientFlapsError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	// User interrupted / deadline elapsed for the whole operation: don't retry.
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return false
-	}
-
-	var flapsErr *flaps.FlapsError
-	if errors.As(err, &flapsErr) {
-		switch {
-		case flapsErr.ResponseStatusCode == http.StatusRequestTimeout,
-			flapsErr.ResponseStatusCode == http.StatusTooManyRequests,
-			flapsErr.ResponseStatusCode >= 500 && flapsErr.ResponseStatusCode < 600:
-			return true
-		}
-	}
-
-	return hasTransientNetworkSubstring(err)
 }
 
 // launchGreenMachineWithRetry launches a single green machine with client-side
@@ -1457,7 +1422,7 @@ func (bg *blueGreen) launchGreenMachineWithRetry(ctx context.Context, launchInpu
 
 		// A non-transient failure (400/404/etc.) isn't going to get better
 		// with another attempt.
-		if !isTransientFlapsError(err) {
+		if !flapsutil.IsTransientFlapsError(err) {
 			return nil, err
 		}
 
@@ -1525,20 +1490,4 @@ func (bg *blueGreen) findGreenMachineByLaunchID(ctx context.Context, launchID st
 	return nil, nil
 }
 
-func hasTransientNetworkSubstring(err error) bool {
-	message := strings.ToLower(err.Error())
-	for _, s := range []string{
-		"connection reset by peer",
-		"connection refused",
-		"network is unreachable",
-		"temporary failure in name resolution",
-		"no such host",
-		"eof",
-	} {
-		if strings.Contains(message, s) {
-			return true
-		}
-	}
-
-	return false
-}
+// This method tags blue-machines with a safe to destroy value.

--- a/internal/command/deploy/strategy_bluegreen_test.go
+++ b/internal/command/deploy/strategy_bluegreen_test.go
@@ -2,7 +2,9 @@ package deploy
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -65,6 +67,9 @@ func newBlueGreenStrategy(client flapsutil.FlapsClient, numberOfExistingMachines
 	strategy.waitBeforeStop = 0
 	strategy.waitBeforeCordon = 0
 	strategy.uncordonRetryDelay = 0
+	strategy.tagRetryDelay = 0
+	strategy.launchRetryDelay = 0
+	strategy.launchLookupDelay = 0
 	strategy.imageRefRetryDelay = 0
 
 	return strategy
@@ -301,6 +306,9 @@ func newBlueGreenStrategyWithState(client flapsutil.FlapsClient, machineState st
 	strategy.waitBeforeStop = 0
 	strategy.waitBeforeCordon = 0
 	strategy.uncordonRetryDelay = 0
+	strategy.tagRetryDelay = 0
+	strategy.launchRetryDelay = 0
+	strategy.launchLookupDelay = 0
 	strategy.imageRefRetryDelay = 0
 
 	return strategy
@@ -781,4 +789,252 @@ func TestFormatDestroyCommand(t *testing.T) {
 		// Must have backslash continuations so each ID is on its own line.
 		assert.Contains(t, cmd, " \\\n", "expected backslash continuation for multi-machine command")
 	})
+}
+
+// TestTagBlueMachinesAsSafeForDeletion covers the checkpointing step's
+// resilience guarantees. The tag is best-effort metadata used by operators
+// to identify hanging blue machines; a transient flaps failure here must
+// never abort the deployment (or we'd leave blue and green versions serving
+// traffic side-by-side).
+func TestTagBlueMachinesAsSafeForDeletion(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("succeeds immediately when no errors occur", func(t *testing.T) {
+		client := &mockFlapsClient{}
+		bg := newBlueGreenStrategy(client, 3)
+
+		err := bg.TagBlueMachinesAsSafeForDeletion(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("succeeds after transient 408s are retried", func(t *testing.T) {
+		client := &mockFlapsClient{setMetadataTransientFailures: 2}
+		bg := newBlueGreenStrategy(client, 1)
+
+		err := bg.TagBlueMachinesAsSafeForDeletion(ctx)
+		assert.NoError(t, err)
+
+		client.mu.Lock()
+		remaining := client.setMetadataTransientFailures
+		client.mu.Unlock()
+		assert.Equal(t, 0, remaining, "all transient failures should be consumed by retries")
+	})
+
+	t.Run("returns nil when retries are exhausted (non-fatal)", func(t *testing.T) {
+		// setMetadataTransientFailures greater than the attempt budget forces
+		// the retry loop to give up. The deployment must still proceed.
+		client := &mockFlapsClient{setMetadataTransientFailures: 100}
+		bg := newBlueGreenStrategy(client, 2)
+		bg.tagRetryAttempts = 3
+
+		err := bg.TagBlueMachinesAsSafeForDeletion(ctx)
+		assert.NoError(t, err, "tag failures must be non-fatal so both blue+green don't stay live")
+	})
+
+	t.Run("does not retry non-transient errors", func(t *testing.T) {
+		client := &mockFlapsClient{breakSetMetadata: true}
+		bg := newBlueGreenStrategy(client, 1)
+		bg.tagRetryAttempts = 5
+
+		start := time.Now()
+		err := bg.TagBlueMachinesAsSafeForDeletion(ctx)
+		elapsed := time.Since(start)
+
+		assert.NoError(t, err)
+		// Non-transient errors bail out on the first attempt, so this must
+		// finish quickly — no exponential back-off between 5 retries.
+		assert.Less(t, elapsed, 500*time.Millisecond, "non-transient failures should not incur retry delay")
+	})
+}
+
+// TestDeployContinuesWhenCheckpointFails guards against a regression where a
+// transient failure of the safe-to-destroy tagging step (SetMetadata against
+// blue machines) aborts the deployment after green machines have already
+// been made ready for traffic. In that state the previous behaviour left
+// both blue and green machines serving traffic side-by-side; the deployment
+// must instead complete end-to-end even when SetMetadata never succeeds.
+func TestDeployContinuesWhenCheckpointFails(t *testing.T) {
+	client := &mockFlapsClient{setMetadataTransientFailures: 999}
+	ctx := flapsutil.NewContextWithClient(context.Background(), client)
+	strategy := newBlueGreenStrategy(client, 2)
+	strategy.tagRetryAttempts = 2
+
+	err := strategy.Deploy(ctx)
+	assert.NoError(t, err, "a persistent SetMetadata failure must not abort the deploy")
+
+	// All blue machines must have been destroyed; leaving any of them alive
+	// alongside green would be the exact bug this test protects against.
+	client.mu.Lock()
+	destroyed := len(client.destroyCalls)
+	client.mu.Unlock()
+	assert.Equal(t, 2, destroyed, "both blue machines should be destroyed at the end of the deploy")
+}
+
+// TestCreateGreenMachinesRetriesLaunchTransients verifies the client-side
+// pseudo-idempotency logic wrapped around flaps.Launch:
+//
+//   - a pre-request transport failure (guaranteed the request never reached
+//     flaps) is retried and eventually succeeds without creating extras;
+//   - an ambiguous 408 that was actually a silent success on the flaps side
+//     is deduplicated via the launch-id metadata lookup so we never end up
+//     with a duplicate green machine;
+//   - an ambiguous 408 that truly failed (no machine committed) is retried
+//     until Launch succeeds;
+//   - a non-transient error (e.g. a 4xx validation error) still fails fast.
+func TestCreateGreenMachinesRetriesLaunchTransients(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("succeeds after transient pre-request failures", func(t *testing.T) {
+		client := &mockFlapsClient{launchPreRequestTransientFailures: 2}
+		ctx := flapsutil.NewContextWithClient(ctx, client)
+		bg := newBlueGreenStrategy(client, 1)
+		bg.launchRetryAttempts = 3
+
+		err := bg.CreateGreenMachines(ctx)
+		assert.NoError(t, err)
+
+		client.mu.Lock()
+		remaining := client.launchPreRequestTransientFailures
+		launched := len(client.launchInputs)
+		client.mu.Unlock()
+		assert.Equal(t, 0, remaining, "transient failures should be consumed by retries")
+		assert.Equal(t, 1, launched, "a truly-failed launch should only produce one committed machine")
+	})
+
+	t.Run("deduplicates silent-success 408 via launch-id lookup", func(t *testing.T) {
+		// The mock commits the machine internally but returns 408. The retry
+		// loop must see the committed machine via List and reuse it instead
+		// of launching again.
+		client := &mockFlapsClient{launchSilentSuccessFailures: 1}
+		ctx := flapsutil.NewContextWithClient(ctx, client)
+		bg := newBlueGreenStrategy(client, 1)
+		bg.launchRetryAttempts = 3
+
+		err := bg.CreateGreenMachines(ctx)
+		assert.NoError(t, err)
+
+		client.mu.Lock()
+		committedMachines := len(client.machines)
+		launchCalls := len(client.launchInputs)
+		client.mu.Unlock()
+
+		assert.Equal(t, 1, committedMachines, "exactly one green machine must exist — the silent-success one")
+		assert.Equal(t, 1, launchCalls, "idempotency lookup must skip the second Launch call")
+		assert.Len(t, bg.greenMachines, 1, "the tracked green machine set must not contain duplicates")
+	})
+
+	t.Run("retries transient 408 that truly failed", func(t *testing.T) {
+		// The mock returns 408 without committing anything. The idempotency
+		// lookup finds nothing, so Launch must be retried until it succeeds.
+		client := &mockFlapsClient{launchTransient408Failures: 2}
+		ctx := flapsutil.NewContextWithClient(ctx, client)
+		bg := newBlueGreenStrategy(client, 1)
+		bg.launchRetryAttempts = 4
+
+		err := bg.CreateGreenMachines(ctx)
+		assert.NoError(t, err)
+
+		client.mu.Lock()
+		remaining := client.launchTransient408Failures
+		committedMachines := len(client.machines)
+		client.mu.Unlock()
+		assert.Equal(t, 0, remaining, "all 408s should have been consumed by retries")
+		assert.Equal(t, 1, committedMachines, "only the eventually-successful Launch commits a machine")
+	})
+
+	t.Run("does not retry non-transient errors", func(t *testing.T) {
+		client := &mockFlapsClient{breakLaunch: true}
+		ctx := flapsutil.NewContextWithClient(ctx, client)
+		bg := newBlueGreenStrategy(client, 1)
+		bg.launchRetryAttempts = 5
+
+		start := time.Now()
+		err := bg.CreateGreenMachines(ctx)
+		elapsed := time.Since(start)
+
+		assert.Error(t, err)
+		assert.Less(t, elapsed, 500*time.Millisecond, "non-retryable errors must fail fast")
+	})
+}
+
+// TestCreateGreenMachinesStampsLaunchID verifies that every green machine
+// launched during a bluegreen deployment carries a unique idempotency tag
+// in its config metadata. Without this tag the retry loop couldn't detect
+// silent-success 408s from flaps.
+func TestCreateGreenMachinesStampsLaunchID(t *testing.T) {
+	client := &mockFlapsClient{}
+	ctx := flapsutil.NewContextWithClient(context.Background(), client)
+	bg := newBlueGreenStrategy(client, 3)
+
+	err := bg.CreateGreenMachines(ctx)
+	require.NoError(t, err)
+
+	client.mu.Lock()
+	inputs := append([]fly.LaunchMachineInput(nil), client.launchInputs...)
+	client.mu.Unlock()
+
+	require.Len(t, inputs, 3, "one launch per blue machine")
+
+	seen := map[string]struct{}{}
+	for _, in := range inputs {
+		require.NotNil(t, in.Config)
+		id := in.Config.Metadata[flyctlBGLaunchIDMetadataKey]
+		assert.NotEmpty(t, id, "every launched green machine must carry a launch-id idempotency tag")
+		_, dup := seen[id]
+		assert.False(t, dup, "launch-id must be unique per intended green machine, got a duplicate: %s", id)
+		seen[id] = struct{}{}
+	}
+}
+
+func TestIsTransientFlapsError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil is not retryable", err: nil, want: false},
+		{name: "context canceled is not retryable", err: context.Canceled, want: false},
+		{name: "context deadline exceeded is not retryable", err: context.DeadlineExceeded, want: false},
+		{
+			name: "flaps 408 is retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusRequestTimeout, OriginalError: errors.New("upstream timeout")},
+			want: true,
+		},
+		{
+			name: "flaps 429 is retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusTooManyRequests, OriginalError: errors.New("rate limited")},
+			want: true,
+		},
+		{
+			name: "flaps 502 is retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusBadGateway, OriginalError: errors.New("bad gateway")},
+			want: true,
+		},
+		{
+			name: "flaps 400 is not retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusBadRequest, OriginalError: errors.New("bad request")},
+			want: false,
+		},
+		{
+			name: "connection reset is retryable",
+			err:  errors.New("read tcp 1.2.3.4:443: connection reset by peer"),
+			want: true,
+		},
+		{
+			name: "connection refused is retryable",
+			err:  errors.New("dial tcp: connection refused"),
+			want: true,
+		},
+		{
+			name: "unrelated error is not retryable",
+			err:  errors.New("machine is misconfigured"),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isTransientFlapsError(tc.err))
+		})
+	}
 }

--- a/internal/command/deploy/strategy_bluegreen_test.go
+++ b/internal/command/deploy/strategy_bluegreen_test.go
@@ -2,9 +2,7 @@ package deploy
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
@@ -983,58 +981,5 @@ func TestCreateGreenMachinesStampsLaunchID(t *testing.T) {
 		_, dup := seen[id]
 		assert.False(t, dup, "launch-id must be unique per intended green machine, got a duplicate: %s", id)
 		seen[id] = struct{}{}
-	}
-}
-
-func TestIsTransientFlapsError(t *testing.T) {
-	cases := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{name: "nil is not retryable", err: nil, want: false},
-		{name: "context canceled is not retryable", err: context.Canceled, want: false},
-		{name: "context deadline exceeded is not retryable", err: context.DeadlineExceeded, want: false},
-		{
-			name: "flaps 408 is retryable",
-			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusRequestTimeout, OriginalError: errors.New("upstream timeout")},
-			want: true,
-		},
-		{
-			name: "flaps 429 is retryable",
-			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusTooManyRequests, OriginalError: errors.New("rate limited")},
-			want: true,
-		},
-		{
-			name: "flaps 502 is retryable",
-			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusBadGateway, OriginalError: errors.New("bad gateway")},
-			want: true,
-		},
-		{
-			name: "flaps 400 is not retryable",
-			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusBadRequest, OriginalError: errors.New("bad request")},
-			want: false,
-		},
-		{
-			name: "connection reset is retryable",
-			err:  errors.New("read tcp 1.2.3.4:443: connection reset by peer"),
-			want: true,
-		},
-		{
-			name: "connection refused is retryable",
-			err:  errors.New("dial tcp: connection refused"),
-			want: true,
-		},
-		{
-			name: "unrelated error is not retryable",
-			err:  errors.New("machine is misconfigured"),
-			want: false,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, isTransientFlapsError(tc.err))
-		})
 	}
 }

--- a/internal/flapsutil/retry.go
+++ b/internal/flapsutil/retry.go
@@ -1,0 +1,77 @@
+package flapsutil
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/superfly/fly-go/flaps"
+)
+
+// IsTransientFlapsError reports whether an error returned by flaps is worth
+// another attempt. It combines two signals:
+//
+//   - HTTP status codes flaps returns for transient upstream conditions:
+//     408 Request Timeout (typically a context.DeadlineExceeded that flaps
+//     hit talking to flyd), 429 Too Many Requests, and any 5xx.
+//   - Transport-level errors from before the request landed (connection
+//     reset/refused, EOF, DNS failures).
+//
+// Context cancellation and deadline expiry are treated as explicit
+// instructions to stop, not as transient failures.
+//
+// IMPORTANT: for non-idempotent endpoints (like flaps' create-machine)
+// a 408 from flaps is *ambiguous* — the upstream side-effect may or may
+// not have happened. Callers targeting those endpoints should either
+// implement client-side idempotency (see the launch-id pattern in the
+// bluegreen deploy strategy) or restrict retries to pre-request transport
+// errors via HasTransientNetworkSubstring.
+func IsTransientFlapsError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// User interrupted / deadline elapsed for the whole operation: don't retry.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var flapsErr *flaps.FlapsError
+	if errors.As(err, &flapsErr) {
+		switch {
+		case flapsErr.ResponseStatusCode == http.StatusRequestTimeout,
+			flapsErr.ResponseStatusCode == http.StatusTooManyRequests,
+			flapsErr.ResponseStatusCode >= 500 && flapsErr.ResponseStatusCode < 600:
+			return true
+		}
+	}
+
+	return HasTransientNetworkSubstring(err)
+}
+
+// HasTransientNetworkSubstring reports whether the error message contains a
+// well-known substring associated with transport-level failures that occur
+// *before* the request reaches the server. These are always safe to retry,
+// even for non-idempotent operations, because no side effect can have
+// happened server-side yet.
+func HasTransientNetworkSubstring(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	for _, s := range []string{
+		"connection reset by peer",
+		"connection refused",
+		"network is unreachable",
+		"temporary failure in name resolution",
+		"no such host",
+		"eof",
+	} {
+		if strings.Contains(message, s) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/flapsutil/retry_test.go
+++ b/internal/flapsutil/retry_test.go
@@ -1,0 +1,101 @@
+package flapsutil
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/superfly/fly-go/flaps"
+)
+
+func TestIsTransientFlapsError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil is not retryable", err: nil, want: false},
+		{name: "context canceled is not retryable", err: context.Canceled, want: false},
+		{name: "context deadline exceeded is not retryable", err: context.DeadlineExceeded, want: false},
+		{
+			name: "flaps 408 is retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusRequestTimeout, OriginalError: errors.New("upstream timeout")},
+			want: true,
+		},
+		{
+			name: "flaps 429 is retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusTooManyRequests, OriginalError: errors.New("rate limited")},
+			want: true,
+		},
+		{
+			name: "flaps 502 is retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusBadGateway, OriginalError: errors.New("bad gateway")},
+			want: true,
+		},
+		{
+			name: "flaps 503 is retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusServiceUnavailable, OriginalError: errors.New("unavailable")},
+			want: true,
+		},
+		{
+			name: "flaps 400 is not retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusBadRequest, OriginalError: errors.New("bad request")},
+			want: false,
+		},
+		{
+			name: "flaps 404 is not retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusNotFound, OriginalError: errors.New("not found")},
+			want: false,
+		},
+		{
+			name: "connection reset is retryable",
+			err:  errors.New("read tcp 1.2.3.4:443: connection reset by peer"),
+			want: true,
+		},
+		{
+			name: "connection refused is retryable",
+			err:  errors.New("dial tcp: connection refused"),
+			want: true,
+		},
+		{
+			name: "no such host is retryable",
+			err:  errors.New("lookup foo.internal: no such host"),
+			want: true,
+		},
+		{
+			name: "unrelated error is not retryable",
+			err:  errors.New("machine is misconfigured"),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsTransientFlapsError(tc.err))
+		})
+	}
+}
+
+func TestHasTransientNetworkSubstring(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil returns false", err: nil, want: false},
+		{name: "connection reset matches", err: errors.New("Connection reset by peer"), want: true},
+		{name: "connection refused matches", err: errors.New("dial: connection refused"), want: true},
+		{name: "network unreachable matches", err: errors.New("network is unreachable"), want: true},
+		{name: "no such host matches", err: errors.New("lookup: no such host"), want: true},
+		{name: "eof matches", err: errors.New("unexpected EOF"), want: true},
+		{name: "unrelated does not match", err: errors.New("permission denied"), want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, HasTransientNetworkSubstring(tc.err))
+		})
+	}
+}

--- a/test/preflight/fly_deploy_bluegreen_test.go
+++ b/test/preflight/fly_deploy_bluegreen_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/superfly/flyctl/test/preflight/testlib"
 )
 
+// flyctlBGLaunchIDMetadataKey mirrors the constant in
+// internal/command/deploy/strategy_bluegreen.go. It's redeclared here so this
+// integration test doesn't depend on the internal package.
+const flyctlBGLaunchIDMetadataKey = "fly_flyctl_bluegreen_launch_id"
+
 func TestFlyDeployBluegreenImplicitAppProcessGroup(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
@@ -62,6 +67,116 @@ func splitFlyLaunchMachines(machines []*fly.Machine) (managedMachines, detachedM
 	}
 
 	return managedMachines, detachedMachines
+}
+
+// TestFlyDeployBluegreen_LaunchIdempotencyMetadata is an end-to-end regression
+// test for the resilience improvements to the bluegreen strategy. It exists
+// primarily to guard the two changes that prevent transient flaps failures
+// from stranding a deployment with both blue and green machines live:
+//
+//  1. Every green machine created during a bluegreen deploy must carry a
+//     unique per-launch idempotency tag in its config metadata. Without it,
+//     the client-side retry loop cannot detect a silent-success Launch (a
+//     flaps 408 that actually committed the machine) and could produce
+//     duplicate green machines on retry.
+//  2. A successful bluegreen deploy must still complete end-to-end and leave
+//     only one image version running. This guards against regressions in the
+//     retry / checkpoint plumbing where a well-intentioned change might
+//     silently break the happy path.
+//
+// The failure modes fixed by the retry logic (transient 408s from flaps)
+// can't be reliably reproduced in preflight without infrastructure-level
+// fault injection, so this test asserts the observable invariants that hold
+// on any successful deploy.
+func TestFlyDeployBluegreen_LaunchIdempotencyMetadata(t *testing.T) {
+	f := testlib.NewTestEnvFromEnv(t)
+	appName := f.CreateRandomAppName()
+
+	f.Fly("launch --org %s --name %s --region %s --image nginx --internal-port 80 --ha=false",
+		f.OrgSlug(), appName, f.PrimaryRegion())
+
+	// Bluegreen requires at least one configured healthcheck; without it the
+	// strategy warns and skips health polling. Add one before the first
+	// deploy so subsequent bluegreen runs behave the same way real apps do.
+	appConfig := f.ReadFile("fly.toml")
+	appConfig += `
+  [[http_service.checks]]
+    grace_period = "5s"
+    interval = "10s"
+    method = "GET"
+    timeout = "5s"
+    path = "/"
+`
+	f.WriteFlyToml("%s", appConfig)
+	f.Fly("deploy --remote-only")
+
+	// First bluegreen deploy — stamps a launch-id on every green machine.
+	f.Fly("deploy --remote-only --strategy bluegreen")
+
+	firstLaunchIDs := collectLaunchIDs(t, f, appName)
+	require.NotEmpty(t, firstLaunchIDs,
+		"every machine created by a bluegreen deploy must carry a %q metadata tag; "+
+			"without it the client-side retry loop can't dedupe silent-success 408s",
+		flyctlBGLaunchIDMetadataKey)
+
+	for _, m := range f.MachinesList(appName) {
+		assert.Equal(t, fly.MachineStateStarted, m.State,
+			"machine %s must be started after a successful bluegreen deploy, got %q",
+			m.ID, m.State)
+		assert.NotEmpty(t, m.Config.Metadata[flyctlBGLaunchIDMetadataKey],
+			"machine %s should carry the launch-id metadata tag", m.ID)
+	}
+
+	// Second bluegreen deploy — fresh green machines, fresh launch-ids. This
+	// exercises the full retry-capable path a second time and proves the
+	// checkpoint step (safe-for-deletion tagging) is idempotent-friendly:
+	// a repeated deploy must still succeed.
+	f.Fly("deploy --remote-only --strategy bluegreen")
+
+	secondLaunchIDs := collectLaunchIDs(t, f, appName)
+	require.NotEmpty(t, secondLaunchIDs, "second bluegreen deploy must also stamp launch-ids on machines")
+
+	// Every launch-id from the second deploy must be different from the ones
+	// on the first — they're generated fresh per machine per deploy.
+	for id := range secondLaunchIDs {
+		assert.NotContains(t, firstLaunchIDs, id,
+			"launch-ids must be regenerated on each deploy; %s was reused across runs", id)
+	}
+
+	// After a healthy bluegreen deploy the machine count and image version
+	// must both be stable — exactly what protecting against the "two versions
+	// live" incident looks like from the outside.
+	machines := f.MachinesList(appName)
+	require.NotEmpty(t, machines, "app must have machines after bluegreen deploy")
+	imageRefs := map[string]struct{}{}
+	for _, m := range machines {
+		assert.Equal(t, fly.MachineStateStarted, m.State,
+			"machine %s must remain started after the second bluegreen deploy", m.ID)
+		imageRefs[m.ImageRef.Repository+":"+m.ImageRef.Tag] = struct{}{}
+	}
+	assert.Len(t, imageRefs, 1,
+		"a completed bluegreen deploy must leave exactly one image version running, saw %d: %v",
+		len(imageRefs), imageRefs)
+}
+
+// collectLaunchIDs returns the set of unique launch-id metadata values found
+// on the app's machines. An empty result signals the bluegreen strategy is
+// no longer stamping the tag — which would break the idempotency retry loop
+// in launchGreenMachineWithRetry.
+func collectLaunchIDs(t *testing.T, f *testlib.FlyctlTestEnv, appName string) map[string]struct{} {
+	t.Helper()
+
+	ids := map[string]struct{}{}
+	for _, m := range f.MachinesList(appName) {
+		if m.Config == nil {
+			continue
+		}
+		if id := m.Config.Metadata[flyctlBGLaunchIDMetadataKey]; id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+
+	return ids
 }
 
 func writeImplicitAppProcessFlyToml(f *testlib.FlyctlTestEnv, appName, generation string) {


### PR DESCRIPTION
### Change Summary

What and Why: we are giving up too soon after failing once while launching an app or changing its metadata. 

How: Im adding some idempotency from client side and retry with backoff before the deployment is given up. If rerunning `fly deploy` would solve it, might as well just do it ourselves

Related to: I will stack another PR with other suggestions but these two issues actually bitten us this week.

---

### Documentation

- [X] Fresh Produce soon
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
