### PR TITLE
Resolve volume names to IDs on the server

### DIFF
--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -129,9 +129,9 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 		return nil
 	}
 
-	// md.setVolumes already queried for existent unattached volumes, do not create more
-	existentVolumes := lo.MapValues(md.volumes, func(vs []fly.Volume, _ string) int {
-		return len(vs)
+	// md.setVolumes already counted existent unattached volumes, do not create more
+	existentVolumes := lo.MapValues(md.availableVolumeCounts, func(_ map[string]int, name string) int {
+		return md.availableVolumeCount(name, "")
 	})
 
 	// The logic here is to provision one volume per process group that needs it only on the primary region
@@ -188,12 +188,18 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 				AutoBackupEnabled:   m.ScheduledSnapshots,
 			}
 
-			vol, err := md.flapsClient.CreateVolume(ctx, md.app.Name, input)
+			_, err = md.flapsClient.CreateVolume(ctx, md.app.Name, input)
 			if err != nil {
 				return err
 			}
 
-			md.volumes[m.Source] = append(md.volumes[m.Source], *vol)
+			if md.availableVolumeCounts == nil {
+				md.availableVolumeCounts = make(map[string]map[string]int)
+			}
+			if md.availableVolumeCounts[m.Source] == nil {
+				md.availableVolumeCounts[m.Source] = make(map[string]int)
+			}
+			md.availableVolumeCounts[m.Source][input.Region]++
 		}
 	}
 

--- a/internal/command/deploy/deploy_first.go
+++ b/internal/command/deploy/deploy_first.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/docker/go-units"
-	"github.com/samber/lo"
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/helpers"
@@ -129,10 +128,9 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 		return nil
 	}
 
