### PR TITLE
fix(deploy): tolerate transient Get errors in wait loops

### DIFF
--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -578,6 +578,13 @@ func (bg *blueGreen) WaitForGreenMachinesToBeHealthy(ctx context.Context) error 
 					errChan <- waitCtx.Err()
 
 					return
+				case err != nil && flapsutil.IsTransientFlapsError(err):
+					// Transient Get errors during health polling are common
+					// (e.g. flaps' 408 when its call to flyd times out).
+					// Keep polling — the wait context caps total time.
+					time.Sleep(interval)
+
+					continue
 				case err != nil:
 					errChan <- err
 

--- a/internal/machine/leasable_machine.go
+++ b/internal/machine/leasable_machine.go
@@ -331,6 +331,28 @@ func (lm *leasableMachine) WaitForSmokeChecksToPass(ctx context.Context) error {
 
 	for {
 		machine, err := lm.flapsClient.Get(waitCtx, lm.appName, lm.Machine().ID)
+		switch {
+		case errors.Is(waitCtx.Err(), context.Canceled):
+			return err
+		case errors.Is(waitCtx.Err(), context.DeadlineExceeded):
+			return nil
+		case err != nil && flapsutil.IsTransientFlapsError(err):
+			// A transient Get failure (typically a 5xx or a 408 from flaps'
+			// call to flyd) shouldn't abort the whole wait loop — we're
+			// polling by design. Sleep and try again until the wait context
+			// expires.
+			select {
+			case <-time.After(b.Duration()):
+			case <-waitCtx.Done():
+			}
+
+			continue
+		case err != nil:
+			span.RecordError(err)
+
+			return fmt.Errorf("error getting machine %s from api: %w", lm.Machine().ID, err)
+		}
+
 		startedAt, startedAtErr := machine.MostRecentStartTimeAfterLaunch()
 		uptime := 0 * time.Second
 		if startedAtErr == nil {
@@ -339,17 +361,6 @@ func (lm *leasableMachine) WaitForSmokeChecksToPass(ctx context.Context) error {
 		switch {
 		case uptime > 10*time.Second && !lm.isConstantlyRestarting(machine):
 			return nil
-		case errors.Is(waitCtx.Err(), context.Canceled):
-			return err
-		case errors.Is(waitCtx.Err(), context.DeadlineExceeded):
-			return nil
-		case err != nil:
-			span.RecordError(err)
-
-			return fmt.Errorf("error getting machine %s from api: %w", lm.Machine().ID, err)
-		}
-
-		switch {
 		case lm.isConstantlyRestarting(machine):
 			err := fmt.Errorf("the app appears to be crashing")
 			span.RecordError(err)
@@ -402,6 +413,16 @@ func (lm *leasableMachine) WaitForHealthchecksToPass(ctx context.Context, timeou
 			span.RecordError(err)
 
 			return fmt.Errorf("timeout reached waiting for health checks to pass for machine %s: %w", lm.Machine().ID, err)
+		case err != nil && flapsutil.IsTransientFlapsError(err):
+			// A transient Get during health polling is common (flaps' 408 when
+			// its call to flyd times out, brief 5xx blips). Sleep and try
+			// again — the outer waitCtx will cap total time.
+			select {
+			case <-time.After(b.Duration()):
+			case <-waitCtx.Done():
+			}
+
+			continue
 		case err != nil:
 			span.RecordError(err)
 
@@ -451,6 +472,15 @@ func (lm *leasableMachine) WaitForEventType(ctx context.Context, eventType strin
 			return nil, err
 		case errors.Is(waitCtx.Err(), context.DeadlineExceeded):
 			return nil, fmt.Errorf("timeout reached waiting for health checks to pass for machine %s: %w", lm.Machine().ID, err)
+		case err != nil && flapsutil.IsTransientFlapsError(err):
+			// Poll loop — transient Get errors are expected and should never
+			// abort the wait. Sleep and try again.
+			select {
+			case <-time.After(b.Duration()):
+			case <-waitCtx.Done():
+			}
+
+			continue
 		case err != nil:
 			return nil, fmt.Errorf("error getting machine %s from api: %w", lm.Machine().ID, err)
 		}
@@ -486,6 +516,13 @@ func (lm *leasableMachine) WaitForEventTypeAfterType(ctx context.Context, eventT
 			return nil, err
 		case errors.Is(waitCtx.Err(), context.DeadlineExceeded):
 			return nil, fmt.Errorf("timeout reached waiting for health checks to pass for machine %s: %w", lm.Machine().ID, err)
+		case err != nil && flapsutil.IsTransientFlapsError(err):
+			select {
+			case <-time.After(b.Duration()):
+			case <-waitCtx.Done():
+			}
+
+			continue
 		case err != nil:
 			return nil, fmt.Errorf("error getting machine %s from api: %w", lm.Machine().ID, err)
 		}

--- a/internal/machine/leasable_machine_test.go
+++ b/internal/machine/leasable_machine_test.go
@@ -2,6 +2,8 @@ package machine
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -196,6 +198,105 @@ func TestWaitForHealthchecksToPass_ServiceChecksAreIncluded(t *testing.T) {
 	err := lm.WaitForHealthchecksToPass(context.Background(), 5*time.Second)
 	assert.NoError(t, err)
 	assert.Greater(t, getCalls.Load(), int32(0), "Get should be called to poll service checks")
+}
+
+// TestWaitForHealthchecksToPass_ToleratesTransientGetErrors verifies the
+// poll loop keeps going when flaps returns a transient error (408 / 5xx /
+// network hiccup). Before the fix a single transient blip during health
+// polling would abort the entire wait — and, therefore, the deploy.
+func TestWaitForHealthchecksToPass_ToleratesTransientGetErrors(t *testing.T) {
+	calls := atomic.Int32{}
+	client := &mock.FlapsClient{
+		GetFunc: func(ctx context.Context, appName, machineID string) (*fly.Machine, error) {
+			n := calls.Add(1)
+			if n <= 2 {
+				return nil, &flaps.FlapsError{
+					OriginalError:      fmt.Errorf("upstream timeout"),
+					ResponseStatusCode: http.StatusRequestTimeout,
+					ResponseBody:       []byte("upstream timeout"),
+				}
+			}
+
+			return &fly.Machine{
+				ID: machineID,
+				Checks: []*fly.MachineCheckStatus{
+					{Name: "alive", Status: fly.Passing},
+				},
+			}, nil
+		},
+	}
+
+	lm := newTestLeasableMachine(client, &fly.Machine{
+		ID: "m1",
+		Config: &fly.MachineConfig{
+			Checks: map[string]fly.MachineCheck{"alive": {}},
+		},
+	})
+
+	err := lm.WaitForHealthchecksToPass(context.Background(), 10*time.Second)
+	assert.NoError(t, err, "transient Get errors during health polling must not abort the wait")
+	assert.GreaterOrEqual(t, calls.Load(), int32(3),
+		"should poll past the two transient 408s and see the passing status")
+}
+
+// TestWaitForHealthchecksToPass_NonTransientErrorSurfaces verifies the wait
+// loop still fails fast on genuinely permanent errors — we don't want to
+// keep hammering flaps for something that will never succeed.
+func TestWaitForHealthchecksToPass_NonTransientErrorSurfaces(t *testing.T) {
+	calls := atomic.Int32{}
+	client := &mock.FlapsClient{
+		GetFunc: func(ctx context.Context, appName, machineID string) (*fly.Machine, error) {
+			calls.Add(1)
+
+			return nil, &flaps.FlapsError{
+				OriginalError:      fmt.Errorf("forbidden"),
+				ResponseStatusCode: http.StatusForbidden,
+				ResponseBody:       []byte("forbidden"),
+			}
+		},
+	}
+
+	lm := newTestLeasableMachine(client, &fly.Machine{
+		ID: "m1",
+		Config: &fly.MachineConfig{
+			Checks: map[string]fly.MachineCheck{"alive": {}},
+		},
+	})
+
+	err := lm.WaitForHealthchecksToPass(context.Background(), 5*time.Second)
+	assert.Error(t, err, "non-transient errors must be surfaced, not retried indefinitely")
+	assert.Equal(t, int32(1), calls.Load(), "non-transient errors must fail on the first poll")
+}
+
+// TestWaitForEventType_ToleratesTransientGetErrors is the event-poll analogue
+// of the health-check tolerance test.
+func TestWaitForEventType_ToleratesTransientGetErrors(t *testing.T) {
+	calls := atomic.Int32{}
+	client := &mock.FlapsClient{
+		GetFunc: func(ctx context.Context, appName, machineID string) (*fly.Machine, error) {
+			n := calls.Add(1)
+			if n <= 2 {
+				return nil, &flaps.FlapsError{
+					OriginalError:      fmt.Errorf("upstream timeout"),
+					ResponseStatusCode: http.StatusRequestTimeout,
+					ResponseBody:       []byte("upstream timeout"),
+				}
+			}
+
+			return &fly.Machine{
+				ID: machineID,
+				Events: []*fly.MachineEvent{
+					{Type: "exit"},
+				},
+			}, nil
+		},
+	}
+
+	lm := newTestLeasableMachine(client, &fly.Machine{ID: "m1"})
+	ev, err := lm.WaitForEventType(context.Background(), "exit", 10*time.Second, false)
+	assert.NoError(t, err, "transient Get errors during event polling must not abort the wait")
+	assert.NotNil(t, ev)
+	assert.GreaterOrEqual(t, calls.Load(), int32(3))
 }
 
 // Ensure the mock satisfies the interface at compile time.


### PR DESCRIPTION
Four poll loops WaitForSmokeChecksToPass, WaitForHealthchecksToPass,
WaitForEventType, WaitForEventTypeAfterType, plus the bluegreen
strategy's WaitForGreenMachinesToBeHealthy all called flapsClient.Get
inside a for-loop and aborted the whole wait on any error. A single
transient 408 or 5xx during health polling would fail a deploy that was
otherwise about to succeed.

Get is idempotent, and these loops already exist because state
propagation takes time. The loops now check IsTransientFlapsError and
keep polling on transient failures; only genuinely permanent errors
(4xx other than 408/429, or non-flaps errors that aren't network
hiccups) still abort the wait. The outer wait context caps total time.
