### PR TITLE
Report org and app IDs on command stats from token scope

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -515,12 +515,33 @@ func killOldAgent(ctx context.Context) (context.Context, error) {
 
 func startMetrics(ctx context.Context) (context.Context, error) {
 	metrics.RecordCommandContext(ctx)
+	recordTokenScopedIDs(ctx)
 
 	task.FromContext(ctx).RunFinalizer(func(ctx context.Context) {
 		metrics.FlushPending()
 	})
 
 	return ctx, nil
+}
+
+// recordTokenScopedIDs attributes this command to an org, and where possible an
+// app, using only what our tokens are already scoped to. Doing it from the
+// tokens rather than by looking the app up keeps this free, and covers the many
+// commands that only ever deal in an app name. Tokens spanning several orgs
+// report nothing instead of guessing, so these are frequently empty.
+func recordTokenScopedIDs(ctx context.Context) {
+	orgID, appID := config.ScopedIDs(config.Tokens(ctx))
+
+	var orgStr, appStr string
+	if orgID != 0 {
+		orgStr = strconv.FormatUint(orgID, 10)
+	}
+
+	if appID != 0 {
+		appStr = strconv.FormatUint(appID, 10)
+	}
+
+	metrics.SetAppOrgIDs(appStr, orgStr)
 }
 
 func notifyStatuspageIncidents(ctx context.Context) (context.Context, error) {

--- a/internal/config/tokens.go
+++ b/internal/config/tokens.go
@@ -411,3 +411,63 @@ func defaultTokenMinter(ctx context.Context, c flyutil.Client, id string) (strin
 
 	return resp.CreateLimitedAccessToken.GetLimitedAccessToken().TokenHeader, nil
 }
+
+// ScopedIDs returns the internal numeric IDs of the organization and app that t
+// is scoped to, or zero for either one that can't be determined. It only reads
+// the caveats of the tokens we already hold, so it costs nothing and works even
+// for commands that never look an app up.
+//
+// Tokens hold one macaroon per organization the user belongs to (see
+// fetchOrgTokens), so an organization is only reported when every permission
+// macaroon agrees on the same one. In practice that means single-org tokens --
+// CI and deploy tokens, and users who belong to a single organization -- report
+// an org, and a token spanning several organizations reports none rather than
+// guessing. Apps are only reported by tokens narrowed to exactly one app.
+func ScopedIDs(t *tokens.Tokens) (orgID, appID uint64) {
+	if t == nil {
+		return 0, 0
+	}
+
+	orgIDs := map[uint64]struct{}{}
+	appIDs := map[uint64]struct{}{}
+
+	for _, tok := range t.GetMacaroonTokens() {
+		parsed, err := macaroon.Parse(tok)
+		if err != nil {
+			continue
+		}
+
+		// Discharge tokens carry no permissions, and a bundle covering several
+		// orgs can't be attributed to one, so both yield no permission macaroon
+		// to read here.
+		permMacs, _, _, _, err := macaroon.FindPermissionAndDischargeTokens(parsed, flyio.LocationPermission)
+		if err != nil || len(permMacs) != 1 {
+			continue
+		}
+
+		if oid, err := flyio.OrganizationScope(&permMacs[0].UnsafeCaveats); err == nil {
+			orgIDs[oid] = struct{}{}
+		}
+
+		// AppScope returns nil when the token is valid for every app, so a
+		// non-empty result always names specific apps.
+		for _, aid := range flyio.AppScope(&permMacs[0].UnsafeCaveats) {
+			appIDs[aid] = struct{}{}
+		}
+	}
+
+	return onlyID(orgIDs), onlyID(appIDs)
+}
+
+// onlyID returns the single ID in ids, or zero if it holds anything else.
+func onlyID(ids map[uint64]struct{}) uint64 {
+	if len(ids) != 1 {
+		return 0
+	}
+
+	for id := range ids {
+		return id
+	}
+
+	return 0
+}

--- a/internal/config/tokens_test.go
+++ b/internal/config/tokens_test.go
@@ -352,3 +352,66 @@ func fakeThirdPartyTokens(tb testing.TB, thirdParty *tp.TP, oids ...uint64) *tok
 
 	return tokens.Parse(macaroon.ToAuthorizationHeader(toks...))
 }
+
+func TestScopedIDs(t *testing.T) {
+	t.Run("token for one org reports that org", func(t *testing.T) {
+		orgID, appID := ScopedIDs(fakeTokens(t, "", 123))
+		require.Equal(t, uint64(123), orgID)
+		require.Zero(t, appID)
+	})
+
+	t.Run("token spanning orgs reports neither", func(t *testing.T) {
+		orgID, appID := ScopedIDs(fakeTokens(t, "", 123, 456))
+		require.Zero(t, orgID)
+		require.Zero(t, appID)
+	})
+
+	t.Run("user token alone reports neither", func(t *testing.T) {
+		orgID, appID := ScopedIDs(fakeTokens(t, "fo1_user"))
+		require.Zero(t, orgID)
+		require.Zero(t, appID)
+	})
+
+	t.Run("no tokens reports neither", func(t *testing.T) {
+		orgID, appID := ScopedIDs(nil)
+		require.Zero(t, orgID)
+		require.Zero(t, appID)
+	})
+
+	t.Run("token narrowed to one app reports the app too", func(t *testing.T) {
+		orgID, appID := ScopedIDs(fakeAppScopedTokens(t, 123, 456))
+		require.Equal(t, uint64(123), orgID)
+		require.Equal(t, uint64(456), appID)
+	})
+
+	t.Run("token narrowed to several apps reports only the org", func(t *testing.T) {
+		orgID, appID := ScopedIDs(fakeAppScopedTokens(t, 123, 456, 789))
+		require.Equal(t, uint64(123), orgID)
+		require.Zero(t, appID)
+	})
+}
+
+// fakeAppScopedTokens builds tokens for a single org, narrowed to the given apps.
+func fakeAppScopedTokens(tb testing.TB, oid uint64, appIDs ...uint64) *tokens.Tokens {
+	tb.Helper()
+
+	apps := resset.ResourceSet[uint64, resset.Action]{}
+	for _, id := range appIDs {
+		apps[id] = resset.ActionAll
+	}
+
+	perm := fakePermissionToken(tb,
+		&flyio.Organization{ID: oid, Mask: resset.ActionAll},
+		&flyio.Apps{Apps: apps},
+	)
+	auth := fakeAuthToken(tb, perm)
+
+	encoded := make([][]byte, 0, 2)
+	for _, m := range []*macaroon.Macaroon{perm, auth} {
+		tok, err := m.Encode()
+		require.NoError(tb, err)
+		encoded = append(encoded, tok)
+	}
+
+	return tokens.Parse(macaroon.ToAuthorizationHeader(encoded...))
+}

--- a/internal/metrics/command.go
+++ b/internal/metrics/command.go
@@ -14,6 +14,10 @@ var (
 	processStartTime = time.Now()
 	commandContext   context.Context
 	mu               sync.Mutex
+
+	// appID and orgID are guarded by mu.
+	appID string
+	orgID string
 )
 
 var IsUsingGPU bool
@@ -31,6 +35,23 @@ type commandStats struct {
 	AgentName       string  `json:"ag,omitempty"`
 	AppID           string  `json:"app_id,omitempty"`
 	OrgID           string  `json:"org_id,omitempty"`
+}
+
+// SetAppOrgIDs records the internal numeric IDs of the app and organization the
+// running command is acting on, to be reported with its stats. Either argument
+// may be empty, so a caller that only knows one of the two can leave the other
+// alone.
+func SetAppOrgIDs(app, org string) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if app != "" {
+		appID = app
+	}
+
+	if org != "" {
+		orgID = org
+	}
 }
 
 func RecordCommandContext(ctx context.Context) {
@@ -67,8 +88,8 @@ func RecordCommandFinish(cmd *cobra.Command, failed bool) {
 			Failed:          failed,
 			Operator:        operator,
 			AgentName:       agentName,
-			AppID:           AppIDFromContext(commandContext),
-			OrgID:           OrgIDFromContext(commandContext),
+			AppID:           appID,
+			OrgID:           orgID,
 		})
 	}
 }

