### PR TITLE
mpg: move lifecycle paths to Machines API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.1
 	github.com/superfly/client-signals/go v0.4.4
-	github.com/superfly/fly-go v0.9.7
+	github.com/superfly/fly-go v0.9.8
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -664,8 +664,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVuwVJGWndfmc8=
 github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
-github.com/superfly/fly-go v0.9.7 h1:a5CCOu4i2RPhWGjnZjxcAo6tFRZoFi2wbI6S17YlI44=
-github.com/superfly/fly-go v0.9.7/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
+github.com/superfly/fly-go v0.9.8 h1:Bb894ej+rirOY6B1D2FkedmUzvtBelr9bbsAYXlHviU=
+github.com/superfly/fly-go v0.9.8/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/build/imgsrc/flaps_mock_test.go
+++ b/internal/build/imgsrc/flaps_mock_test.go
@@ -291,6 +291,20 @@ func (mr *MockFlapsClientMockRecorder) DeleteIPAssignment(ctx, appName, ip any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteIPAssignment", reflect.TypeOf((*MockFlapsClient)(nil).DeleteIPAssignment), ctx, appName, ip)
 }
 
+// DeleteManagedPostgresCluster mocks base method.
+func (m *MockFlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteManagedPostgresCluster", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteManagedPostgresCluster indicates an expected call of DeleteManagedPostgresCluster.
+func (mr *MockFlapsClientMockRecorder) DeleteManagedPostgresCluster(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteManagedPostgresCluster", reflect.TypeOf((*MockFlapsClient)(nil).DeleteManagedPostgresCluster), ctx, id)
+}
+
 // DeleteMetadata mocks base method.
 func (m *MockFlapsClient) DeleteMetadata(ctx context.Context, appName, machineID, key string) error {
 	m.ctrl.T.Helper()
@@ -752,6 +766,21 @@ func (m *MockFlapsClient) ListFlyAppsMachines(ctx context.Context, appName strin
 func (mr *MockFlapsClientMockRecorder) ListFlyAppsMachines(ctx, appName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFlyAppsMachines", reflect.TypeOf((*MockFlapsClient)(nil).ListFlyAppsMachines), ctx, appName)
+}
+
+// ListManagedPostgresClusters mocks base method.
+func (m *MockFlapsClient) ListManagedPostgresClusters(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListManagedPostgresClusters", ctx, req)
+	ret0, _ := ret[0].([]flaps.ManagedPostgresClusterSummary)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListManagedPostgresClusters indicates an expected call of ListManagedPostgresClusters.
+func (mr *MockFlapsClientMockRecorder) ListManagedPostgresClusters(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListManagedPostgresClusters", reflect.TypeOf((*MockFlapsClient)(nil).ListManagedPostgresClusters), ctx, req)
 }
 
 // ListSecretKeys mocks base method.

--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -168,6 +168,10 @@ func (m *mockFlapsClient) DeleteCustomCertificate(ctx context.Context, appName, 
 	return fmt.Errorf("not implemented")
 }
 
+func (m *mockFlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id string) error {
+	return fmt.Errorf("not implemented")
+}
+
 func (m *mockFlapsClient) DeleteMetadata(ctx context.Context, appName, machineID, key string) error {
 	return fmt.Errorf("failed to delete metadata %s", key)
 }
@@ -428,6 +432,10 @@ func (m *mockFlapsClient) ListCertificates(ctx context.Context, appName string, 
 
 func (m *mockFlapsClient) ListFlyAppsMachines(ctx context.Context, appName string) ([]*fly.Machine, *fly.Machine, error) {
 	return nil, nil, fmt.Errorf("failed to list fly apps machines")
+}
+
+func (m *mockFlapsClient) ListManagedPostgresClusters(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 func (m *mockFlapsClient) ListAppSecrets(ctx context.Context, appName string, version *uint64, showSecrets bool) ([]fly.AppSecret, error) {

--- a/internal/command/mpg/attach.go
+++ b/internal/command/mpg/attach.go
@@ -83,7 +83,7 @@ func runAttach(ctx context.Context) error {
 	clusterOrgSlug := cluster.Organization.Slug
 
 	// Verify that the app and cluster are in the same organization
-	if appOrgSlug != clusterOrgSlug {
+	if !organizationSlugMatches(app.Organization, clusterOrgSlug) {
 		return fmt.Errorf("app %s is in organization %s, but cluster %s is in organization %s. They must be in the same organization to attach",
 			appName, appOrgSlug, cluster.Id, clusterOrgSlug)
 	}

--- a/internal/command/mpg/detach.go
+++ b/internal/command/mpg/detach.go
@@ -67,7 +67,7 @@ func runDetach(ctx context.Context) error {
 	clusterOrgSlug := cluster.Organization.Slug
 
 	// Verify that the app and cluster are in the same organization
-	if appOrgSlug != clusterOrgSlug {
+	if !organizationSlugMatches(app.Organization, clusterOrgSlug) {
 		return fmt.Errorf("app %s is in organization %s, but cluster %s is in organization %s. They must be in the same organization",
 			appName, appOrgSlug, cluster.Id, clusterOrgSlug)
 	}

--- a/internal/command/mpg/list.go
+++ b/internal/command/mpg/list.go
@@ -14,7 +14,6 @@ import (
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 	"github.com/superfly/flyctl/internal/uiex/mpg"
-	mpgv1 "github.com/superfly/flyctl/internal/uiex/mpg/v1"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -54,7 +53,6 @@ func runList(ctx context.Context) error {
 	}
 	orgSlug := org.Slug
 
-	mpgv1Client := mpgv1.ClientFromContext(ctx)
 	genqClient := flyutil.ClientFromContext(ctx).GenqClient()
 
 	// For ui-ex request we need the real org slug
@@ -64,12 +62,12 @@ func runList(ctx context.Context) error {
 	}
 
 	deleted := flag.GetBool(ctx, "deleted")
-	clusters, err := mpgv1Client.ListManagedClusters(ctx, fullOrg.Organization.RawSlug, deleted)
+	clusters, err := listManagedClusters(ctx, fullOrg.Organization.RawSlug, deleted)
 	if err != nil {
 		return fmt.Errorf("failed to list postgres clusters for organization %s: %w", orgSlug, err)
 	}
 
-	if len(clusters.Data) == 0 {
+	if len(clusters) == 0 {
 		if deleted {
 			fmt.Fprintf(out, "No deleted managed postgres clusters found in organization %s\n", orgSlug)
 		} else {
@@ -80,11 +78,11 @@ func runList(ctx context.Context) error {
 	}
 
 	if cfg.JSONOutput {
-		return render.JSON(out, clusters.Data)
+		return render.JSON(out, clusters)
 	}
 
-	rows := make([][]string, 0, len(clusters.Data))
-	for _, cluster := range clusters.Data {
+	rows := make([][]string, 0, len(clusters))
+	for _, cluster := range clusters {
 		rows = append(rows, []string{
 			cluster.Id,
 			cluster.Name,

--- a/internal/command/mpg/list_test.go
+++ b/internal/command/mpg/list_test.go
@@ -1,0 +1,91 @@
+package mpg
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	genq "github.com/Khan/genqlient/graphql"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/gql"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/mock"
+	mpgv1 "github.com/superfly/flyctl/internal/uiex/mpg/v1"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+type organizationGraphQLClient struct{}
+
+func (organizationGraphQLClient) MakeRequest(_ context.Context, _ *genq.Request, response *genq.Response) error {
+	data := response.Data.(*gql.GetOrganizationResponse)
+	data.Organization.OrganizationData = gql.OrganizationData{
+		Id:       "org-id",
+		Slug:     "personal",
+		RawSlug:  "raw-personal",
+		PaidPlan: true,
+		Name:     "Personal",
+		Billable: true,
+	}
+
+	return nil
+}
+
+func TestRunListUsesMergedMachinesAndLegacyResults(t *testing.T) {
+	io, _, stdout, _ := iostreams.Test()
+	ctx := iostreams.NewContext(context.Background(), io)
+	ctx = config.NewContext(ctx, &config.Config{JSONOutput: true})
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("org", "personal", "")
+	flags.Bool("deleted", false, "")
+	ctx = flagctx.NewContext(ctx, flags)
+
+	ctx = flyutil.NewContextWithClient(ctx, &mock.Client{
+		GetOrganizationBySlugFunc: func(_ context.Context, slug string) (*fly.Organization, error) {
+			require.Equal(t, "personal", slug)
+
+			return &fly.Organization{Slug: slug, RawSlug: "raw-personal"}, nil
+		},
+		GenqClientFunc: func() genq.Client {
+			return organizationGraphQLClient{}
+		},
+	})
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+		ListManagedPostgresClustersFunc: func(_ context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error) {
+			require.Equal(t, "raw-personal", req.OrgSlug)
+			require.False(t, req.IncludeDeleted)
+
+			return []flaps.ManagedPostgresClusterSummary{{
+				ID: "mpg-v2", Name: "public", Region: "iad", Status: "ready", Plan: "basic",
+			}}, nil
+		},
+	})
+	ctx = mpgv1.NewContextWithClient(ctx, &mock.MpgV1Client{
+		ListManagedClustersFunc: func(_ context.Context, orgSlug string, deleted bool) (mpgv1.ListManagedClustersResponse, error) {
+			require.Equal(t, "raw-personal", orgSlug)
+			require.False(t, deleted)
+
+			return mpgv1.ListManagedClustersResponse{Data: []mpgv1.ManagedCluster{
+				{Id: "mpg-v2", ClusterId: "fly-mpg-v2", Name: "legacy duplicate", Version: 2},
+				{Id: "mpg-v1", Name: "legacy", Region: "ord", Status: "ready", Plan: "basic", Version: 1},
+			}}, nil
+		},
+	})
+
+	require.NoError(t, runList(ctx))
+	var clusters []mpgv1.ManagedCluster
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &clusters))
+	require.Len(t, clusters, 2)
+	require.Equal(t, "mpg-v2", clusters[0].Id)
+	require.Equal(t, "fly-mpg-v2", clusters[0].ClusterId)
+	require.Equal(t, 2, clusters[0].Version)
+	require.Equal(t, "public", clusters[0].Name)
+	require.Equal(t, "raw-personal", clusters[0].Organization.Slug)
+	require.Equal(t, "mpg-v1", clusters[1].Id)
+	require.Equal(t, 1, clusters[1].Version)
+}

--- a/internal/command/mpg/mpg.go
+++ b/internal/command/mpg/mpg.go
@@ -2,18 +2,21 @@ package mpg
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/uiex/mpg"
 	mpgv1 "github.com/superfly/flyctl/internal/uiex/mpg/v1"
-	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
 )
 
 func New() *cobra.Command {
@@ -53,30 +56,30 @@ func New() *cobra.Command {
 // It prompts for the org if the org slug is not provided.
 func ClusterFromArgOrSelect(ctx context.Context, clusterID, orgSlug string) (*mpg.Cluster, string, error) {
 	mpgv1Client := mpgv1.ClientFromContext(ctx)
-	mpgv2Client := mpgv2.ClientFromContext(ctx)
+	mpgClient := flapsutil.ClientFromContext(ctx)
 
 	// If user told us which cluster they want
 	if clusterID != "" {
-		// Check if its a V2 cluster. Otherwise, fallback to V1.
-		if c, err := mpgv2Client.GetClusterById(ctx, clusterID); err == nil && c.Data.MpgdClusterId != "" {
-			cluster := &mpg.Cluster{
-				Id:            c.Data.Id,
-				Name:          c.Data.Name,
-				Region:        c.Data.Region,
-				Status:        c.Data.Status,
-				Plan:          c.Data.Plan,
-				Disk:          c.Data.Disk,
-				Replicas:      c.Data.Replicas,
-				Organization:  c.Data.Organization,
-				IpAssignments: c.Data.IpAssignments,
-				AttachedApps:  c.Data.AttachedApps,
-				Version:       mpg.VersionV2,
+		// The public Machines API is the MPGv2 source. Only a genuine not-found
+		// falls back to the legacy MPGv1 client; auth and service failures must
+		// remain visible instead of being misreported as a missing cluster.
+		if c, err := mpgClient.GetManagedPostgresCluster(ctx, clusterID); err == nil {
+			if c.ID == "" {
+				return nil, orgSlug, fmt.Errorf("invalid response retrieving managed postgres cluster %q: missing cluster ID", clusterID)
 			}
+			cluster := clusterFromMachinesAPI(c)
 
 			return cluster, cluster.Organization.Slug, nil
+		} else if !errors.Is(err, flaps.ErrFlapsNotFound) {
+			return nil, orgSlug, fmt.Errorf("failed retrieving managed postgres cluster %q: %w", clusterID, err)
 		}
 
 		if c, err := mpgv1Client.GetManagedClusterById(ctx, clusterID); err == nil {
+			version := mpg.VersionV1
+			if c.Data.Version == 2 {
+				version = mpg.VersionV2
+			}
+
 			cluster := &mpg.Cluster{
 				Id:            c.Data.Id,
 				Name:          c.Data.Name,
@@ -88,7 +91,7 @@ func ClusterFromArgOrSelect(ctx context.Context, clusterID, orgSlug string) (*mp
 				Organization:  c.Data.Organization,
 				IpAssignments: c.Data.IpAssignments,
 				AttachedApps:  c.Data.AttachedApps,
-				Version:       mpg.VersionV1,
+				Version:       version,
 			}
 
 			return cluster, cluster.Organization.Slug, nil
@@ -109,38 +112,17 @@ func ClusterFromArgOrSelect(ctx context.Context, clusterID, orgSlug string) (*mp
 		orgSlug = org.RawSlug
 	}
 
-	// Fetch clusters. Odd but the v1 client endpoint returns both v1 and v2 clusters,
-	// they are just identified with the `Version` field being 1 or 2.
-	mc, err := mpgv1Client.ListManagedClusters(ctx, orgSlug, false)
+	clusters, err := listSelectableClusters(ctx, orgSlug)
 	if err != nil {
 		return nil, orgSlug, fmt.Errorf("failed retrieving postgres clusters: %w", err)
 	}
 
-	if len(mc.Data) == 0 {
+	if len(clusters) == 0 {
 		return nil, orgSlug, fmt.Errorf("no managed postgres clusters found in organization %s", orgSlug)
 	}
 
-	clusters := make([]*mpg.Cluster, 0, len(mc.Data))
-	options := make([]string, 0, len(mc.Data))
-
-	for _, cluster := range mc.Data {
-		version := mpg.VersionV1
-		if cluster.Version == 2 {
-			version = mpg.VersionV2
-		}
-
-		clusters = append(clusters, &mpg.Cluster{
-			Id:           cluster.Id,
-			Name:         cluster.Name,
-			Region:       cluster.Region,
-			Status:       cluster.Status,
-			Plan:         cluster.Plan,
-			Disk:         cluster.Disk,
-			Replicas:     cluster.Replicas,
-			Organization: cluster.Organization,
-			Version:      version,
-		})
-
+	options := make([]string, 0, len(clusters))
+	for _, cluster := range clusters {
 		options = append(options, fmt.Sprintf("%s [%s] (%s)", cluster.Name, cluster.Id, cluster.Region))
 	}
 
@@ -150,6 +132,95 @@ func ClusterFromArgOrSelect(ctx context.Context, clusterID, orgSlug string) (*mp
 	}
 
 	return clusters[index], orgSlug, nil
+}
+
+func listSelectableClusters(ctx context.Context, orgSlug string) ([]*mpg.Cluster, error) {
+	mpgClient := flapsutil.ClientFromContext(ctx)
+	publicClusters, err := mpgClient.ListManagedPostgresClusters(ctx, flaps.ListManagedPostgresClustersRequest{OrgSlug: orgSlug})
+	publicUnavailable := errors.Is(err, flaps.ErrFlapsNotFound)
+	if err != nil && !publicUnavailable {
+		return nil, err
+	}
+
+	mpgv1Client := mpgv1.ClientFromContext(ctx)
+	legacyClusters, err := mpgv1Client.ListManagedClusters(ctx, orgSlug, false)
+	if err != nil {
+		return nil, err
+	}
+
+	clusters := make([]*mpg.Cluster, 0, len(publicClusters)+len(legacyClusters.Data))
+	publicIDs := make(map[string]struct{}, len(publicClusters))
+	if !publicUnavailable {
+		for _, cluster := range publicClusters {
+			publicIDs[cluster.ID] = struct{}{}
+			clusters = append(clusters, clusterFromMachinesAPISummary(cluster, orgSlug))
+		}
+	}
+	for _, cluster := range legacyClusters.Data {
+		if _, duplicated := publicIDs[cluster.Id]; duplicated {
+			continue
+		}
+		version := mpg.VersionV1
+		if cluster.Version == 2 {
+			version = mpg.VersionV2
+		}
+		clusters = append(clusters, &mpg.Cluster{
+			Id:            cluster.Id,
+			Name:          cluster.Name,
+			Region:        cluster.Region,
+			Status:        cluster.Status,
+			Plan:          cluster.Plan,
+			Disk:          cluster.Disk,
+			Replicas:      cluster.Replicas,
+			Organization:  cluster.Organization,
+			IpAssignments: cluster.IpAssignments,
+			AttachedApps:  cluster.AttachedApps,
+			Version:       version,
+		})
+	}
+
+	return clusters, nil
+}
+
+func clusterFromMachinesAPI(cluster flaps.ManagedPostgresCluster) *mpg.Cluster {
+	return &mpg.Cluster{
+		Id:           cluster.ID,
+		Name:         cluster.Name,
+		Region:       cluster.Region,
+		Status:       cluster.Status,
+		Plan:         cluster.Plan,
+		Disk:         cluster.DiskSizeGB,
+		Replicas:     cluster.Replicas,
+		Organization: fly.Organization{Name: cluster.Organization.Name, Slug: cluster.Organization.Slug},
+		AttachedApps: attachedAppsFromMachinesAPI(cluster.AttachedApps),
+		Version:      mpg.VersionV2,
+	}
+}
+
+func clusterFromMachinesAPISummary(cluster flaps.ManagedPostgresClusterSummary, orgSlug string) *mpg.Cluster {
+	return &mpg.Cluster{
+		Id:           cluster.ID,
+		Name:         cluster.Name,
+		Region:       cluster.Region,
+		Status:       cluster.Status,
+		Plan:         cluster.Plan,
+		Organization: fly.Organization{Slug: orgSlug},
+		AttachedApps: attachedAppsFromMachinesAPI(cluster.AttachedApps),
+		Version:      mpg.VersionV2,
+	}
+}
+
+func attachedAppsFromMachinesAPI(apps []flaps.ManagedPostgresAttachedApp) []mpg.AttachedApp {
+	result := make([]mpg.AttachedApp, 0, len(apps))
+	for _, app := range apps {
+		result = append(result, mpg.AttachedApp{Name: app.Name})
+	}
+
+	return result
+}
+
+func organizationSlugMatches(org *fly.OrganizationBasic, slug string) bool {
+	return org != nil && (slug == org.RawSlug || slug == org.Slug)
 }
 
 // ClusterFromFlagOrSelect retrieves the cluster ID from the --cluster flag.

--- a/internal/command/mpg/mpg.go
+++ b/internal/command/mpg/mpg.go
@@ -135,51 +135,84 @@ func ClusterFromArgOrSelect(ctx context.Context, clusterID, orgSlug string) (*mp
 }
 
 func listSelectableClusters(ctx context.Context, orgSlug string) ([]*mpg.Cluster, error) {
+	managedClusters, err := listManagedClusters(ctx, orgSlug, false)
+	if err != nil {
+		return nil, err
+	}
+
+	clusters := make([]*mpg.Cluster, 0, len(managedClusters))
+	for _, cluster := range managedClusters {
+		clusters = append(clusters, clusterFromLegacyAPI(cluster))
+	}
+
+	return clusters, nil
+}
+
+func listManagedClusters(ctx context.Context, orgSlug string, deleted bool) ([]mpgv1.ManagedCluster, error) {
 	mpgClient := flapsutil.ClientFromContext(ctx)
-	publicClusters, err := mpgClient.ListManagedPostgresClusters(ctx, flaps.ListManagedPostgresClustersRequest{OrgSlug: orgSlug})
+	publicClusters, err := mpgClient.ListManagedPostgresClusters(ctx, flaps.ListManagedPostgresClustersRequest{
+		OrgSlug:        orgSlug,
+		IncludeDeleted: deleted,
+	})
 	publicUnavailable := errors.Is(err, flaps.ErrFlapsNotFound)
 	if err != nil && !publicUnavailable {
 		return nil, err
 	}
 
 	mpgv1Client := mpgv1.ClientFromContext(ctx)
-	legacyClusters, err := mpgv1Client.ListManagedClusters(ctx, orgSlug, false)
+	legacyClusters, err := mpgv1Client.ListManagedClusters(ctx, orgSlug, deleted)
 	if err != nil {
 		return nil, err
 	}
 
-	clusters := make([]*mpg.Cluster, 0, len(publicClusters)+len(legacyClusters.Data))
-	publicIDs := make(map[string]struct{}, len(publicClusters))
+	clusters := make([]mpgv1.ManagedCluster, 0, len(publicClusters)+len(legacyClusters.Data))
+	publicIndexes := make(map[string]int, len(publicClusters))
 	if !publicUnavailable {
 		for _, cluster := range publicClusters {
-			publicIDs[cluster.ID] = struct{}{}
-			clusters = append(clusters, clusterFromMachinesAPISummary(cluster, orgSlug))
+			if deleted && cluster.DeletedAt == "" {
+				continue
+			}
+			publicIndexes[cluster.ID] = len(clusters)
+			clusters = append(clusters, managedClusterFromMachinesAPISummary(cluster, orgSlug))
 		}
 	}
 	for _, cluster := range legacyClusters.Data {
-		if _, duplicated := publicIDs[cluster.Id]; duplicated {
+		if index, duplicated := publicIndexes[cluster.Id]; duplicated {
+			clusters[index].ClusterId = cluster.ClusterId
+			clusters[index].Disk = cluster.Disk
+			clusters[index].Replicas = cluster.Replicas
+			if cluster.Organization.Slug != "" {
+				clusters[index].Organization = cluster.Organization
+			}
+			clusters[index].IpAssignments = cluster.IpAssignments
+
 			continue
 		}
-		version := mpg.VersionV1
-		if cluster.Version == 2 {
-			version = mpg.VersionV2
-		}
-		clusters = append(clusters, &mpg.Cluster{
-			Id:            cluster.Id,
-			Name:          cluster.Name,
-			Region:        cluster.Region,
-			Status:        cluster.Status,
-			Plan:          cluster.Plan,
-			Disk:          cluster.Disk,
-			Replicas:      cluster.Replicas,
-			Organization:  cluster.Organization,
-			IpAssignments: cluster.IpAssignments,
-			AttachedApps:  cluster.AttachedApps,
-			Version:       version,
-		})
+		clusters = append(clusters, cluster)
 	}
 
 	return clusters, nil
+}
+
+func clusterFromLegacyAPI(cluster mpgv1.ManagedCluster) *mpg.Cluster {
+	version := mpg.VersionV1
+	if cluster.Version == 2 {
+		version = mpg.VersionV2
+	}
+
+	return &mpg.Cluster{
+		Id:            cluster.Id,
+		Name:          cluster.Name,
+		Region:        cluster.Region,
+		Status:        cluster.Status,
+		Plan:          cluster.Plan,
+		Disk:          cluster.Disk,
+		Replicas:      cluster.Replicas,
+		Organization:  cluster.Organization,
+		IpAssignments: cluster.IpAssignments,
+		AttachedApps:  cluster.AttachedApps,
+		Version:       version,
+	}
 }
 
 func clusterFromMachinesAPI(cluster flaps.ManagedPostgresCluster) *mpg.Cluster {
@@ -197,8 +230,8 @@ func clusterFromMachinesAPI(cluster flaps.ManagedPostgresCluster) *mpg.Cluster {
 	}
 }
 
-func clusterFromMachinesAPISummary(cluster flaps.ManagedPostgresClusterSummary, orgSlug string) *mpg.Cluster {
-	return &mpg.Cluster{
+func managedClusterFromMachinesAPISummary(cluster flaps.ManagedPostgresClusterSummary, orgSlug string) mpgv1.ManagedCluster {
+	return mpgv1.ManagedCluster{
 		Id:           cluster.ID,
 		Name:         cluster.Name,
 		Region:       cluster.Region,
@@ -206,7 +239,7 @@ func clusterFromMachinesAPISummary(cluster flaps.ManagedPostgresClusterSummary, 
 		Plan:         cluster.Plan,
 		Organization: fly.Organization{Slug: orgSlug},
 		AttachedApps: attachedAppsFromMachinesAPI(cluster.AttachedApps),
-		Version:      mpg.VersionV2,
+		Version:      2,
 	}
 }
 

--- a/internal/command/mpg/mpg_test.go
+++ b/internal/command/mpg/mpg_test.go
@@ -12,11 +12,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/fly-go/tokens"
 	regionsv2 "github.com/superfly/flyctl/internal/command/mpg/v2/regions"
 	"github.com/superfly/flyctl/internal/command_context"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/mock"
 	"github.com/superfly/flyctl/internal/uiex/mpg"
 	mpgv1 "github.com/superfly/flyctl/internal/uiex/mpg/v1"
@@ -56,6 +58,14 @@ func setupTestContext() context.Context {
 	flagSet.String("org", "", "Organization")
 	flagSet.Bool("json", false, "JSON output")
 	ctx = flagctx.NewContext(ctx, flagSet)
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+		GetManagedPostgresClusterFunc: func(context.Context, string) (flaps.ManagedPostgresCluster, error) {
+			return flaps.ManagedPostgresCluster{}, flaps.ErrFlapsNotFound
+		},
+		ListManagedPostgresClustersFunc: func(context.Context, flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error) {
+			return nil, nil
+		},
+	})
 
 	return ctx
 }
@@ -143,6 +153,195 @@ func TestClusterFromFlagOrSelect_WithFlagContext(t *testing.T) {
 		assert.Equal(t, expectedCluster.Id, cluster.Id)
 		assert.Equal(t, expectedCluster.Name, cluster.Name)
 	})
+}
+
+func TestClusterFromArgOrSelectByID(t *testing.T) {
+	publicCluster := flaps.ManagedPostgresCluster{
+		ID:         "mpg-123",
+		Name:       "public-cluster",
+		Region:     "ord",
+		Status:     "ready",
+		Plan:       "basic",
+		DiskSizeGB: 20,
+		Replicas:   3,
+		Organization: flaps.ManagedPostgresOrganization{
+			Name: "Example Org",
+			Slug: "example-org",
+		},
+	}
+
+	tests := []struct {
+		name          string
+		publicCluster flaps.ManagedPostgresCluster
+		publicErr     error
+		legacyCluster mpgv1.ManagedCluster
+		wantLegacy    bool
+		wantErr       string
+		wantName      string
+		wantOrg       string
+		wantDisk      int
+		wantVersion   mpg.Version
+	}{
+		{
+			name:          "uses public API for MPGv2",
+			publicCluster: publicCluster,
+			wantName:      "public-cluster",
+			wantOrg:       "example-org",
+			wantDisk:      20,
+			wantVersion:   mpg.VersionV2,
+		},
+		{
+			name:      "does not fall back on public failure",
+			publicErr: errors.New("machines api unavailable"),
+			wantErr:   `failed retrieving managed postgres cluster "mpg-123": machines api unavailable`,
+		},
+		{
+			name:       "preserves MPGv2 version from legacy fallback",
+			publicErr:  flaps.ErrFlapsNotFound,
+			wantLegacy: true,
+			legacyCluster: mpgv1.ManagedCluster{
+				Id:      "mpg-123",
+				Name:    "v2-from-legacy-fallback",
+				Version: 2,
+			},
+			wantName:    "v2-from-legacy-fallback",
+			wantVersion: mpg.VersionV2,
+		},
+		{
+			name:          "rejects malformed public success",
+			publicCluster: flaps.ManagedPostgresCluster{},
+			wantErr:       `invalid response retrieving managed postgres cluster "mpg-123": missing cluster ID`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := setupTestContext()
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				GetManagedPostgresClusterFunc: func(_ context.Context, id string) (flaps.ManagedPostgresCluster, error) {
+					require.Equal(t, "mpg-123", id)
+
+					return test.publicCluster, test.publicErr
+				},
+			})
+			legacyCalled := false
+			ctx = mpgv1.NewContextWithClient(ctx, &mock.MpgV1Client{
+				GetManagedClusterByIdFunc: func(_ context.Context, id string) (mpgv1.GetManagedClusterResponse, error) {
+					legacyCalled = true
+					require.Equal(t, "mpg-123", id)
+
+					return mpgv1.GetManagedClusterResponse{Data: test.legacyCluster}, nil
+				},
+			})
+
+			cluster, orgSlug, err := ClusterFromArgOrSelect(ctx, "mpg-123", "")
+			if test.wantErr != "" {
+				require.EqualError(t, err, test.wantErr)
+				require.Equal(t, test.wantLegacy, legacyCalled)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.wantLegacy, legacyCalled)
+			require.Equal(t, test.wantVersion, cluster.Version)
+			require.Equal(t, test.wantName, cluster.Name)
+			require.Equal(t, test.wantDisk, cluster.Disk)
+			require.Equal(t, test.wantOrg, orgSlug)
+		})
+	}
+}
+
+func TestOrganizationSlugMatchesRawOrAliasedSlug(t *testing.T) {
+	org := &fly.OrganizationBasic{RawSlug: "user-org", Slug: "personal"}
+
+	require.True(t, organizationSlugMatches(org, "user-org"))
+	require.True(t, organizationSlugMatches(org, "personal"))
+	require.False(t, organizationSlugMatches(org, "other-org"))
+	require.False(t, organizationSlugMatches(nil, "user-org"))
+}
+
+func TestListSelectableClusters(t *testing.T) {
+	tests := []struct {
+		name           string
+		publicClusters []flaps.ManagedPostgresClusterSummary
+		publicErr      error
+		legacyClusters []mpgv1.ManagedCluster
+		wantLegacy     bool
+		wantIDs        []string
+		wantVersions   []mpg.Version
+		wantErr        string
+	}{
+		{
+			name: "merges public and legacy clusters without duplicates",
+			publicClusters: []flaps.ManagedPostgresClusterSummary{{
+				ID: "mpg-v2", Name: "public-cluster", Region: "ord", Status: "ready", Plan: "basic",
+			}},
+			legacyClusters: []mpgv1.ManagedCluster{
+				{Id: "mpg-v1", Name: "legacy-cluster"},
+				{Id: "mpg-v2", Name: "duplicate-private-v2", Version: 2},
+				{Id: "mpg-v2-private-only", Name: "private-only-v2", Version: 2},
+			},
+			wantLegacy:   true,
+			wantIDs:      []string{"mpg-v2", "mpg-v1", "mpg-v2-private-only"},
+			wantVersions: []mpg.Version{mpg.VersionV2, mpg.VersionV1, mpg.VersionV2},
+		},
+		{
+			name:       "uses legacy list when public endpoint is unavailable",
+			publicErr:  flaps.ErrFlapsNotFound,
+			wantLegacy: true,
+			legacyClusters: []mpgv1.ManagedCluster{
+				{Id: "mpg-v1", Name: "legacy-cluster"},
+				{Id: "mpg-v2", Name: "private-v2", Version: 2},
+			},
+			wantIDs:      []string{"mpg-v1", "mpg-v2"},
+			wantVersions: []mpg.Version{mpg.VersionV1, mpg.VersionV2},
+		},
+		{
+			name:      "does not fall back on public failure",
+			publicErr: errors.New("machines api unavailable"),
+			wantErr:   "machines api unavailable",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := setupTestContext()
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				ListManagedPostgresClustersFunc: func(_ context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error) {
+					require.Equal(t, "example-org", req.OrgSlug)
+
+					return test.publicClusters, test.publicErr
+				},
+			})
+			legacyCalled := false
+			ctx = mpgv1.NewContextWithClient(ctx, &mock.MpgV1Client{
+				ListManagedClustersFunc: func(_ context.Context, orgSlug string, deleted bool) (mpgv1.ListManagedClustersResponse, error) {
+					legacyCalled = true
+					require.Equal(t, "example-org", orgSlug)
+					require.False(t, deleted)
+
+					return mpgv1.ListManagedClustersResponse{Data: test.legacyClusters}, nil
+				},
+			})
+
+			clusters, err := listSelectableClusters(ctx, "example-org")
+			if test.wantErr != "" {
+				require.EqualError(t, err, test.wantErr)
+				require.Equal(t, test.wantLegacy, legacyCalled)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.wantLegacy, legacyCalled)
+			require.Len(t, clusters, len(test.wantIDs))
+			for i := range clusters {
+				require.Equal(t, test.wantIDs[i], clusters[i].Id)
+				require.Equal(t, test.wantVersions[i], clusters[i].Version)
+			}
+		})
+	}
 }
 
 // Test the actual GetAvailableMPGRegions function with mocked dependencies
@@ -786,6 +985,11 @@ func TestBackupList(t *testing.T) {
 
 	ctx = mpgv1.NewContextWithClient(ctx, mockv1)
 	ctx = mpgv2.NewContextWithClient(ctx, mockv2)
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+		GetManagedPostgresClusterFunc: func(context.Context, string) (flaps.ManagedPostgresCluster, error) {
+			return flaps.ManagedPostgresCluster{}, flaps.ErrFlapsNotFound
+		},
+	})
 
 	// Run the backup list command
 	err := runBackupList(ctx)

--- a/internal/command/mpg/mpg_test.go
+++ b/internal/command/mpg/mpg_test.go
@@ -261,15 +261,17 @@ func TestOrganizationSlugMatchesRawOrAliasedSlug(t *testing.T) {
 	require.False(t, organizationSlugMatches(nil, "user-org"))
 }
 
-func TestListSelectableClusters(t *testing.T) {
+func TestListManagedClusters(t *testing.T) {
 	tests := []struct {
 		name           string
+		deleted        bool
 		publicClusters []flaps.ManagedPostgresClusterSummary
 		publicErr      error
 		legacyClusters []mpgv1.ManagedCluster
 		wantLegacy     bool
 		wantIDs        []string
 		wantVersions   []mpg.Version
+		wantClusterIDs []string
 		wantErr        string
 	}{
 		{
@@ -279,12 +281,15 @@ func TestListSelectableClusters(t *testing.T) {
 			}},
 			legacyClusters: []mpgv1.ManagedCluster{
 				{Id: "mpg-v1", Name: "legacy-cluster"},
-				{Id: "mpg-v2", Name: "duplicate-private-v2", Version: 2},
+				{Id: "mpg-v2", ClusterId: "fly-mpg-v2", Name: "duplicate-private-v2", Version: 2},
 				{Id: "mpg-v2-private-only", Name: "private-only-v2", Version: 2},
 			},
 			wantLegacy:   true,
 			wantIDs:      []string{"mpg-v2", "mpg-v1", "mpg-v2-private-only"},
 			wantVersions: []mpg.Version{mpg.VersionV2, mpg.VersionV1, mpg.VersionV2},
+			wantClusterIDs: []string{
+				"fly-mpg-v2", "", "",
+			},
 		},
 		{
 			name:       "uses legacy list when public endpoint is unavailable",
@@ -296,6 +301,21 @@ func TestListSelectableClusters(t *testing.T) {
 			},
 			wantIDs:      []string{"mpg-v1", "mpg-v2"},
 			wantVersions: []mpg.Version{mpg.VersionV1, mpg.VersionV2},
+		},
+		{
+			name:    "filters active public clusters from deleted results",
+			deleted: true,
+			publicClusters: []flaps.ManagedPostgresClusterSummary{
+				{ID: "mpg-active", Name: "active"},
+				{ID: "mpg-deleted", Name: "deleted", DeletedAt: "2026-08-25T00:00:00Z"},
+			},
+			legacyClusters: []mpgv1.ManagedCluster{
+				{Id: "mpg-deleted", Name: "duplicate-deleted", Version: 2},
+				{Id: "mpg-v1-deleted", Name: "legacy-deleted", Version: 1},
+			},
+			wantLegacy:   true,
+			wantIDs:      []string{"mpg-deleted", "mpg-v1-deleted"},
+			wantVersions: []mpg.Version{mpg.VersionV2, mpg.VersionV1},
 		},
 		{
 			name:      "does not fall back on public failure",
@@ -310,6 +330,7 @@ func TestListSelectableClusters(t *testing.T) {
 			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
 				ListManagedPostgresClustersFunc: func(_ context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error) {
 					require.Equal(t, "example-org", req.OrgSlug)
+					require.Equal(t, test.deleted, req.IncludeDeleted)
 
 					return test.publicClusters, test.publicErr
 				},
@@ -319,13 +340,13 @@ func TestListSelectableClusters(t *testing.T) {
 				ListManagedClustersFunc: func(_ context.Context, orgSlug string, deleted bool) (mpgv1.ListManagedClustersResponse, error) {
 					legacyCalled = true
 					require.Equal(t, "example-org", orgSlug)
-					require.False(t, deleted)
+					require.Equal(t, test.deleted, deleted)
 
 					return mpgv1.ListManagedClustersResponse{Data: test.legacyClusters}, nil
 				},
 			})
 
-			clusters, err := listSelectableClusters(ctx, "example-org")
+			managedClusters, err := listManagedClusters(ctx, "example-org", test.deleted)
 			if test.wantErr != "" {
 				require.EqualError(t, err, test.wantErr)
 				require.Equal(t, test.wantLegacy, legacyCalled)
@@ -334,11 +355,18 @@ func TestListSelectableClusters(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			clusters := make([]*mpg.Cluster, 0, len(managedClusters))
+			for _, cluster := range managedClusters {
+				clusters = append(clusters, clusterFromLegacyAPI(cluster))
+			}
 			require.Equal(t, test.wantLegacy, legacyCalled)
 			require.Len(t, clusters, len(test.wantIDs))
 			for i := range clusters {
 				require.Equal(t, test.wantIDs[i], clusters[i].Id)
 				require.Equal(t, test.wantVersions[i], clusters[i].Version)
+				if len(test.wantClusterIDs) != 0 {
+					require.Equal(t, test.wantClusterIDs[i], managedClusters[i].ClusterId)
+				}
 			}
 		})
 	}

--- a/internal/command/mpg/restore_test.go
+++ b/internal/command/mpg/restore_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/superfly/fly-go/flaps"
 	cmdv2 "github.com/superfly/flyctl/internal/command/mpg/v2"
 	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/mock"
 	mpgv1 "github.com/superfly/flyctl/internal/uiex/mpg/v1"
 	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
@@ -126,14 +128,6 @@ func TestRunRestore(t *testing.T) {
 				},
 			}
 			v2Client := &mock.MpgV2Client{
-				GetClusterByIdFunc: func(context.Context, string) (mpgv2.GetClusterResponse, error) {
-					lookupCalled = true
-					if tt.clusterVersion != 2 {
-						return mpgv2.GetClusterResponse{}, errors.New("not found")
-					}
-
-					return mpgv2.GetClusterResponse{Data: mpgv2.ManagedCluster{Id: clusterID, MpgdClusterId: "mpgd-123"}}, nil
-				},
 				RestoreClusterBackupFunc: func(_ context.Context, gotClusterID string, input mpgv2.RestoreClusterBackupInput) (mpgv2.RestoreClusterBackupResponse, error) {
 					v2RestoreCalled = true
 					assert.Equal(t, clusterID, gotClusterID)
@@ -143,8 +137,19 @@ func TestRunRestore(t *testing.T) {
 					return mpgv2.RestoreClusterBackupResponse{}, nil
 				},
 			}
+			publicClient := &mock.FlapsClient{
+				GetManagedPostgresClusterFunc: func(context.Context, string) (flaps.ManagedPostgresCluster, error) {
+					lookupCalled = true
+					if tt.clusterVersion != 2 {
+						return flaps.ManagedPostgresCluster{}, flaps.ErrFlapsNotFound
+					}
+
+					return flaps.ManagedPostgresCluster{ID: clusterID}, nil
+				},
+			}
 			ctx = mpgv1.NewContextWithClient(ctx, v1Client)
 			ctx = mpgv2.NewContextWithClient(ctx, v2Client)
+			ctx = flapsutil.NewContextWithClient(ctx, publicClient)
 
 			err := runRestore(ctx)
 			if tt.wantErr != "" {

--- a/internal/command/mpg/v2/run_destroy.go
+++ b/internal/command/mpg/v2/run_destroy.go
@@ -2,9 +2,12 @@ package cmdv2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
 	"github.com/superfly/flyctl/iostreams"
@@ -12,22 +15,33 @@ import (
 
 func RunDestroy(ctx context.Context, clusterId string) error {
 	var (
-		mpgClient = mpgv2.ClientFromContext(ctx)
-		io        = iostreams.FromContext(ctx)
-		colorize  = io.ColorScheme()
+		mpgClient    = flapsutil.ClientFromContext(ctx)
+		legacyClient = mpgv2.ClientFromContext(ctx)
+		io           = iostreams.FromContext(ctx)
+		colorize     = io.ColorScheme()
 	)
 
 	// Get cluster details to verify ownership and show info
-	response, err := mpgClient.GetClusterById(ctx, clusterId)
-	if err != nil {
+	cluster, err := mpgClient.GetManagedPostgresCluster(ctx, clusterId)
+	useLegacy := errors.Is(err, flaps.ErrFlapsNotFound)
+	if err != nil && !useLegacy {
 		return fmt.Errorf("failed retrieving cluster %s: %w", clusterId, err)
+	}
+	if useLegacy {
+		response, err := legacyClient.GetClusterById(ctx, clusterId)
+		if err != nil {
+			return fmt.Errorf("failed retrieving cluster %s: %w", clusterId, err)
+		}
+		cluster.Name = response.Data.Name
+		cluster.Organization.Name = response.Data.Organization.Name
+		cluster.Organization.Slug = response.Data.Organization.Slug
 	}
 
 	if !flag.GetYes(ctx) {
 		const msg = "Destroying a managed Postgres cluster is not reversible. All data will be permanently lost."
 		fmt.Fprintln(io.ErrOut, colorize.Red(msg))
 
-		switch confirmed, err := prompt.Confirmf(ctx, "Destroy managed Postgres cluster %s from organization %s (%s)?", response.Data.Name, response.Data.Organization.Name, clusterId); {
+		switch confirmed, err := prompt.Confirmf(ctx, "Destroy managed Postgres cluster %s from organization %s (%s)?", cluster.Name, cluster.Organization.Name, clusterId); {
 		case err == nil:
 			if !confirmed {
 				return nil
@@ -40,12 +54,16 @@ func RunDestroy(ctx context.Context, clusterId string) error {
 	}
 
 	// Destroy the cluster
-	err = mpgClient.DestroyCluster(ctx, response.Data.Organization.Slug, clusterId)
+	if useLegacy {
+		err = legacyClient.DestroyCluster(ctx, cluster.Organization.Slug, clusterId)
+	} else {
+		err = mpgClient.DeleteManagedPostgresCluster(ctx, clusterId)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to destroy cluster %s: %w", clusterId, err)
 	}
 
-	fmt.Fprintf(io.Out, "Managed Postgres cluster %s (%s) scheduled to be destroyed (may take some time)\n", response.Data.Name, clusterId)
+	fmt.Fprintf(io.Out, "Managed Postgres cluster %s (%s) scheduled to be destroyed (may take some time)\n", cluster.Name, clusterId)
 
 	return nil
 }

--- a/internal/command/mpg/v2/run_destroy_test.go
+++ b/internal/command/mpg/v2/run_destroy_test.go
@@ -1,0 +1,145 @@
+package cmdv2
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/mock"
+	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func destroyTestContext(t *testing.T, yes bool) (context.Context, *bytes.Buffer) {
+	t.Helper()
+
+	io, _, stdout, _ := iostreams.Test()
+	ctx := iostreams.NewContext(context.Background(), io)
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Bool("yes", yes, "")
+
+	return flagctx.NewContext(ctx, flags), stdout
+}
+
+func TestRunDestroy(t *testing.T) {
+	publicCluster := flaps.ManagedPostgresCluster{
+		ID:   "mpg-123",
+		Name: "example",
+		Organization: flaps.ManagedPostgresOrganization{
+			Name: "Example Org",
+			Slug: "example-org",
+		},
+	}
+	legacyCluster := mpgv2.ManagedCluster{
+		Id:   "mpg-123",
+		Name: "example",
+		Organization: fly.Organization{
+			Name: "Example Org",
+			Slug: "example-org",
+		},
+	}
+
+	tests := []struct {
+		name             string
+		yes              bool
+		publicCluster    flaps.ManagedPostgresCluster
+		publicLookupErr  error
+		publicDeleteErr  error
+		legacyCluster    mpgv2.ManagedCluster
+		wantPublicDelete bool
+		wantLegacy       bool
+		wantErr          string
+		wantOutput       string
+	}{
+		{
+			name:             "uses Machines API",
+			yes:              true,
+			publicCluster:    publicCluster,
+			wantPublicDelete: true,
+			wantOutput:       "Managed Postgres cluster example (mpg-123) scheduled to be destroyed",
+		},
+		{
+			name:             "returns Machines API delete failure",
+			yes:              true,
+			publicCluster:    publicCluster,
+			publicDeleteErr:  errors.New("delete failed"),
+			wantPublicDelete: true,
+			wantErr:          "failed to destroy cluster mpg-123: delete failed",
+		},
+		{
+			name:            "does not delete when lookup fails",
+			yes:             true,
+			publicLookupErr: errors.New("lookup failed"),
+			wantErr:         "failed retrieving cluster mpg-123: lookup failed",
+		},
+		{
+			name:            "falls back to legacy API on public not found",
+			yes:             true,
+			publicLookupErr: flaps.ErrFlapsNotFound,
+			legacyCluster:   legacyCluster,
+			wantLegacy:      true,
+			wantOutput:      "Managed Postgres cluster example (mpg-123) scheduled to be destroyed",
+		},
+		{
+			name:          "requires yes when non-interactive",
+			publicCluster: publicCluster,
+			wantErr:       "--yes flag must be specified",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, stdout := destroyTestContext(t, test.yes)
+			publicDeleteCalled := false
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				GetManagedPostgresClusterFunc: func(_ context.Context, id string) (flaps.ManagedPostgresCluster, error) {
+					require.Equal(t, "mpg-123", id)
+
+					return test.publicCluster, test.publicLookupErr
+				},
+				DeleteManagedPostgresClusterFunc: func(_ context.Context, id string) error {
+					publicDeleteCalled = true
+					require.Equal(t, "mpg-123", id)
+
+					return test.publicDeleteErr
+				},
+			})
+
+			legacyCalled := false
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+				GetClusterByIdFunc: func(_ context.Context, id string) (mpgv2.GetClusterResponse, error) {
+					legacyCalled = true
+					require.Equal(t, "mpg-123", id)
+
+					return mpgv2.GetClusterResponse{Data: test.legacyCluster}, nil
+				},
+				DestroyClusterFunc: func(_ context.Context, orgSlug, id string) error {
+					legacyCalled = true
+					require.Equal(t, "example-org", orgSlug)
+					require.Equal(t, "mpg-123", id)
+
+					return nil
+				},
+			})
+
+			err := RunDestroy(ctx, "mpg-123")
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.wantPublicDelete, publicDeleteCalled)
+			require.Equal(t, test.wantLegacy, legacyCalled)
+			if test.wantOutput != "" {
+				require.Contains(t, stdout.String(), test.wantOutput)
+			}
+		})
+	}
+}

--- a/internal/flapsutil/flaps_client.go
+++ b/internal/flapsutil/flaps_client.go
@@ -25,6 +25,7 @@ type FlapsClient interface {
 	DeleteACMECertificate(ctx context.Context, appName, hostname string) error
 	DeleteCertificate(ctx context.Context, appName, hostname string) error
 	DeleteCustomCertificate(ctx context.Context, appName, hostname string) error
+	DeleteManagedPostgresCluster(ctx context.Context, id string) error
 	DeleteMetadata(ctx context.Context, appName, machineID, key string) error
 	DeleteAppSecret(ctx context.Context, appName, name string) (*fly.DeleteAppSecretResp, error)
 	DeleteIPAssignment(ctx context.Context, appName, ip string) (err error)
@@ -59,6 +60,7 @@ type FlapsClient interface {
 	ListAppSecrets(ctx context.Context, appName string, version *uint64, showSecrets bool) ([]fly.AppSecret, error)
 	ListCertificates(ctx context.Context, appName string, opts *flaps.ListCertificatesOpts) (*fly.ListCertificatesResponse, error)
 	ListFlyAppsMachines(ctx context.Context, appName string) ([]*fly.Machine, *fly.Machine, error)
+	ListManagedPostgresClusters(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error)
 	ListSecretKeys(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error)
 	NewRequest(ctx context.Context, method, path string, in any, headers map[string][]string) (*http.Request, error)
 	RefreshLease(ctx context.Context, appName, machineID string, ttl *int, nonce string) (*fly.MachineLease, error)

--- a/internal/inmem/flaps_client.go
+++ b/internal/inmem/flaps_client.go
@@ -76,6 +76,10 @@ func (m *FlapsClient) DeleteCustomCertificate(ctx context.Context, appName, host
 	panic("TODO")
 }
 
+func (m *FlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id string) error {
+	panic("TODO")
+}
+
 func (m *FlapsClient) DeleteMetadata(ctx context.Context, appName, machineID, key string) error {
 	panic("TODO")
 }
@@ -249,6 +253,10 @@ func (m *FlapsClient) ListFlyAppsMachines(ctx context.Context, appName string) (
 	}
 
 	return machines, releaseCmdMachine, nil
+}
+
+func (m *FlapsClient) ListManagedPostgresClusters(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error) {
+	panic("TODO")
 }
 
 func (m *FlapsClient) ListSecretKeys(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error) {

--- a/internal/mock/flaps_client.go
+++ b/internal/mock/flaps_client.go
@@ -26,6 +26,7 @@ type FlapsClient struct {
 	DeleteACMECertificateFunc             func(ctx context.Context, appName, hostname string) error
 	DeleteCertificateFunc                 func(ctx context.Context, appName, hostname string) error
 	DeleteCustomCertificateFunc           func(ctx context.Context, appName, hostname string) error
+	DeleteManagedPostgresClusterFunc      func(ctx context.Context, id string) error
 	DeleteMetadataFunc                    func(ctx context.Context, appName, machineID, key string) error
 	DeleteAppSecretFunc                   func(ctx context.Context, appName, name string) (*fly.DeleteAppSecretResp, error)
 	DeleteIPAssignmentFunc                func(ctx context.Context, appName, ip string) (err error)
@@ -60,6 +61,7 @@ type FlapsClient struct {
 	ListAppSecretsFunc                    func(ctx context.Context, appName string, version *uint64, showSecrets bool) ([]fly.AppSecret, error)
 	ListCertificatesFunc                  func(ctx context.Context, appName string, opts *flaps.ListCertificatesOpts) (*fly.ListCertificatesResponse, error)
 	ListFlyAppsMachinesFunc               func(ctx context.Context, appName string) ([]*fly.Machine, *fly.Machine, error)
+	ListManagedPostgresClustersFunc       func(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error)
 	ListSecretKeysFunc                    func(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error)
 	NewRequestFunc                        func(ctx context.Context, method, path string, in any, headers map[string][]string) (*http.Request, error)
 	RefreshLeaseFunc                      func(ctx context.Context, appName, machineID string, ttl *int, nonce string) (*fly.MachineLease, error)
@@ -137,6 +139,10 @@ func (m *FlapsClient) DeleteCertificate(ctx context.Context, appName, hostname s
 
 func (m *FlapsClient) DeleteCustomCertificate(ctx context.Context, appName, hostname string) error {
 	return m.DeleteCustomCertificateFunc(ctx, appName, hostname)
+}
+
+func (m *FlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id string) error {
+	return m.DeleteManagedPostgresClusterFunc(ctx, id)
 }
 
 func (m *FlapsClient) DeleteMetadata(ctx context.Context, appName, machineID, key string) error {
@@ -273,6 +279,10 @@ func (m *FlapsClient) ListCertificates(ctx context.Context, appName string, opts
 
 func (m *FlapsClient) ListFlyAppsMachines(ctx context.Context, appName string) ([]*fly.Machine, *fly.Machine, error) {
 	return m.ListFlyAppsMachinesFunc(ctx, appName)
+}
+
+func (m *FlapsClient) ListManagedPostgresClusters(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error) {
+	return m.ListManagedPostgresClustersFunc(ctx, req)
 }
 
 func (m *FlapsClient) ListSecretKeys(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error) {


### PR DESCRIPTION
Moves MPGv2 cluster resolution, listing, and destroy to the Machines API, falling back to the legacy API only on 404 (MPGv1). Non-404 failures now surface instead of being treated as "not found."

Active and deleted listings merge Machines API and legacy results, deduplicate shared clusters, and keep legacy-only metadata such as the mpgd cluster ID, disk, replicas, and IPs.

Uses `fly-go` v0.9.8.

Test: `go test ./internal/command/mpg/... -count=1`
