### PR TITLE
Report the app name with command stats

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -802,6 +802,8 @@ func RequireAppName(ctx context.Context) (context.Context, error) {
 		return nil, ErrRequireAppName
 	}
 
+	metrics.SetAppName(name)
+
 	return appconfig.WithName(ctx, name), nil
 }
 
@@ -828,6 +830,8 @@ func RequireAppNameNoFlag(ctx context.Context) (context.Context, error) {
 	if name == "" {
 		return nil, ErrRequireAppName
 	}
+
+	metrics.SetAppName(name)
 
 	return appconfig.WithName(ctx, name), nil
 }

--- a/internal/metrics/command.go
+++ b/internal/metrics/command.go
@@ -15,9 +15,10 @@ var (
 	commandContext   context.Context
 	mu               sync.Mutex
 
-	// appID and orgID are guarded by mu.
-	appID string
-	orgID string
+	// appID, orgID and appName are guarded by mu.
+	appID   string
+	orgID   string
+	appName string
 )
 
 var IsUsingGPU bool
@@ -33,6 +34,7 @@ type commandStats struct {
 	Failed          bool    `json:"f"`
 	Operator        string  `json:"op,omitempty"`
 	AgentName       string  `json:"ag,omitempty"`
+	AppName         string  `json:"app,omitempty"`
 	AppID           string  `json:"app_id,omitempty"`
 	OrgID           string  `json:"org_id,omitempty"`
 }
@@ -51,6 +53,21 @@ func SetAppOrgIDs(app, org string) {
 
 	if org != "" {
 		orgID = org
+	}
+}
+
+// SetAppName records the name of the app the running command is acting on. The
+// name comes from the --app flag, FLY_APP or fly.toml, so it costs nothing to
+// resolve and is known to every app-scoped command, including the many that
+// never look the app up. Reporting it lets an invocation be attributed to an
+// app and an organization after the fact even when our tokens span several
+// organizations and ScopedIDs declines to name one.
+func SetAppName(name string) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if name != "" {
+		appName = name
 	}
 }
 
@@ -88,6 +105,7 @@ func RecordCommandFinish(cmd *cobra.Command, failed bool) {
 			Failed:          failed,
 			Operator:        operator,
 			AgentName:       agentName,
+			AppName:         appName,
 			AppID:           appID,
 			OrgID:           orgID,
 		})

--- a/internal/metrics/command_test.go
+++ b/internal/metrics/command_test.go
@@ -1,0 +1,51 @@
+package metrics
+
+import "testing"
+
+func TestSetAppName(t *testing.T) {
+	t.Cleanup(func() { appName = "" })
+
+	SetAppName("my-app")
+	if appName != "my-app" {
+		t.Fatalf("appName = %q, want %q", appName, "my-app")
+	}
+
+	// Preparers run in sequence and a later one resolving no app must not
+	// erase a name an earlier one already reported.
+	SetAppName("")
+	if appName != "my-app" {
+		t.Fatalf("appName = %q after empty name, want it left alone", appName)
+	}
+}
+
+func TestSetAppOrgIDs(t *testing.T) {
+	t.Cleanup(func() { appID, orgID = "", "" })
+
+	SetAppOrgIDs("123", "456")
+	if appID != "123" || orgID != "456" {
+		t.Fatalf("appID, orgID = %q, %q; want %q, %q", appID, orgID, "123", "456")
+	}
+
+	// A caller that only knows one of the two leaves the other alone.
+	SetAppOrgIDs("", "789")
+	if appID != "123" || orgID != "789" {
+		t.Fatalf("appID, orgID = %q, %q; want %q, %q", appID, orgID, "123", "789")
+	}
+}
+
+// The app name and the token-scoped IDs are independent signals: a command can
+// report a name while its tokens span too many orgs to name one, and a command
+// with no app at all can still be attributed by an org-scoped token.
+func TestAppNameAndIDsAreIndependent(t *testing.T) {
+	t.Cleanup(func() { appName, appID, orgID = "", "", "" })
+
+	SetAppName("my-app")
+	if appID != "" || orgID != "" {
+		t.Fatalf("SetAppName touched IDs: appID=%q orgID=%q", appID, orgID)
+	}
+
+	SetAppOrgIDs("123", "456")
+	if appName != "my-app" {
+		t.Fatalf("SetAppOrgIDs touched appName: %q", appName)
+	}
+}


