### PR TITLE
refactor(retry): extract IsTransientFlapsError to flapsutil

### DIFF
--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -1345,7 +1344,7 @@ func (bg *blueGreen) TagBlueMachinesAsSafeForDeletion(ctx context.Context) error
 				retry.Delay(bg.tagRetryDelay),
 				retry.MaxDelay(10*time.Second),
 				retry.DelayType(retry.BackOffDelay),
-				retry.RetryIf(isTransientFlapsError),
+				retry.RetryIf(flapsutil.IsTransientFlapsError),
 				retry.LastErrorOnly(true),
 				retry.OnRetry(func(n uint, err error) {
 					fmt.Fprintf(bg.io.ErrOut, "  Retrying safe-for-deletion tag for machine %s (attempt %d/%d): %v\n",
@@ -1383,40 +1382,6 @@ func (bg *blueGreen) TagBlueMachinesAsSafeForDeletion(ctx context.Context) error
 	}
 
 	return nil
-}
-
-// isTransientFlapsError reports whether an error returned by flaps is worth
-// another attempt. It's intentionally strict about "pre-request" transports
-// (connection reset/refused, EOF, etc.) but also includes HTTP status codes
-// that flaps uses for transient upstream conditions:
-//   - 408 Request Timeout: flaps hit a context.DeadlineExceeded talking to flyd
-//   - 429 Too Many Requests: rate-limited
-//   - 5xx Server Error: transient server-side failure
-//
-// This classifier must NOT be used with non-idempotent endpoints (like Launch)
-// unless the caller only relies on the pre-request substrings, since a 408
-// from flaps doesn't tell us whether the upstream side-effect happened.
-func isTransientFlapsError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	// User interrupted / deadline elapsed for the whole operation: don't retry.
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return false
-	}
-
-	var flapsErr *flaps.FlapsError
-	if errors.As(err, &flapsErr) {
-		switch {
-		case flapsErr.ResponseStatusCode == http.StatusRequestTimeout,
-			flapsErr.ResponseStatusCode == http.StatusTooManyRequests,
-			flapsErr.ResponseStatusCode >= 500 && flapsErr.ResponseStatusCode < 600:
-			return true
-		}
-	}
-
-	return hasTransientNetworkSubstring(err)
 }
 
 // launchGreenMachineWithRetry launches a single green machine with client-side
@@ -1457,7 +1422,7 @@ func (bg *blueGreen) launchGreenMachineWithRetry(ctx context.Context, launchInpu
 
 		// A non-transient failure (400/404/etc.) isn't going to get better
 		// with another attempt.
-		if !isTransientFlapsError(err) {
+		if !flapsutil.IsTransientFlapsError(err) {
 			return nil, err
 		}
 
@@ -1525,20 +1490,4 @@ func (bg *blueGreen) findGreenMachineByLaunchID(ctx context.Context, launchID st
 	return nil, nil
 }
 
-func hasTransientNetworkSubstring(err error) bool {
-	message := strings.ToLower(err.Error())
-	for _, s := range []string{
-		"connection reset by peer",
-		"connection refused",
-		"network is unreachable",
-		"temporary failure in name resolution",
-		"no such host",
-		"eof",
-	} {
-		if strings.Contains(message, s) {
-			return true
-		}
-	}
-
-	return false
-}
+// This method tags blue-machines with a safe to destroy value.

--- a/internal/command/deploy/strategy_bluegreen_test.go
+++ b/internal/command/deploy/strategy_bluegreen_test.go
@@ -2,9 +2,7 @@ package deploy
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
@@ -983,58 +981,5 @@ func TestCreateGreenMachinesStampsLaunchID(t *testing.T) {
 		_, dup := seen[id]
 		assert.False(t, dup, "launch-id must be unique per intended green machine, got a duplicate: %s", id)
 		seen[id] = struct{}{}
-	}
-}
-
-func TestIsTransientFlapsError(t *testing.T) {
-	cases := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{name: "nil is not retryable", err: nil, want: false},
-		{name: "context canceled is not retryable", err: context.Canceled, want: false},
-		{name: "context deadline exceeded is not retryable", err: context.DeadlineExceeded, want: false},
-		{
-			name: "flaps 408 is retryable",
-			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusRequestTimeout, OriginalError: errors.New("upstream timeout")},
-			want: true,
-		},
-		{
-			name: "flaps 429 is retryable",
-			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusTooManyRequests, OriginalError: errors.New("rate limited")},
-			want: true,
-		},
-		{
-			name: "flaps 502 is retryable",
-			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusBadGateway, OriginalError: errors.New("bad gateway")},
-			want: true,
-		},
-		{
-			name: "flaps 400 is not retryable",
-			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusBadRequest, OriginalError: errors.New("bad request")},
-			want: false,
-		},
-		{
-			name: "connection reset is retryable",
-			err:  errors.New("read tcp 1.2.3.4:443: connection reset by peer"),
-			want: true,
-		},
-		{
-			name: "connection refused is retryable",
-			err:  errors.New("dial tcp: connection refused"),
-			want: true,
-		},
-		{
-			name: "unrelated error is not retryable",
-			err:  errors.New("machine is misconfigured"),
-			want: false,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, isTransientFlapsError(tc.err))
-		})
 	}
 }