--- a/internal/metrics/helpers.go
+++ b/internal/metrics/helpers.go
@@ -182,39 +182,6 @@ func OperatorFromSignals(s clientsignals.Signals) (operator, agentName string) {
 	return s.Operator(), s.Agent
 }
 
-type appIDKey struct{}
-type orgIDKey struct{}
-
-// WithAppID returns a context carrying the given app's internal numeric ID,
-// for later retrieval by AppIDFromContext when reporting command metrics.
-func WithAppID(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, appIDKey{}, id)
-}
-
-// AppIDFromContext returns the app ID stored via WithAppID, or "" if none.
-func AppIDFromContext(ctx context.Context) string {
-	if v, ok := ctx.Value(appIDKey{}).(string); ok {
-		return v
-	}
-
-	return ""
-}
-
-// WithOrgID returns a context carrying the given org's internal numeric ID,
-// for later retrieval by OrgIDFromContext when reporting command metrics.
-func WithOrgID(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, orgIDKey{}, id)
-}
-
-// OrgIDFromContext returns the org ID stored via WithOrgID, or "" if none.
-func OrgIDFromContext(ctx context.Context) string {
-	if v, ok := ctx.Value(orgIDKey{}).(string); ok {
-		return v
-	}
-
-	return ""
-}
-
 type disableFlushMetricsKey struct{}
 
 // WithDisableFlushMetrics returns a context with a flag that disables