-	// md.setVolumes already counted existent unattached volumes, do not create more
-	existentVolumes := lo.MapValues(md.availableVolumeCounts, func(_ map[string]int, name string) int {
-		return md.availableVolumeCount(name, "")
-	})
+	// md.setVolumes already counted existent unattached volumes. Reserve those
+	// by name and region before creating anything missing.
+	existentVolumes := cloneAvailableVolumeCounts(md.availableVolumeCounts)
 
 	// The logic here is to provision one volume per process group that needs it only on the primary region
 	for _, groupName := range md.appConfig.ProcessNames() {
@@ -151,9 +149,7 @@ func (md *machineDeployment) provisionVolumesOnFirstDeploy(ctx context.Context) 
 		}
 
 		for _, m := range groupConfig.Mounts {
-			if v := existentVolumes[m.Source]; v > 0 {
-				existentVolumes[m.Source]--
-
+			if consumeAvailableVolumeCount(existentVolumes, m.Source, groupConfig.PrimaryRegion, 1) > 0 {
 				continue
 			}
 

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -133,7 +133,7 @@ type machineDeployment struct {
 	// machineSet is this application's machines.
 	machineSet            machine.MachineSet
 	releaseCommandMachine machine.MachineSet
-	volumes               map[string][]fly.Volume
+	availableVolumeCounts map[string]map[string]int
 	strategy              string
 	releaseId             string
 	releaseVersion        int
@@ -545,24 +545,27 @@ func (md *machineDeployment) setVolumes(ctx context.Context) error {
 		return v.AttachedAllocation == nil && v.AttachedMachine == nil && v.HostStatus == "ok"
 	})
 
-	md.volumes = lo.GroupBy(unattached, func(v fly.Volume) string {
-		return v.Name
-	})
+	md.availableVolumeCounts = lo.MapValues(
+		lo.GroupBy(unattached, func(v fly.Volume) string {
+			return v.Name
+		}),
+		func(volumes []fly.Volume, _ string) map[string]int {
+			return lo.CountValuesBy(volumes, func(v fly.Volume) string {
+				return v.Region
+			})
+		},
+	)
 
 	return nil
 }
 
-func (md *machineDeployment) popVolumeFor(name, region string) *fly.Volume {
-	volumes := md.volumes[name]
-	for idx, v := range volumes {
-		if region == "" || region == v.Region {
-			md.volumes[name] = append(volumes[:idx], volumes[idx+1:]...)
-
-			return &v
-		}
+func (md *machineDeployment) availableVolumeCount(name, region string) int {
+	counts := md.availableVolumeCounts[name]
+	if region != "" {
+		return counts[region]
 	}
 
-	return nil
+	return lo.Sum(lo.Values(counts))
 }
 
 func (md *machineDeployment) validateVolumeConfig(ctx context.Context) error {
@@ -631,7 +634,7 @@ func (md *machineDeployment) validateVolumeConfig(ctx context.Context) error {
 
 			// Compute the volume differences per region
 			for volSrc, regions := range needsVol {
-				currentPerRegion := lo.CountValuesBy(md.volumes[volSrc], func(v fly.Volume) string { return v.Region })
+				currentPerRegion := md.availableVolumeCounts[volSrc]
 				needsPerRegion := lo.CountValues(regions)
 
 				var missing []string
@@ -654,10 +657,11 @@ func (md *machineDeployment) validateVolumeConfig(ctx context.Context) error {
 		case false:
 			// Check if there are unattached volumes for new groups with mounts
 			for _, m := range groupConfig.Mounts {
-				if vs := md.volumes[m.Source]; len(vs) == 0 {
+				region := md.appConfig.PrimaryRegion
+				if md.availableVolumeCount(m.Source, region) == 0 {
 					return fmt.Errorf(
-						"creating a new machine in group '%s' requires an unattached '%s' volume. Create it with `fly volume create %s`",
-						groupName, m.Source, m.Source)
+						"creating a new machine in group '%s' requires an unattached '%s' volume in region '%s'. Create it with `fly volume create %s --region %s`",
+						groupName, m.Source, region, m.Source, region)
 				}
 			}
 		}

--- a/internal/command/deploy/machines.go
+++ b/internal/command/deploy/machines.go
@@ -559,13 +559,22 @@ func (md *machineDeployment) setVolumes(ctx context.Context) error {
 	return nil
 }
 
-func (md *machineDeployment) availableVolumeCount(name, region string) int {
-	counts := md.availableVolumeCounts[name]
-	if region != "" {
-		return counts[region]
+func cloneAvailableVolumeCounts(counts map[string]map[string]int) map[string]map[string]int {
+	return lo.MapValues(counts, func(regions map[string]int, _ string) map[string]int {
+		return maps.Clone(regions)
+	})
+}
+
+// consumeAvailableVolumeCount subtracts up to requested volumes from the
+// available count for name and region. It returns the number consumed.
+func consumeAvailableVolumeCount(counts map[string]map[string]int, name, region string, requested int) int {
+	available := counts[name][region]
+	taken := min(available, requested)
+	if taken > 0 {
+		counts[name][region] -= taken
 	}
 
-	return lo.Sum(lo.Values(counts))
+	return taken
 }
 
 func (md *machineDeployment) validateVolumeConfig(ctx context.Context) error {
@@ -576,6 +585,7 @@ func (md *machineDeployment) validateVolumeConfig(ctx context.Context) error {
 		func(m *fly.Machine) string {
 			return m.ProcessGroup()
 		})
+	rolloutVolumes := cloneAvailableVolumeCounts(md.availableVolumeCounts)
 
 	for _, groupName := range md.ProcessNames() {
 		groupConfig, err := md.appConfig.Flatten(groupName)
@@ -633,15 +643,19 @@ func (md *machineDeployment) validateVolumeConfig(ctx context.Context) error {
 			}
 
 			// Compute the volume differences per region
-			for volSrc, regions := range needsVol {
-				currentPerRegion := md.availableVolumeCounts[volSrc]
+			volumeSources := lo.Keys(needsVol)
+			slices.Sort(volumeSources)
+			for _, volSrc := range volumeSources {
+				regions := needsVol[volSrc]
 				needsPerRegion := lo.CountValues(regions)
 
 				var missing []string
-				for rn, rc := range needsPerRegion {
-					diff := rc - currentPerRegion[rn]
-					if diff > 0 {
-						missing = append(missing, fmt.Sprintf("%s=%d", rn, diff))
+				regionNames := lo.Keys(needsPerRegion)
+				slices.Sort(regionNames)
+				for _, rn := range regionNames {
+					requested := needsPerRegion[rn]
+					if count := requested - consumeAvailableVolumeCount(rolloutVolumes, volSrc, rn, requested); count > 0 {
+						missing = append(missing, fmt.Sprintf("%s=%d", rn, count))
 					}
 				}
 				if len(missing) > 0 {
@@ -658,7 +672,7 @@ func (md *machineDeployment) validateVolumeConfig(ctx context.Context) error {
 			// Check if there are unattached volumes for new groups with mounts
 			for _, m := range groupConfig.Mounts {
 				region := md.appConfig.PrimaryRegion
-				if md.availableVolumeCount(m.Source, region) == 0 {
+				if consumeAvailableVolumeCount(rolloutVolumes, m.Source, region, 1) == 0 {
 					return fmt.Errorf(
 						"creating a new machine in group '%s' requires an unattached '%s' volume in region '%s'. Create it with `fly volume create %s --region %s`",
 						groupName, m.Source, region, m.Source, region)

--- a/internal/command/deploy/machines_launchinput.go
+++ b/internal/command/deploy/machines_launchinput.go
@@ -46,17 +46,11 @@ func (md *machineDeployment) launchInputForLaunch(processGroup string, guest *fl
 
 	mConfig.Image = md.img
 	md.setMachineReleaseData(mConfig)
-	// Get the final process group and prevent empty string
-	processGroup = mConfig.ProcessGroup()
 	region := md.appConfig.PrimaryRegion
 
 	if len(mConfig.Mounts) > 0 {
 		mount0 := &mConfig.Mounts[0]
-		vol := md.popVolumeFor(mount0.Name, region)
-		if vol == nil {
-			return nil, fmt.Errorf("New machine in group '%s' needs an unattached volume named '%s' in region '%s'", processGroup, mount0.Name, region)
-		}
-		mount0.Volume = vol.ID
+		mount0.Volume = mount0.Name
 	}
 
 	if len(standbyFor) > 0 {
@@ -103,8 +97,6 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *fly.Machine) (
 	}
 	mConfig.Image = md.img
 	md.setMachineReleaseData(mConfig)
-	// Get the final process group and prevent empty string
-	processGroup = mConfig.ProcessGroup()
 
 	// Update container image
 	if err = md.updateContainerImage(mConfig); err != nil {
@@ -164,11 +156,7 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *fly.Machine) (
 			// way is to destroy the current machine and launch a new one with the new volume attached
 			mount0 := &mMounts[0]
 			terminal.Warnf("Machine %s has volume '%s' attached but fly.toml have a different name: '%s'\n", mID, oMounts[0].Name, mount0.Name)
-			vol := md.popVolumeFor(mount0.Name, origMachineRaw.Region)
-			if vol == nil {
-				return nil, fmt.Errorf("machine in group '%s' needs an unattached volume named '%s' in region '%s'", processGroup, mount0.Name, origMachineRaw.Region)
-			}
-			mount0.Volume = vol.ID
+			mount0.Volume = mount0.Name
 			machineShouldBeReplaced = true
 		case mMounts[0].Path != oMounts[0].Path:
 			// The volume is the same but its mount path changed. Not a big deal.
@@ -193,11 +181,7 @@ func (md *machineDeployment) launchInputForUpdate(origMachineRaw *fly.Machine) (
 		// and it is not possible to attach a volume to an existing machine.
 		// The volume could be in a different zone than the machine.
 		mount0 := &mMounts[0]
-		vol := md.popVolumeFor(mount0.Name, origMachineRaw.Region)
-		if vol == nil {
-			return nil, fmt.Errorf("machine in group '%s' needs an unattached volume named '%s' in region '%s'", processGroup, mMounts[0].Name, origMachineRaw.Region)
-		}
-		mount0.Volume = vol.ID
+		mount0.Volume = mount0.Name
 		machineShouldBeReplaced = true
 	}
 

--- a/internal/command/deploy/machines_launchinput_test.go
+++ b/internal/command/deploy/machines_launchinput_test.go
@@ -150,12 +150,9 @@ func testLaunchInputForUpdateHostStatusUnreachable(t *testing.T) {
 	})
 	require.ErrorContains(t, err, "unreachable")
 
-	// Changing the volume name returns a new machine with a different volume attached
-	md.volumes = map[string][]fly.Volume{
-		"data": {
-			{ID: "vol_10001", Name: "data"},
-		},
-	}
+	// Defensive/future behavior: normal deploy validation currently rejects changing
+	// an attached volume's name before launch inputs are built. If this helper is
+	// reached directly, the replacement must still ask flaps to select by name.
 	li, err = md.launchInputForUpdate(&fly.Machine{
 		ID: "ab1234567890",
 		IncompleteConfig: &fly.MachineConfig{
@@ -165,7 +162,7 @@ func testLaunchInputForUpdateHostStatusUnreachable(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, li.RequiresReplacement)
-	require.Equal(t, li.Config.Mounts, []fly.MachineMount{{Path: "/data", Volume: "vol_10001", Name: "data"}})
+	require.Equal(t, li.Config.Mounts, []fly.MachineMount{{Path: "/data", Volume: "data", Name: "data"}})
 }
 
 // Regression for a nil pointer dereference: deploying an app with a
@@ -198,19 +195,11 @@ func testLaunchInputForOnMounts(t *testing.T) {
 		Mounts: []appconfig.Mount{{Source: "data", Destination: "/data"}},
 	})
 	assert.NoError(t, err)
-	md.volumes = map[string][]fly.Volume{
-		"data": {
-			{ID: "vol_10001", Name: "data"},
-			{ID: "vol_10002", Name: "data"},
-			{ID: "vol_10003", Name: "data"},
-		},
-	}
-
-	// New machine must get a volume attached
+	// New machine must ask flaps to select an available volume by name.
 	li, err := md.launchInputForLaunch("", nil, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, li.Config.Mounts)
-	assert.Equal(t, fly.MachineMount{Volume: "vol_10001", Path: "/data", Name: "data"}, li.Config.Mounts[0])
+	assert.Equal(t, fly.MachineMount{Volume: "data", Path: "/data", Name: "data"}, li.Config.Mounts[0])
 
 	// The machine already has a volume that matches fly.toml [mounts] section
 	li, err = md.launchInputForUpdate(&fly.Machine{
@@ -266,7 +255,7 @@ func testLaunchInputForOnMounts(t *testing.T) {
 	require.NotEmpty(t, li.Config.Mounts)
 	assert.Equal(t, "ab1234567890", li.ID)
 	assert.True(t, li.RequiresReplacement)
-	assert.Equal(t, fly.MachineMount{Volume: "vol_10002", Path: "/data", Name: "data"}, li.Config.Mounts[0])
+	assert.Equal(t, fly.MachineMount{Volume: "data", Path: "/data", Name: "data"}, li.Config.Mounts[0])
 
 	// Updating a machine with an attached volume should trigger a replacement if fly.toml doesn't define one.
 	md.appConfig.Mounts = nil
@@ -295,20 +284,12 @@ func testLaunchInputForOnMountsAndAutoResize(t *testing.T) {
 		}},
 	})
 	assert.NoError(t, err)
-	md.volumes = map[string][]fly.Volume{
-		"data": {
-			{ID: "vol_10001", Name: "data"},
-			{ID: "vol_10002", Name: "data"},
-			{ID: "vol_10003", Name: "data"},
-		},
-	}
-
-	// New machine must get a volume attached
+	// New machine must ask flaps to select an available volume by name.
 	li, err := md.launchInputForLaunch("", nil, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, li.Config.Mounts)
 	assert.Equal(t, fly.MachineMount{
-		Volume:                 "vol_10001",
+		Volume:                 "data",
 		Path:                   "/data",
 		Name:                   "data",
 		ExtendThresholdPercent: 80,
@@ -409,7 +390,7 @@ func testLaunchInputForOnMountsAndAutoResize(t *testing.T) {
 	assert.Equal(t, "ab1234567890", li.ID)
 	assert.True(t, li.RequiresReplacement)
 	assert.Equal(t, fly.MachineMount{
-		Volume:                 "vol_10002",
+		Volume:                 "data",
 		Path:                   "/data",
 		Name:                   "data",
 		ExtendThresholdPercent: 80,

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -34,11 +34,18 @@ func stabMachineDeployment(appConfig *appconfig.Config) (*machineDeployment, err
 
 type volumeListFlapsClient struct {
 	flapsutil.FlapsClient
-	volumes []fly.Volume
+	volumes        []fly.Volume
+	createRequests []fly.CreateVolumeRequest
 }
 
 func (c *volumeListFlapsClient) GetVolumes(context.Context, string) ([]fly.Volume, error) {
 	return c.volumes, nil
+}
+
+func (c *volumeListFlapsClient) CreateVolume(_ context.Context, _ string, request fly.CreateVolumeRequest) (*fly.Volume, error) {
+	c.createRequests = append(c.createRequests, request)
+
+	return &fly.Volume{Name: request.Name, Region: request.Region, State: "created", HostStatus: "ok"}, nil
 }
 
 func Test_resolveUpdatedMachineConfig_Basic(t *testing.T) {
@@ -467,6 +474,62 @@ func TestValidateVolumeConfigNewGroupRequiresVolumeInPrimaryRegion(t *testing.T)
 	require.NoError(t, md.validateVolumeConfig(context.Background()))
 }
 
+func TestValidateVolumeConfigReservesSharedVolumesAcrossNewGroups(t *testing.T) {
+	md, err := stabMachineDeployment(&appconfig.Config{
+		PrimaryRegion: "qmx",
+		Processes: map[string]string{
+			"alpha": "/bin/alpha",
+			"beta":  "/bin/beta",
+		},
+		Mounts: []appconfig.Mount{{
+			Source:      "shared_data",
+			Destination: "/data",
+			Processes:   []string{"alpha", "beta"},
+		}},
+	})
+	require.NoError(t, err)
+	md.availableVolumeCounts = map[string]map[string]int{"shared_data": {"qmx": 1}}
+
+	err = md.validateVolumeConfig(context.Background())
+	require.ErrorContains(t, err, "group 'beta' requires an unattached 'shared_data' volume")
+
+	md.availableVolumeCounts["shared_data"]["qmx"] = 2
+	require.NoError(t, md.validateVolumeConfig(context.Background()))
+}
+
+func TestValidateVolumeConfigReservesSharedVolumesAcrossExistingAndNewGroups(t *testing.T) {
+	md, err := stabMachineDeployment(&appconfig.Config{
+		PrimaryRegion: "qmx",
+		Processes: map[string]string{
+			"alpha": "/bin/alpha",
+			"beta":  "/bin/beta",
+		},
+		Mounts: []appconfig.Mount{{
+			Source:      "shared_data",
+			Destination: "/data",
+			Processes:   []string{"alpha", "beta"},
+		}},
+	})
+	require.NoError(t, err)
+	ios, _, _, _ := iostreams.Test()
+	md.io = ios
+	md.colorize = ios.ColorScheme()
+	md.machineSet = machine.NewMachineSet(nil, ios, "", []*fly.Machine{{
+		ID:     "machine-alpha",
+		Region: "qmx",
+		Config: &fly.MachineConfig{
+			Metadata: map[string]string{fly.MachineConfigMetadataKeyFlyProcessGroup: "alpha"},
+		},
+	}}, true)
+	md.availableVolumeCounts = map[string]map[string]int{"shared_data": {"qmx": 1}}
+
+	err = md.validateVolumeConfig(context.Background())
+	require.ErrorContains(t, err, "group 'beta' requires an unattached 'shared_data' volume")
+
+	md.availableVolumeCounts["shared_data"]["qmx"] = 2
+	require.NoError(t, md.validateVolumeConfig(context.Background()))
+}
+
 func TestSetVolumesOnlyCountsResolvableVolumes(t *testing.T) {
 	attachedMachine := "machine-id"
 	attachedAllocation := "allocation-id"
@@ -483,6 +546,35 @@ func TestSetVolumesOnlyCountsResolvableVolumes(t *testing.T) {
 
 	require.NoError(t, md.setVolumes(context.Background()))
 	require.Equal(t, map[string]map[string]int{"data": {"qmx": 1, "syd": 1}}, md.availableVolumeCounts)
+}
+
+func TestProvisionVolumesOnFirstDeployReservesByNameAndRegion(t *testing.T) {
+	client := &volumeListFlapsClient{}
+	md, err := stabMachineDeployment(&appconfig.Config{
+		PrimaryRegion: "qmx",
+		Processes: map[string]string{
+			"alpha": "/bin/alpha",
+			"beta":  "/bin/beta",
+		},
+		Mounts: []appconfig.Mount{{
+			Source:      "shared_data",
+			Destination: "/data",
+			Processes:   []string{"alpha", "beta"},
+		}},
+	})
+	require.NoError(t, err)
+	ios, _, _, _ := iostreams.Test()
+	md.io = ios
+	md.colorize = ios.ColorScheme()
+	md.flapsClient = client
+	md.isFirstDeploy = true
+	md.availableVolumeCounts = map[string]map[string]int{"shared_data": {"qmx": 1, "syd": 1}}
+
+	require.NoError(t, md.provisionVolumesOnFirstDeploy(context.Background()))
+	require.Len(t, client.createRequests, 1)
+	require.Equal(t, "shared_data", client.createRequests[0].Name)
+	require.Equal(t, "qmx", client.createRequests[0].Region)
+	require.Equal(t, 2, md.availableVolumeCounts["shared_data"]["qmx"])
 }
 
 func TestValidateVolumeConfigReplacementChecksCountByRegion(t *testing.T) {

--- a/internal/command/deploy/machines_test.go
+++ b/internal/command/deploy/machines_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/buildinfo"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/mock"
 	"github.com/superfly/flyctl/iostreams"
@@ -29,6 +30,15 @@ func stabMachineDeployment(appConfig *appconfig.Config) (*machineDeployment, err
 	}
 
 	return md, nil
+}
+
+type volumeListFlapsClient struct {
+	flapsutil.FlapsClient
+	volumes []fly.Volume
+}
+
+func (c *volumeListFlapsClient) GetVolumes(context.Context, string) ([]fly.Volume, error) {
+	return c.volumes, nil
 }
 
 func Test_resolveUpdatedMachineConfig_Basic(t *testing.T) {
@@ -229,10 +239,6 @@ func Test_resolveUpdatedMachineConfig_ReleaseCommand(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	md.volumes = map[string][]fly.Volume{
-		"data": {{ID: "vol_12345"}},
-	}
-
 	// New app machine
 	li, err := md.launchInputForLaunch("", nil, nil)
 	require.NoError(t, err)
@@ -258,7 +264,7 @@ func Test_resolveUpdatedMachineConfig_ReleaseCommand(t *testing.T) {
 			},
 			Mounts: []fly.MachineMount{{
 				Name:   "data",
-				Volume: "vol_12345",
+				Volume: "data",
 				Path:   "/data",
 			}},
 			Statics: []*fly.Static{{
@@ -377,10 +383,6 @@ func Test_resolveUpdatedMachineConfig_Mounts(t *testing.T) {
 		}},
 	})
 	require.NoError(t, err)
-	md.volumes = map[string][]fly.Volume{
-		"data": {{ID: "vol_12345"}},
-	}
-
 	// New app machine
 	li, err := md.launchInputForLaunch("", nil, nil)
 	require.NoError(t, err)
@@ -399,7 +401,7 @@ func Test_resolveUpdatedMachineConfig_Mounts(t *testing.T) {
 				"FLY_PROCESS_GROUP": "app",
 			},
 			Mounts: []fly.MachineMount{{
-				Volume: "vol_12345",
+				Volume: "data",
 				Path:   "/data",
 				Name:   "data",
 			}},
@@ -442,6 +444,74 @@ func Test_resolveUpdatedMachineConfig_Mounts(t *testing.T) {
 		},
 		MinSecretsVersion: nil,
 	}, li)
+}
+
+func TestValidateVolumeConfigNewGroupRequiresVolumeInPrimaryRegion(t *testing.T) {
+	md, err := stabMachineDeployment(&appconfig.Config{
+		PrimaryRegion: "qmx",
+		Processes:     map[string]string{"worker": "/bin/worker"},
+		Mounts: []appconfig.Mount{{
+			Source:      "data",
+			Destination: "/data",
+			Processes:   []string{"worker"},
+		}},
+	})
+	require.NoError(t, err)
+	md.availableVolumeCounts = map[string]map[string]int{"data": {"syd": 1}}
+
+	err = md.validateVolumeConfig(context.Background())
+	require.ErrorContains(t, err, "requires an unattached 'data' volume in region 'qmx'")
+	require.ErrorContains(t, err, "fly volume create data --region qmx")
+
+	md.availableVolumeCounts["data"]["qmx"] = 1
+	require.NoError(t, md.validateVolumeConfig(context.Background()))
+}
+
+func TestSetVolumesOnlyCountsResolvableVolumes(t *testing.T) {
+	attachedMachine := "machine-id"
+	attachedAllocation := "allocation-id"
+	client := &volumeListFlapsClient{volumes: []fly.Volume{
+		{Name: "data", Region: "qmx", State: "created", HostStatus: "ok"},
+		{Name: "data", Region: "syd", State: "created", HostStatus: "ok"},
+		{Name: "data", Region: "qmx", State: "created", HostStatus: "unreachable"},
+		{Name: "data", Region: "qmx", State: "created", HostStatus: "ok", AttachedMachine: &attachedMachine},
+		{Name: "data", Region: "qmx", State: "created", HostStatus: "ok", AttachedAllocation: &attachedAllocation},
+	}}
+	md, err := stabMachineDeployment(&appconfig.Config{Mounts: []appconfig.Mount{{Source: "data", Destination: "/data"}}})
+	require.NoError(t, err)
+	md.flapsClient = client
+
+	require.NoError(t, md.setVolumes(context.Background()))
+	require.Equal(t, map[string]map[string]int{"data": {"qmx": 1, "syd": 1}}, md.availableVolumeCounts)
+}
+
+func TestValidateVolumeConfigReplacementChecksCountByRegion(t *testing.T) {
+	md, err := stabMachineDeployment(&appconfig.Config{
+		PrimaryRegion: "qmx",
+		Processes:     map[string]string{"worker": "/bin/worker"},
+		Mounts: []appconfig.Mount{{
+			Source:      "data",
+			Destination: "/data",
+			Processes:   []string{"worker"},
+		}},
+	})
+	require.NoError(t, err)
+	machines := []*fly.Machine{
+		{ID: "machine-1", Region: "qmx", Config: &fly.MachineConfig{Metadata: map[string]string{fly.MachineConfigMetadataKeyFlyProcessGroup: "worker"}}},
+		{ID: "machine-2", Region: "qmx", Config: &fly.MachineConfig{Metadata: map[string]string{fly.MachineConfigMetadataKeyFlyProcessGroup: "worker"}}},
+	}
+	ios, _, _, _ := iostreams.Test()
+	md.io = ios
+	md.colorize = ios.ColorScheme()
+	md.machineSet = machine.NewMachineSet(nil, ios, "", machines, true)
+	md.availableVolumeCounts = map[string]map[string]int{"data": {"qmx": 1, "syd": 2}}
+
+	err = md.validateVolumeConfig(context.Background())
+	require.ErrorContains(t, err, "Process group 'worker' needs volumes with name 'data'")
+	require.ErrorContains(t, err, "qmx=1")
+
+	md.availableVolumeCounts["data"]["qmx"] = 2
+	require.NoError(t, md.validateVolumeConfig(context.Background()))
 }
 
 // Test machineDeployment.restartOnly

--- a/internal/command/deploy/plan.go
+++ b/internal/command/deploy/plan.go
@@ -313,11 +313,6 @@ func (md *machineDeployment) updateMachinesWRecovery(ctx context.Context, origin
 
 				return fmt.Errorf("failed to get current app state: %w", err)
 			}
-			// we need to refresh information about the state of unattached volumes in the app
-			err = md.setVolumes(ctx)
-			if err != nil {
-				return err
-			}
 			err = md.updateMachinesWRecovery(ctx, originalAppState, currentState, newAppState, sl, updateMachineSettings{
 				pushForward:          false,
 				skipHealthChecks:     settings.skipHealthChecks,

--- a/internal/command/deploy/plan_test.go
+++ b/internal/command/deploy/plan_test.go
@@ -397,6 +397,97 @@ func TestUpdateMachines(t *testing.T) {
 	assert.ErrorAs(t, err, &unrecoverableErr)
 }
 
+func TestUpdateMachinesRecoveryDoesNotRefreshVolumes(t *testing.T) {
+	t.Parallel()
+
+	ctx := withQuietIOStreams(context.Background())
+	oldMachine := &fly.Machine{
+		ID:         "machine1",
+		State:      "started",
+		HostStatus: fly.HostStatusOk,
+		Config: &fly.MachineConfig{
+			Image:  "image1",
+			Mounts: []fly.MachineMount{{Name: "data", Volume: "vol_data", Path: "/data"}},
+		},
+	}
+	newMachine := &fly.Machine{
+		ID:         "machine1",
+		State:      "started",
+		HostStatus: fly.HostStatusOk,
+		Config: &fly.MachineConfig{
+			Image:  "image2",
+			Mounts: []fly.MachineMount{{Name: "data", Volume: "vol_data", Path: "/data"}},
+		},
+	}
+
+	var updateCalls atomic.Int32
+	var getVolumesCalls atomic.Int32
+	flapsClient := &mock.FlapsClient{
+		AcquireLeaseFunc: func(context.Context, string, string, *int) (*fly.MachineLease, error) {
+			return &fly.MachineLease{Data: &fly.MachineLeaseData{Nonce: "nonce"}}, nil
+		},
+		ReleaseLeaseFunc: func(context.Context, string, string, string) error {
+			return nil
+		},
+		RefreshLeaseFunc: func(_ context.Context, _, _ string, _ *int, _ string) (*fly.MachineLease, error) {
+			return &fly.MachineLease{Status: "success", Data: &fly.MachineLeaseData{Nonce: "nonce"}}, nil
+		},
+		UpdateFunc: func(_ context.Context, _ string, input fly.LaunchMachineInput, _ string) (*fly.Machine, error) {
+			if updateCalls.Add(1) == 1 {
+				return nil, assert.AnError
+			}
+
+			return &fly.Machine{ID: input.ID, State: "started", HostStatus: fly.HostStatusOk, Config: input.Config}, nil
+		},
+		WaitFunc: func(context.Context, string, string, ...flaps.WaitOption) error {
+			return nil
+		},
+		StartFunc: func(context.Context, string, string, string) (*fly.MachineStartResponse, error) {
+			return &fly.MachineStartResponse{}, nil
+		},
+		ListFunc: func(context.Context, string, string) ([]*fly.Machine, error) {
+			return []*fly.Machine{oldMachine}, nil
+		},
+		GetFunc: func(context.Context, string, string) (*fly.Machine, error) {
+			return newMachine, nil
+		},
+		GetProcessesFunc: func(context.Context, string, string) (fly.MachinePsResponse, error) {
+			return fly.MachinePsResponse{}, nil
+		},
+		GetVolumesFunc: func(context.Context, string) ([]fly.Volume, error) {
+			getVolumesCalls.Add(1)
+
+			return nil, assert.AnError
+		},
+	}
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
+	md := &machineDeployment{
+		flapsClient: flapsClient,
+		io:          iostreams.FromContext(ctx),
+		app:         &flaps.App{Name: "myapp"},
+		appConfig: &appconfig.Config{
+			AppName: "myapp",
+			Mounts:  []appconfig.Mount{{Source: "data", Destination: "/data"}},
+		},
+		waitTimeout:     10 * time.Second,
+		deployRetries:   1,
+		maxUnavailable:  1,
+		skipSmokeChecks: true,
+	}
+	oldState := &AppState{Machines: []*fly.Machine{oldMachine}}
+	newState := &AppState{Machines: []*fly.Machine{newMachine}}
+
+	err := md.updateMachinesWRecovery(ctx, oldState, oldState, newState, nil, updateMachineSettings{
+		pushForward:          true,
+		skipHealthChecks:     true,
+		skipSmokeChecks:      true,
+		skipLeaseAcquisition: false,
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, int32(2), updateCalls.Load())
+	assert.Zero(t, getVolumesCalls.Load(), "deploy recovery must not refresh the obsolete client-side volume inventory")
+}
+
 // TestUpdateMachinesWithNewMachine verifies that deploying with a new machine
 // (oldMachine=nil) doesn't panic when health checks need to run. This
 // reproduces the nil pointer dereference that occurred when oldMachine.ID was

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -202,9 +202,10 @@ func launchMachine(ctx context.Context, appName string, action *planItem, idx in
 	input := helpers.Clone(*action.LaunchMachineInput)
 
 	if len(input.Config.Mounts) > 0 {
+		input.Config.Mounts[0].Volume = input.Config.Mounts[0].Name
 		switch {
 		case idx < action.AvailableVolumeCount:
-			input.Config.Mounts[0].Volume = input.Config.Mounts[0].Name
+			// Reuse an existing volume by name
 		case action.CreateVolumeRequest != nil:
 			cvr := action.CreateVolumeRequest
 			fmt.Fprintf(io.Out, "  Creating volume %s region:%s", colorize.Bold(cvr.Name), cvr.Region)
@@ -220,7 +221,9 @@ func launchMachine(ctx context.Context, appName string, action *planItem, idx in
 			if err != nil {
 				return nil, err
 			}
-			input.Config.Mounts[0].Volume = volume.ID
+			if action.WithNewVolumes {
+				input.Config.Mounts[0].Volume = volume.ID
+			}
 		default:
 			return nil, fmt.Errorf("Launching the machine requires a volume but there is no volume to attach or create")
 		}
@@ -250,6 +253,8 @@ type planItem struct {
 	AvailableVolumeCount int
 	// Input used to create new volumes
 	CreateVolumeRequest *fly.CreateVolumeRequest
+	// Specifically attach newly created volumes by ID instead of selecting any by name
+	WithNewVolumes bool
 }
 
 func (pi *planItem) VolumesDelta() int {
@@ -330,6 +335,7 @@ func computeActions(appName string, machines []*fly.Machine, expectedGroupCounts
 				LaunchMachineInput:   &fly.LaunchMachineInput{Region: region, Config: mConfig, MinSecretsVersion: minvers},
 				AvailableVolumeCount: defaults.consumeAvailableVolumeCount(mConfig, region, delta),
 				CreateVolumeRequest:  defaults.CreateVolumeRequest(mConfig, region, delta, len(existingMachinesInRegion)),
+				WithNewVolumes:       defaults.withNewVolumes,
 			})
 		}
 	}
@@ -358,6 +364,7 @@ func computeActions(appName string, machines []*fly.Machine, expectedGroupCounts
 				LaunchMachineInput:   &fly.LaunchMachineInput{Region: region, Config: mConfig, MinSecretsVersion: minvers},
 				AvailableVolumeCount: defaults.consumeAvailableVolumeCount(mConfig, region, delta),
 				CreateVolumeRequest:  defaults.CreateVolumeRequest(mConfig, region, delta, 0), // No existing machines for new groups
+				WithNewVolumes:       defaults.withNewVolumes,
 			})
 		}
 	}

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -102,7 +102,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 		fmt.Fprintf(io.Out, "%+4d machines for group '%s' on region '%s' of size '%s'\n",
 			action.Delta, action.GroupName, action.Region, action.MachineSize())
 
-		volumesToReuse := len(action.Volumes)
+		volumesToReuse := action.AvailableVolumeCount
 		volumesToCreate := action.VolumesDelta()
 		switch {
 		case volumesToReuse > 0 && volumesToCreate > 0:
@@ -202,11 +202,9 @@ func launchMachine(ctx context.Context, appName string, action *planItem, idx in
 	input := helpers.Clone(*action.LaunchMachineInput)
 
 	if len(input.Config.Mounts) > 0 {
-		var volume *fly.Volume
-
 		switch {
-		case idx < len(action.Volumes):
-			volume = action.Volumes[idx]
+		case idx < action.AvailableVolumeCount:
+			input.Config.Mounts[0].Volume = input.Config.Mounts[0].Name
 		case action.CreateVolumeRequest != nil:
 			cvr := action.CreateVolumeRequest
 			fmt.Fprintf(io.Out, "  Creating volume %s region:%s", colorize.Bold(cvr.Name), cvr.Region)
@@ -218,15 +216,14 @@ func launchMachine(ctx context.Context, appName string, action *planItem, idx in
 			}
 			fmt.Fprintln(io.Out)
 
-			var err error
-			volume, err = flapsClient.CreateVolume(ctx, appName, *cvr)
+			volume, err := flapsClient.CreateVolume(ctx, appName, *cvr)
 			if err != nil {
 				return nil, err
 			}
+			input.Config.Mounts[0].Volume = volume.ID
 		default:
 			return nil, fmt.Errorf("Launching the machine requires a volume but there is no volume to attach or create")
 		}
-		input.Config.Mounts[0].Volume = volume.ID
 	}
 
 	return flapsClient.Launch(ctx, appName, input)
@@ -249,8 +246,8 @@ type planItem struct {
 	Delta              int
 	Machines           []*fly.Machine
 	LaunchMachineInput *fly.LaunchMachineInput
-	// Volumes to reuse
-	Volumes []*fly.Volume
+	// Number of existing volumes to reuse by name
+	AvailableVolumeCount int
 	// Input used to create new volumes
 	CreateVolumeRequest *fly.CreateVolumeRequest
 }
@@ -260,7 +257,7 @@ func (pi *planItem) VolumesDelta() int {
 		return 0
 	}
 
-	return pi.Delta - len(pi.Volumes)
+	return pi.Delta - pi.AvailableVolumeCount
 }
 
 func (pi *planItem) MachineSize() string {
@@ -326,13 +323,13 @@ func computeActions(appName string, machines []*fly.Machine, expectedGroupCounts
 		for region, delta := range regionDiffs {
 			existingMachinesInRegion := perRegionMachines[region]
 			actions = append(actions, &planItem{
-				GroupName:           groupName,
-				Region:              region,
-				Delta:               delta,
-				Machines:            existingMachinesInRegion,
-				LaunchMachineInput:  &fly.LaunchMachineInput{Region: region, Config: mConfig, MinSecretsVersion: minvers},
-				Volumes:             defaults.PopAvailableVolumes(mConfig, region, delta),
-				CreateVolumeRequest: defaults.CreateVolumeRequest(mConfig, region, delta, len(existingMachinesInRegion)),
+				GroupName:            groupName,
+				Region:               region,
+				Delta:                delta,
+				Machines:             existingMachinesInRegion,
+				LaunchMachineInput:   &fly.LaunchMachineInput{Region: region, Config: mConfig, MinSecretsVersion: minvers},
+				AvailableVolumeCount: defaults.consumeAvailableVolumeCount(mConfig, region, delta),
+				CreateVolumeRequest:  defaults.CreateVolumeRequest(mConfig, region, delta, len(existingMachinesInRegion)),
 			})
 		}
 	}
@@ -355,12 +352,12 @@ func computeActions(appName string, machines []*fly.Machine, expectedGroupCounts
 
 		for region, delta := range regionDiffs {
 			actions = append(actions, &planItem{
-				GroupName:           groupName,
-				Region:              region,
-				Delta:               delta,
-				LaunchMachineInput:  &fly.LaunchMachineInput{Region: region, Config: mConfig, MinSecretsVersion: minvers},
-				Volumes:             defaults.PopAvailableVolumes(mConfig, region, delta),
-				CreateVolumeRequest: defaults.CreateVolumeRequest(mConfig, region, delta, 0), // No existing machines for new groups
+				GroupName:            groupName,
+				Region:               region,
+				Delta:                delta,
+				LaunchMachineInput:   &fly.LaunchMachineInput{Region: region, Config: mConfig, MinSecretsVersion: minvers},
+				AvailableVolumeCount: defaults.consumeAvailableVolumeCount(mConfig, region, delta),
+				CreateVolumeRequest:  defaults.CreateVolumeRequest(mConfig, region, delta, 0), // No existing machines for new groups
 			})
 		}
 	}

--- a/internal/command/scale/count_machines_test.go
+++ b/internal/command/scale/count_machines_test.go
@@ -1,11 +1,148 @@
 package scale
 
 import (
+	"context"
+	"errors"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/iostreams"
 )
+
+type launchMachineFlapsClient struct {
+	flapsutil.FlapsClient
+	createRequests []fly.CreateVolumeRequest
+	createdVolume  *fly.Volume
+	createErr      error
+	launchInput    fly.LaunchMachineInput
+	launchCalls    int
+	launchErr      error
+}
+
+func (c *launchMachineFlapsClient) CreateVolume(_ context.Context, _ string, req fly.CreateVolumeRequest) (*fly.Volume, error) {
+	c.createRequests = append(c.createRequests, req)
+
+	return c.createdVolume, c.createErr
+}
+
+func (c *launchMachineFlapsClient) Launch(_ context.Context, _ string, input fly.LaunchMachineInput) (*fly.Machine, error) {
+	c.launchInput = input
+	c.launchCalls++
+	if c.launchErr != nil {
+		return nil, c.launchErr
+	}
+
+	return &fly.Machine{Config: input.Config}, nil
+}
+
+func TestLaunchMachineVolumeSelection(t *testing.T) {
+	newContext := func(client *launchMachineFlapsClient) context.Context {
+		ctx := flapsutil.NewContextWithClient(context.Background(), client)
+
+		return iostreams.NewContext(ctx, &iostreams.IOStreams{Out: io.Discard, ErrOut: io.Discard})
+	}
+	newAction := func() *planItem {
+		return &planItem{
+			LaunchMachineInput: &fly.LaunchMachineInput{
+				Config: &fly.MachineConfig{
+					Mounts: []fly.MachineMount{{Name: "data", Path: "/data"}},
+				},
+			},
+		}
+	}
+
+	t.Run("existing volume is selected by name", func(t *testing.T) {
+		client := &launchMachineFlapsClient{}
+		action := newAction()
+		action.AvailableVolumeCount = 1
+
+		_, err := launchMachine(newContext(client), "app", action, 0)
+		require.NoError(t, err)
+		require.Empty(t, client.createRequests)
+		require.Equal(t, "data", client.launchInput.Config.Mounts[0].Volume)
+	})
+
+	t.Run("newly created volume is selected by ID", func(t *testing.T) {
+		client := &launchMachineFlapsClient{createdVolume: &fly.Volume{ID: "vol_created"}}
+		action := newAction()
+		action.CreateVolumeRequest = &fly.CreateVolumeRequest{Name: "data", Region: "qmx"}
+
+		_, err := launchMachine(newContext(client), "app", action, 0)
+		require.NoError(t, err)
+		require.Len(t, client.createRequests, 1)
+		require.Equal(t, "vol_created", client.launchInput.Config.Mounts[0].Volume)
+	})
+
+	t.Run("missing volume source fails before launch", func(t *testing.T) {
+		client := &launchMachineFlapsClient{}
+
+		_, err := launchMachine(newContext(client), "app", newAction(), 0)
+		require.ErrorContains(t, err, "there is no volume to attach or create")
+		require.Zero(t, client.launchCalls)
+	})
+
+	t.Run("volume creation failure is returned before launch", func(t *testing.T) {
+		client := &launchMachineFlapsClient{createErr: errors.New("volume create failed")}
+		action := newAction()
+		action.CreateVolumeRequest = &fly.CreateVolumeRequest{Name: "data", Region: "qmx"}
+
+		_, err := launchMachine(newContext(client), "app", action, 0)
+		require.ErrorIs(t, err, client.createErr)
+		require.Len(t, client.createRequests, 1)
+		require.Zero(t, client.launchCalls)
+	})
+
+	t.Run("launch failure after name selection is returned", func(t *testing.T) {
+		client := &launchMachineFlapsClient{launchErr: errors.New("machine launch failed")}
+		action := newAction()
+		action.AvailableVolumeCount = 1
+
+		_, err := launchMachine(newContext(client), "app", action, 0)
+		require.ErrorIs(t, err, client.launchErr)
+		require.Equal(t, 1, client.launchCalls)
+		require.Equal(t, "data", client.launchInput.Config.Mounts[0].Volume)
+	})
+}
+
+func TestConsumeAvailableVolumeCount(t *testing.T) {
+	defaults := &defaultValues{
+		availableVolumeCounts: map[string]map[string]int{"data": {"qmx": 2}},
+	}
+	config := &fly.MachineConfig{Mounts: []fly.MachineMount{{Name: "data"}}}
+
+	require.Equal(t, 2, defaults.consumeAvailableVolumeCount(config, "qmx", 3))
+	require.Equal(t, 0, defaults.consumeAvailableVolumeCount(config, "qmx", 1))
+	require.Equal(t, 0, (&defaultValues{}).consumeAvailableVolumeCount(config, "qmx", 1))
+}
+
+func TestNewDefaultsOnlyCountsReusableVolumes(t *testing.T) {
+	attachedMachine := "machine-id"
+	attachedAllocation := "allocation-id"
+	volumes := []fly.Volume{
+		{Name: "data", Region: "qmx", State: "created", HostStatus: "ok"},
+		{Name: "data", Region: "qmx", State: "created", HostStatus: "ok"},
+		{Name: "data", Region: "syd", State: "created", HostStatus: "ok"},
+		{Name: "data", Region: "qmx", State: "created", HostStatus: "unreachable"},
+		{Name: "data", Region: "qmx", State: "created", HostStatus: "ok", AttachedMachine: &attachedMachine},
+		{Name: "data", Region: "qmx", State: "created", HostStatus: "ok", AttachedAllocation: &attachedAllocation},
+		{Name: "other", Region: "qmx", State: "created", HostStatus: "ok"},
+	}
+
+	defaults := newDefaults(&appconfig.Config{}, fly.Release{}, nil, volumes, "", false, nil)
+	require.Equal(t, map[string]map[string]int{
+		"data":  {"qmx": 2, "syd": 1},
+		"other": {"qmx": 1},
+	}, defaults.availableVolumeCounts)
+
+	createOnly := newDefaults(&appconfig.Config{}, fly.Release{}, nil, volumes, "", true, nil)
+	require.Nil(t, createOnly.availableVolumeCounts)
+}
 
 func Test_convergeGroupCounts(t *testing.T) {
 	testcases := []struct {

--- a/internal/command/scale/count_machines_test.go
+++ b/internal/command/scale/count_machines_test.go
@@ -68,10 +68,22 @@ func TestLaunchMachineVolumeSelection(t *testing.T) {
 		require.Equal(t, "data", client.launchInput.Config.Mounts[0].Volume)
 	})
 
-	t.Run("newly created volume is selected by ID", func(t *testing.T) {
+	t.Run("newly created volume joins the named pool", func(t *testing.T) {
 		client := &launchMachineFlapsClient{createdVolume: &fly.Volume{ID: "vol_created"}}
 		action := newAction()
 		action.CreateVolumeRequest = &fly.CreateVolumeRequest{Name: "data", Region: "qmx"}
+
+		_, err := launchMachine(newContext(client), "app", action, 0)
+		require.NoError(t, err)
+		require.Len(t, client.createRequests, 1)
+		require.Equal(t, "data", client.launchInput.Config.Mounts[0].Volume)
+	})
+
+	t.Run("with-new-volumes selects the newly created volume by ID", func(t *testing.T) {
+		client := &launchMachineFlapsClient{createdVolume: &fly.Volume{ID: "vol_created"}}
+		action := newAction()
+		action.CreateVolumeRequest = &fly.CreateVolumeRequest{Name: "data", Region: "qmx"}
+		action.WithNewVolumes = true
 
 		_, err := launchMachine(newContext(client), "app", action, 0)
 		require.NoError(t, err)
@@ -142,6 +154,7 @@ func TestNewDefaultsOnlyCountsReusableVolumes(t *testing.T) {
 
 	createOnly := newDefaults(&appconfig.Config{}, fly.Release{}, nil, volumes, "", true, nil)
 	require.Nil(t, createOnly.availableVolumeCounts)
+	require.True(t, createOnly.withNewVolumes)
 }
 
 func Test_convergeGroupCounts(t *testing.T) {

--- a/internal/command/scale/machine_defaults.go
+++ b/internal/command/scale/machine_defaults.go
@@ -10,16 +10,16 @@ import (
 )
 
 type defaultValues struct {
-	image           string
-	guest           *fly.MachineGuest
-	guestPerGroup   map[string]*fly.MachineGuest
-	volsize         int
-	volsizeByName   map[string]int
-	releaseId       string
-	releaseVersion  string
-	appConfig       *appconfig.Config
-	existingVolumes map[string]map[string][]*fly.Volume
-	snapshotID      *string
+	image                 string
+	guest                 *fly.MachineGuest
+	guestPerGroup         map[string]*fly.MachineGuest
+	volsize               int
+	volsizeByName         map[string]int
+	releaseId             string
+	releaseVersion        string
+	appConfig             *appconfig.Config
+	availableVolumeCounts map[string]map[string]int
+	snapshotID            *string
 }
 
 func newDefaults(appConfig *appconfig.Config, latest fly.Release, machines []*fly.Machine, volumes []fly.Volume, snapshotID string, withNewVolumes bool, fallbackGuest *fly.MachineGuest) *defaultValues {
@@ -67,15 +67,15 @@ func newDefaults(appConfig *appconfig.Config, latest fly.Release, machines []*fl
 	}, make(map[string]int))
 
 	if !withNewVolumes {
-		defaults.existingVolumes = lo.MapValues(
+		defaults.availableVolumeCounts = lo.MapValues(
 			lo.GroupBy(
-				lo.FilterMap(volumes, func(v fly.Volume, _ int) (*fly.Volume, bool) {
-					return &v, !v.IsAttached() && v.HostStatus == "ok"
+				lo.Filter(volumes, func(v fly.Volume, _ int) bool {
+					return !v.IsAttached() && v.HostStatus == "ok"
 				}),
-				func(v *fly.Volume) string { return v.Name },
+				func(v fly.Volume) string { return v.Name },
 			),
-			func(vl []*fly.Volume, _ string) map[string][]*fly.Volume {
-				return lo.GroupBy(vl, func(v *fly.Volume) string {
+			func(vl []fly.Volume, _ string) map[string]int {
+				return lo.CountValuesBy(vl, func(v fly.Volume) string {
 					return v.Region
 				})
 			},
@@ -109,18 +109,20 @@ func (d *defaultValues) ToMachineConfig(groupName string) (*fly.MachineConfig, e
 	return mc, nil
 }
 
-func (d *defaultValues) PopAvailableVolumes(mConfig *fly.MachineConfig, region string, delta int) []*fly.Volume {
+// consumeAvailableVolumeCount subtracts up to delta matching volumes from the
+// available count for the machine config and region. It returns the number consumed.
+func (d *defaultValues) consumeAvailableVolumeCount(mConfig *fly.MachineConfig, region string, delta int) int {
 	if delta <= 0 || len(mConfig.Mounts) == 0 {
-		return nil
+		return 0
 	}
 	name := mConfig.Mounts[0].Name
-	regionVolumes := d.existingVolumes[name][region]
-	availableVolumes := regionVolumes[0:lo.Min([]int{len(regionVolumes), delta})]
-	if len(availableVolumes) > 0 {
-		d.existingVolumes[name][region] = lo.Drop(regionVolumes, len(availableVolumes))
+	available := d.availableVolumeCounts[name][region]
+	count := min(available, delta)
+	if count > 0 {
+		d.availableVolumeCounts[name][region] -= count
 	}
 
-	return availableVolumes
+	return count
 }
 
 func (d *defaultValues) CreateVolumeRequest(mConfig *fly.MachineConfig, region string, delta int, existingMachineCount int) *fly.CreateVolumeRequest {

--- a/internal/command/scale/machine_defaults.go
+++ b/internal/command/scale/machine_defaults.go
@@ -19,6 +19,7 @@ type defaultValues struct {
 	releaseVersion        string
 	appConfig             *appconfig.Config
 	availableVolumeCounts map[string]map[string]int
+	withNewVolumes        bool
 	snapshotID            *string
 }
 
@@ -54,6 +55,7 @@ func newDefaults(appConfig *appconfig.Config, latest fly.Release, machines []*fl
 		releaseId:      latest.ID,
 		releaseVersion: strconv.Itoa(latest.Version),
 		appConfig:      appConfig,
+		withNewVolumes: withNewVolumes,
 	}
 
 	if snapshotID != "" {


### PR DESCRIPTION
### Change Summary

What and Why:

Apps may have a pool of detached volumes with the same name and expect a new Machine to use any eligible member of that pool.

Previously, flyctl resolved the name to one volume ID before launching the Machine. Because that ID pins placement to that volume’s host, the launch could fail when that host lacked capacity, even when another same-named volume could accommodate the Machine. This caused deploy and scaling failures.

How:
* Send volume names, rather than preselected volume IDs, when `deploy` and `scale` commands attach detached named volumes.
* Track reusable volume capacity as counts keyed by name and region, rather than IDs.
* Treat existing and newly created same-name volumes as one pool during `scale`, avoiding races between name-based and ID-based launches.

Related to:
https://github.com/superfly/machines-meta/issues/9

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
