### PR TITLE
Check app-name availability over the Machines API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/superfly/client-signals/go v0.4.4
-	github.com/superfly/fly-go v0.9.5
+	github.com/superfly/fly-go v0.9.6
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -662,8 +662,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVuwVJGWndfmc8=
 github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
-github.com/superfly/fly-go v0.9.5 h1:m7VujJfb0PaNMZPsgoWXyuZfKk20gL36E0oYzEqIk5g=
-github.com/superfly/fly-go v0.9.5/go.mod h1:hym5J4lJz5MWPodZN2ZjZSjkIWfgbfYgphdTZAm/eV8=
+github.com/superfly/fly-go v0.9.6 h1:sM5OOaycniDMVgLfH8iaC1CwW97HBjF22XucQPsL1dg=
+github.com/superfly/fly-go v0.9.6/go.mod h1:hym5J4lJz5MWPodZN2ZjZSjkIWfgbfYgphdTZAm/eV8=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/build/imgsrc/flaps_mock_test.go
+++ b/internal/build/imgsrc/flaps_mock_test.go
@@ -58,6 +58,21 @@ func (mr *MockFlapsClientMockRecorder) AcquireLease(ctx, appName, machineID, ttl
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcquireLease", reflect.TypeOf((*MockFlapsClient)(nil).AcquireLease), ctx, appName, machineID, ttl)
 }
 
