### PR TITLE
Don't choke on region duplicates.

### DIFF
--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -376,6 +376,7 @@ func convergeGroupCounts(expectedTotal int, current map[string]int, regions []st
 	if len(regions) == 0 {
 		regions = lo.Keys(current)
 	}
+	regions = lo.Uniq(regions)
 
 	if maxPerRegion >= 0 {
 		if len(regions)*maxPerRegion < expectedTotal {

--- a/internal/command/scale/count_machines_test.go
+++ b/internal/command/scale/count_machines_test.go
@@ -2,6 +2,7 @@ package scale
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -135,5 +136,22 @@ func Test_convergeGroupCounts_maxPerRegion(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tc.want, got)
 		})
+	}
+}
+
+func TestConvergeGroupCounts_DuplicateRegions(t *testing.T) {
+	errCh := make(chan error, 1)
+	go func() {
+		// Pass a duplicate region. This is a regression test because the function
+		// would choke on duplicates.
+		_, err := convergeGroupCounts(20, nil, []string{"dfw", "sjc", "lhr", "lax", "cdg", "ams", "dfw", "gru", "arn", "sin"}, 2)
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		assert.ErrorIs(t, err, ErrMaxPerRegion)
+	case <-time.After(time.Second):
+		t.Fatal("convergeGroupCounts did not return when regions contained a duplicate")
 	}
 }

--- a/internal/command/scale/count_machines_test.go
+++ b/internal/command/scale/count_machines_test.go
@@ -139,7 +139,7 @@ func Test_convergeGroupCounts_maxPerRegion(t *testing.T) {
 	}
 }
 
-func TestConvergeGroupCounts_DuplicateRegions(t *testing.T) {
+func Test_convergeGroupCounts_duplicateRegions(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() {
 		// Pass a duplicate region. This is a regression test because the function


### PR DESCRIPTION
The function `convergeGroupCounts` takes as input regions represented as a slice. If the slice contains duplicates, the function's math no longer works, and we end up in an endless loop.

This PR fixes that by eliminating duplicates in the given region slice.