### PR TITLE
Size each discharge pass's timeout for what it waits on

### DIFF
--- a/internal/config/tokens.go
+++ b/internal/config/tokens.go
@@ -184,9 +184,34 @@ func keepConfigTokensFresh(ctx context.Context, m *sync.Mutex, t *tokens.Tokens,
 //
 // Don't call this when other goroutines might also be accessing it.
 func refreshDischargeTokens(ctx context.Context, t *tokens.Tokens, uucb UserURLCallback, advancePrune time.Duration) (bool, error) {
+	return doRefreshDischargeTokens(ctx, t, uucb, advancePrune, nonInteractiveDischargeTimeout, interactiveDischargeTimeout)
+}
+
+const (
+	// nonInteractiveDischargeTimeout bounds a discharge pass that has no
+	// UserURLCallback attached. A third party asking for the user fails
+	// immediately in that pass, so everything it can still do is a server round
+	// trip and it has no reason to hold the interactive budget.
+	nonInteractiveDischargeTimeout = 30 * time.Second
+
+	// interactiveDischargeTimeout bounds the retry that can send the user to
+	// their browser. It is sized for a person working through an identity
+	// provider, which is where the whole cost of that pass is.
+	interactiveDischargeTimeout = 90 * time.Second
+)
+
+func doRefreshDischargeTokens(
+	ctx context.Context,
+	t *tokens.Tokens,
+	uucb UserURLCallback,
+	advancePrune time.Duration,
+	nonInteractiveTimeout time.Duration,
+	interactiveTimeout time.Duration,
+) (bool, error) {
 	updateOpts := []tokens.UpdateOption{
 		tokens.WithDebugger(logger.FromContext(ctx)),
 		tokens.WithAdvancePrune(advancePrune),
+		tokens.WithDischargeTimeout(nonInteractiveTimeout),
 	}
 
 	// tokens discharged by the first pass have to be reported even if the
@@ -204,8 +229,12 @@ func refreshDischargeTokens(ctx context.Context, t *tokens.Tokens, uucb UserURLC
 		updatedParallel = updated
 
 		// Retry with UserURLCallback if a third party wants to send the user to
-		// their browser.
-		updateOpts = append(updateOpts, tokens.WithUserURLCallback(uucb))
+		// their browser. This is the pass with a person in it, and the only one
+		// that needs the longer budget; the later option wins.
+		updateOpts = append(updateOpts,
+			tokens.WithUserURLCallback(uucb),
+			tokens.WithDischargeTimeout(interactiveTimeout),
+		)
 	}
 
 	updated, err := t.Update(ctx, updateOpts...)

--- a/internal/config/tokens_test.go
+++ b/internal/config/tokens_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -216,54 +217,26 @@ func TestRefreshDischargeTokensPartialSuccess(t *testing.T) {
 	ctx := logger.NewContext(context.Background(), logger.New(os.Stdout, logger.Debug, true))
 
 	var (
-		thirdParty *tp.TP
-		m          sync.Mutex
-		inits      int
+		m     sync.Mutex
+		inits int
 	)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch path := r.URL.EscapedPath(); path {
-		case tp.InitPath:
-			thirdParty.InitRequestMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				m.Lock()
-				inits++
-				first := inits == 1
-				m.Unlock()
+	thirdParty := fakeThirdParty(t, func(w http.ResponseWriter, r *http.Request, tp3 *tp.TP) {
+		m.Lock()
+		inits++
+		first := inits == 1
+		m.Unlock()
 
-				// the first ticket to arrive is discharged outright; anything
-				// after it needs the user.
-				if first {
-					thirdParty.RespondDischarge(w, r)
+		// the first ticket to arrive is discharged outright; anything after it
+		// needs the user.
+		if first {
+			tp3.RespondDischarge(w, r)
 
-					return
-				}
-
-				thirdParty.RespondUserInteractive(w, r)
-			})).ServeHTTP(w, r)
-		default:
-			t.Errorf("unexpected request to %s", path)
+			return
 		}
-	}))
-	t.Cleanup(server.Close)
 
