### PR TITLE
Route MPG backup list/create through Machines API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.1
 	github.com/superfly/client-signals/go v0.4.4
-	github.com/superfly/fly-go v0.9.9
+	github.com/superfly/fly-go v0.9.10
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -664,8 +664,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVuwVJGWndfmc8=
 github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
-github.com/superfly/fly-go v0.9.9 h1:r/Nt40VTqzPhdtLWPlXkPcUI3Vuv51bUTNC3TjMAElo=
-github.com/superfly/fly-go v0.9.9/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
+github.com/superfly/fly-go v0.9.10 h1:z5d/6uujrjTNdpPFmlqoMc9B/MFL9qkTw42WG2RtMPU=
+github.com/superfly/fly-go v0.9.10/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/build/imgsrc/flaps_mock_test.go
+++ b/internal/build/imgsrc/flaps_mock_test.go
@@ -162,6 +162,20 @@ func (mr *MockFlapsClientMockRecorder) CreateCustomCertificate(ctx, appName, req
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCustomCertificate", reflect.TypeOf((*MockFlapsClient)(nil).CreateCustomCertificate), ctx, appName, req)
 }
 
+// CreateManagedPostgresBackup mocks base method.
+func (m *MockFlapsClient) CreateManagedPostgresBackup(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateManagedPostgresBackup", ctx, id, req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateManagedPostgresBackup indicates an expected call of CreateManagedPostgresBackup.
+func (mr *MockFlapsClientMockRecorder) CreateManagedPostgresBackup(ctx, id, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateManagedPostgresBackup", reflect.TypeOf((*MockFlapsClient)(nil).CreateManagedPostgresBackup), ctx, id, req)
+}
+
 // CreateManagedPostgresCluster mocks base method.
 func (m *MockFlapsClient) CreateManagedPostgresCluster(ctx context.Context, req flaps.CreateManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
 	m.ctrl.T.Helper()
@@ -781,6 +795,21 @@ func (m *MockFlapsClient) ListFlyAppsMachines(ctx context.Context, appName strin
 func (mr *MockFlapsClientMockRecorder) ListFlyAppsMachines(ctx, appName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFlyAppsMachines", reflect.TypeOf((*MockFlapsClient)(nil).ListFlyAppsMachines), ctx, appName)
+}
+
+// ListManagedPostgresBackups mocks base method.
+func (m *MockFlapsClient) ListManagedPostgresBackups(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListManagedPostgresBackups", ctx, id)
+	ret0, _ := ret[0].([]flaps.ManagedPostgresBackup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListManagedPostgresBackups indicates an expected call of ListManagedPostgresBackups.
+func (mr *MockFlapsClientMockRecorder) ListManagedPostgresBackups(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListManagedPostgresBackups", reflect.TypeOf((*MockFlapsClient)(nil).ListManagedPostgresBackups), ctx, id)
 }
 
 // ListManagedPostgresClusters mocks base method.

--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -148,6 +148,10 @@ func (m *mockFlapsClient) CreateManagedPostgresDatabase(ctx context.Context, id 
 	return flaps.ManagedPostgresDatabase{}, fmt.Errorf("not implemented")
 }
 
+func (m *mockFlapsClient) CreateManagedPostgresBackup(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error {
+	return fmt.Errorf("not implemented")
+}
+
 func (m *mockFlapsClient) CreateVolume(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error) {
 	return nil, fmt.Errorf("failed to create volume %s", req.Name)
 }
@@ -443,6 +447,10 @@ func (m *mockFlapsClient) ListManagedPostgresClusters(ctx context.Context, req f
 }
 
 func (m *mockFlapsClient) ListManagedPostgresDatabases(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockFlapsClient) ListManagedPostgresBackups(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/internal/command/mpg/v2/run_backup.go
+++ b/internal/command/mpg/v2/run_backup.go
@@ -2,11 +2,14 @@ package cmdv2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/render"
 	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
 	"github.com/superfly/flyctl/iostreams"
@@ -15,14 +18,32 @@ import (
 func RunBackupList(ctx context.Context, clusterID string) error {
 	cfg := config.FromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
-	mpgClient := mpgv2.ClientFromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
-	backups, err := mpgClient.ListClusterBackups(ctx, clusterID)
-	if err != nil {
+	var backups []mpgv2.ClusterBackup
+	publicBackups, err := flapsClient.ListManagedPostgresBackups(ctx, clusterID)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		response, legacyErr := mpgv2.ClientFromContext(ctx).ListClusterBackups(ctx, clusterID)
+		if legacyErr != nil {
+			return fmt.Errorf("failed to list backups for cluster %s: %w", clusterID, legacyErr)
+		}
+		backups = response.Data
+	} else if err != nil {
 		return fmt.Errorf("failed to list backups for cluster %s: %w", clusterID, err)
+	} else {
+		backups = make([]mpgv2.ClusterBackup, 0, len(publicBackups))
+		for _, backup := range publicBackups {
+			backups = append(backups, mpgv2.ClusterBackup{
+				Id:     backup.ID,
+				Status: backup.Status,
+				Type:   backup.Type,
+				Start:  backup.StartedAt,
+				Stop:   backup.FinishedAt,
+			})
+		}
 	}
 
-	if len(backups.Data) == 0 {
+	if len(backups) == 0 {
 		fmt.Fprintf(out, "No backups found for cluster %s\n", clusterID)
 
 		return nil
@@ -33,11 +54,11 @@ func RunBackupList(ctx context.Context, clusterID string) error {
 	showAll := flag.GetBool(ctx, "all")
 
 	if showAll {
-		filteredBackups = backups.Data
+		filteredBackups = backups
 	} else {
 		// Filter to last 24 hours
 		cutoff := time.Now().Add(-24 * time.Hour)
-		for _, backup := range backups.Data {
+		for _, backup := range backups {
 			startTime, err := time.Parse(time.RFC3339, backup.Start)
 			if err != nil {
 				// If we can't parse the time, include the backup
@@ -76,7 +97,7 @@ func RunBackupList(ctx context.Context, clusterID string) error {
 
 func RunBackupCreate(ctx context.Context, clusterID string) error {
 	out := iostreams.FromContext(ctx).Out
-	mpgClient := mpgv2.ClientFromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	backupType := flag.GetString(ctx, "type")
 	if backupType != "full" && backupType != "incr" {
@@ -85,11 +106,10 @@ func RunBackupCreate(ctx context.Context, clusterID string) error {
 
 	fmt.Fprintf(out, "Creating %s backup for cluster %s...\n", backupType, clusterID)
 
-	input := mpgv2.CreateClusterBackupInput{
-		Type: backupType,
+	err := flapsClient.CreateManagedPostgresBackup(ctx, clusterID, flaps.CreateManagedPostgresBackupRequest{Type: backupType})
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		err = mpgv2.ClientFromContext(ctx).CreateClusterBackup(ctx, clusterID, mpgv2.CreateClusterBackupInput{Type: backupType})
 	}
-
-	err := mpgClient.CreateClusterBackup(ctx, clusterID, input)
 	if err != nil {
 		return fmt.Errorf("failed to create backup: %w", err)
 	}

--- a/internal/command/mpg/v2/run_backup_test.go
+++ b/internal/command/mpg/v2/run_backup_test.go
@@ -1,0 +1,218 @@
+package cmdv2
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/mock"
+	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func backupTestContext(t *testing.T, jsonOutput, showAll bool) (context.Context, *bytes.Buffer) {
+	t.Helper()
+
+	io, _, stdout, _ := iostreams.Test()
+	ctx := iostreams.NewContext(context.Background(), io)
+	ctx = config.NewContext(ctx, &config.Config{JSONOutput: jsonOutput})
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.Bool("all", showAll, "")
+	flags.String("type", "", "")
+
+	return flagctx.NewContext(ctx, flags), stdout
+}
+
+func TestRunBackupListUsesPublicAPIAndLegacyJSONShape(t *testing.T) {
+	ctx, stdout := backupTestContext(t, true, true)
+	public := []flaps.ManagedPostgresBackup{{
+		ID: "backup-1", Status: "completed", Type: "full", SizeBytes: 42,
+		StartedAt: "2026-08-26T12:00:00Z", FinishedAt: "2026-08-26T12:05:00Z",
+	}}
+	publicCalled := false
+	legacyCalled := false
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+		ListManagedPostgresBackupsFunc: func(_ context.Context, id string) ([]flaps.ManagedPostgresBackup, error) {
+			publicCalled = true
+			require.Equal(t, "mpg-123", id)
+
+			return public, nil
+		},
+	})
+	ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+		ListClusterBackupsFunc: func(_ context.Context, _ string) (mpgv2.ListClusterBackupsResponse, error) {
+			legacyCalled = true
+
+			return mpgv2.ListClusterBackupsResponse{}, nil
+		},
+	})
+
+	require.NoError(t, RunBackupList(ctx, "mpg-123"))
+	require.True(t, publicCalled)
+	require.False(t, legacyCalled)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	require.Equal(t, []map[string]any{{
+		"id": "backup-1", "status": "completed", "type": "full",
+		"start": "2026-08-26T12:00:00Z", "stop": "2026-08-26T12:05:00Z",
+	}}, got)
+}
+
+func TestRunBackupListFiltersPublicStartTimestamp(t *testing.T) {
+	ctx, stdout := backupTestContext(t, false, false)
+	public := []flaps.ManagedPostgresBackup{
+		{ID: "old", StartedAt: time.Now().Add(-25 * time.Hour).UTC().Format(time.RFC3339), Type: "full"},
+		{ID: "new", StartedAt: time.Now().Add(-time.Hour).UTC().Format(time.RFC3339), Type: "incr"},
+	}
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+		ListManagedPostgresBackupsFunc: func(context.Context, string) ([]flaps.ManagedPostgresBackup, error) {
+			return public, nil
+		},
+	})
+	ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{})
+
+	require.NoError(t, RunBackupList(ctx, "mpg-123"))
+	require.Contains(t, stdout.String(), "new")
+	require.NotContains(t, stdout.String(), "old")
+}
+
+func TestRunBackupListEmptyPublicResult(t *testing.T) {
+	ctx, stdout := backupTestContext(t, false, true)
+	legacyCalled := false
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+		ListManagedPostgresBackupsFunc: func(context.Context, string) ([]flaps.ManagedPostgresBackup, error) {
+			return []flaps.ManagedPostgresBackup{}, nil
+		},
+	})
+	ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+		ListClusterBackupsFunc: func(context.Context, string) (mpgv2.ListClusterBackupsResponse, error) {
+			legacyCalled = true
+
+			return mpgv2.ListClusterBackupsResponse{}, nil
+		},
+	})
+
+	require.NoError(t, RunBackupList(ctx, "mpg-123"))
+	require.False(t, legacyCalled)
+	require.Contains(t, stdout.String(), "No backups found for cluster mpg-123")
+}
+
+func TestRunBackupListFallsBackOnlyOnPublic404(t *testing.T) {
+	tests := []struct {
+		name             string
+		publicErr        error
+		legacyErr        error
+		wantLegacyCalled bool
+		wantErr          string
+		wantPublicStatus int
+		wantOutput       string
+	}{
+		{name: "404", publicErr: flaps.ErrFlapsNotFound, wantLegacyCalled: true, wantOutput: "legacy"},
+		{name: "non-404", publicErr: &flaps.FlapsError{ResponseStatusCode: 500, OriginalError: errors.New("public boom")}, wantErr: "failed to list backups for cluster mpg-123: public boom", wantPublicStatus: 500},
+		{name: "legacy failure", publicErr: flaps.ErrFlapsNotFound, legacyErr: errors.New("legacy boom"), wantLegacyCalled: true, wantErr: "failed to list backups for cluster mpg-123: legacy boom"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, stdout := backupTestContext(t, false, true)
+			legacyCalled := false
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				ListManagedPostgresBackupsFunc: func(context.Context, string) ([]flaps.ManagedPostgresBackup, error) {
+					return nil, test.publicErr
+				},
+			})
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+				ListClusterBackupsFunc: func(context.Context, string) (mpgv2.ListClusterBackupsResponse, error) {
+					legacyCalled = true
+
+					return mpgv2.ListClusterBackupsResponse{Data: []mpgv2.ClusterBackup{{Id: "legacy"}}}, test.legacyErr
+				},
+			})
+			err := RunBackupList(ctx, "mpg-123")
+			require.Equal(t, test.wantLegacyCalled, legacyCalled)
+			if test.wantPublicStatus != 0 {
+				var publicErr *flaps.FlapsError
+				require.True(t, errors.As(err, &publicErr))
+				require.Equal(t, test.wantPublicStatus, publicErr.ResponseStatusCode)
+			}
+			if test.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.wantErr)
+			}
+			if test.wantOutput != "" {
+				require.Contains(t, stdout.String(), test.wantOutput)
+			}
+		})
+	}
+}
+
+func TestRunBackupCreateUsesPublicAPIAndFallsBackOn404(t *testing.T) {
+	tests := []struct {
+		name             string
+		publicErr        error
+		legacyErr        error
+		wantLegacyCalled bool
+		wantErr          string
+		wantPublicStatus int
+	}{
+		{name: "public", wantErr: ""},
+		{name: "404 fallback", publicErr: flaps.ErrFlapsNotFound, wantLegacyCalled: true},
+		{name: "non-404", publicErr: errors.New("public boom"), wantErr: "failed to create backup: public boom"},
+		{name: "concurrent backup 409", publicErr: &flaps.FlapsError{ResponseStatusCode: 409, OriginalError: errors.New("backup already in progress")}, wantErr: "failed to create backup: backup already in progress", wantPublicStatus: 409},
+		{name: "legacy failure", publicErr: flaps.ErrFlapsNotFound, legacyErr: errors.New("legacy boom"), wantLegacyCalled: true, wantErr: "failed to create backup: legacy boom"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, _ := backupTestContext(t, false, false)
+			require.NoError(t, flag.SetString(ctx, "type", "incr"))
+			legacyCalled := false
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				CreateManagedPostgresBackupFunc: func(_ context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error {
+					require.Equal(t, "mpg-123", id)
+					require.Equal(t, "incr", req.Type)
+
+					return test.publicErr
+				},
+			})
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+				CreateClusterBackupFunc: func(_ context.Context, id string, input mpgv2.CreateClusterBackupInput) error {
+					legacyCalled = true
+					require.Equal(t, "mpg-123", id)
+					require.Equal(t, "incr", input.Type)
+
+					return test.legacyErr
+				},
+			})
+			err := RunBackupCreate(ctx, "mpg-123")
+			require.Equal(t, test.wantLegacyCalled, legacyCalled)
+			if test.wantPublicStatus != 0 {
+				var publicErr *flaps.FlapsError
+				require.True(t, errors.As(err, &publicErr))
+				require.Equal(t, test.wantPublicStatus, publicErr.ResponseStatusCode)
+			}
+			if test.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestRunBackupCreateRejectsOtherTypes(t *testing.T) {
+	ctx, _ := backupTestContext(t, false, false)
+	require.NoError(t, flag.SetString(ctx, "type", "diff"))
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{})
+	ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{})
+	require.EqualError(t, RunBackupCreate(ctx, "mpg-123"), "--type must be either 'full' or 'incr'")
+}

