### PR TITLE
Add documentation link for ProdPack Upstash addon

### DIFF
--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -179,7 +179,7 @@ func runCreate(ctx context.Context) (err error) {
 	if flag.IsSpecified(ctx, "enable-prodpack") {
 		enableProdpack = flag.GetBool(ctx, "enable-prodpack")
 	} else {
-		fmt.Fprintf(io.Out, "\nProdPack adds enhanced features for production workloads at $200/mo.\nThis setting can be changed later.\n\n")
+		fmt.Fprintf(io.Out, "\nProdPack adds enhanced features for production workloads at $200/mo.\nThis setting can be changed later.\nFor more information, see https://fly.io/docs/upstash/redis/#prod-pack-200-mo.\n\n")
 		enableProdpack, err = prompt.Confirm(ctx, "Would you like to enable ProdPack?")
 		if err != nil {
 			return


### PR DESCRIPTION
### Change Summary

What and Why:
Sertug from Upstash asked if we could add a link to the docs outlining the ProdPack add-on - see the Plain ticket [here](https://app.plain.com/workspace/w_01J30S94JDD57QXMT9Q47J928E/thread/th_01KZY1WJNJB9PTB34V10KZ0DZJ/).

How:
Just updated the prompt in `redis/create.go` to include the link.