### PR TITLE
mpg: route database list/create through Machines API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.1
 	github.com/superfly/client-signals/go v0.4.4
-	github.com/superfly/fly-go v0.9.8
+	github.com/superfly/fly-go v0.9.9
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -664,8 +664,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVuwVJGWndfmc8=
 github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
-github.com/superfly/fly-go v0.9.8 h1:Bb894ej+rirOY6B1D2FkedmUzvtBelr9bbsAYXlHviU=
-github.com/superfly/fly-go v0.9.8/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
+github.com/superfly/fly-go v0.9.9 h1:r/Nt40VTqzPhdtLWPlXkPcUI3Vuv51bUTNC3TjMAElo=
+github.com/superfly/fly-go v0.9.9/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/build/imgsrc/flaps_mock_test.go
+++ b/internal/build/imgsrc/flaps_mock_test.go
@@ -177,6 +177,21 @@ func (mr *MockFlapsClientMockRecorder) CreateManagedPostgresCluster(ctx, req any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateManagedPostgresCluster", reflect.TypeOf((*MockFlapsClient)(nil).CreateManagedPostgresCluster), ctx, req)
 }
 
+// CreateManagedPostgresDatabase mocks base method.
+func (m *MockFlapsClient) CreateManagedPostgresDatabase(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateManagedPostgresDatabase", ctx, id, req)
+	ret0, _ := ret[0].(flaps.ManagedPostgresDatabase)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateManagedPostgresDatabase indicates an expected call of CreateManagedPostgresDatabase.
+func (mr *MockFlapsClientMockRecorder) CreateManagedPostgresDatabase(ctx, id, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateManagedPostgresDatabase", reflect.TypeOf((*MockFlapsClient)(nil).CreateManagedPostgresDatabase), ctx, id, req)
+}
+
 // CreateVolume mocks base method.
 func (m *MockFlapsClient) CreateVolume(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error) {
 	m.ctrl.T.Helper()
@@ -781,6 +796,21 @@ func (m *MockFlapsClient) ListManagedPostgresClusters(ctx context.Context, req f
 func (mr *MockFlapsClientMockRecorder) ListManagedPostgresClusters(ctx, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListManagedPostgresClusters", reflect.TypeOf((*MockFlapsClient)(nil).ListManagedPostgresClusters), ctx, req)
+}
+
+// ListManagedPostgresDatabases mocks base method.
+func (m *MockFlapsClient) ListManagedPostgresDatabases(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListManagedPostgresDatabases", ctx, id)
+	ret0, _ := ret[0].([]flaps.ManagedPostgresDatabase)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListManagedPostgresDatabases indicates an expected call of ListManagedPostgresDatabases.
+func (mr *MockFlapsClientMockRecorder) ListManagedPostgresDatabases(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListManagedPostgresDatabases", reflect.TypeOf((*MockFlapsClient)(nil).ListManagedPostgresDatabases), ctx, id)
 }
 
 // ListSecretKeys mocks base method.

--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -144,6 +144,10 @@ func (m *mockFlapsClient) CreateManagedPostgresCluster(ctx context.Context, req 
 	return flaps.ManagedPostgresCluster{}, fmt.Errorf("failed to create managed postgres cluster")
 }
 
+func (m *mockFlapsClient) CreateManagedPostgresDatabase(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error) {
+	return flaps.ManagedPostgresDatabase{}, fmt.Errorf("not implemented")
+}
+
 func (m *mockFlapsClient) CreateVolume(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error) {
 	return nil, fmt.Errorf("failed to create volume %s", req.Name)
 }
@@ -435,6 +439,10 @@ func (m *mockFlapsClient) ListFlyAppsMachines(ctx context.Context, appName strin
 }
 
 func (m *mockFlapsClient) ListManagedPostgresClusters(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockFlapsClient) ListManagedPostgresDatabases(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/internal/command/mpg/v2/run_databases.go
+++ b/internal/command/mpg/v2/run_databases.go
@@ -2,10 +2,13 @@ package cmdv2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
 	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
@@ -15,25 +18,34 @@ import (
 func RunDatabasesList(ctx context.Context, clusterID string) error {
 	cfg := config.FromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
-	mpgClient := mpgv2.ClientFromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
-	databases, err := mpgClient.ListDatabases(ctx, clusterID)
-	if err != nil {
+	databases, err := flapsClient.ListManagedPostgresDatabases(ctx, clusterID)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		response, legacyErr := mpgv2.ClientFromContext(ctx).ListDatabases(ctx, clusterID)
+		if legacyErr != nil {
+			return fmt.Errorf("failed to list databases for cluster %s: %w", clusterID, legacyErr)
+		}
+		databases = make([]flaps.ManagedPostgresDatabase, 0, len(response.Data))
+		for _, db := range response.Data {
+			databases = append(databases, flaps.ManagedPostgresDatabase{Name: db.Name})
+		}
+	} else if err != nil {
 		return fmt.Errorf("failed to list databases for cluster %s: %w", clusterID, err)
 	}
 
-	if len(databases.Data) == 0 {
+	if len(databases) == 0 {
 		fmt.Fprintf(out, "No databases found for cluster %s\n", clusterID)
 
 		return nil
 	}
 
 	if cfg.JSONOutput {
-		return render.JSON(out, databases.Data)
+		return render.JSON(out, databases)
 	}
 
-	rows := make([][]string, 0, len(databases.Data))
-	for _, db := range databases.Data {
+	rows := make([][]string, 0, len(databases))
+	for _, db := range databases {
 		rows = append(rows, []string{
 			db.Name,
 		})
@@ -44,7 +56,7 @@ func RunDatabasesList(ctx context.Context, clusterID string) error {
 
 func RunDatabasesCreate(ctx context.Context, clusterID string) error {
 	out := iostreams.FromContext(ctx).Out
-	mpgClient := mpgv2.ClientFromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	dbName := flag.GetString(ctx, "name")
 	if dbName == "" {
@@ -63,17 +75,22 @@ func RunDatabasesCreate(ctx context.Context, clusterID string) error {
 
 	fmt.Fprintf(out, "Creating database %s in cluster %s...\n", dbName, clusterID)
 
-	input := mpgv2.CreateDatabaseInput{
-		Name: dbName,
-	}
-
-	err := mpgClient.CreateDatabase(ctx, clusterID, input)
-	if err != nil {
+	created, err := flapsClient.CreateManagedPostgresDatabase(ctx, clusterID, flaps.CreateManagedPostgresDatabaseRequest{Name: dbName})
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		legacyErr := mpgv2.ClientFromContext(ctx).CreateDatabase(ctx, clusterID, mpgv2.CreateDatabaseInput{Name: dbName})
+		if legacyErr != nil {
+			return fmt.Errorf("failed to create database: %w", legacyErr)
+		}
+	} else if err != nil {
 		return fmt.Errorf("failed to create database: %w", err)
 	}
 
 	fmt.Fprintf(out, "Database created successfully!\n")
-	fmt.Fprintf(out, "  Name: %s\n", dbName)
+	name := created.Name
+	if name == "" {
+		name = dbName
+	}
+	fmt.Fprintf(out, "  Name: %s\n", name)
 
 	return nil
 }

--- a/internal/command/mpg/v2/run_databases_test.go
+++ b/internal/command/mpg/v2/run_databases_test.go
@@ -1,0 +1,250 @@
+package cmdv2
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/mock"
+	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func databasesTestContext(t *testing.T, jsonOutput bool) (context.Context, *bytes.Buffer) {
+	t.Helper()
+
+	io, _, stdout, _ := iostreams.Test()
+	ctx := iostreams.NewContext(context.Background(), io)
+	ctx = config.NewContext(ctx, &config.Config{JSONOutput: jsonOutput})
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("name", "", "")
+
+	return flagctx.NewContext(ctx, flags), stdout
+}
+
+func TestRunDatabasesList(t *testing.T) {
+	publicDatabases := []flaps.ManagedPostgresDatabase{
+		{Name: "app"},
+		{Name: "metrics"},
+	}
+	legacyDatabases := []mpgv2.Database{
+		{Name: "app"},
+		{Name: "metrics"},
+	}
+
+	tests := []struct {
+		name                string
+		jsonOutput          bool
+		publicDatabases     []flaps.ManagedPostgresDatabase
+		publicListErr       error
+		legacyDatabases     []mpgv2.Database
+		legacyListErr       error
+		wantPublicCalled    bool
+		wantLegacyCalled    bool
+		wantErr             string
+		wantOutputContains  []string
+		wantJSONOutputShape string
+	}{
+		{
+			name:               "uses Machines API",
+			publicDatabases:    publicDatabases,
+			wantPublicCalled:   true,
+			wantOutputContains: []string{"app", "metrics", "NAME"},
+		},
+		{
+			name:                "renders JSON output from Machines API",
+			jsonOutput:          true,
+			publicDatabases:     publicDatabases,
+			wantPublicCalled:    true,
+			wantJSONOutputShape: `[{"name":"app"},{"name":"metrics"}]`,
+		},
+		{
+			name:               "renders empty message when Machines API returns no databases",
+			publicDatabases:    nil,
+			wantPublicCalled:   true,
+			wantOutputContains: []string{"No databases found for cluster mpg-123"},
+		},
+		{
+			name:       "renders legacy JSON after wrapped Machines 404",
+			jsonOutput: true,
+			publicListErr: fmt.Errorf("list Managed Postgres databases: %w", &flaps.FlapsError{
+				ResponseStatusCode: 404,
+				OriginalError:      errors.New("not found"),
+			}),
+			legacyDatabases:     legacyDatabases,
+			wantPublicCalled:    true,
+			wantLegacyCalled:    true,
+			wantJSONOutputShape: `[{"name":"app"},{"name":"metrics"}]`,
+		},
+		{
+			name:             "returns non-404 Machines API error without falling back",
+			publicListErr:    errors.New("boom"),
+			wantPublicCalled: true,
+			wantErr:          "failed to list databases for cluster mpg-123: boom",
+		},
+		{
+			name:             "returns legacy error when fallback fails",
+			publicListErr:    flaps.ErrFlapsNotFound,
+			legacyListErr:    errors.New("legacy boom"),
+			wantPublicCalled: true,
+			wantLegacyCalled: true,
+			wantErr:          "failed to list databases for cluster mpg-123: legacy boom",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, stdout := databasesTestContext(t, test.jsonOutput)
+			publicCalled := false
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				ListManagedPostgresDatabasesFunc: func(_ context.Context, id string) ([]flaps.ManagedPostgresDatabase, error) {
+					publicCalled = true
+					require.Equal(t, "mpg-123", id)
+
+					return test.publicDatabases, test.publicListErr
+				},
+			})
+
+			legacyCalled := false
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+				ListDatabasesFunc: func(_ context.Context, id string) (mpgv2.ListDatabasesResponse, error) {
+					legacyCalled = true
+					require.Equal(t, "mpg-123", id)
+
+					return mpgv2.ListDatabasesResponse{Data: test.legacyDatabases}, test.legacyListErr
+				},
+			})
+
+			err := RunDatabasesList(ctx, "mpg-123")
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.wantPublicCalled, publicCalled)
+			require.Equal(t, test.wantLegacyCalled, legacyCalled)
+
+			if test.wantJSONOutputShape != "" {
+				var got []map[string]any
+				require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+				var want []map[string]any
+				require.NoError(t, json.Unmarshal([]byte(test.wantJSONOutputShape), &want))
+				require.Equal(t, want, got)
+			}
+			for _, want := range test.wantOutputContains {
+				require.Contains(t, stdout.String(), want)
+			}
+		})
+	}
+}
+
+func TestRunDatabasesCreate(t *testing.T) {
+	publicCreated := flaps.ManagedPostgresDatabase{Name: "reports-created"}
+
+	tests := []struct {
+		name                string
+		nameFlag            string
+		publicCreated       flaps.ManagedPostgresDatabase
+		publicCreateErr     error
+		legacyCreateErr     error
+		wantPublicCalled    bool
+		wantLegacyCalled    bool
+		wantPublicNameField string
+		wantErr             string
+		wantOutputContains  []string
+	}{
+		{
+			name:                "uses Machines API",
+			nameFlag:            "reports",
+			publicCreated:       publicCreated,
+			wantPublicCalled:    true,
+			wantPublicNameField: "reports",
+			wantOutputContains:  []string{"Creating database reports in cluster mpg-123...", "Database created successfully!", "Name: reports-created"},
+		},
+		{
+			name:               "falls back to legacy API on public not found",
+			nameFlag:           "reports",
+			publicCreateErr:    flaps.ErrFlapsNotFound,
+			wantPublicCalled:   true,
+			wantLegacyCalled:   true,
+			wantOutputContains: []string{"Creating database reports in cluster mpg-123...", "Database created successfully!", "Name: reports"},
+		},
+		{
+			name:             "returns non-404 Machines API error without falling back",
+			nameFlag:         "reports",
+			publicCreateErr:  errors.New("boom"),
+			wantPublicCalled: true,
+			wantErr:          "failed to create database: boom",
+		},
+		{
+			name:             "returns legacy error when fallback fails",
+			nameFlag:         "reports",
+			publicCreateErr:  flaps.ErrFlapsNotFound,
+			legacyCreateErr:  errors.New("legacy boom"),
+			wantPublicCalled: true,
+			wantLegacyCalled: true,
+			wantErr:          "failed to create database: legacy boom",
+		},
+		{
+			name:    "requires --name when not interactive",
+			wantErr: "database name must be specified with --name flag",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, stdout := databasesTestContext(t, false)
+			if test.nameFlag != "" {
+				require.NoError(t, flag.SetString(ctx, "name", test.nameFlag))
+			}
+
+			publicCalled := false
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				CreateManagedPostgresDatabaseFunc: func(_ context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error) {
+					publicCalled = true
+					require.Equal(t, "mpg-123", id)
+					if test.wantPublicNameField != "" {
+						require.Equal(t, test.wantPublicNameField, req.Name)
+					}
+
+					return test.publicCreated, test.publicCreateErr
+				},
+			})
+
+			legacyCalled := false
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+				CreateDatabaseFunc: func(_ context.Context, id string, input mpgv2.CreateDatabaseInput) error {
+					legacyCalled = true
+					require.Equal(t, "mpg-123", id)
+					if test.nameFlag != "" {
+						require.Equal(t, test.nameFlag, input.Name)
+					}
+
+					return test.legacyCreateErr
+				},
+			})
+
+			err := RunDatabasesCreate(ctx, "mpg-123")
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.wantPublicCalled, publicCalled)
+			require.Equal(t, test.wantLegacyCalled, legacyCalled)
+			for _, want := range test.wantOutputContains {
+				require.Contains(t, stdout.String(), want)
+			}
+		})
+	}
+}

--- a/internal/flapsutil/flaps_client.go
+++ b/internal/flapsutil/flaps_client.go
@@ -19,6 +19,7 @@ type FlapsClient interface {
 	CreateApp(ctx context.Context, req flaps.CreateAppRequest) (*flaps.App, error)
 	CreateACMECertificate(ctx context.Context, appName string, req fly.CreateCertificateRequest) (*fly.CertificateDetailResponse, error)
 	CreateManagedPostgresCluster(ctx context.Context, req flaps.CreateManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error)
+	CreateManagedPostgresDatabase(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error)
 	CreateVolume(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error)
 	CreateVolumeSnapshot(ctx context.Context, appName, volumeId string) error
 	DeleteApp(ctx context.Context, name string) error
@@ -61,6 +62,7 @@ type FlapsClient interface {
 	ListCertificates(ctx context.Context, appName string, opts *flaps.ListCertificatesOpts) (*fly.ListCertificatesResponse, error)
 	ListFlyAppsMachines(ctx context.Context, appName string) ([]*fly.Machine, *fly.Machine, error)
 	ListManagedPostgresClusters(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error)
+	ListManagedPostgresDatabases(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error)
 	ListSecretKeys(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error)
 	NewRequest(ctx context.Context, method, path string, in any, headers map[string][]string) (*http.Request, error)
 	RefreshLease(ctx context.Context, appName, machineID string, ttl *int, nonce string) (*fly.MachineLease, error)

--- a/internal/inmem/flaps_client.go
+++ b/internal/inmem/flaps_client.go
@@ -157,6 +157,10 @@ func (m *FlapsClient) CreateManagedPostgresCluster(ctx context.Context, req flap
 	panic("TODO")
 }
 
+func (m *FlapsClient) CreateManagedPostgresDatabase(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error) {
+	panic("TODO")
+}
+
 func (m *FlapsClient) GetManagedPostgresCluster(ctx context.Context, id string) (flaps.ManagedPostgresCluster, error) {
 	panic("TODO")
 }
@@ -256,6 +260,10 @@ func (m *FlapsClient) ListFlyAppsMachines(ctx context.Context, appName string) (
 }
 
 func (m *FlapsClient) ListManagedPostgresClusters(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) ListManagedPostgresDatabases(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error) {
 	panic("TODO")
 }
 

--- a/internal/mock/flaps_client.go
+++ b/internal/mock/flaps_client.go
@@ -20,6 +20,7 @@ type FlapsClient struct {
 	CreateAppFunc                         func(ctx context.Context, req flaps.CreateAppRequest) (*flaps.App, error)
 	CreateACMECertificateFunc             func(ctx context.Context, appName string, req fly.CreateCertificateRequest) (*fly.CertificateDetailResponse, error)
 	CreateManagedPostgresClusterFunc      func(ctx context.Context, req flaps.CreateManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error)
+	CreateManagedPostgresDatabaseFunc     func(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error)
 	CreateVolumeFunc                      func(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error)
 	CreateVolumeSnapshotFunc              func(ctx context.Context, appName, volumeId string) error
 	DeleteAppFunc                         func(ctx context.Context, name string) error
@@ -62,6 +63,7 @@ type FlapsClient struct {
 	ListCertificatesFunc                  func(ctx context.Context, appName string, opts *flaps.ListCertificatesOpts) (*fly.ListCertificatesResponse, error)
 	ListFlyAppsMachinesFunc               func(ctx context.Context, appName string) ([]*fly.Machine, *fly.Machine, error)
 	ListManagedPostgresClustersFunc       func(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error)
+	ListManagedPostgresDatabasesFunc      func(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error)
 	ListSecretKeysFunc                    func(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error)
 	NewRequestFunc                        func(ctx context.Context, method, path string, in any, headers map[string][]string) (*http.Request, error)
 	RefreshLeaseFunc                      func(ctx context.Context, appName, machineID string, ttl *int, nonce string) (*fly.MachineLease, error)
@@ -111,6 +113,10 @@ func (m *FlapsClient) CreateACMECertificate(ctx context.Context, appName string,
 
 func (m *FlapsClient) CreateManagedPostgresCluster(ctx context.Context, req flaps.CreateManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
 	return m.CreateManagedPostgresClusterFunc(ctx, req)
+}
+
+func (m *FlapsClient) CreateManagedPostgresDatabase(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error) {
+	return m.CreateManagedPostgresDatabaseFunc(ctx, id, req)
 }
 
 func (m *FlapsClient) CreateVolume(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error) {
@@ -283,6 +289,10 @@ func (m *FlapsClient) ListFlyAppsMachines(ctx context.Context, appName string) (
 
 func (m *FlapsClient) ListManagedPostgresClusters(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error) {
 	return m.ListManagedPostgresClustersFunc(ctx, req)
+}
+
+func (m *FlapsClient) ListManagedPostgresDatabases(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error) {
+	return m.ListManagedPostgresDatabasesFunc(ctx, id)
 }
 
 func (m *FlapsClient) ListSecretKeys(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error) {


### PR DESCRIPTION
## Summary

- route MPGv2 `database list` / `database create` through the Machines API
- fall back to the legacy MPG API only on 404 (cluster not served by the Machines API); other errors now surface
- bump fly-go to v0.9.9 and add coverage for the 404 fallback, error paths, and JSON/table output compatibility

Uses the database endpoints added in superfly/fly-go#288.

## Testing

- `go test ./... -count=1`, race tests on affected packages, vet, lint, `go generate` check, build
- live validation against a disposable MPG cluster: list (table + JSON), create + verify, destroy