### PR TITLE
Detect a taken app name with flaps.IsNameTakenError

### DIFF
--- a/flypg/tigris.go
+++ b/flypg/tigris.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/iostreams"
 
 	extensions_core "github.com/superfly/flyctl/internal/command/extensions/core"
@@ -46,7 +47,14 @@ func CreateTigrisBucket(ctx context.Context, config *CreateClusterInput) error {
 		var err error
 		extension, err = extensions_core.ProvisionExtension(ctx, params)
 		if err != nil {
-			if strings.Contains(err.Error(), "unavailable") || strings.Contains(err.Error(), "Name has already been taken") {
+			// The bucket's app name is derived from the cluster's, so a
+			// collision here is expected rather than exceptional: retry under
+			// a numbered name. flaps.IsNameTakenError reads the API's
+			// name_taken code where there is one and falls back to the message
+			// otherwise -- which is what happens here, since extensions are
+			// provisioned over GraphQL and never see a Machines API status
+			// code.
+			if strings.Contains(err.Error(), "unavailable") || flaps.IsNameTakenError(err) {
 				name := fmt.Sprintf("%s-postgres-%d", config.AppName, index)
 				params.OverrideName = &name
 				index++

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/superfly/client-signals/go v0.4.4
-	github.com/superfly/fly-go v0.9.4
+	github.com/superfly/fly-go v0.9.5
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -662,8 +662,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVuwVJGWndfmc8=
 github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
-github.com/superfly/fly-go v0.9.4 h1:lhIVm6xbEu75mpLiCltcu5wldHybEKpSsj3ULLwJSVo=
-github.com/superfly/fly-go v0.9.4/go.mod h1:hym5J4lJz5MWPodZN2ZjZSjkIWfgbfYgphdTZAm/eV8=
+github.com/superfly/fly-go v0.9.5 h1:m7VujJfb0PaNMZPsgoWXyuZfKk20gL36E0oYzEqIk5g=
+github.com/superfly/fly-go v0.9.5/go.mod h1:hym5J4lJz5MWPodZN2ZjZSjkIWfgbfYgphdTZAm/eV8=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=


### PR DESCRIPTION
Replaces the `strings.Contains(err.Error(), "Name has already been taken")` check in the Tigris bucket retry loop with `flaps.IsNameTakenError`.

## Context

The bucket's app name is derived from the cluster's, so a collision is expected rather than exceptional and the loop retries under a numbered name. Finding the collision meant matching a string the Fly.io API generates rather than documents; if it is ever reworded, this loop stops retrying and starts failing backup setup outright.

fly-go now has a predicate for it, which reads the `name_taken` status code the Machines API sets and falls back to the message otherwise. The fallback is what applies here, since extensions are provisioned over GraphQL and never see a Machines API status code -- so the gain today is that the string lives in one place instead of in a released binary, and the gain later is that this call site needs no change if it does move onto the API.

`fly apps create` picks up the rest for free: a name collision there comes back as a `FlapsError` carrying the code, and `flyerr.GetErrorSuggestion` prints fly-go's suggestion, which spells out that app names are unique across all of Fly.io and not just the caller's organization.

Depends on superfly/fly-go#279; CI here fails until that merges and the go.mod bump follows.