--- a/internal/flapsutil/retry.go
+++ b/internal/flapsutil/retry.go
@@ -1,0 +1,77 @@
+package flapsutil
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/superfly/fly-go/flaps"
+)
+
+// IsTransientFlapsError reports whether an error returned by flaps is worth
+// another attempt. It combines two signals:
+//
+//   - HTTP status codes flaps returns for transient upstream conditions:
+//     408 Request Timeout (typically a context.DeadlineExceeded that flaps
+//     hit talking to flyd), 429 Too Many Requests, and any 5xx.
+//   - Transport-level errors from before the request landed (connection
+//     reset/refused, EOF, DNS failures).
+//
+// Context cancellation and deadline expiry are treated as explicit
+// instructions to stop, not as transient failures.
+//
+// IMPORTANT: for non-idempotent endpoints (like flaps' create-machine)
+// a 408 from flaps is *ambiguous* — the upstream side-effect may or may
+// not have happened. Callers targeting those endpoints should either
+// implement client-side idempotency (see the launch-id pattern in the
+// bluegreen deploy strategy) or restrict retries to pre-request transport
+// errors via HasTransientNetworkSubstring.
+func IsTransientFlapsError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// User interrupted / deadline elapsed for the whole operation: don't retry.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var flapsErr *flaps.FlapsError
+	if errors.As(err, &flapsErr) {
+		switch {
+		case flapsErr.ResponseStatusCode == http.StatusRequestTimeout,
+			flapsErr.ResponseStatusCode == http.StatusTooManyRequests,
+			flapsErr.ResponseStatusCode >= 500 && flapsErr.ResponseStatusCode < 600:
+			return true
+		}
+	}
+
+	return HasTransientNetworkSubstring(err)
+}
+
+// HasTransientNetworkSubstring reports whether the error message contains a
+// well-known substring associated with transport-level failures that occur
+// *before* the request reaches the server. These are always safe to retry,
+// even for non-idempotent operations, because no side effect can have
+// happened server-side yet.
+func HasTransientNetworkSubstring(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	for _, s := range []string{
+		"connection reset by peer",
+		"connection refused",
+		"network is unreachable",
+		"temporary failure in name resolution",
+		"no such host",
+		"eof",
+	} {
+		if strings.Contains(message, s) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/flapsutil/retry_test.go
+++ b/internal/flapsutil/retry_test.go
@@ -1,0 +1,101 @@
+package flapsutil
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/superfly/fly-go/flaps"
+)
+
+func TestIsTransientFlapsError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil is not retryable", err: nil, want: false},
+		{name: "context canceled is not retryable", err: context.Canceled, want: false},
+		{name: "context deadline exceeded is not retryable", err: context.DeadlineExceeded, want: false},
+		{
+			name: "flaps 408 is retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusRequestTimeout, OriginalError: errors.New("upstream timeout")},
+			want: true,
+		},
+		{
+			name: "flaps 429 is retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusTooManyRequests, OriginalError: errors.New("rate limited")},
+			want: true,
+		},
+		{
+			name: "flaps 502 is retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusBadGateway, OriginalError: errors.New("bad gateway")},
+			want: true,
+		},
+		{
+			name: "flaps 503 is retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusServiceUnavailable, OriginalError: errors.New("unavailable")},
+			want: true,
+		},
+		{
+			name: "flaps 400 is not retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusBadRequest, OriginalError: errors.New("bad request")},
+			want: false,
+		},
+		{
+			name: "flaps 404 is not retryable",
+			err:  &flaps.FlapsError{ResponseStatusCode: http.StatusNotFound, OriginalError: errors.New("not found")},
+			want: false,
+		},
+		{
+			name: "connection reset is retryable",
+			err:  errors.New("read tcp 1.2.3.4:443: connection reset by peer"),
+			want: true,
+		},
+		{
+			name: "connection refused is retryable",
+			err:  errors.New("dial tcp: connection refused"),
+			want: true,
+		},
+		{
+			name: "no such host is retryable",
+			err:  errors.New("lookup foo.internal: no such host"),
+			want: true,
+		},
+		{
+			name: "unrelated error is not retryable",
+			err:  errors.New("machine is misconfigured"),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsTransientFlapsError(tc.err))
+		})
+	}
+}
+
+func TestHasTransientNetworkSubstring(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil returns false", err: nil, want: false},
+		{name: "connection reset matches", err: errors.New("Connection reset by peer"), want: true},
+		{name: "connection refused matches", err: errors.New("dial: connection refused"), want: true},
+		{name: "network unreachable matches", err: errors.New("network is unreachable"), want: true},
+		{name: "no such host matches", err: errors.New("lookup: no such host"), want: true},
+		{name: "eof matches", err: errors.New("unexpected EOF"), want: true},
+		{name: "unrelated does not match", err: errors.New("permission denied"), want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, HasTransientNetworkSubstring(tc.err))
+		})
+	}
+}


### PR DESCRIPTION
Moves the transient-error classifier from strategy_bluegreen.go into a
shared internal/flapsutil/retry.go so upcoming resilience work on other
deploy paths (rolling update, blue teardown, health-check polls, etc.)
can reuse the same classification rules without duplicating the logic
per call site.

No behaviour change: strategy_bluegreen.go delegates to
flapsutil.IsTransientFlapsError instead of its private copy, and the
existing test coverage moves to internal/flapsutil/retry_test.go.
