### PR TITLE
Solidify listing of organizations.

### DIFF
--- a/internal/command/orgs/list.go
+++ b/internal/command/orgs/list.go
@@ -3,6 +3,7 @@ package orgs
 import (
 	"bytes"
 	"context"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
@@ -58,11 +59,13 @@ func runList(ctx context.Context) error {
 		b     bytes.Buffer
 		first = true
 	)
+	table := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
 
 	for _, org := range orgs {
-		printOrg(&b, &org, first)
+		printOrg(table, &org, first)
 		first = false
 	}
+	_ = table.Flush()
 
 	b.WriteTo(out)
 

--- a/internal/command/orgs/orgs.go
+++ b/internal/command/orgs/orgs.go
@@ -132,9 +132,9 @@ func OrgFromSlug(ctx context.Context, slug string) (*fly.Organization, error) {
 
 func printOrg(w io.Writer, org *fly.Organization, headers bool) {
 	if headers {
-		fmt.Fprintf(w, "%-20s %-20s %-10s\n", "Name", "Slug", "Type")
-		fmt.Fprintf(w, "%-20s %-20s %-10s\n", "----", "----", "----")
+		fmt.Fprintln(w, "Name\tSlug\tType")
+		fmt.Fprintln(w, "----\t----\t----")
 	}
 
-	fmt.Fprintf(w, "%-20s %-20s %-10s\n", org.Name, org.Slug, org.Type)
+	fmt.Fprintf(w, "%s\t%s\t%s\n", org.Name, org.Slug, org.Type)
 }


### PR DESCRIPTION
So far, we would allocate a fixed amount of space for each organization name. If the name is longer, it would spill into the organization slug which looks ugly. This PR makes flyctl use tabwriter to guarantee a nicely formatted listing.
