### PR TITLE
Add app_id and org_id to metrics payloads

### DIFF
--- a/internal/command/deploy/deploy.go
+++ b/internal/command/deploy/deploy.go
@@ -609,6 +609,8 @@ func deployToMachines(
 
 	status.AppName = app.Name
 	status.OrgSlug = app.Organization.Slug
+	status.AppID = fmt.Sprint(app.InternalNumericID)
+	status.OrgID = fmt.Sprint(app.Organization.InternalNumericID)
 	status.Image = img.Tag
 	status.Strategy = cfg.DeployStrategy()
 	if flag.GetString(ctx, "strategy") != "" {

--- a/internal/command/launch/cmd.go
+++ b/internal/command/launch/cmd.go
@@ -592,6 +592,8 @@ func run(ctx context.Context) (err error) {
 	}
 
 	err = state.Launch(ctx)
+	status.AppID = state.appID
+	status.OrgID = state.orgID
 	if err != nil {
 		return err
 	}

--- a/internal/command/launch/launch.go
+++ b/internal/command/launch/launch.go
@@ -472,6 +472,9 @@ func (state *launchState) createApp(ctx context.Context) (*fly.App, error) {
 		return nil, err
 	}
 
+	state.appID = fmt.Sprint(app.InternalNumericID)
+	state.orgID = fmt.Sprint(app.Organization.InternalNumericID)
+
 	return &fly.App{
 		ID:     app.ID,
 		Name:   app.Name,

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -54,6 +54,11 @@ type launchState struct {
 	env map[string]string
 	planBuildCache
 	cache map[string]any
+
+	// appID and orgID are the internal numeric IDs of the app and org,
+	// populated once createApp succeeds, for use in metrics reporting.
+	appID string
+	orgID string
 }
 
 func cacheGrab[T any](cache map[string]any, key string, cb func() (T, error)) (T, error) {

--- a/internal/metrics/command.go
+++ b/internal/metrics/command.go
@@ -29,6 +29,8 @@ type commandStats struct {
 	Failed          bool    `json:"f"`
 	Operator        string  `json:"op,omitempty"`
 	AgentName       string  `json:"ag,omitempty"`
+	AppID           string  `json:"app_id,omitempty"`
+	OrgID           string  `json:"org_id,omitempty"`
 }
 
 func RecordCommandContext(ctx context.Context) {
@@ -65,6 +67,8 @@ func RecordCommandFinish(cmd *cobra.Command, failed bool) {
 			Failed:          failed,
 			Operator:        operator,
 			AgentName:       agentName,
+			AppID:           AppIDFromContext(commandContext),
+			OrgID:           OrgIDFromContext(commandContext),
 		})
 	}
 }

--- a/internal/metrics/helpers.go
+++ b/internal/metrics/helpers.go
@@ -196,6 +196,7 @@ func AppIDFromContext(ctx context.Context) string {
 	if v, ok := ctx.Value(appIDKey{}).(string); ok {
 		return v
 	}
+
 	return ""
 }
 
@@ -210,6 +211,7 @@ func OrgIDFromContext(ctx context.Context) string {
 	if v, ok := ctx.Value(orgIDKey{}).(string); ok {
 		return v
 	}
+
 	return ""
 }
 

--- a/internal/metrics/helpers.go
+++ b/internal/metrics/helpers.go
@@ -66,6 +66,8 @@ type LaunchStatusPayload struct {
 
 	AppName          string `json:"app"`
 	OrgSlug          string `json:"org"`
+	AppID            string `json:"app_id,omitempty"`
+	OrgID            string `json:"org_id,omitempty"`
 	Region           string `json:"region"`
 	HighAvailability bool   `json:"ha"`
 
@@ -111,6 +113,8 @@ type DeployStatusPayload struct {
 
 	AppName       string `json:"app"`
 	OrgSlug       string `json:"org"`
+	AppID         string `json:"app_id,omitempty"`
+	OrgID         string `json:"org_id,omitempty"`
 	PrimaryRegion string `json:"primary_region"`
 	Image         string `json:"image"`
 	Strategy      string `json:"strategy"`
@@ -176,6 +180,37 @@ func StartTiming(ctx context.Context, metricSlug string) func() {
 // clientsignals.Signals.Operator(): ci > agent > interactive > unknown.
 func OperatorFromSignals(s clientsignals.Signals) (operator, agentName string) {
 	return s.Operator(), s.Agent
+}
+
+type appIDKey struct{}
+type orgIDKey struct{}
+
+// WithAppID returns a context carrying the given app's internal numeric ID,
+// for later retrieval by AppIDFromContext when reporting command metrics.
+func WithAppID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, appIDKey{}, id)
+}
+
+// AppIDFromContext returns the app ID stored via WithAppID, or "" if none.
+func AppIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(appIDKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// WithOrgID returns a context carrying the given org's internal numeric ID,
+// for later retrieval by OrgIDFromContext when reporting command metrics.
+func WithOrgID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, orgIDKey{}, id)
+}
+
+// OrgIDFromContext returns the org ID stored via WithOrgID, or "" if none.
+func OrgIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(orgIDKey{}).(string); ok {
+		return v
+	}
+	return ""
 }
 
 type disableFlushMetricsKey struct{}


### PR DESCRIPTION
## Summary
- Adds `app_id` and `org_id` (internal numeric IDs) alongside the existing app name / org slug fields on the deploy, launch, and command-stats telemetry payloads, so they can flow through to Snowflake for analytics.
- All new fields are `omitempty`, so older flyctl builds and any code path that doesn't populate them send the same payload as today.
- Requires a companion PR to flyctl-metrics (the receiver) to persist these fields. Until that lands, the new fields are silently ignored by the receiver since it decodes with `json.Decoder` and no `DisallowUnknownFields`.

### Deploy payload
`DeployStatusPayload.AppID`/`OrgID` are populated in `deployToMachines()` from the `*flaps.App` already fetched for the deploy (`app.InternalNumericID`, `app.Organization.InternalNumericID`).

### Launch payload
`LaunchStatusPayload.AppID`/`OrgID` are populated from the app created in `launchState.createApp()`. Since app creation happens in a different function than where the metrics payload is built in `cmd.go`, the IDs are stashed on `launchState` (`appID`/`orgID`) at creation time and copied onto `status` right after `state.Launch(ctx)` returns. If `--no-create` is used (no app creation), these stay empty as before.

### Command stats payload
Added `metrics.WithAppID`/`WithOrgID` context helpers and wired `RecordCommandFinish` to read `AppID`/`OrgID` from context. However, nothing currently calls the setters: `command.RequireAppName` only resolves the app *name* (no network call), and `metrics.RecordCommandContext` captures the context once, early, before app resolution would happen. Populating this properly needs a `GetApp` call threaded through the preparer chain (a real behavior/perf change beyond the scope here), so it's left for a follow-up PR. The plumbing is in place for that follow-up.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Manual verification against a local flyctl-metrics receiver once the companion PR lands