-	store, err := tp.NewMemoryStore(tp.PrefixMunger("/user/"), 100)
-	require.NoError(t, err)
-
-	thirdParty = &tp.TP{
-		Location: server.URL,
-		Key:      macaroon.NewEncryptionKey(),
-		Store:    store,
-	}
-
-	toks := make([][]byte, 0, 2)
-	for _, oid := range []uint64{1, 2} {
-		perm := fakePermissionToken(t, &flyio.Organization{ID: oid, Mask: resset.ActionAll})
-		require.NoError(t, perm.Add3P(thirdParty.Key, thirdParty.Location))
-
-		tok, err := perm.Encode()
-		require.NoError(t, err)
-		toks = append(toks, tok)
-	}
+		tp3.RespondUserInteractive(w, r)
+	})
 
 	var callbacks int
 	uucb := func(context.Context, string) error {
@@ -272,9 +245,110 @@ func TestRefreshDischargeTokensPartialSuccess(t *testing.T) {
 		return errors.New("no browser here")
 	}
 
-	updated, err := refreshDischargeTokens(ctx, tokens.Parse(macaroon.ToAuthorizationHeader(toks...)), uucb, time.Minute)
+	updated, err := refreshDischargeTokens(ctx, fakeThirdPartyTokens(t, thirdParty, 1, 2), uucb, time.Minute)
 
 	require.Error(t, err)
 	require.Equal(t, 1, callbacks, "the interactive retry should have run")
 	require.True(t, updated, "the discharge from the parallel pass was dropped")
+}
+
+// TestRefreshDischargeTokensTimeouts checks that each discharge pass is bounded
+// by the budget sized for what it actually waits on: a server round trip for
+// the pass that cannot open a browser, a person for the pass that can.
+func TestRefreshDischargeTokensTimeouts(t *testing.T) {
+	ctx := logger.NewContext(context.Background(), logger.New(os.Stdout, logger.Debug, true))
+
+	const (
+		nonInteractive = 250 * time.Millisecond
+		interactive    = 2 * time.Second
+	)
+
+	t.Run("a pass with no user in it stops at the short budget", func(t *testing.T) {
+		// polls forever without ever discharging, and never asks for the user,
+		// so there is no interactive retry to fall through to.
+		thirdParty := fakeThirdParty(t, func(w http.ResponseWriter, r *http.Request, tp3 *tp.TP) {
+			tp3.RespondPoll(w, r)
+		})
+
+		uucb := func(context.Context, string) error {
+			t.Error("should not have been asked to open a browser")
+
+			return nil
+		}
+
+		start := time.Now()
+		_, err := doRefreshDischargeTokens(ctx, fakeThirdPartyTokens(t, thirdParty, 1), uucb, time.Minute, nonInteractive, interactive)
+		took := time.Since(start)
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Less(t, took, interactive, "the pass ran on the interactive budget")
+	})
+
+	t.Run("the interactive retry gets the long budget", func(t *testing.T) {
+		// asks for the user every time, so the first pass fails immediately and
+		// the retry polls for a discharge that never comes.
+		thirdParty := fakeThirdParty(t, func(w http.ResponseWriter, r *http.Request, tp3 *tp.TP) {
+			tp3.RespondUserInteractive(w, r)
+		})
+
+		uucb := func(context.Context, string) error { return nil }
+
+		start := time.Now()
+		_, err := doRefreshDischargeTokens(ctx, fakeThirdPartyTokens(t, thirdParty, 1), uucb, time.Minute, nonInteractive, interactive)
+		took := time.Since(start)
+
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Greater(t, took, interactive-nonInteractive, "the retry ran on the non-interactive budget")
+	})
+}
+
+// fakeThirdParty stands up a third party whose discharge requests are answered
+// by respond.
+func fakeThirdParty(tb testing.TB, respond func(w http.ResponseWriter, r *http.Request, tp3 *tp.TP)) *tp.TP {
+	tb.Helper()
+
+	var thirdParty *tp.TP
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch path := r.URL.EscapedPath(); {
+		case path == tp.InitPath:
+			thirdParty.InitRequestMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				respond(w, r, thirdParty)
+			})).ServeHTTP(w, r)
+		case strings.HasPrefix(path, tp.PollPathPrefix):
+			thirdParty.HandlePollRequest(w, r)
+		default:
+			tb.Errorf("unexpected request to %s", path)
+		}
+	}))
+	tb.Cleanup(server.Close)
+
+	store, err := tp.NewMemoryStore(tp.PrefixMunger("/user/"), 100)
+	require.NoError(tb, err)
+
+	thirdParty = &tp.TP{
+		Location: server.URL,
+		Key:      macaroon.NewEncryptionKey(),
+		Store:    store,
+	}
+
+	return thirdParty
+}
+
+// fakeThirdPartyTokens returns permission tokens for the given orgs, each with
+// an undischarged third party caveat for thirdParty.
+func fakeThirdPartyTokens(tb testing.TB, thirdParty *tp.TP, oids ...uint64) *tokens.Tokens {
+	tb.Helper()
+
+	toks := make([][]byte, 0, len(oids))
+	for _, oid := range oids {
+		perm := fakePermissionToken(tb, &flyio.Organization{ID: oid, Mask: resset.ActionAll})
+		require.NoError(tb, perm.Add3P(thirdParty.Key, thirdParty.Location))
+
+		tok, err := perm.Encode()
+		require.NoError(tb, err)
+		toks = append(toks, tok)
+	}
+
+	return tokens.Parse(macaroon.ToAuthorizationHeader(toks...))
 }


### PR DESCRIPTION
`refreshDischargeTokens` makes up to two passes over the undischarged tickets and each one builds its own context from fly-go's default, so a single command can spend twice that budget. This gives the two passes separate timeouts, sized for the kind of wait each one actually does: 30 seconds for the pass that can only talk to servers, 90 for the pass that waits on a person.

## Context

The first pass runs without a `UserURLCallback`, which is what makes the macaroon client fetch every ticket in parallel. A third party that wants the user cannot be satisfied there and fails immediately, so everything that pass can still accomplish is a server round trip. It was holding the same 90 second budget as the interactive retry, which nothing in it can use.

The retry is where the cost is: the browser opens, the user works through their identity provider, and the client polls until the discharge appears. That is the wait 90 seconds was chosen for in superfly/fly-go#286.

Consequences of splitting them:

- the worst case a user can observe drops from about three minutes to about two.
- the agent (`agent/server/server.go`) passes `uucb = nil` and so only ever runs the non-interactive pass. It stops reserving a 90 second budget it can never spend.
- a genuinely slow non-interactive discharge now has 30 seconds rather than 90. That is the same budget this path had before v0.4.89, and it is not the case the longer default was raised for.

## Details

The timeouts move behind `doRefreshDischargeTokens`, following the `fetchOrgTokens` / `doFetchOrgTokens` seam already in this file, so the split can be tested in a couple of seconds instead of on the real durations. The tests drive a third party that never discharges and assert each pass stops at its own budget; each one fails if the other pass's timeout is wired in.