+// AppNameAvailable mocks base method.
+func (m *MockFlapsClient) AppNameAvailable(ctx context.Context, name string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AppNameAvailable", ctx, name)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AppNameAvailable indicates an expected call of AppNameAvailable.
+func (mr *MockFlapsClientMockRecorder) AppNameAvailable(ctx, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppNameAvailable", reflect.TypeOf((*MockFlapsClient)(nil).AppNameAvailable), ctx, name)
+}
+
 // AssignIP mocks base method.
 func (m *MockFlapsClient) AssignIP(ctx context.Context, appName string, req flaps.AssignIPRequest) (*flaps.IPAssignment, error) {
 	m.ctrl.T.Helper()

--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -99,6 +99,10 @@ func (m *mockFlapsClient) AcquireLease(ctx context.Context, appName, machineID s
 	return m.RefreshLease(ctx, appName, machineID, ttl, nonce)
 }
 
+func (m *mockFlapsClient) AppNameAvailable(ctx context.Context, name string) (bool, error) {
+	return false, fmt.Errorf("not implemented")
+}
+
 func (m *mockFlapsClient) AssignIP(ctx context.Context, appName string, req flaps.AssignIPRequest) (res *flaps.IPAssignment, err error) {
 	return nil, fmt.Errorf("failed to assign IP to %s", appName)
 }

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -660,8 +660,13 @@ func determineAppName(ctx context.Context, parentConfig *appconfig.Config, appCo
 	return appName, cause, nil
 }
 
+// appNameTaken reports whether name is already in use, over the Machines API.
+//
+// A name held by an app in an organization the user cannot see counts as
+// taken: app names are one global namespace, and the API says so rather than
+// pretending the name is free.
 func appNameTaken(ctx context.Context, name string) (bool, error) {
-	client := flyutil.ClientFromContext(ctx)
+	client := flapsutil.ClientFromContext(ctx)
 
 	available, err := client.AppNameAvailable(ctx, name)
 	if err != nil {

--- a/internal/command/launch/plan_builder_test.go
+++ b/internal/command/launch/plan_builder_test.go
@@ -2,6 +2,7 @@ package launch
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -10,6 +11,7 @@ import (
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/mock"
 	"github.com/superfly/flyctl/iostreams"
@@ -29,6 +31,42 @@ func newDetermineOrgCtx(t *testing.T, orgFlag string) context.Context {
 	}
 
 	return flagctx.NewContext(ctx, flagSet)
+}
+
+func TestAppNameTaken(t *testing.T) {
+	someErr := errors.New("flaps is having a day")
+
+	for _, tc := range []struct {
+		name      string
+		available bool
+		err       error
+		wantTaken bool
+		wantErr   error
+	}{
+		{name: "available", available: true},
+		{name: "taken", available: false, wantTaken: true},
+		{name: "error propagates", err: someErr, wantErr: someErr},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var asked string
+			ctx := flapsutil.NewContextWithClient(context.Background(), &mock.FlapsClient{
+				AppNameAvailableFunc: func(ctx context.Context, name string) (bool, error) {
+					asked = name
+					return tc.available, tc.err
+				},
+			})
+
+			taken, err := appNameTaken(ctx, "some-app")
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantTaken, taken)
+			assert.Equal(t, "some-app", asked)
+		})
+	}
 }
 
 func TestDetermineOrg(t *testing.T) {

--- a/internal/command/launch/plan_builder_test.go
+++ b/internal/command/launch/plan_builder_test.go
@@ -52,6 +52,7 @@ func TestAppNameTaken(t *testing.T) {
 			ctx := flapsutil.NewContextWithClient(context.Background(), &mock.FlapsClient{
 				AppNameAvailableFunc: func(ctx context.Context, name string) (bool, error) {
 					asked = name
+
 					return tc.available, tc.err
 				},
 			})

--- a/internal/flapsutil/flaps_client.go
+++ b/internal/flapsutil/flaps_client.go
@@ -12,6 +12,7 @@ var _ FlapsClient = (*flaps.Client)(nil)
 
 type FlapsClient interface {
 	AcquireLease(ctx context.Context, appName, machineID string, ttl *int) (*fly.MachineLease, error)
+	AppNameAvailable(ctx context.Context, name string) (bool, error)
 	AssignIP(ctx context.Context, appName string, req flaps.AssignIPRequest) (res *flaps.IPAssignment, err error)
 	CheckCertificate(ctx context.Context, appName, hostname string) (*fly.CertificateDetailResponse, error)
 	Cordon(ctx context.Context, appName, machineID string, nonce string) (err error)

--- a/internal/inmem/flaps_client.go
+++ b/internal/inmem/flaps_client.go
@@ -28,6 +28,10 @@ func (m *FlapsClient) AcquireLease(ctx context.Context, appName, machineID strin
 	panic("TODO")
 }
 
+func (m *FlapsClient) AppNameAvailable(ctx context.Context, name string) (bool, error) {
+	panic("TODO")
+}
+
 func (m *FlapsClient) AssignIP(ctx context.Context, appName string, req flaps.AssignIPRequest) (res *flaps.IPAssignment, err error) {
 	panic("TODO")
 }

--- a/internal/mock/flaps_client.go
+++ b/internal/mock/flaps_client.go
@@ -13,6 +13,7 @@ var _ flapsutil.FlapsClient = (*FlapsClient)(nil)
 
 type FlapsClient struct {
 	AcquireLeaseFunc                      func(ctx context.Context, appName, machineID string, ttl *int) (*fly.MachineLease, error)
+	AppNameAvailableFunc                  func(ctx context.Context, name string) (bool, error)
 	AssignIPFunc                          func(ctx context.Context, appName string, req flaps.AssignIPRequest) (res *flaps.IPAssignment, err error)
 	CheckCertificateFunc                  func(ctx context.Context, appName, hostname string) (*fly.CertificateDetailResponse, error)
 	CordonFunc                            func(ctx context.Context, appName, machineID string, nonce string) (err error)
@@ -80,6 +81,10 @@ type FlapsClient struct {
 
 func (m *FlapsClient) AcquireLease(ctx context.Context, appName, machineID string, ttl *int) (*fly.MachineLease, error) {
 	return m.AcquireLeaseFunc(ctx, appName, machineID, ttl)
+}
+
+func (m *FlapsClient) AppNameAvailable(ctx context.Context, name string) (bool, error) {
+	return m.AppNameAvailableFunc(ctx, name)
 }
 
 func (m *FlapsClient) AssignIP(ctx context.Context, appName string, req flaps.AssignIPRequest) (res *flaps.IPAssignment, err error) {


### PR DESCRIPTION
Refs #5104.

`fly launch` decided whether an app name was taken with the GraphQL
`appNameAvailable` query. fly-go's flaps client answers the same question with a
`GET` on the app, and the rest of launch's app work already goes through flaps,
so `appNameTaken` now uses it.

What a caller sees is unchanged. A name is taken if an app holds it, whether or
not the user can see that app — app names are one global namespace. Over flaps
the second case comes back as a 403 rather than as a readable app, and fly-go
classifies it as taken.

## Landing order — done

1. superfly/fly-go#281 — fixes a nil dereference that panicked on the taken
   name, which is the case this check exists for. Merged.
2. superfly/fly-go#282 — classifies the foreign-app case as 403 rather than 401.
   Without it a name held by an org the user cannot see returns an error here,
   and at `plan_builder.go:640` that error is discarded
   (`taken, _ = appNameTaken(...)`), so launch would treat the name as free and
   collide at app creation. Merged.
3. fly-go `v0.9.6` cut from those two, and `go.mod` bumped to it in this branch.

This branch is only correct with that bump: `v0.9.5` predates both fixes, and
the unit tests here use a mocked flaps client, so they cannot catch it.

## Notes

`AppNameAvailable` joins `flapsutil.FlapsClient`, which is why the mocks and the
inmem client grow a method. The imgsrc mock is regenerated with mockgen rather
than hand-edited.

Two things deliberately left alone:

- `flyutil.Client` keeps its `AppNameAvailable`. It mirrors the GraphQL client's
  surface rather than flyctl's usage of it, and nothing else in the port needs
  it gone. Happy to drop it if you'd rather it went.
- `nudgeTowardsDeploy` (`plan_builder.go:313`) still runs a GraphQL `GetApp` on
  the same name, immediately before this check. Over flaps those are the same
  request — one `GetApp` answers both "can the user see it" and "is it taken" —
  so they could collapse into a single round trip. That is a behaviour change to
  the launch flow, so it is noted in #5104 rather than folded in here.

New test covers `appNameTaken` over a mocked flaps client: available, taken, and
an error that must propagate rather than read as "free". `go build ./...` and
`go test ./internal/...` are clean, against the published fly-go as well as
locally.
