### PR TITLE
Detect Containerfile during fly launch

### DIFF
--- a/internal/command/launch/sourceinfo.go
+++ b/internal/command/launch/sourceinfo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -76,6 +77,15 @@ func determineSourceInfo(ctx context.Context, appConfig *appconfig.Config, copyC
 	srcInfo, err = scanner.Scan(workingDir, scannerConfig)
 	if err != nil {
 		return nil, nil, err
+	}
+	if srcInfo != nil && srcInfo.DockerfilePath != "" {
+		dockerfilePath, err := filepath.Rel(workingDir, srcInfo.DockerfilePath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("could not resolve Dockerfile path: %w", err)
+		}
+		if dockerfilePath != "Dockerfile" {
+			build.Dockerfile = dockerfilePath
+		}
 	}
 
 	if srcInfo == nil {

--- a/internal/command/launch/sourceinfo_test.go
+++ b/internal/command/launch/sourceinfo_test.go
@@ -1,0 +1,62 @@
+package launch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func TestDetermineSourceInfoDockerfileDetection(t *testing.T) {
+	t.Setenv("OPT_OUT_GITHUB_ACTIONS", "1")
+
+	tests := []struct {
+		name               string
+		files              map[string]string
+		expectedDockerfile string
+		expectedBuildPath  string
+	}{
+		{
+			name: "Containerfile",
+			files: map[string]string{
+				"Containerfile": "FROM alpine\nEXPOSE 3000\n",
+			},
+			expectedDockerfile: "Containerfile",
+			expectedBuildPath:  "Containerfile",
+		},
+		{
+			name: "Dockerfile takes precedence",
+			files: map[string]string{
+				"Containerfile": "FROM alpine\nEXPOSE 3000\n",
+				"Dockerfile":    "FROM alpine\nEXPOSE 8080\n",
+			},
+			expectedDockerfile: "Dockerfile",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for name, contents := range tt.files {
+				require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o644))
+			}
+
+			io, _, _, _ := iostreams.Test()
+			ctx := iostreams.NewContext(context.Background(), io)
+			ctx = flagctx.NewContext(ctx, pflag.NewFlagSet("test", pflag.ContinueOnError))
+
+			sourceInfo, build, err := determineSourceInfo(ctx, appconfig.NewConfig(), false, dir)
+			require.NoError(t, err)
+			require.NotNil(t, sourceInfo)
+			require.NotNil(t, build)
+			require.Equal(t, filepath.Join(dir, tt.expectedDockerfile), sourceInfo.DockerfilePath)
+			require.Equal(t, tt.expectedBuildPath, build.Dockerfile)
+		})
+	}
+}

--- a/scanner/dockerfile.go
+++ b/scanner/dockerfile.go
@@ -12,7 +12,12 @@ const defaultPort = 8080
 var portRegex = regexp.MustCompile(`(?m)^EXPOSE\s+(?P<port>\d+)`)
 
 func configureDockerfile(sourceDir string, config *ScannerConfig) (*SourceInfo, error) {
-	return ScanDockerfile(filepath.Join(sourceDir, "Dockerfile"), config)
+	sourceInfo, err := ScanDockerfile(filepath.Join(sourceDir, "Dockerfile"), config)
+	if sourceInfo != nil || err != nil {
+		return sourceInfo, err
+	}
+
+	return ScanDockerfile(filepath.Join(sourceDir, "Containerfile"), config)
 }
 
 func ScanDockerfile(dockerfilePath string, config *ScannerConfig) (*SourceInfo, error) {


### PR DESCRIPTION
### Change Summary

What and Why:

`fly launch` only auto-detects a file named `Dockerfile`, so projects that use `Containerfile` are treated as having no Dockerfile and fail when launch tries to build them. This change detects a root `Containerfile` and records it as the Dockerfile used by the generated configuration.

How:

The source scanner keeps `Dockerfile` precedence, then checks `Containerfile`. Launch persists the non-default filename so first deploy and later deploys use the file that was scanned, while explicit `--dockerfile`, existing `[build]` configuration, framework scanner precedence, and plain `fly deploy` behavior remain unchanged.

Tested with:

- `go test ./internal/command/launch -run '^TestDetermineSourceInfoDockerfileDetection$' -count=1`
- `go test ./scanner ./internal/command/launch -count=1`
- `make test`

Related to:

Fixes #1785

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
