### PR TITLE
fix(deploy): extract launch-with-idempotency helper, apply to all Launch sites

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -1075,7 +1075,18 @@ func (md *machineDeployment) updateMachineByReplace(ctx context.Context, e *mach
 	// while we wait for its state and/or health checks
 	e.launchInput.LeaseTTL = int(md.waitTimeout.Seconds())
 
-	newMachineRaw, err := md.flapsClient.Launch(ctx, md.app.Name, *e.launchInput)
+	newMachineRaw, err := machine.LaunchWithIdempotency(
+		ctx, md.flapsClient, md.app.Name, e.launchInput,
+		machine.LaunchIdempotencyOpts{
+			RetryAttempts: 3,
+			RetryDelay:    500 * time.Millisecond,
+			LookupDelay:   500 * time.Millisecond,
+			OnRetry: func(attempt, total uint, err error) {
+				terminal.Debugf("retrying machine replacement launch (attempt %d/%d): %v\n",
+					attempt, total, err)
+			},
+		},
+	)
 	if err != nil {
 		return err
 	}
@@ -1176,7 +1187,18 @@ func (md *machineDeployment) spawnMachineInGroup(ctx context.Context, groupName 
 	// while we wait for its state and/or health checks
 	launchInput.LeaseTTL = int(md.waitTimeout.Seconds())
 
-	newMachineRaw, err := md.flapsClient.Launch(ctx, md.app.Name, *launchInput)
+	newMachineRaw, err := machine.LaunchWithIdempotency(
+		ctx, md.flapsClient, md.app.Name, launchInput,
+		machine.LaunchIdempotencyOpts{
+			RetryAttempts: 3,
+			RetryDelay:    500 * time.Millisecond,
+			LookupDelay:   500 * time.Millisecond,
+			OnRetry: func(attempt, total uint, err error) {
+				terminal.Debugf("retrying machine scale-up launch (attempt %d/%d): %v\n",
+					attempt, total, err)
+			},
+		},
+	)
 	if err != nil {
 		relCmdWarning := ""
 		if strings.Contains(err.Error(), "please add a payment method") && !md.releaseCommandMachine.IsEmpty() {

--- a/internal/command/deploy/machines_releasecommand.go
+++ b/internal/command/deploy/machines_releasecommand.go
@@ -25,6 +25,7 @@ import (
 	"github.com/superfly/flyctl/internal/statuslogger"
 	"github.com/superfly/flyctl/internal/tracing"
 	"github.com/superfly/flyctl/logs"
+	"github.com/superfly/flyctl/terminal"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 )
@@ -263,7 +264,26 @@ func (md *machineDeployment) createReleaseCommandMachine(ctx context.Context) er
 		return err
 	}
 
-	releaseCmdMachine, err := md.flapsClient.Launch(ctx, md.app.Name, *launchInput)
+	// Release commands run before the app deploy, so a single transient
+	// failure here used to fail the entire deploy before any user code ran.
+	// LaunchWithIdempotency retries transient errors and deduplicates any
+	// silent-success 408s via a per-launch metadata tag — no duplicate
+	// release_command machines even under flaps hiccups.
+	releaseCmdMachine, err := machine.LaunchWithIdempotency(
+		ctx, md.flapsClient, md.app.Name, launchInput,
+		machine.LaunchIdempotencyOpts{
+			RetryAttempts: 3,
+			RetryDelay:    500 * time.Millisecond,
+			LookupDelay:   500 * time.Millisecond,
+			OnRetry: func(attempt, total uint, err error) {
+				terminal.Debugf("retrying release_command machine launch (attempt %d/%d): %v\n",
+					attempt, total, err)
+			},
+			OnSilentSuccess: func(m *fly.Machine) {
+				terminal.Debugf("release_command machine %s was already created (idempotency tag matched)\n", m.ID)
+			},
+		},
+	)
 	if err != nil {
 		tracing.RecordError(span, err, "failed to get ip addresses")
 

--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -62,7 +62,7 @@ type mockFlapsClient struct {
 	// registering the machine in the mock's internal state, simulating the
 	// case where flaps' upstream call to flyd committed the create but the
 	// response was lost. This lets tests exercise the client-side
-	// idempotency lookup path in launchGreenMachineWithRetry.
+	// idempotency lookup path in machine.LaunchWithIdempotency.
 	launchSilentSuccessFailures int
 
 	// launchTransient408Failures makes Launch return a 408 without

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -18,6 +18,7 @@ import (
 	"github.com/superfly/flyctl/internal/statuslogger"
 	"github.com/superfly/flyctl/internal/tracing"
 	"github.com/superfly/flyctl/iostreams"
+	"github.com/superfly/flyctl/terminal"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
@@ -855,14 +856,21 @@ func (md *machineDeployment) updateMachineConfig(ctx context.Context, oldMachine
 }
 
 func (md *machineDeployment) createMachine(ctx context.Context, machConfig *fly.MachineConfig, region string, skipLaunch bool) (*fly.Machine, error) {
-	machine, err := md.flapsClient.Launch(ctx, md.app.Name, fly.LaunchMachineInput{
-		Config:     machConfig,
-		Region:     region,
-		SkipLaunch: skipLaunch,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return machine, nil
+	return mach.LaunchWithIdempotency(
+		ctx, md.flapsClient, md.app.Name,
+		&fly.LaunchMachineInput{
+			Config:     machConfig,
+			Region:     region,
+			SkipLaunch: skipLaunch,
+		},
+		mach.LaunchIdempotencyOpts{
+			RetryAttempts: 3,
+			RetryDelay:    500 * time.Millisecond,
+			LookupDelay:   500 * time.Millisecond,
+			OnRetry: func(attempt, total uint, err error) {
+				terminal.Debugf("retrying machine creation (attempt %d/%d): %v\n",
+					attempt, total, err)
+			},
+		},
+	)
 }

--- a/internal/command/deploy/strategy_bluegreen.go
+++ b/internal/command/deploy/strategy_bluegreen.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	"github.com/hashicorp/go-multierror"
-	"github.com/oklog/ulid/v2"
 	"github.com/sourcegraph/conc/pool"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -50,15 +49,6 @@ var (
 	ErrMultipleImageVersions = errors.New("found multiple image versions")
 
 	safeToDestroyValue = "safe_to_destroy"
-
-	// flyctlBGLaunchIDMetadataKey is a per-launch idempotency tag that flyctl
-	// writes into the machine config's metadata before calling flaps.Launch.
-	// Each intended green machine gets a unique value. When Launch fails with
-	// an ambiguous transient error (like a 408 propagated from flyd via flaps),
-	// the retry loop looks the machine up by this key to detect a silent
-	// success and avoid creating a duplicate machine. The key is intentionally
-	// namespaced under "fly_flyctl_" so it can coexist with any user metadata.
-	flyctlBGLaunchIDMetadataKey = "fly_flyctl_bluegreen_launch_id"
 )
 
 type RollbackLog struct {
@@ -112,10 +102,10 @@ type blueGreen struct {
 	// launchRetryAttempts / launchRetryDelay control the back-off used when
 	// CreateGreenMachines retries a Launch that failed with a transient error.
 	// Retries are safe because each launch input carries a unique per-machine
-	// idempotency tag (flyctlBGLaunchIDMetadataKey) that lets the retry loop
-	// detect a "silent success" (a Launch that hit an ambiguous 408/5xx but
-	// still committed the machine on the flyd side) by listing machines with
-	// that tag before creating a new one.
+	// idempotency tag (machine.FlyctlLaunchIDMetadataKey) that lets the retry
+	// loop detect a "silent success" (a Launch that hit an ambiguous 408/5xx
+	// but still committed the machine on the flyd side) by listing machines
+	// with that tag before creating a new one.
 	launchRetryAttempts uint
 	launchRetryDelay    time.Duration
 
@@ -321,15 +311,28 @@ func (bg *blueGreen) CreateGreenMachines(ctx context.Context) error {
 				launchInput.SkipLaunch = false
 			}
 			launchInput.Config.Metadata[fly.MachineConfigMetadataKeyFlyctlBGTag] = bg.timestamp
-			// A per-machine ULID lets us safely retry Launch on ambiguous
-			// transient errors (e.g. 408 from flaps): the retry loop first
-			// looks up any machine flaps has already committed with this key
-			// before attempting another Launch, so a "silent success" doesn't
-			// turn into a duplicate green machine.
-			launchID := ulid.Make().String()
-			launchInput.Config.Metadata[flyctlBGLaunchIDMetadataKey] = launchID
 
-			newMachineRaw, err := bg.launchGreenMachineWithRetry(ctx, launchInput, launchID)
+			// machine.LaunchWithIdempotency stamps a per-machine ULID into the
+			// launch input's metadata so a transient 408 that silently
+			// committed the machine gets deduplicated on retry — no duplicate
+			// green machines.
+			newMachineRaw, err := machine.LaunchWithIdempotency(
+				ctx, bg.flaps, bg.app.Name, launchInput,
+				machine.LaunchIdempotencyOpts{
+					RetryAttempts: bg.launchRetryAttempts,
+					RetryDelay:    bg.launchRetryDelay,
+					LookupDelay:   bg.launchLookupDelay,
+					OnRetry: func(attempt, total uint, err error) {
+						fmt.Fprintf(bg.io.ErrOut, "  Retrying green machine launch (attempt %d/%d): %v\n",
+							attempt, total, err)
+					},
+					OnSilentSuccess: func(m *fly.Machine) {
+						fmt.Fprintf(bg.io.ErrOut,
+							"  Launch reported an error but machine %s was already created (idempotency tag matched); reusing it\n",
+							bg.colorize.Bold(m.ID))
+					},
+				},
+			)
 			if err != nil {
 				tracing.RecordError(span, err, "failed to launch machine")
 
@@ -1475,112 +1478,6 @@ func (bg *blueGreen) TagBlueMachinesAsSafeForDeletion(ctx context.Context) error
 	}
 
 	return nil
-}
-
-// launchGreenMachineWithRetry launches a single green machine with client-side
-// pseudo-idempotency. flaps' create-machine endpoint doesn't accept an
-// Idempotency-Key header, so we simulate one by writing a unique ULID into
-// the machine's metadata under flyctlBGLaunchIDMetadataKey before every
-// attempt. If a Launch call fails with a transient error we don't know
-// whether the machine was actually committed on the flyd side, so before
-// retrying we list machines and look for one carrying our launch ID. If we
-// find one, we treat the failed Launch as a silent success and return that
-// machine — no duplicate is created.
-//
-// The race we can't fully close is when flaps commits the machine but the
-// list-lookup runs before that write propagates to the read side flaps'
-// list handler queries (Corrosion). launchLookupDelay gives it a brief
-// window to catch up; in the unlikely event a duplicate does slip through,
-// it will be tagged with the same bg.timestamp as the tracked one and get
-// swept by the normal blue→green cycle on the next deployment. That's a
-// strictly better outcome than aborting the deployment mid-flight.
-func (bg *blueGreen) launchGreenMachineWithRetry(ctx context.Context, launchInput *fly.LaunchMachineInput, launchID string) (*fly.Machine, error) {
-	var lastErr error
-	attempts := bg.launchRetryAttempts
-	if attempts == 0 {
-		attempts = 1
-	}
-
-	delay := bg.launchRetryDelay
-	for attempt := uint(0); attempt < attempts; attempt++ {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-
-		newMachineRaw, err := bg.flaps.Launch(ctx, bg.app.Name, *launchInput)
-		if err == nil {
-			return newMachineRaw, nil
-		}
-		lastErr = err
-
-		// A non-transient failure (400/404/etc.) isn't going to get better
-		// with another attempt.
-		if !flapsutil.IsTransientFlapsError(err) {
-			return nil, err
-		}
-
-		// This might have been a silent success. Give flaps' backing store a
-		// moment to reflect the commit, then look for a machine with our
-		// launch ID.
-		if bg.launchLookupDelay > 0 {
-			select {
-			case <-time.After(bg.launchLookupDelay):
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
-		}
-
-		if existing, lookupErr := bg.findGreenMachineByLaunchID(ctx, launchID); lookupErr != nil {
-			// A failed lookup shouldn't mask the original Launch error, but we
-			// still want the user to see it so they can debug if the retry
-			// also fails.
-			fmt.Fprintf(bg.io.ErrOut, "  Idempotency lookup after failed launch returned an error: %v\n", lookupErr)
-		} else if existing != nil {
-			fmt.Fprintf(bg.io.ErrOut,
-				"  Launch reported an error but machine %s was already created (idempotency tag matched); reusing it\n",
-				bg.colorize.Bold(existing.ID))
-
-			return existing, nil
-		}
-
-		// Not the last attempt: back off and try again.
-		if attempt+1 < attempts {
-			fmt.Fprintf(bg.io.ErrOut, "  Retrying green machine launch (attempt %d/%d): %v\n",
-				attempt+2, attempts, err)
-			select {
-			case <-time.After(delay):
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			}
-			if delay < 5*time.Second {
-				delay *= 2
-			}
-		}
-	}
-
-	return nil, lastErr
-}
-
-// findGreenMachineByLaunchID scans the app's machines and returns the one
-// whose metadata carries the given launch ID, if any. It's a client-side
-// filter because flaps' List does not (yet) expose a metadata query in the
-// fly-go client interface.
-func (bg *blueGreen) findGreenMachineByLaunchID(ctx context.Context, launchID string) (*fly.Machine, error) {
-	machines, err := bg.flaps.List(ctx, bg.app.Name, "")
-	if err != nil {
-		return nil, err
-	}
-
-	for _, m := range machines {
-		if m == nil || m.Config == nil {
-			continue
-		}
-		if m.Config.Metadata[flyctlBGLaunchIDMetadataKey] == launchID {
-			return m, nil
-		}
-	}
-
-	return nil, nil
 }
 
 // This method tags blue-machines with a safe to destroy value.

--- a/internal/command/deploy/strategy_bluegreen_test.go
+++ b/internal/command/deploy/strategy_bluegreen_test.go
@@ -1063,7 +1063,7 @@ func TestCreateGreenMachinesStampsLaunchID(t *testing.T) {
 	seen := map[string]struct{}{}
 	for _, in := range inputs {
 		require.NotNil(t, in.Config)
-		id := in.Config.Metadata[flyctlBGLaunchIDMetadataKey]
+		id := in.Config.Metadata[machine.FlyctlLaunchIDMetadataKey]
 		assert.NotEmpty(t, id, "every launched green machine must carry a launch-id idempotency tag")
 		_, dup := seen[id]
 		assert.False(t, dup, "launch-id must be unique per intended green machine, got a duplicate: %s", id)

--- a/internal/machine/launch.go
+++ b/internal/machine/launch.go
@@ -16,8 +16,10 @@ import (
 // ambiguous 408/5xx but committed the machine anyway) and reuse the
 // committed machine instead of creating a duplicate on retry.
 //
-// The key is intentionally namespaced under "fly_flyctl_" so it can coexist
-// with any user metadata.
+// LaunchWithIdempotency always stamps a fresh value here on entry, so any
+// pre-existing value (e.g. carried over from a machine config cloned from a
+// previous deploy) is discarded. The key is intentionally namespaced under
+// "fly_flyctl_" so it can coexist with any user metadata.
 const FlyctlLaunchIDMetadataKey = "fly_flyctl_launch_id"
 
 // LaunchIdempotencyOpts controls the retry behaviour of LaunchWithIdempotency.
@@ -61,12 +63,19 @@ func (o *LaunchIdempotencyOpts) applyDefaults() {
 // LaunchWithIdempotency wraps flaps.Launch with client-side pseudo-idempotency.
 //
 // flaps' create-machine endpoint doesn't accept an Idempotency-Key header, so
-// we simulate one: this helper stamps a unique ULID into the launch input's
-// metadata under FlyctlLaunchIDMetadataKey (unless the caller already set
-// one), calls Launch, and on transient failure lists machines for the app
-// looking for one carrying that ID before retrying. If it finds one, the
-// "failure" is treated as a silent success and the committed machine is
-// returned \u2014 no duplicate is created.
+// we simulate one: this helper stamps a freshly-generated ULID into the
+// launch input's metadata under FlyctlLaunchIDMetadataKey, calls Launch, and
+// on transient failure lists machines for the app looking for one carrying
+// that ID before retrying. If it finds one, the "failure" is treated as a
+// silent success and the committed machine is returned — no duplicate is
+// created.
+//
+// The launch-id is always regenerated, overwriting any value already present
+// in the input's metadata. Callers commonly derive launch inputs by cloning
+// an existing machine's config (bluegreen green machines, rolling replacements,
+// scale-ups), which means a stale launch-id from a previous deploy would
+// otherwise be carried forward and collide with this deploy's idempotency
+// lookup.
 //
 // The race we can't fully close is when flaps commits the machine but the
 // lookup runs before that write propagates to the read side flaps' List
@@ -92,11 +101,10 @@ func LaunchWithIdempotency(
 		input.Config.Metadata = map[string]string{}
 	}
 
-	launchID := input.Config.Metadata[FlyctlLaunchIDMetadataKey]
-	if launchID == "" {
-		launchID = ulid.Make().String()
-		input.Config.Metadata[FlyctlLaunchIDMetadataKey] = launchID
-	}
+	// Always stamp a fresh ULID. See the doc comment: a caller-provided or
+	// cloned-from-previous-deploy value here would break dedup across deploys.
+	launchID := ulid.Make().String()
+	input.Config.Metadata[FlyctlLaunchIDMetadataKey] = launchID
 
 	var lastErr error
 	delay := opts.RetryDelay

--- a/internal/machine/launch.go
+++ b/internal/machine/launch.go
@@ -1,0 +1,175 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/flapsutil"
+)
+
+// FlyctlLaunchIDMetadataKey is a per-launch idempotency tag written by flyctl
+// into a machine's config metadata before calling flaps.Launch. It exists so
+// LaunchWithIdempotency can detect a "silent success" (a Launch that hit an
+// ambiguous 408/5xx but committed the machine anyway) and reuse the
+// committed machine instead of creating a duplicate on retry.
+//
+// The key is intentionally namespaced under "fly_flyctl_" so it can coexist
+// with any user metadata.
+const FlyctlLaunchIDMetadataKey = "fly_flyctl_launch_id"
+
+// LaunchIdempotencyOpts controls the retry behaviour of LaunchWithIdempotency.
+type LaunchIdempotencyOpts struct {
+	// RetryAttempts is the maximum number of Launch attempts (including the
+	// first). Must be >= 1; a value of 0 is treated as 1 (no retries).
+	RetryAttempts uint
+
+	// RetryDelay is the initial back-off between attempts. Doubled between
+	// attempts up to a hard cap of 5s.
+	RetryDelay time.Duration
+
+	// LookupDelay is the pause between a failed Launch attempt and the
+	// idempotency lookup that follows it. It gives flaps' backing store a
+	// moment to reflect a machine that a silent-success Launch just
+	// committed, which reduces (but does not eliminate) the race where a
+	// retry could otherwise create a duplicate.
+	LookupDelay time.Duration
+
+	// OnRetry, when set, is invoked before each retry attempt (i.e. after
+	// the *first* failure and any subsequent failures). `attempt` is the
+	// 1-indexed attempt number about to be made.
+	OnRetry func(attempt, total uint, err error)
+
+	// OnSilentSuccess, when set, is invoked when the idempotency lookup
+	// finds a machine that a prior failed-looking attempt actually
+	// committed. Typically used for logging.
+	OnSilentSuccess func(m *fly.Machine)
+}
+
+func (o *LaunchIdempotencyOpts) applyDefaults() {
+	if o.RetryAttempts == 0 {
+		o.RetryAttempts = 3
+	}
+	if o.RetryDelay == 0 {
+		o.RetryDelay = 500 * time.Millisecond
+	}
+	// LookupDelay is allowed to be zero for tests \u2014 don't fill it in.
+}
+
+// LaunchWithIdempotency wraps flaps.Launch with client-side pseudo-idempotency.
+//
+// flaps' create-machine endpoint doesn't accept an Idempotency-Key header, so
+// we simulate one: this helper stamps a unique ULID into the launch input's
+// metadata under FlyctlLaunchIDMetadataKey (unless the caller already set
+// one), calls Launch, and on transient failure lists machines for the app
+// looking for one carrying that ID before retrying. If it finds one, the
+// "failure" is treated as a silent success and the committed machine is
+// returned \u2014 no duplicate is created.
+//
+// The race we can't fully close is when flaps commits the machine but the
+// lookup runs before that write propagates to the read side flaps' List
+// handler queries. LookupDelay gives it a brief window to catch up; in the
+// unlikely event a duplicate does slip through it will be identifiable by
+// the shared idempotency tag and can be reconciled by the caller.
+//
+// Non-transient failures (validation errors, 4xx other than 408/429) fail
+// on the first attempt without retry.
+func LaunchWithIdempotency(
+	ctx context.Context,
+	flapsClient flapsutil.FlapsClient,
+	appName string,
+	input *fly.LaunchMachineInput,
+	opts LaunchIdempotencyOpts,
+) (*fly.Machine, error) {
+	opts.applyDefaults()
+
+	if input.Config == nil {
+		return nil, fmt.Errorf("LaunchWithIdempotency: input.Config must not be nil")
+	}
+	if input.Config.Metadata == nil {
+		input.Config.Metadata = map[string]string{}
+	}
+
+	launchID := input.Config.Metadata[FlyctlLaunchIDMetadataKey]
+	if launchID == "" {
+		launchID = ulid.Make().String()
+		input.Config.Metadata[FlyctlLaunchIDMetadataKey] = launchID
+	}
+
+	var lastErr error
+	delay := opts.RetryDelay
+	for attempt := uint(0); attempt < opts.RetryAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		created, err := flapsClient.Launch(ctx, appName, *input)
+		if err == nil {
+			return created, nil
+		}
+		lastErr = err
+
+		if !flapsutil.IsTransientFlapsError(err) {
+			return nil, err
+		}
+
+		// Might have been a silent success. Give flaps' backing store a
+		// moment to catch up, then look for a machine with our launch ID.
+		if opts.LookupDelay > 0 {
+			select {
+			case <-time.After(opts.LookupDelay):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		existing, lookupErr := findMachineByLaunchID(ctx, flapsClient, appName, launchID)
+		if lookupErr == nil && existing != nil {
+			if opts.OnSilentSuccess != nil {
+				opts.OnSilentSuccess(existing)
+			}
+
+			return existing, nil
+		}
+
+		if attempt+1 < opts.RetryAttempts {
+			if opts.OnRetry != nil {
+				opts.OnRetry(attempt+2, opts.RetryAttempts, err)
+			}
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			if delay < 5*time.Second {
+				delay *= 2
+			}
+		}
+	}
+
+	return nil, lastErr
+}
+
+// findMachineByLaunchID scans the app's machines and returns the one whose
+// metadata carries the given launch ID, if any. It's a client-side filter
+// because flaps' List does not (yet) expose a metadata query in the fly-go
+// client interface.
+func findMachineByLaunchID(ctx context.Context, flapsClient flapsutil.FlapsClient, appName, launchID string) (*fly.Machine, error) {
+	machines, err := flapsClient.List(ctx, appName, "")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, m := range machines {
+		if m == nil || m.Config == nil {
+			continue
+		}
+		if m.Config.Metadata[FlyctlLaunchIDMetadataKey] == launchID {
+			return m, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/internal/machine/launch_test.go
+++ b/internal/machine/launch_test.go
@@ -1,0 +1,236 @@
+package machine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/mock"
+)
+
+func newLaunchTestClient(t *testing.T) *mock.FlapsClient {
+	t.Helper()
+
+	return &mock.FlapsClient{
+		// Default List returns nothing \u2014 tests override as needed.
+		ListFunc: func(ctx context.Context, appName, state string) ([]*fly.Machine, error) {
+			return nil, nil
+		},
+	}
+}
+
+func transient408() error {
+	return &flaps.FlapsError{
+		OriginalError:      fmt.Errorf("upstream timeout"),
+		ResponseStatusCode: http.StatusRequestTimeout,
+		ResponseBody:       []byte("upstream timeout"),
+	}
+}
+
+// TestLaunchWithIdempotency_HappyPath verifies the common case: Launch
+// succeeds on the first attempt, no lookup needed.
+func TestLaunchWithIdempotency_HappyPath(t *testing.T) {
+	client := newLaunchTestClient(t)
+	launchCalls := atomic.Int32{}
+	client.LaunchFunc = func(ctx context.Context, appName string, in fly.LaunchMachineInput) (*fly.Machine, error) {
+		launchCalls.Add(1)
+
+		return &fly.Machine{ID: "m1", Config: in.Config}, nil
+	}
+
+	m, err := LaunchWithIdempotency(
+		context.Background(), client, "test-app",
+		&fly.LaunchMachineInput{Config: &fly.MachineConfig{}},
+		LaunchIdempotencyOpts{RetryAttempts: 3},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "m1", m.ID)
+	assert.Equal(t, int32(1), launchCalls.Load(), "no retry needed on happy path")
+	assert.NotEmpty(t, m.Config.Metadata[FlyctlLaunchIDMetadataKey], "launch-id must be stamped even on the first attempt")
+}
+
+// TestLaunchWithIdempotency_RetriesTransientFailures covers the case where
+// several transient 408s happen back-to-back with no side effect on the
+// server. The retry loop must keep trying until Launch actually lands.
+func TestLaunchWithIdempotency_RetriesTransientFailures(t *testing.T) {
+	client := newLaunchTestClient(t)
+	launchCalls := atomic.Int32{}
+	client.LaunchFunc = func(ctx context.Context, appName string, in fly.LaunchMachineInput) (*fly.Machine, error) {
+		n := launchCalls.Add(1)
+		if n <= 2 {
+			return nil, transient408()
+		}
+
+		return &fly.Machine{ID: "m1", Config: in.Config}, nil
+	}
+
+	m, err := LaunchWithIdempotency(
+		context.Background(), client, "test-app",
+		&fly.LaunchMachineInput{Config: &fly.MachineConfig{}},
+		LaunchIdempotencyOpts{RetryAttempts: 4},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "m1", m.ID)
+	assert.Equal(t, int32(3), launchCalls.Load())
+}
+
+// TestLaunchWithIdempotency_DetectsSilentSuccess covers the case where a
+// Launch call committed the machine on the flaps side but returned a
+// transient error. On retry the lookup finds the machine by its launch-id
+// metadata and returns it without creating a duplicate.
+func TestLaunchWithIdempotency_DetectsSilentSuccess(t *testing.T) {
+	client := newLaunchTestClient(t)
+
+	var committed []*fly.Machine
+	launchCalls := atomic.Int32{}
+	client.LaunchFunc = func(ctx context.Context, appName string, in fly.LaunchMachineInput) (*fly.Machine, error) {
+		launchCalls.Add(1)
+		// Commit on the mock side but return 408.
+		m := &fly.Machine{
+			ID:     fmt.Sprintf("m%d", len(committed)+1),
+			Config: &fly.MachineConfig{Metadata: map[string]string{}},
+		}
+		for k, v := range in.Config.Metadata {
+			m.Config.Metadata[k] = v
+		}
+		committed = append(committed, m)
+
+		return nil, transient408()
+	}
+	client.ListFunc = func(ctx context.Context, appName, state string) ([]*fly.Machine, error) {
+		return committed, nil
+	}
+
+	silentSuccessCalls := atomic.Int32{}
+	m, err := LaunchWithIdempotency(
+		context.Background(), client, "test-app",
+		&fly.LaunchMachineInput{Config: &fly.MachineConfig{}},
+		LaunchIdempotencyOpts{
+			RetryAttempts: 3,
+			OnSilentSuccess: func(_ *fly.Machine) {
+				silentSuccessCalls.Add(1)
+			},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "m1", m.ID, "must return the machine committed by the first (silent-success) attempt")
+	assert.Equal(t, int32(1), launchCalls.Load(),
+		"only one Launch call should be made \u2014 the lookup deduplicates before retry")
+	assert.Len(t, committed, 1, "no duplicate machine should have been created")
+	assert.Equal(t, int32(1), silentSuccessCalls.Load(), "OnSilentSuccess must be notified")
+}
+
+// TestLaunchWithIdempotency_NonTransientErrorFailsFast verifies that a
+// validation error or other non-retryable failure surfaces immediately
+// without wasting attempts.
+func TestLaunchWithIdempotency_NonTransientErrorFailsFast(t *testing.T) {
+	client := newLaunchTestClient(t)
+	launchCalls := atomic.Int32{}
+	client.LaunchFunc = func(ctx context.Context, appName string, in fly.LaunchMachineInput) (*fly.Machine, error) {
+		launchCalls.Add(1)
+
+		return nil, &flaps.FlapsError{
+			OriginalError:      errors.New("bad request"),
+			ResponseStatusCode: http.StatusBadRequest,
+			ResponseBody:       []byte("bad request"),
+		}
+	}
+
+	_, err := LaunchWithIdempotency(
+		context.Background(), client, "test-app",
+		&fly.LaunchMachineInput{Config: &fly.MachineConfig{}},
+		LaunchIdempotencyOpts{RetryAttempts: 5},
+	)
+	assert.Error(t, err)
+	assert.Equal(t, int32(1), launchCalls.Load(), "non-transient errors must fail on the first attempt")
+}
+
+// TestLaunchWithIdempotency_ExhaustsRetries verifies the helper eventually
+// gives up and surfaces the last error.
+func TestLaunchWithIdempotency_ExhaustsRetries(t *testing.T) {
+	client := newLaunchTestClient(t)
+	launchCalls := atomic.Int32{}
+	client.LaunchFunc = func(ctx context.Context, appName string, in fly.LaunchMachineInput) (*fly.Machine, error) {
+		launchCalls.Add(1)
+
+		return nil, transient408()
+	}
+
+	_, err := LaunchWithIdempotency(
+		context.Background(), client, "test-app",
+		&fly.LaunchMachineInput{Config: &fly.MachineConfig{}},
+		LaunchIdempotencyOpts{RetryAttempts: 3},
+	)
+	assert.Error(t, err, "exhausted retries must surface the last error")
+	assert.Equal(t, int32(3), launchCalls.Load(), "should attempt exactly RetryAttempts times")
+}
+
+// TestLaunchWithIdempotency_UsesCallerProvidedLaunchID verifies the helper
+// respects a launch-id the caller pre-set (useful when the caller wants
+// the ID to be visible outside the helper for correlation).
+func TestLaunchWithIdempotency_UsesCallerProvidedLaunchID(t *testing.T) {
+	client := newLaunchTestClient(t)
+	client.LaunchFunc = func(ctx context.Context, appName string, in fly.LaunchMachineInput) (*fly.Machine, error) {
+		return &fly.Machine{ID: "m1", Config: in.Config}, nil
+	}
+
+	m, err := LaunchWithIdempotency(
+		context.Background(), client, "test-app",
+		&fly.LaunchMachineInput{Config: &fly.MachineConfig{
+			Metadata: map[string]string{FlyctlLaunchIDMetadataKey: "caller-provided-id"},
+		}},
+		LaunchIdempotencyOpts{RetryAttempts: 2},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "caller-provided-id", m.Config.Metadata[FlyctlLaunchIDMetadataKey])
+}
+
+// TestLaunchWithIdempotency_NilConfigReturnsError enforces the API contract
+// that the caller must provide a Config \u2014 launching a machine without one
+// is a bug we should catch loudly.
+func TestLaunchWithIdempotency_NilConfigReturnsError(t *testing.T) {
+	client := newLaunchTestClient(t)
+	client.LaunchFunc = func(ctx context.Context, appName string, in fly.LaunchMachineInput) (*fly.Machine, error) {
+		t.Fatal("Launch should not be called when Config is nil")
+
+		return nil, nil
+	}
+
+	_, err := LaunchWithIdempotency(
+		context.Background(), client, "test-app",
+		&fly.LaunchMachineInput{Config: nil},
+		LaunchIdempotencyOpts{RetryAttempts: 3},
+	)
+	assert.Error(t, err)
+}
+
+// TestLaunchWithIdempotency_ContextCancellation ensures cancellation between
+// attempts short-circuits the retry loop.
+func TestLaunchWithIdempotency_ContextCancellation(t *testing.T) {
+	client := newLaunchTestClient(t)
+	launchCalls := atomic.Int32{}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	client.LaunchFunc = func(_ context.Context, _ string, _ fly.LaunchMachineInput) (*fly.Machine, error) {
+		launchCalls.Add(1)
+		cancel() // cancel between the first failure and the first retry.
+
+		return nil, transient408()
+	}
+
+	_, err := LaunchWithIdempotency(
+		ctx, client, "test-app",
+		&fly.LaunchMachineInput{Config: &fly.MachineConfig{}},
+		LaunchIdempotencyOpts{RetryAttempts: 5, LookupDelay: 10 * time.Millisecond},
+	)
+	assert.Error(t, err, "cancellation must surface as an error")
+	assert.LessOrEqual(t, launchCalls.Load(), int32(2), "cancellation must stop retries quickly")
+}

--- a/internal/machine/launch_test.go
+++ b/internal/machine/launch_test.go
@@ -173,24 +173,30 @@ func TestLaunchWithIdempotency_ExhaustsRetries(t *testing.T) {
 	assert.Equal(t, int32(3), launchCalls.Load(), "should attempt exactly RetryAttempts times")
 }
 
-// TestLaunchWithIdempotency_UsesCallerProvidedLaunchID verifies the helper
-// respects a launch-id the caller pre-set (useful when the caller wants
-// the ID to be visible outside the helper for correlation).
-func TestLaunchWithIdempotency_UsesCallerProvidedLaunchID(t *testing.T) {
+// TestLaunchWithIdempotency_OverwritesStaleLaunchID verifies the helper
+// always stamps a fresh launch-id, even when the input's metadata already
+// carries one. This matters because callers commonly derive launch inputs
+// from an existing machine's config (bluegreen green machines cloned from
+// blue, rolling replacements, scale-ups) — a stale ID from a previous
+// deploy would otherwise be carried forward and break dedup on this deploy.
+func TestLaunchWithIdempotency_OverwritesStaleLaunchID(t *testing.T) {
 	client := newLaunchTestClient(t)
 	client.LaunchFunc = func(ctx context.Context, appName string, in fly.LaunchMachineInput) (*fly.Machine, error) {
 		return &fly.Machine{ID: "m1", Config: in.Config}, nil
 	}
 
+	const stale = "stale-id-from-previous-deploy"
 	m, err := LaunchWithIdempotency(
 		context.Background(), client, "test-app",
 		&fly.LaunchMachineInput{Config: &fly.MachineConfig{
-			Metadata: map[string]string{FlyctlLaunchIDMetadataKey: "caller-provided-id"},
+			Metadata: map[string]string{FlyctlLaunchIDMetadataKey: stale},
 		}},
 		LaunchIdempotencyOpts{RetryAttempts: 2},
 	)
 	require.NoError(t, err)
-	assert.Equal(t, "caller-provided-id", m.Config.Metadata[FlyctlLaunchIDMetadataKey])
+	got := m.Config.Metadata[FlyctlLaunchIDMetadataKey]
+	assert.NotEmpty(t, got, "a fresh launch-id must always be stamped")
+	assert.NotEqual(t, stale, got, "a stale launch-id in the input must be overwritten")
 }
 
 // TestLaunchWithIdempotency_NilConfigReturnsError enforces the API contract

--- a/test/preflight/fly_deploy_bluegreen_test.go
+++ b/test/preflight/fly_deploy_bluegreen_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/superfly/flyctl/test/preflight/testlib"
 )
 
-// flyctlBGLaunchIDMetadataKey mirrors the constant in
-// internal/command/deploy/strategy_bluegreen.go. It's redeclared here so this
-// integration test doesn't depend on the internal package.
-const flyctlBGLaunchIDMetadataKey = "fly_flyctl_bluegreen_launch_id"
+// flyctlLaunchIDMetadataKey mirrors machine.FlyctlLaunchIDMetadataKey from
+// internal/machine/launch.go. It's redeclared here so this integration test
+// doesn't depend on the internal package.
+const flyctlLaunchIDMetadataKey = "fly_flyctl_launch_id"
 
 func TestFlyDeployBluegreenImplicitAppProcessGroup(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
@@ -117,13 +117,13 @@ func TestFlyDeploy_BlueGreen_LaunchIdempotencyMetadata(t *testing.T) {
 	require.NotEmpty(t, firstLaunchIDs,
 		"every machine created by a bluegreen deploy must carry a %q metadata tag; "+
 			"without it the client-side retry loop can't dedupe silent-success 408s",
-		flyctlBGLaunchIDMetadataKey)
+		flyctlLaunchIDMetadataKey)
 
 	for _, m := range f.MachinesList(appName) {
 		assert.Equal(t, fly.MachineStateStarted, m.State,
 			"machine %s must be started after a successful bluegreen deploy, got %q",
 			m.ID, m.State)
-		assert.NotEmpty(t, m.Config.Metadata[flyctlBGLaunchIDMetadataKey],
+		assert.NotEmpty(t, m.Config.Metadata[flyctlLaunchIDMetadataKey],
 			"machine %s should carry the launch-id metadata tag", m.ID)
 	}
 
@@ -162,7 +162,7 @@ func TestFlyDeploy_BlueGreen_LaunchIdempotencyMetadata(t *testing.T) {
 // collectLaunchIDs returns the set of unique launch-id metadata values found
 // on the app's machines. An empty result signals the bluegreen strategy is
 // no longer stamping the tag — which would break the idempotency retry loop
-// in launchGreenMachineWithRetry.
+// in machine.LaunchWithIdempotency.
 func collectLaunchIDs(t *testing.T, f *testlib.FlyctlTestEnv, appName string) map[string]struct{} {
 	t.Helper()
 
@@ -171,7 +171,7 @@ func collectLaunchIDs(t *testing.T, f *testlib.FlyctlTestEnv, appName string) ma
 		if m.Config == nil {
 			continue
 		}
-		if id := m.Config.Metadata[flyctlBGLaunchIDMetadataKey]; id != "" {
+		if id := m.Config.Metadata[flyctlLaunchIDMetadataKey]; id != "" {
 			ids[id] = struct{}{}
 		}
 	}


### PR DESCRIPTION
Every flaps.Launch call outside bluegreen used to fail the deploy on the
first transient error. Rolling deploys with volumes, scale-ups, plan
migrations, and release commands all had the same 408-during-Launch
ambiguity we already solved for bluegreen: the machine may or may not
have been committed on the flaps side, so a naive retry could create a
duplicate.

This PR extracts the client-side pseudo-idempotency pattern into a
shared machine.LaunchWithIdempotency helper. It stamps a per-launch
ULID under machine.FlyctlLaunchIDMetadataKey before each attempt and,
after a transient failure, lists machines with that tag before retrying.
A silent-success 408 (upstream committed but response was lost) is
detected via the tag and the committed machine is reused instead of
creating a duplicate.

The bluegreen strategy is refactored to use the shared helper (dropping
its private launchGreenMachineWithRetry + findGreenMachineByLaunchID +
private metadata constant). Then the same helper is applied to:

  - createReleaseCommandMachine (release_command launch)
  - updateMachineByReplace     (rolling replacement, e.g. volume changes)
  - spawnMachineInGroup        (rolling / immediate scale-up)
  - plan.go createMachine      (plan-based new-machine launch)

The metadata key value changes from 'fly_flyctl_bluegreen_launch_id' to
'fly_flyctl_launch_id' since the helper is now generic. The bluegreen
preflight test is updated to check the new key.