--- a/internal/flapsutil/flaps_client.go
+++ b/internal/flapsutil/flaps_client.go
@@ -20,6 +20,7 @@ type FlapsClient interface {
 	CreateACMECertificate(ctx context.Context, appName string, req fly.CreateCertificateRequest) (*fly.CertificateDetailResponse, error)
 	CreateManagedPostgresCluster(ctx context.Context, req flaps.CreateManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error)
 	CreateManagedPostgresDatabase(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error)
+	CreateManagedPostgresBackup(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error
 	CreateVolume(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error)
 	CreateVolumeSnapshot(ctx context.Context, appName, volumeId string) error
 	DeleteApp(ctx context.Context, name string) error
@@ -63,6 +64,7 @@ type FlapsClient interface {
 	ListFlyAppsMachines(ctx context.Context, appName string) ([]*fly.Machine, *fly.Machine, error)
 	ListManagedPostgresClusters(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error)
 	ListManagedPostgresDatabases(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error)
+	ListManagedPostgresBackups(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error)
 	ListSecretKeys(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error)
 	NewRequest(ctx context.Context, method, path string, in any, headers map[string][]string) (*http.Request, error)
 	RefreshLease(ctx context.Context, appName, machineID string, ttl *int, nonce string) (*fly.MachineLease, error)

--- a/internal/inmem/flaps_client.go
+++ b/internal/inmem/flaps_client.go
@@ -161,6 +161,10 @@ func (m *FlapsClient) CreateManagedPostgresDatabase(ctx context.Context, id stri
 	panic("TODO")
 }
 
+func (m *FlapsClient) CreateManagedPostgresBackup(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error {
+	panic("TODO")
+}
+
 func (m *FlapsClient) GetManagedPostgresCluster(ctx context.Context, id string) (flaps.ManagedPostgresCluster, error) {
 	panic("TODO")
 }
@@ -264,6 +268,10 @@ func (m *FlapsClient) ListManagedPostgresClusters(ctx context.Context, req flaps
 }
 
 func (m *FlapsClient) ListManagedPostgresDatabases(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) ListManagedPostgresBackups(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error) {
 	panic("TODO")
 }
 

--- a/internal/mock/flaps_client.go
+++ b/internal/mock/flaps_client.go
@@ -21,6 +21,7 @@ type FlapsClient struct {
 	CreateACMECertificateFunc             func(ctx context.Context, appName string, req fly.CreateCertificateRequest) (*fly.CertificateDetailResponse, error)
 	CreateManagedPostgresClusterFunc      func(ctx context.Context, req flaps.CreateManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error)
 	CreateManagedPostgresDatabaseFunc     func(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error)
+	CreateManagedPostgresBackupFunc       func(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error
 	CreateVolumeFunc                      func(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error)
 	CreateVolumeSnapshotFunc              func(ctx context.Context, appName, volumeId string) error
 	DeleteAppFunc                         func(ctx context.Context, name string) error
@@ -64,6 +65,7 @@ type FlapsClient struct {
 	ListFlyAppsMachinesFunc               func(ctx context.Context, appName string) ([]*fly.Machine, *fly.Machine, error)
 	ListManagedPostgresClustersFunc       func(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error)
 	ListManagedPostgresDatabasesFunc      func(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error)
+	ListManagedPostgresBackupsFunc        func(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error)
 	ListSecretKeysFunc                    func(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error)
 	NewRequestFunc                        func(ctx context.Context, method, path string, in any, headers map[string][]string) (*http.Request, error)
 	RefreshLeaseFunc                      func(ctx context.Context, appName, machineID string, ttl *int, nonce string) (*fly.MachineLease, error)
@@ -117,6 +119,10 @@ func (m *FlapsClient) CreateManagedPostgresCluster(ctx context.Context, req flap
 
 func (m *FlapsClient) CreateManagedPostgresDatabase(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error) {
 	return m.CreateManagedPostgresDatabaseFunc(ctx, id, req)
+}
+
+func (m *FlapsClient) CreateManagedPostgresBackup(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error {
+	return m.CreateManagedPostgresBackupFunc(ctx, id, req)
 }
 
 func (m *FlapsClient) CreateVolume(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error) {
@@ -293,6 +299,10 @@ func (m *FlapsClient) ListManagedPostgresClusters(ctx context.Context, req flaps
 
 func (m *FlapsClient) ListManagedPostgresDatabases(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error) {
 	return m.ListManagedPostgresDatabasesFunc(ctx, id)
+}
+
+func (m *FlapsClient) ListManagedPostgresBackups(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error) {
+	return m.ListManagedPostgresBackupsFunc(ctx, id)
 }
 
 func (m *FlapsClient) ListSecretKeys(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error) {


### PR DESCRIPTION
## What

Route `fly mpg backup list` and `fly mpg backup create` through the public Machines API for MPGv2 clusters.

- Use the typed backup methods published in `fly-go v0.9.10` and regenerate the affected mock.
- Fall back to the existing MPGv2 API only when the public endpoint returns HTTP 404 (`flaps.ErrFlapsNotFound`).
- Propagate all other public API errors (auth, 409 conflicts, 5xx, and transport errors) instead of retrying them through the legacy API.
- Preserve the existing backup type validation, 24-hour filtering, table output, JSON schema, and user-facing messages.
- Keep `size_bytes` out of the JSON output for now so this migration does not change the command's existing output contract.

## Why

This moves another MPGv2 flyctl workflow onto the public Machines API while retaining compatibility with environments where the corresponding endpoint is not yet available.

Restricting fallback to HTTP 404 prevents authorization, server, conflict, and transport failures from being silently retried through the legacy API.

## Testing

- `go test ./... -count=1`
- `go test -race ./internal/command/mpg/v2 -count=1`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.3 run ./...`
- `go build -buildvcs=false ./...`
- `git diff --check`

Also validated with a locally built flyctl against the published `fly-go v0.9.10` and a live MPGv2 test cluster:

- Listed existing backups successfully.
- Queued an incremental backup successfully.
- Confirmed the backup completed and appeared in a subsequent listing.
