### PR TITLE
metrics: record the client-signals operator and agent with command stats

### DIFF
--- a/internal/metrics/command.go
+++ b/internal/metrics/command.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/superfly/client-signals/go"
 	"github.com/superfly/flyctl/internal/instrument"
 )
 
@@ -26,6 +27,8 @@ type commandStats struct {
 	FlapsDuration   float64 `json:"fd"`
 	UsingGPU        bool    `json:"gpu"`
 	Failed          bool    `json:"f"`
+	Operator        string  `json:"op,omitempty"`
+	AgentName       string  `json:"ag,omitempty"`
 }
 
 func RecordCommandContext(ctx context.Context) {
@@ -49,6 +52,8 @@ func RecordCommandFinish(cmd *cobra.Command, failed bool) {
 	flaps := instrument.Flaps.Get()
 
 	if commandContext != nil {
+		operator, agentName := OperatorFromSignals(clientsignals.DetectOnce())
+
 		Send(commandContext, "command/stats", commandStats{
 			Command:         cmd.CommandPath(),
 			Duration:        duration.Seconds(),
@@ -58,6 +63,8 @@ func RecordCommandFinish(cmd *cobra.Command, failed bool) {
 			FlapsDuration:   flaps.Duration,
 			UsingGPU:        IsUsingGPU,
 			Failed:          failed,
+			Operator:        operator,
+			AgentName:       agentName,
 		})
 	}
 }


### PR DESCRIPTION
`command/stats` already carries the command path, which says what was run; it did not say who ran it. This adds the client-signals operator classification and the agent name to that payload, reusing the `OperatorFromSignals` helper that `deploy/status` and `launch/status` already call.

## Context

flyctl detects its client signals once per process, via `clientsignals.DetectOnce()` in `internal/cmdutil/preparers`, and hands the result to all five of its HTTP clients, so every outgoing request already carries them. On the metrics side, though, only deploy and launch recorded who was driving. Every other command was invisible, which made it impossible to break flyctl usage down by human, agent or CI outside those two paths.

`RecordCommandFinish` is where that costs nothing to fix. It runs once per invocation, it already has the command context, and the detection it calls is the same process-wide cached value the clients use, so no extra work happens at runtime. Both fields are `omitempty` and use short keys to match the rest of the struct, so a run with nothing to classify sends exactly what it sends today.

Per the client-signals guidance this is aggregate observability only. The values are self-reported and must never drive authentication, authorization or rate limiting, and the absence of an agent marker is not evidence of a human.