### PR TITLE
mpg: show v1 to v2 migration notices

### DIFF
--- a/internal/command/mpg/list.go
+++ b/internal/command/mpg/list.go
@@ -81,6 +81,7 @@ func runList(ctx context.Context) error {
 		for _, cluster := range clusters {
 			if cluster.Version != 2 {
 				printV2MigrationNotice(ctx)
+
 				break
 			}
 		}

--- a/internal/command/mpg/list.go
+++ b/internal/command/mpg/list.go
@@ -77,6 +77,15 @@ func runList(ctx context.Context) error {
 		return nil
 	}
 
+	if !deleted {
+		for _, cluster := range clusters {
+			if cluster.Version != 2 {
+				printV2MigrationNotice(ctx)
+				break
+			}
+		}
+	}
+
 	if cfg.JSONOutput {
 		return render.JSON(out, clusters)
 	}

--- a/internal/command/mpg/mpg.go
+++ b/internal/command/mpg/mpg.go
@@ -22,11 +22,7 @@ import (
 
 const dashboardURL = "https://fly.io/dashboard"
 
-// v2MigrationNotice is the plain-text migration notice for `fly mpg` help
-// output; printV2MigrationNotice renders the styled equivalent. Migration is
-// dashboard-driven and gated by server-side eligibility, so both point at the
-// dashboard rather than a CLI command and don't promise every cluster can
-// migrate yet.
+// Plain-text notice for help output; printV2MigrationNotice renders the styled version.
 const v2MigrationNotice = "Managed Postgres v2 is here! Migrate eligible MPG v1 clusters to v2 from your cluster's page in the Fly.io dashboard (" + dashboardURL + ") — connection strings stay the same.\n"
 
 func New() *cobra.Command {
@@ -60,9 +56,6 @@ func New() *cobra.Command {
 	return cmd
 }
 
-// printV2MigrationNotice announces v1 -> v2 migrations for commands that don't
-// act on a single cluster; cluster-scoped commands print printV1MigrationLink
-// once the resolved cluster is known to be v1.
 func printV2MigrationNotice(ctx context.Context) {
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
@@ -75,11 +68,14 @@ func printV2MigrationNotice(ctx context.Context) {
 	)
 }
 
-// printV1MigrationLink links directly to the dashboard page that migrates the
-// given cluster to MPG v2. The page is per-cluster, so this can only run after
-// a command has resolved which cluster it is acting on.
+// Unknown eligibility (nil) still shows the link; only the dashboard can run
+// the full eligibility checks.
 func printV1MigrationLink(ctx context.Context, cluster *mpg.Cluster, orgSlug string) {
 	if cluster == nil || cluster.Version != mpg.VersionV1 {
+		return
+	}
+
+	if cluster.EligibleForV2Migration != nil && !*cluster.EligibleForV2Migration {
 		return
 	}
 
@@ -129,17 +125,18 @@ func ClusterFromArgOrSelect(ctx context.Context, clusterID, orgSlug string) (*mp
 			}
 
 			cluster := &mpg.Cluster{
-				Id:            c.Data.Id,
-				Name:          c.Data.Name,
-				Region:        c.Data.Region,
-				Status:        c.Data.Status,
-				Plan:          c.Data.Plan,
-				Disk:          c.Data.Disk,
-				Replicas:      c.Data.Replicas,
-				Organization:  c.Data.Organization,
-				IpAssignments: c.Data.IpAssignments,
-				AttachedApps:  c.Data.AttachedApps,
-				Version:       version,
+				Id:                     c.Data.Id,
+				Name:                   c.Data.Name,
+				Region:                 c.Data.Region,
+				Status:                 c.Data.Status,
+				Plan:                   c.Data.Plan,
+				Disk:                   c.Data.Disk,
+				Replicas:               c.Data.Replicas,
+				Organization:           c.Data.Organization,
+				IpAssignments:          c.Data.IpAssignments,
+				AttachedApps:           c.Data.AttachedApps,
+				Version:                version,
+				EligibleForV2Migration: c.Data.EligibleForV2Migration,
 			}
 
 			printV1MigrationLink(ctx, cluster, cluster.Organization.Slug)
@@ -253,17 +250,18 @@ func clusterFromLegacyAPI(cluster mpgv1.ManagedCluster) *mpg.Cluster {
 	}
 
 	return &mpg.Cluster{
-		Id:            cluster.Id,
-		Name:          cluster.Name,
-		Region:        cluster.Region,
-		Status:        cluster.Status,
-		Plan:          cluster.Plan,
-		Disk:          cluster.Disk,
-		Replicas:      cluster.Replicas,
-		Organization:  cluster.Organization,
-		IpAssignments: cluster.IpAssignments,
-		AttachedApps:  cluster.AttachedApps,
-		Version:       version,
+		Id:                     cluster.Id,
+		Name:                   cluster.Name,
+		Region:                 cluster.Region,
+		Status:                 cluster.Status,
+		Plan:                   cluster.Plan,
+		Disk:                   cluster.Disk,
+		Replicas:               cluster.Replicas,
+		Organization:           cluster.Organization,
+		IpAssignments:          cluster.IpAssignments,
+		AttachedApps:           cluster.AttachedApps,
+		Version:                version,
+		EligibleForV2Migration: cluster.EligibleForV2Migration,
 	}
 }
 

--- a/internal/command/mpg/mpg.go
+++ b/internal/command/mpg/mpg.go
@@ -23,10 +23,10 @@ import (
 const dashboardURL = "https://fly.io/dashboard"
 
 // v2MigrationNotice is the plain-text migration notice for `fly mpg` help
-// output; printV2MigrationNotice renders the styled equivalent before every
-// runnable subcommand. Migration is dashboard-driven and gated by server-side
-// eligibility, so both point at the dashboard rather than a CLI command and
-// don't promise every cluster can migrate yet.
+// output; printV2MigrationNotice renders the styled equivalent. Migration is
+// dashboard-driven and gated by server-side eligibility, so both point at the
+// dashboard rather than a CLI command and don't promise every cluster can
+// migrate yet.
 const v2MigrationNotice = "Managed Postgres v2 is here! Migrate eligible MPG v1 clusters to v2 from your cluster's page in the Fly.io dashboard (" + dashboardURL + ") — connection strings stay the same.\n"
 
 func New() *cobra.Command {

--- a/internal/command/mpg/mpg.go
+++ b/internal/command/mpg/mpg.go
@@ -17,13 +17,23 @@ import (
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/uiex/mpg"
 	mpgv1 "github.com/superfly/flyctl/internal/uiex/mpg/v1"
+	"github.com/superfly/flyctl/iostreams"
 )
+
+const dashboardURL = "https://fly.io/dashboard"
+
+// v2MigrationNotice is the plain-text migration notice for `fly mpg` help
+// output; printV2MigrationNotice renders the styled equivalent before every
+// runnable subcommand. Migration is dashboard-driven and gated by server-side
+// eligibility, so both point at the dashboard rather than a CLI command and
+// don't promise every cluster can migrate yet.
+const v2MigrationNotice = "Managed Postgres v2 is here! Migrate eligible MPG v1 clusters to v2 from your cluster's page in the Fly.io dashboard (" + dashboardURL + ") — connection strings stay the same.\n"
 
 func New() *cobra.Command {
 	const (
 		short = `Manage Managed Postgres clusters.`
 
-		long = short + "\n"
+		long = short + "\n\n" + v2MigrationNotice
 	)
 
 	cmd := command.New("mpg", short, long, nil)
@@ -48,6 +58,44 @@ func New() *cobra.Command {
 	)
 
 	return cmd
+}
+
+// printV2MigrationNotice announces v1 -> v2 migrations for commands that don't
+// act on a single cluster; cluster-scoped commands print printV1MigrationLink
+// once the resolved cluster is known to be v1.
+func printV2MigrationNotice(ctx context.Context) {
+	io := iostreams.FromContext(ctx)
+	colorize := io.ColorScheme()
+
+	dashboard := colorize.Cyan(io.CreateLink("the Fly.io dashboard", dashboardURL))
+
+	fmt.Fprintf(io.ErrOut, "\n%s\nMigrate eligible MPG v1 clusters to v2 from your cluster's page in %s — connection strings stay the same.\n\n",
+		colorize.Yellow("Managed Postgres v2 is here!"),
+		dashboard,
+	)
+}
+
+// printV1MigrationLink links directly to the dashboard page that migrates the
+// given cluster to MPG v2. The page is per-cluster, so this can only run after
+// a command has resolved which cluster it is acting on.
+func printV1MigrationLink(ctx context.Context, cluster *mpg.Cluster, orgSlug string) {
+	if cluster == nil || cluster.Version != mpg.VersionV1 {
+		return
+	}
+
+	if cluster.Organization.Slug != "" {
+		orgSlug = cluster.Organization.Slug
+	}
+
+	io := iostreams.FromContext(ctx)
+	colorize := io.ColorScheme()
+
+	url := fmt.Sprintf("%s/%s/managed_postgres/%s/v2-migration", dashboardURL, orgSlug, cluster.Id)
+
+	fmt.Fprintf(io.ErrOut, "%s\n%s\n\n",
+		colorize.Yellow(fmt.Sprintf("Cluster %q is on MPG v1 — migrate it to v2 at:", cluster.Name)),
+		colorize.Cyan(io.CreateLinkURL(url)),
+	)
 }
 
 // ClusterFromArgOrSelect retrieves the cluster if the cluster ID is passed in
@@ -94,6 +142,8 @@ func ClusterFromArgOrSelect(ctx context.Context, clusterID, orgSlug string) (*mp
 				Version:       version,
 			}
 
+			printV1MigrationLink(ctx, cluster, cluster.Organization.Slug)
+
 			return cluster, cluster.Organization.Slug, nil
 		}
 
@@ -130,6 +180,8 @@ func ClusterFromArgOrSelect(ctx context.Context, clusterID, orgSlug string) (*mp
 	if err := prompt.Select(ctx, &index, "Select a Postgres cluster", "", options...); err != nil {
 		return nil, orgSlug, err
 	}
+
+	printV1MigrationLink(ctx, clusters[index], orgSlug)
 
 	return clusters[index], orgSlug, nil
 }

--- a/internal/command/mpg/notice_test.go
+++ b/internal/command/mpg/notice_test.go
@@ -62,4 +62,34 @@ func TestPrintV1MigrationLink(t *testing.T) {
 
 		assert.Empty(t, stderr.String())
 	})
+
+	t.Run("ineligible v1 cluster prints nothing", func(t *testing.T) {
+		ios, _, _, stderr := iostreams.Test()
+		ctx := iostreams.NewContext(context.Background(), ios)
+		eligible := false
+
+		printV1MigrationLink(ctx, &mpg.Cluster{
+			Id:                     "abc123",
+			Name:                   "my-db",
+			Version:                mpg.VersionV1,
+			EligibleForV2Migration: &eligible,
+		}, "acme")
+
+		assert.Empty(t, stderr.String())
+	})
+
+	t.Run("eligible v1 cluster gets its migration link", func(t *testing.T) {
+		ios, _, _, stderr := iostreams.Test()
+		ctx := iostreams.NewContext(context.Background(), ios)
+		eligible := true
+
+		printV1MigrationLink(ctx, &mpg.Cluster{
+			Id:                     "abc123",
+			Name:                   "my-db",
+			Version:                mpg.VersionV1,
+			EligibleForV2Migration: &eligible,
+		}, "acme")
+
+		assert.Contains(t, stderr.String(), "https://fly.io/dashboard/acme/managed_postgres/abc123/v2-migration")
+	})
 }

--- a/internal/command/mpg/notice_test.go
+++ b/internal/command/mpg/notice_test.go
@@ -1,0 +1,65 @@
+package mpg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/uiex/mpg"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func TestPrintV2MigrationNotice(t *testing.T) {
+	ios, _, stdout, stderr := iostreams.Test()
+	ctx := iostreams.NewContext(context.Background(), ios)
+
+	printV2MigrationNotice(ctx)
+
+	assert.Contains(t, stderr.String(), "Managed Postgres v2 is here!")
+	assert.Contains(t, stderr.String(), dashboardURL)
+	assert.Empty(t, stdout.String())
+}
+
+func TestPrintV1MigrationLink(t *testing.T) {
+	t.Run("v1 cluster gets its migration link", func(t *testing.T) {
+		ios, _, _, stderr := iostreams.Test()
+		ctx := iostreams.NewContext(context.Background(), ios)
+
+		printV1MigrationLink(ctx, &mpg.Cluster{
+			Id:           "abc123",
+			Name:         "my-db",
+			Version:      mpg.VersionV1,
+			Organization: fly.Organization{Slug: "acme"},
+		}, "")
+
+		assert.Contains(t, stderr.String(), `Cluster "my-db" is on MPG v1`)
+		assert.Contains(t, stderr.String(), "https://fly.io/dashboard/acme/managed_postgres/abc123/v2-migration")
+	})
+
+	t.Run("falls back to the provided org slug", func(t *testing.T) {
+		ios, _, _, stderr := iostreams.Test()
+		ctx := iostreams.NewContext(context.Background(), ios)
+
+		printV1MigrationLink(ctx, &mpg.Cluster{
+			Id:      "abc123",
+			Name:    "my-db",
+			Version: mpg.VersionV1,
+		}, "personal")
+
+		assert.Contains(t, stderr.String(), "https://fly.io/dashboard/personal/managed_postgres/abc123/v2-migration")
+	})
+
+	t.Run("v2 cluster prints nothing", func(t *testing.T) {
+		ios, _, _, stderr := iostreams.Test()
+		ctx := iostreams.NewContext(context.Background(), ios)
+
+		printV1MigrationLink(ctx, &mpg.Cluster{
+			Id:      "abc123",
+			Name:    "my-db",
+			Version: mpg.VersionV2,
+		}, "acme")
+
+		assert.Empty(t, stderr.String())
+	})
+}

--- a/internal/uiex/mpg/types.go
+++ b/internal/uiex/mpg/types.go
@@ -24,6 +24,8 @@ type Cluster struct {
 	IpAssignments ManagedClusterIpAssignments
 	AttachedApps  []AttachedApp
 	Version       Version
+
+	EligibleForV2Migration *bool // nil when the API did not report it
 }
 
 type ManagedClusterIpAssignments struct {

--- a/internal/uiex/mpg/v1/client.go
+++ b/internal/uiex/mpg/v1/client.go
@@ -87,6 +87,9 @@ type ManagedCluster struct {
 	Organization  fly.Organization                `json:"organization"`
 	IpAssignments mpg.ManagedClusterIpAssignments `json:"ip_assignments"`
 	AttachedApps  []mpg.AttachedApp               `json:"attached_apps"`
+
+	// nil when the server did not return it (only the get-cluster endpoint does)
+	EligibleForV2Migration *bool `json:"eligible_for_v2_migration"`
 }
 
 type ListManagedClustersResponse struct {

--- a/iostreams/iostreams.go
+++ b/iostreams/iostreams.go
@@ -341,6 +341,17 @@ func (s *IOStreams) CreateLink(text string, url string) string {
 	}
 }
 
+// CreateLinkURL renders url as a clickable hyperlink where supported. Unlike
+// CreateLink it uses the URL itself as the link text, so unsupported
+// terminals print the URL once rather than twice.
+func (s *IOStreams) CreateLinkURL(url string) string {
+	if isTextClickable() {
+		return "\x1b]8;;" + url + "\x07" + url + "\x1b]8;;\x07"
+	}
+
+	return url
+}
+
 // writerWithFd implements a [terminal.FileWriter]
 type writerWithFd struct {
 	io.Writer


### PR DESCRIPTION
## Summary

This change adds migration messages to the `fly mpg` commands. The messages tell users about the migration from MPG v1 to MPG v2.

- A command that operates on one cluster shows a message if that cluster is MPG v1. The message contains a link to the migration page for that cluster in the Fly.io dashboard.
- The command `fly mpg list` shows a general message if the organization has MPG v1 clusters.
- The commands do not show a message for MPG v2 clusters.
- The messages go to stderr. The JSON output on stdout does not change.

## Changes

- `internal/command/mpg/mpg.go`: This file gets the message text and two print functions. The function `ClusterFromArgOrSelect` prints the cluster message when it finds an MPG v1 cluster.
- `internal/command/mpg/list.go`: The list command prints the general message when the list contains an MPG v1 cluster. It does not print the message for deleted clusters.
- `iostreams/iostreams.go`: The new function `CreateLinkURL` makes a URL clickable in terminals that support hyperlinks. Other terminals show the plain URL one time.
- `internal/command/mpg/notice_test.go`: New tests examine the two print functions.

## Test

1. Run `go test ./internal/command/mpg/ ./iostreams/`. All tests pass.
2. Run `fly mpg status <v1-cluster-id>`. The command shows the cluster message and the link.
3. Run `fly mpg status <v2-cluster-id>`. The command shows no migration message.
4. Run `fly mpg list`. The command shows the general message if v1 clusters are in the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)