### PR DESCRIPTION
Follows #5134, which populated `app_id`/`org_id` on `command/stats` from token scope.

## The gap

`config.ScopedIDs` only names an org when every permission macaroon we hold agrees on one. Tokens loaded from the config file fan out to one macaroon per org the user belongs to (`fetchOrgTokens`), so an interactive user in more than one org reports **nothing** rather than guessing. Since everyone has a personal org alongside any org they work in, that's nearly every human at a business — exactly the population we most want to attribute.

Worth being precise: this is a property of the **credential**, not the person. `fetchOrgTokens` early-returns when `t.FromFile() == ""`, so a token supplied through the environment never fans out. Tightly scoped tokens used for CI and agentic work already report both IDs today and are unaffected by this change.

## The change

Send the app name rather than trying harder to resolve an ID on the client.

`RequireAppName` already resolves it from `--app` / `FLY_APP` / `fly.toml` with **no I/O at all**, and app names are unique, so a name identifies an app and its org regardless of how many macaroons we're holding. The warehouse already resolves names this way for deploys and launches (against `raw_web_pg.apps` and `base__flyio__organizations`), so this needs no new lookup anywhere.

Coverage is the 40 app-scoped command packages — including `status`, `logs`, `ssh`, `scale`, `machine`, `volumes`, `ips`, `certificates` and `config`, where `command/stats` is the only event covering the invocation.

## Why this complements the IDs rather than replacing them

- The token-scoped IDs are **first-hand and accurate as of the moment the command ran**. A name resolves to whichever org owns the app *today*, which drifts if an app moves orgs.
- Roughly half our command packages aren't app-scoped at all. For those there is no name to send, and an org-scoped token remains the only attribution available.

Resolution downstream should prefer the event's own id and fall back to the name — the two-step pattern the existing staging models already use, rather than coalescing output columns.

## Alternatives considered

- **A `GetApp` call in a shared preparer.** Adds a network round trip to the highest-volume event we have (~2.09M command invocations/day vs ~50k deploys/day) and a network failure mode to `RequireAppName`, which today does no I/O.
- **Decorating `FlapsClient.GetApp`.** Free, but only covers commands that already fetch an app — which overlap with deploy and launch, and notably exclude `status`/`logs`/`ssh`. Doesn't fix the multi-org case at all.
- **Having the server return the authorizing org on responses.** Would give a definitive answer, but needs changes in three repos, puts telemetry on the flaps auth hot path, and risks becoming an oracle if it's ever emitted on a failed or unauthorized response.

## Follow-ups (not in this PR)

- `flyctl-metrics` must restore the `sendToRudderstack("flyctl_command_stats", …)` block — `command/stats` is currently accepted but not forwarded, so nothing on this payload reaches Snowflake yet.
- A `stg_rudderstack__flyctl_commands` dbt model doing the same deduped, id-first resolution as the deploys/launches models. Name joins against `raw_web_pg.apps` must be deduped (a deleted app frees its name) or they silently fan out.
- Consider an `org_id_source` provenance column. Attribution mechanism correlates with interactive-vs-automation use, so an unlabelled mix will quietly bias any comparison across those segments.

## Testing

`go build ./internal/...`, `go vet`, `go test ./internal/metrics/... ./internal/command/ ./internal/config/...` all pass; `golangci-lint v2.11.3` (the pinned CI version) reports `0 issues.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)