### PR TITLE
fix(deploy): retry transient failures during blue-machine teardown

### DIFF
--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -70,6 +70,14 @@ type mockFlapsClient struct {
 	// the lookup finds no matching machine and we must launch again.
 	launchTransient408Failures int
 
+	// cordonTransientFailures / stopTransientFailures / destroyTransientFailures
+	// each make the corresponding endpoint fail this many times with a
+	// retryable 408 before succeeding. They let tests exercise the retry
+	// loops added to the blue-machine teardown stages of a bluegreen deploy.
+	cordonTransientFailures  int
+	stopTransientFailures    int
+	destroyTransientFailures int
+
 	// mu to protect the members below.
 	mu            sync.Mutex
 	machines      []*fly.Machine
@@ -100,7 +108,20 @@ func (m *mockFlapsClient) CheckCertificate(ctx context.Context, appName, hostnam
 }
 
 func (m *mockFlapsClient) Cordon(ctx context.Context, appName, machineID string, nonce string) (err error) {
-	return fmt.Errorf("failed to cordon %s", machineID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.cordonTransientFailures > 0 {
+		m.cordonTransientFailures--
+
+		return &flaps.FlapsError{
+			OriginalError:      fmt.Errorf("transient error cordoning %s", machineID),
+			ResponseStatusCode: http.StatusRequestTimeout,
+			ResponseBody:       []byte("upstream timeout"),
+		}
+	}
+
+	return nil
 }
 
 func (m *mockFlapsClient) CreateACMECertificate(ctx context.Context, appName string, req fly.CreateCertificateRequest) (*fly.CertificateDetailResponse, error) {
@@ -166,6 +187,16 @@ func (m *mockFlapsClient) DeleteVolume(ctx context.Context, appName, volumeId st
 func (m *mockFlapsClient) Destroy(ctx context.Context, appName string, input fly.RemoveMachineInput, nonce string) (err error) {
 	m.mu.Lock()
 	m.destroyCalls = append(m.destroyCalls, destroyCall{input: input, nonce: nonce})
+	if m.destroyTransientFailures > 0 {
+		m.destroyTransientFailures--
+		m.mu.Unlock()
+
+		return &flaps.FlapsError{
+			OriginalError:      fmt.Errorf("transient error destroying %s", input.ID),
+			ResponseStatusCode: http.StatusRequestTimeout,
+			ResponseBody:       []byte("upstream timeout"),
+		}
+	}
 	m.mu.Unlock()
 
 	if m.breakDestroy {
@@ -477,7 +508,20 @@ func (m *mockFlapsClient) Start(ctx context.Context, appName, machineID string, 
 }
 
 func (m *mockFlapsClient) Stop(ctx context.Context, appName string, in fly.StopMachineInput, nonce string) (err error) {
-	return fmt.Errorf("failed to stop %s", in.ID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.stopTransientFailures > 0 {
+		m.stopTransientFailures--
+
+		return &flaps.FlapsError{
+			OriginalError:      fmt.Errorf("transient error stopping %s", in.ID),
+			ResponseStatusCode: http.StatusRequestTimeout,
+			ResponseBody:       []byte("upstream timeout"),
+		}
+	}
+
+	return nil
 }
 
 func (m *mockFlapsClient) Suspend(ctx context.Context, appName, machineID, nonce string) (err error) {

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -130,6 +131,16 @@ type blueGreen struct {
 	// empty from the list API (e.g. due to a transient API error).
 	imageRefRetryAttempts uint
 	imageRefRetryDelay    time.Duration
+
+	// teardownRetryAttempts / teardownRetryDelay control the back-off used when
+	// CordonBlueMachines / StopBlueMachines / DestroyBlueMachines hit transient
+	// flaps errors. All three operations are idempotent so retries are safe:
+	//   - Cordon: setting cordon=true twice is a no-op.
+	//   - Stop: stopping an already-stopped machine returns success on flaps.
+	//   - Destroy: destroying an already-destroyed machine returns 404, which
+	//     the destroy wrapper treats as a no-op.
+	teardownRetryAttempts uint
+	teardownRetryDelay    time.Duration
 }
 
 // hostIsOk reports whether the machine's host is confirmed healthy. Anything
@@ -206,6 +217,9 @@ func (bg *blueGreen) initialize() {
 
 	bg.imageRefRetryAttempts = 3
 	bg.imageRefRetryDelay = 1 * time.Second
+
+	bg.teardownRetryAttempts = 5
+	bg.teardownRetryDelay = 500 * time.Millisecond
 }
 
 func (bg *blueGreen) isAborted() bool {
@@ -668,10 +682,31 @@ func (bg *blueGreen) CordonBlueMachines(ctx context.Context) error {
 			if bg.isAborted() {
 				return ErrAborted
 			}
-			err := gm.leasableMachine.Cordon(ctx)
+			// Cordon is idempotent: writing cordon=true twice is a no-op, so
+			// we can retry transient failures freely. Without retries a single
+			// 408 leaves the machine uncordoned, which prolongs the window
+			// where blue is still taking traffic after green went ready.
+			err := retry.Do(
+				func() error { return gm.leasableMachine.Cordon(ctx) },
+				retry.Context(ctx),
+				retry.Attempts(bg.teardownRetryAttempts),
+				retry.Delay(bg.teardownRetryDelay),
+				retry.MaxDelay(10*time.Second),
+				retry.DelayType(retry.BackOffDelay),
+				retry.RetryIf(flapsutil.IsTransientFlapsError),
+				retry.LastErrorOnly(true),
+				retry.OnRetry(func(n uint, err error) {
+					fmt.Fprintf(bg.io.ErrOut, "  Retrying cordon for machine %s (attempt %d/%d): %v\n",
+						bg.colorize.Bold(gm.leasableMachine.FormattedMachineId()), n+2, bg.teardownRetryAttempts, err)
+				}),
+			)
 			if err != nil {
-				// Just let the user know, it's not a critical error
-				fmt.Fprintf(bg.io.ErrOut, "  Failed to cordon machine %s: %v\n", bg.colorize.Bold(gm.leasableMachine.FormattedMachineId()), err)
+				// Non-fatal: the machine will still be stopped and destroyed
+				// below. Warn the user so they can correlate an unusually long
+				// "two versions live" window with a flaps hiccup.
+				tracing.RecordError(span, err, "failed to cordon blue machine")
+				fmt.Fprintf(bg.io.ErrOut, "  [warn] Failed to cordon machine %s after %d attempts: %v\n",
+					bg.colorize.Bold(gm.leasableMachine.FormattedMachineId()), bg.teardownRetryAttempts, err)
 
 				return nil
 			}
@@ -703,11 +738,30 @@ func (bg *blueGreen) StopBlueMachines(ctx context.Context) error {
 			if bg.isAborted() {
 				return ErrAborted
 			}
-			err := gm.leasableMachine.Stop(ctx, bg.stopSignal)
+			// Stop is idempotent: stopping an already-stopped machine returns
+			// success. Retrying transient failures gives the app another
+			// chance at a graceful SIGTERM before the destroy step force-kills.
+			err := retry.Do(
+				func() error { return gm.leasableMachine.Stop(ctx, bg.stopSignal) },
+				retry.Context(ctx),
+				retry.Attempts(bg.teardownRetryAttempts),
+				retry.Delay(bg.teardownRetryDelay),
+				retry.MaxDelay(10*time.Second),
+				retry.DelayType(retry.BackOffDelay),
+				retry.RetryIf(flapsutil.IsTransientFlapsError),
+				retry.LastErrorOnly(true),
+				retry.OnRetry(func(n uint, err error) {
+					fmt.Fprintf(bg.io.ErrOut, "  Retrying stop for machine %s (attempt %d/%d): %v\n",
+						bg.colorize.Bold(gm.leasableMachine.FormattedMachineId()), n+2, bg.teardownRetryAttempts, err)
+				}),
+			)
 			if err != nil {
-				// Just let the user know, it's not a critical error as we are gonna destroy the
-				// machines with force later
-				fmt.Fprintf(bg.io.ErrOut, "  Failed to stop machine %s: %v\n", bg.colorize.Bold(gm.leasableMachine.FormattedMachineId()), err)
+				// Non-fatal: the destroy step below force-kills. Losing the
+				// graceful-shutdown window is a per-machine annoyance, not a
+				// deploy-blocker.
+				tracing.RecordError(span, err, "failed to stop blue machine")
+				fmt.Fprintf(bg.io.ErrOut, "  [warn] Failed to stop machine %s after %d attempts: %v\n",
+					bg.colorize.Bold(gm.leasableMachine.FormattedMachineId()), bg.teardownRetryAttempts, err)
 
 				return nil
 			}
@@ -798,26 +852,58 @@ func (bg *blueGreen) DestroyBlueMachines(ctx context.Context) error {
 				return ErrAborted
 			}
 
-			var err error
-			if hostIsOk(gm.leasableMachine.Machine()) {
-				err = gm.leasableMachine.Destroy(ctx, true)
-			} else {
-				// No lease exists for a machine on a non-ok host (lease
-				// acquisition skips them), so bypass the leasable wrapper and
-				// issue the destroy straight through the flaps API with
-				// kill=true and no nonce — the exact call behind
-				// `fly machine destroy --force`. A stale nonce from the list
-				// response could otherwise make flaps reject the destroy.
-				err = bg.flaps.Destroy(ctx, bg.app.Name, fly.RemoveMachineInput{
-					ID:   gm.leasableMachine.Machine().ID,
-					Kill: true,
-				}, "")
+			// Destroy is idempotent from flyctl's perspective: destroying an
+			// already-destroyed machine returns 404, which we treat as success
+			// (the desired state is "machine gone"), and the leasable-wrapper
+			// treats a machine it already destroyed as a no-op. Retrying
+			// transient failures directly translates into fewer "hanging blue
+			// machines" support tickets after otherwise-successful deploys.
+			destroyOp := func() error {
+				var err error
+				if hostIsOk(gm.leasableMachine.Machine()) {
+					err = gm.leasableMachine.Destroy(ctx, true)
+				} else {
+					// No lease exists for a machine on a non-ok host (lease
+					// acquisition skips them), so bypass the leasable wrapper and
+					// issue the destroy straight through the flaps API with
+					// kill=true and no nonce — the exact call behind
+					// `fly machine destroy --force`. A stale nonce from the list
+					// response could otherwise make flaps reject the destroy.
+					err = bg.flaps.Destroy(ctx, bg.app.Name, fly.RemoveMachineInput{
+						ID:   gm.leasableMachine.Machine().ID,
+						Kill: true,
+					}, "")
+				}
+				// 404 after a successful-but-timed-out prior attempt is a silent
+				// success — the machine really is gone, so surface it as such.
+				var flapsErr *flaps.FlapsError
+				if errors.As(err, &flapsErr) && flapsErr.ResponseStatusCode == http.StatusNotFound {
+					return nil
+				}
+
+				return err
 			}
+
+			err := retry.Do(
+				destroyOp,
+				retry.Context(ctx),
+				retry.Attempts(bg.teardownRetryAttempts),
+				retry.Delay(bg.teardownRetryDelay),
+				retry.MaxDelay(10*time.Second),
+				retry.DelayType(retry.BackOffDelay),
+				retry.RetryIf(flapsutil.IsTransientFlapsError),
+				retry.LastErrorOnly(true),
+				retry.OnRetry(func(n uint, err error) {
+					fmt.Fprintf(bg.io.ErrOut, "  Retrying destroy for machine %s (attempt %d/%d): %v\n",
+						bg.colorize.Bold(gm.leasableMachine.FormattedMachineId()), n+2, bg.teardownRetryAttempts, err)
+				}),
+			)
 
 			mu.Lock()
 			defer mu.Unlock()
 
 			if err != nil {
+				tracing.RecordError(span, err, "failed to destroy blue machine")
 				bg.hangingBlueMachines = append(bg.hangingBlueMachines, gm.launchInput.ID)
 
 				return nil

--- a/internal/command/deploy/strategy_bluegreen_test.go
+++ b/internal/command/deploy/strategy_bluegreen_test.go
@@ -69,6 +69,7 @@ func newBlueGreenStrategy(client flapsutil.FlapsClient, numberOfExistingMachines
 	strategy.launchRetryDelay = 0
 	strategy.launchLookupDelay = 0
 	strategy.imageRefRetryDelay = 0
+	strategy.teardownRetryDelay = 0
 
 	return strategy
 }
@@ -308,6 +309,7 @@ func newBlueGreenStrategyWithState(client flapsutil.FlapsClient, machineState st
 	strategy.launchRetryDelay = 0
 	strategy.launchLookupDelay = 0
 	strategy.imageRefRetryDelay = 0
+	strategy.teardownRetryDelay = 0
 
 	return strategy
 }
@@ -952,6 +954,91 @@ func TestCreateGreenMachinesRetriesLaunchTransients(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Less(t, elapsed, 500*time.Millisecond, "non-retryable errors must fail fast")
+	})
+}
+
+// TestBlueTeardownRetriesTransientFailures covers the Cordon/Stop/Destroy
+// retries added to the bluegreen teardown stages. All three are idempotent,
+// so transient flaps failures (typically 408 propagated from flyd) must not
+// leave blue machines cordoned-but-not-stopped or hanging around after
+// destroy — the observable pain point behind the resilience work.
+func TestBlueTeardownRetriesTransientFailures(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Cordon retries transient failures", func(t *testing.T) {
+		client := &mockFlapsClient{cordonTransientFailures: 2}
+		bg := newBlueGreenStrategy(client, 1)
+		bg.teardownRetryAttempts = 5
+
+		err := bg.CordonBlueMachines(ctx)
+		assert.NoError(t, err)
+
+		client.mu.Lock()
+		remaining := client.cordonTransientFailures
+		client.mu.Unlock()
+		assert.Equal(t, 0, remaining, "all transient failures should be consumed by retries")
+	})
+
+	t.Run("Stop retries transient failures", func(t *testing.T) {
+		client := &mockFlapsClient{stopTransientFailures: 2}
+		bg := newBlueGreenStrategy(client, 1)
+		bg.teardownRetryAttempts = 5
+
+		err := bg.StopBlueMachines(ctx)
+		assert.NoError(t, err)
+
+		client.mu.Lock()
+		remaining := client.stopTransientFailures
+		client.mu.Unlock()
+		assert.Equal(t, 0, remaining, "all transient failures should be consumed by retries")
+	})
+
+	t.Run("Destroy retries transient failures", func(t *testing.T) {
+		client := &mockFlapsClient{destroyTransientFailures: 2}
+		bg := newBlueGreenStrategy(client, 1)
+		bg.teardownRetryAttempts = 5
+
+		err := bg.DestroyBlueMachines(ctx)
+		assert.NoError(t, err)
+
+		client.mu.Lock()
+		remaining := client.destroyTransientFailures
+		client.mu.Unlock()
+		assert.Equal(t, 0, remaining, "all transient failures should be consumed by retries")
+		assert.Empty(t, bg.hangingBlueMachines,
+			"blue machines that were successfully destroyed on retry must NOT be reported as hanging")
+	})
+
+	t.Run("Destroy is non-fatal when retries exhaust", func(t *testing.T) {
+		// Force way more failures than the retry budget: destroy must fail
+		// gracefully (adding the machine to hangingBlueMachines), NOT abort
+		// the deploy.
+		client := &mockFlapsClient{destroyTransientFailures: 100}
+		bg := newBlueGreenStrategy(client, 1)
+		bg.teardownRetryAttempts = 3
+
+		err := bg.DestroyBlueMachines(ctx)
+		assert.NoError(t, err, "destroy failure must not abort the pool")
+		assert.Len(t, bg.hangingBlueMachines, 1,
+			"a machine that couldn't be destroyed must be reported to the user for manual cleanup")
+	})
+
+	t.Run("Cordon warns but continues when retries exhaust", func(t *testing.T) {
+		client := &mockFlapsClient{cordonTransientFailures: 100}
+		bg := newBlueGreenStrategy(client, 1)
+		bg.teardownRetryAttempts = 2
+
+		err := bg.CordonBlueMachines(ctx)
+		assert.NoError(t, err, "cordon exhaustion must not fail the deploy")
+	})
+
+	t.Run("Stop warns but continues when retries exhaust", func(t *testing.T) {
+		client := &mockFlapsClient{stopTransientFailures: 100}
+		bg := newBlueGreenStrategy(client, 1)
+		bg.teardownRetryAttempts = 2
+
+		err := bg.StopBlueMachines(ctx)
+		assert.NoError(t, err, "stop exhaustion must not fail the deploy — destroy will force-kill")
 	})
 }
 


### PR DESCRIPTION
Cordon, Stop and Destroy on blue machines are all idempotent, but each
was making a single flaps call and bailing out on any error. A single
transient 408 during Cordon prolonged the window where blue was still
taking traffic after green went ready; a Destroy hiccup showed up as
hanging blue machines the user had to manually clean up.

All three now retry transient errors (408 / 429 / 5xx / connection
reset/refused) with exponential back-off via IsTransientFlapsError,
capped by teardownRetryAttempts. Cordon and Stop remain non-fatal on
retry exhaustion (the destroy step force-kills anyway); Destroy stays
non-fatal too but appends the machine to hangingBlueMachines with the
usual manual-destroy hint, matching the pre-existing UX.

Destroy also now treats a 404 from a retried attempt as a silent
success: it means a prior attempt's write actually landed and the
machine really is gone.