### PR DESCRIPTION
Follow-up to #5130, which added `app_id`/`org_id` to the `command/stats` payload but never populated them.

## Approach: derive the IDs from token scope, not from an app lookup

Our tokens are already scoped to an org, and sometimes to an app. `flyio.OrganizationScope`/`flyio.AppScope` read that straight out of the macaroon caveats, so this costs **no API call** and works for commands that never fetch an app. Measured at ~5.8µs per invocation.

The alternative — calling `GetApp` during command setup — looks appealing but inverts the value:

| | app-scoped command packages |
|---|---|
| Total (`RequireAppName`/`LoadAppNameIfPresent*`) | 128 files / **39 packages** |
| Ever call `GetApp` | **5** (`apps`, `deploy`, `mcp`, `registry`, `secrets`) |

Those 5 overlap heavily with `deploy`/`launch`, which **already report both IDs on their own payloads**. The other 34 — `status`, `logs`, `ssh`, `scale`, `machine`, `volumes`, `ips`, `certificates`, `config`, `console`, … — only ever deal in an app *name*, and `command/stats` is the only event covering them. So a `GetApp`-based approach would mostly duplicate IDs we already have, add a network round trip to every invocation of the highest-volume event we emit, and introduce a network failure mode into `RequireAppName`, which today does no I/O at all.

## Expected coverage

`org_id` is reported when every permission macaroon agrees on one org:

- **CI and deploy tokens** (single org-scoped macaroon) — reported
- **Users belonging to one org** — reported
- **Users in several orgs** — *not* reported. `fetchOrgTokens` deliberately holds one macaroon per org, so there is no correct single answer without knowing the app; we emit nothing rather than guess and mis-attribute.
- **OAuth-only tokens** — not reported; OAuth tokens are per-user and carry no org.

`app_id` is only reported by tokens narrowed to exactly one app (`fly tokens create deploy -a …`), so expect it to be empty far more often than `org_id`. `AppScope` already returns `nil` for a wildcard token, so a non-empty result always names specific apps.

Both fields are `omitempty`, so an invocation we can't attribute sends exactly what it sends today.

## Also: removes the context helpers from #5130

`WithAppID`/`WithOrgID`/`AppIDFromContext`/`OrgIDFromContext` **could never have worked**. `RecordCommandFinish` reads the package-global `commandContext`, which `startMetrics` snapshots once — 11th of 12 in `commonPreparers`, before auth and before any command-specific preparer runs. Contexts are immutable, so `ctx = metrics.WithAppID(ctx, …)` later produces a different context the global never sees. Replaced with a mutex-guarded package-level setter, matching how `metrics.IsUsingGPU` is already reported from `command.go`.

## ⚠️ Companion change still required

flyctl-metrics PR #70 accepts these fields on `command/stats` but **deliberately does not forward that endpoint to Rudderstack**, because the IDs weren't populated yet. Landing this without restoring the `go sendToRudderstack("flyctl_command_stats", …)` block in flyctl-metrics `main.go` (it's in commit `c500ecc`) means the IDs still never reach Snowflake. I have not touched that repo.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/config/... ./internal/command/`
- [x] New `TestScopedIDs` covering single-org, multi-org, OAuth-only, nil, single-app and multi-app tokens
- [x] Verified end-to-end against a real `FlyV1 fm2_…` token: org ID extracted, zero network calls