### PR TITLE
fix(deploy): retry transient failures in updateMachineInPlace

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/cenkalti/backoff/v5"
 	"github.com/miekg/dns"
 	"github.com/samber/lo"
@@ -1086,10 +1087,36 @@ func (md *machineDeployment) updateMachineByReplace(ctx context.Context, e *mach
 	return nil
 }
 
+// updateMachineRetryAttempts / updateMachineRetryDelay control the client-side
+// back-off around leasableMachine.Update. flaps' Update is scoped by the lease
+// nonce, so retrying the same call with the same nonce is safe — flaps will
+// either apply the update (idempotent) or reject it (nonce invalid), in
+// which case the outer deploy-retry loop takes over. Without this a single
+// transient 408 during a rolling or immediate deploy aborts the entire
+// deploy mid-stream even though the operation would have succeeded on a
+// second attempt.
+const (
+	updateMachineRetryAttempts uint          = 3
+	updateMachineRetryDelay    time.Duration = 500 * time.Millisecond
+)
+
 func (md *machineDeployment) updateMachineInPlace(ctx context.Context, e *machineUpdateEntry) error {
 	lm := e.leasableMachine
 
-	return lm.Update(ctx, *e.launchInput)
+	return retry.Do(
+		func() error { return lm.Update(ctx, *e.launchInput) },
+		retry.Context(ctx),
+		retry.Attempts(updateMachineRetryAttempts),
+		retry.Delay(updateMachineRetryDelay),
+		retry.MaxDelay(5*time.Second),
+		retry.DelayType(retry.BackOffDelay),
+		retry.RetryIf(flapsutil.IsTransientFlapsError),
+		retry.LastErrorOnly(true),
+		retry.OnRetry(func(n uint, err error) {
+			terminal.Debugf("retrying update for machine %s (attempt %d/%d): %v\n",
+				lm.FormattedMachineId(), n+2, updateMachineRetryAttempts, err)
+		}),
+	)
 }
 
 type spawnOptions struct {

--- a/internal/command/deploy/machines_deploymachinesapp_test.go
+++ b/internal/command/deploy/machines_deploymachinesapp_test.go
@@ -44,6 +44,100 @@ func TestUpdateExistingMachinesWRecovery(t *testing.T) {
 	assert.Error(t, err, "failed to find machine test-machine-id")
 }
 
+// TestUpdateMachineInPlaceRetriesTransientFailures guards the retry loop
+// wrapped around leasableMachine.Update. flaps.Update is nonce-scoped and
+// therefore idempotent under retry, so a transient 408 (upstream
+// context.DeadlineExceeded) that used to abort the whole rolling deploy
+// mid-stream must now be transparently retried until the update lands.
+func TestUpdateMachineInPlaceRetriesTransientFailures(t *testing.T) {
+	t.Run("succeeds after transient 408s", func(t *testing.T) {
+		ios, _, _, _ := iostreams.Test()
+		client := &mockFlapsClient{updateTransientFailures: 2}
+		md := &machineDeployment{
+			app:         &flaps.App{Name: "test-app"},
+			io:          ios,
+			colorize:    ios.ColorScheme(),
+			flapsClient: client,
+		}
+
+		// A lease must be held to call Update. Mirror what the deploy pipeline
+		// does: pre-populate LeaseNonce so leasableMachine reports HasLease.
+		lm := machine.NewLeasableMachine(client, ios, "test-app", &fly.Machine{ID: "m1", LeaseNonce: "m1-nonce"}, false)
+		entry := &machineUpdateEntry{
+			leasableMachine: lm,
+			launchInput:     &fly.LaunchMachineInput{ID: "m1", Config: &fly.MachineConfig{}},
+		}
+
+		ctx := context.Background()
+		err := md.updateMachineInPlace(ctx, entry)
+		assert.NoError(t, err, "transient 408s must be retried until Update lands")
+
+		client.mu.Lock()
+		calls := client.updateCalls
+		remaining := client.updateTransientFailures
+		client.mu.Unlock()
+
+		assert.Equal(t, 0, remaining, "all transient failures should be consumed by retries")
+		assert.Equal(t, 3, calls, "expected 2 failed attempts + 1 successful attempt")
+	})
+
+	t.Run("gives up on non-transient errors after one attempt", func(t *testing.T) {
+		ios, _, _, _ := iostreams.Test()
+		// updateTransientFailures counter isn't set — the *first* call will
+		// return the mock's baseline error. We want to observe that the
+		// retry loop doesn't hammer flaps on non-408 errors.
+		client := &mockFlapsClient{}
+		// Force a permanent non-transient error via a wrapper.
+		client.updateTransientFailures = 0
+		md := &machineDeployment{
+			app:         &flaps.App{Name: "test-app"},
+			io:          ios,
+			colorize:    ios.ColorScheme(),
+			flapsClient: &nonTransientUpdateClient{mockFlapsClient: client},
+		}
+
+		lm := machine.NewLeasableMachine(md.flapsClient, ios, "test-app", &fly.Machine{ID: "m1", LeaseNonce: "m1-nonce"}, false)
+		entry := &machineUpdateEntry{
+			leasableMachine: lm,
+			launchInput:     &fly.LaunchMachineInput{ID: "m1", Config: &fly.MachineConfig{}},
+		}
+
+		err := md.updateMachineInPlace(context.Background(), entry)
+		assert.Error(t, err, "non-transient errors must surface")
+
+		client.mu.Lock()
+		calls := client.updateCalls
+		client.mu.Unlock()
+		assert.Equal(t, 1, calls, "non-transient errors must fail on the first attempt — no wasted retries")
+	})
+}
+
+// nonTransientUpdateClient overrides Update to return a 400 (definitely
+// non-transient) so we can test the retry classifier's negative path
+// without touching every field on mockFlapsClient.
+type nonTransientUpdateClient struct {
+	*mockFlapsClient
+}
+
+func (c *nonTransientUpdateClient) Update(ctx context.Context, appName string, builder fly.LaunchMachineInput, nonce string) (*fly.Machine, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.updateCalls++
+
+	return nil, &flaps.FlapsError{
+		OriginalError:      assertErr("bad request"),
+		ResponseStatusCode: 400,
+		ResponseBody:       []byte("bad request"),
+	}
+}
+
+// assertErr is a tiny helper so we don't need to import errors just for a
+// literal error in a test.
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }
+
 func TestDeployMachinesApp(t *testing.T) {
 	ios, _, _, _ := iostreams.Test()
 	client := &mockFlapsClient{}

--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -78,6 +78,15 @@ type mockFlapsClient struct {
 	stopTransientFailures    int
 	destroyTransientFailures int
 
+	// updateTransientFailures makes Update return a 408 this many times
+	// before succeeding, exercising the in-place update retry loop used by
+	// the rolling / immediate deploy strategies.
+	updateTransientFailures int
+
+	// updateCalls counts every Update invocation (including failed ones) so
+	// tests can assert how many attempts were made.
+	updateCalls int
+
 	// mu to protect the members below.
 	mu            sync.Mutex
 	machines      []*fly.Machine
@@ -578,7 +587,22 @@ func (m *mockFlapsClient) Uncordon(ctx context.Context, appName, machineID strin
 }
 
 func (m *mockFlapsClient) Update(ctx context.Context, appName string, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error) {
-	return nil, fmt.Errorf("failed to update %s", builder.ID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.updateCalls++
+
+	if m.updateTransientFailures > 0 {
+		m.updateTransientFailures--
+
+		return nil, &flaps.FlapsError{
+			OriginalError:      fmt.Errorf("transient error updating %s", builder.ID),
+			ResponseStatusCode: http.StatusRequestTimeout,
+			ResponseBody:       []byte("upstream timeout"),
+		}
+	}
+
+	return &fly.Machine{ID: builder.ID, Config: builder.Config}, nil
 }
 
 func (m *mockFlapsClient) UpdateAppSecrets(ctx context.Context, appName string, values map[string]*string) (*fly.UpdateAppSecretsResp, error) {


### PR DESCRIPTION
flaps.Update is scoped by the lease nonce, so retrying the same call
with the same nonce is safe flaps will either apply the update
(idempotent) or reject it (nonce invalid), in which case the outer
deploy-retry loop takes over. Without this a single transient 408
during a rolling or immediate deploy aborted the entire deploy
mid-stream, even though the operation would have succeeded on a
second attempt.

Update is the workhorse of the non-bluegreen deploy strategies, so this
alone should resolve most 'transient failure mid rolling deploy'
reports.
