### PR TITLE
Route MPGv2 restores through Machines API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.1
 	github.com/superfly/client-signals/go v0.4.4
-	github.com/superfly/fly-go v0.9.10
+	github.com/superfly/fly-go v0.9.11
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -664,8 +664,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVuwVJGWndfmc8=
 github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
-github.com/superfly/fly-go v0.9.10 h1:z5d/6uujrjTNdpPFmlqoMc9B/MFL9qkTw42WG2RtMPU=
-github.com/superfly/fly-go v0.9.10/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
+github.com/superfly/fly-go v0.9.11 h1:Yfkxwm93+YWfLgdsoAnOtjN89zurnaQAUILDPPiWKKU=
+github.com/superfly/fly-go v0.9.11/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/build/imgsrc/flaps_mock_test.go
+++ b/internal/build/imgsrc/flaps_mock_test.go
@@ -915,6 +915,21 @@ func (mr *MockFlapsClientMockRecorder) Restart(ctx, appName, in, nonce any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Restart", reflect.TypeOf((*MockFlapsClient)(nil).Restart), ctx, appName, in, nonce)
 }
 
+// RestoreManagedPostgresCluster mocks base method.
+func (m *MockFlapsClient) RestoreManagedPostgresCluster(ctx context.Context, id string, req flaps.RestoreManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestoreManagedPostgresCluster", ctx, id, req)
+	ret0, _ := ret[0].(flaps.ManagedPostgresCluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RestoreManagedPostgresCluster indicates an expected call of RestoreManagedPostgresCluster.
+func (mr *MockFlapsClientMockRecorder) RestoreManagedPostgresCluster(ctx, id, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreManagedPostgresCluster", reflect.TypeOf((*MockFlapsClient)(nil).RestoreManagedPostgresCluster), ctx, id, req)
+}
+
 // SetAppSecret mocks base method.
 func (m *MockFlapsClient) SetAppSecret(ctx context.Context, appName, name, value string) (*fly.SetAppSecretResp, error) {
 	m.ctrl.T.Helper()

--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -498,6 +498,10 @@ func (m *mockFlapsClient) ReleaseLease(ctx context.Context, appName, machineID, 
 	return nil
 }
 
+func (m *mockFlapsClient) RestoreManagedPostgresCluster(ctx context.Context, id string, req flaps.RestoreManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+	panic("not implemented")
+}
+
 func (m *mockFlapsClient) Restart(ctx context.Context, appName string, in fly.RestartMachineInput, nonce string) (err error) {
 	return fmt.Errorf("failed to restart %s", in.ID)
 }

--- a/internal/command/mpg/restore_test.go
+++ b/internal/command/mpg/restore_test.go
@@ -108,7 +108,8 @@ func TestRunRestore(t *testing.T) {
 			ctx = flagctx.NewContext(ctx, flagSet)
 
 			v1RestoreCalled := false
-			v2RestoreCalled := false
+			legacyV2RestoreCalled := false
+			publicV2RestoreCalled := false
 			lookupCalled := false
 			v1Client := &mock.MpgV1Client{
 				GetManagedClusterByIdFunc: func(context.Context, string) (mpgv1.GetManagedClusterResponse, error) {
@@ -129,7 +130,7 @@ func TestRunRestore(t *testing.T) {
 			}
 			v2Client := &mock.MpgV2Client{
 				RestoreClusterBackupFunc: func(_ context.Context, gotClusterID string, input mpgv2.RestoreClusterBackupInput) (mpgv2.RestoreClusterBackupResponse, error) {
-					v2RestoreCalled = true
+					legacyV2RestoreCalled = true
 					assert.Equal(t, clusterID, gotClusterID)
 					assert.Equal(t, tt.backupID, input.BackupId)
 					assert.Equal(t, tt.pitrTime, input.PitrTime)
@@ -147,7 +148,7 @@ func TestRunRestore(t *testing.T) {
 					return flaps.ManagedPostgresCluster{ID: clusterID}, nil
 				},
 				RestoreManagedPostgresClusterFunc: func(_ context.Context, gotClusterID string, input flaps.RestoreManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
-					v2RestoreCalled = true
+					publicV2RestoreCalled = true
 					assert.Equal(t, clusterID, gotClusterID)
 					assert.Equal(t, tt.backupID, input.BackupID)
 					assert.Equal(t, tt.pitrTime, input.PITRTime)
@@ -169,7 +170,8 @@ func TestRunRestore(t *testing.T) {
 			}
 			assert.Equal(t, tt.wantLookup, lookupCalled)
 			assert.Equal(t, tt.wantV1Restore, v1RestoreCalled)
-			assert.Equal(t, tt.wantV2Restore, v2RestoreCalled)
+			assert.Equal(t, tt.wantV2Restore, publicV2RestoreCalled)
+			assert.False(t, legacyV2RestoreCalled)
 		})
 	}
 }

--- a/internal/command/mpg/restore_test.go
+++ b/internal/command/mpg/restore_test.go
@@ -146,6 +146,14 @@ func TestRunRestore(t *testing.T) {
 
 					return flaps.ManagedPostgresCluster{ID: clusterID}, nil
 				},
+				RestoreManagedPostgresClusterFunc: func(_ context.Context, gotClusterID string, input flaps.RestoreManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+					v2RestoreCalled = true
+					assert.Equal(t, clusterID, gotClusterID)
+					assert.Equal(t, tt.backupID, input.BackupID)
+					assert.Equal(t, tt.pitrTime, input.PITRTime)
+
+					return flaps.ManagedPostgresCluster{}, nil
+				},
 			}
 			ctx = mpgv1.NewContextWithClient(ctx, v1Client)
 			ctx = mpgv2.NewContextWithClient(ctx, v2Client)
@@ -205,6 +213,11 @@ func TestRunRestoreV2Serialization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := setupTestContext()
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				RestoreManagedPostgresClusterFunc: func(context.Context, string, flaps.RestoreManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+					return flaps.ManagedPostgresCluster{}, flaps.ErrFlapsNotFound
+				},
+			})
 			var capturedInput mpgv2.RestoreClusterBackupInput
 			client := &mock.MpgV2Client{
 				RestoreClusterBackupFunc: func(_ context.Context, gotClusterID string, input mpgv2.RestoreClusterBackupInput) (mpgv2.RestoreClusterBackupResponse, error) {

--- a/internal/command/mpg/v2/run_restore.go
+++ b/internal/command/mpg/v2/run_restore.go
@@ -2,8 +2,11 @@ package cmdv2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -18,20 +21,37 @@ func RunRestore(ctx context.Context, clusterID string, backupID string, name str
 		fmt.Fprintf(out, "Restoring cluster %s to point in time %s...\n", clusterID, pitrTime)
 	}
 
-	input := mpgv2.RestoreClusterBackupInput{
-		BackupId: backupID,
+	request := flaps.RestoreManagedPostgresClusterRequest{
+		BackupID: backupID,
 		Name:     name,
-		PitrTime: pitrTime,
+		PITRTime: pitrTime,
 	}
 
-	response, err := mpgClient.RestoreClusterBackup(ctx, clusterID, input)
+	response, err := flapsutil.ClientFromContext(ctx).RestoreManagedPostgresCluster(ctx, clusterID, request)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		publicErr := err
+		var legacyResponse mpgv2.RestoreClusterBackupResponse
+		legacyResponse, err = mpgClient.RestoreClusterBackup(ctx, clusterID, mpgv2.RestoreClusterBackupInput{
+			BackupId: backupID,
+			Name:     name,
+			PitrTime: pitrTime,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to restore cluster: %w", publicErr)
+		}
+
+		response = flaps.ManagedPostgresCluster{
+			ID:   legacyResponse.Data.Id,
+			Name: legacyResponse.Data.Name,
+		}
+	}
 	if err != nil {
 		return fmt.Errorf("failed to restore cluster: %w", err)
 	}
 
 	fmt.Fprintf(out, "Restore initiated successfully!\n")
-	fmt.Fprintf(out, "  Cluster ID: %s\n", response.Data.Id)
-	fmt.Fprintf(out, "  Cluster Name: %s\n", response.Data.Name)
+	fmt.Fprintf(out, "  Cluster ID: %s\n", response.ID)
+	fmt.Fprintf(out, "  Cluster Name: %s\n", response.Name)
 
 	return nil
 }

--- a/internal/command/mpg/v2/run_restore_test.go
+++ b/internal/command/mpg/v2/run_restore_test.go
@@ -16,6 +16,7 @@ import (
 
 func restoreTestContext() (context.Context, *bytes.Buffer) {
 	io, _, stdout, _ := iostreams.Test()
+
 	return iostreams.NewContext(context.Background(), io), stdout
 }
 
@@ -35,6 +36,7 @@ func TestRunRestoreUsesPublicAPI(t *testing.T) {
 	ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
 		RestoreClusterBackupFunc: func(context.Context, string, mpgv2.RestoreClusterBackupInput) (mpgv2.RestoreClusterBackupResponse, error) {
 			legacyCalled = true
+
 			return mpgv2.RestoreClusterBackupResponse{}, nil
 		},
 	})
@@ -79,6 +81,7 @@ func TestRunRestoreDoesNotFallbackOnOtherPublicErrors(t *testing.T) {
 	ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
 		RestoreClusterBackupFunc: func(context.Context, string, mpgv2.RestoreClusterBackupInput) (mpgv2.RestoreClusterBackupResponse, error) {
 			legacyCalled = true
+
 			return mpgv2.RestoreClusterBackupResponse{}, nil
 		},
 	})

--- a/internal/command/mpg/v2/run_restore_test.go
+++ b/internal/command/mpg/v2/run_restore_test.go
@@ -1,0 +1,109 @@
+package cmdv2
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/mock"
+	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func restoreTestContext() (context.Context, *bytes.Buffer) {
+	io, _, stdout, _ := iostreams.Test()
+	return iostreams.NewContext(context.Background(), io), stdout
+}
+
+func TestRunRestoreUsesPublicAPI(t *testing.T) {
+	ctx, stdout := restoreTestContext()
+	legacyCalled := false
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+		RestoreManagedPostgresClusterFunc: func(_ context.Context, id string, req flaps.RestoreManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+			require.Equal(t, "mpg-source", id)
+			require.Equal(t, "backup-1", req.BackupID)
+			require.Empty(t, req.PITRTime)
+			require.Equal(t, "restored-db", req.Name)
+
+			return flaps.ManagedPostgresCluster{ID: "mpg-restored", Name: "restored-db"}, nil
+		},
+	})
+	ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+		RestoreClusterBackupFunc: func(context.Context, string, mpgv2.RestoreClusterBackupInput) (mpgv2.RestoreClusterBackupResponse, error) {
+			legacyCalled = true
+			return mpgv2.RestoreClusterBackupResponse{}, nil
+		},
+	})
+
+	require.NoError(t, RunRestore(ctx, "mpg-source", "backup-1", "restored-db", ""))
+	require.False(t, legacyCalled)
+	require.Contains(t, stdout.String(), "Cluster ID: mpg-restored")
+	require.Contains(t, stdout.String(), "Cluster Name: restored-db")
+}
+
+func TestRunRestoreFallsBackOnPublic404(t *testing.T) {
+	ctx, stdout := restoreTestContext()
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+		RestoreManagedPostgresClusterFunc: func(context.Context, string, flaps.RestoreManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+			return flaps.ManagedPostgresCluster{}, flaps.ErrFlapsNotFound
+		},
+	})
+	ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+		RestoreClusterBackupFunc: func(_ context.Context, id string, input mpgv2.RestoreClusterBackupInput) (mpgv2.RestoreClusterBackupResponse, error) {
+			require.Equal(t, "mpg-source", id)
+			require.Empty(t, input.BackupId)
+			require.Equal(t, "2026-06-01T12:02:30Z", input.PitrTime)
+			require.Equal(t, "restored-db", input.Name)
+
+			return mpgv2.RestoreClusterBackupResponse{Data: mpgv2.ManagedCluster{Id: "legacy-restored", Name: "restored-db"}}, nil
+		},
+	})
+
+	require.NoError(t, RunRestore(ctx, "mpg-source", "", "restored-db", "2026-06-01T12:02:30Z"))
+	require.Contains(t, stdout.String(), "Cluster ID: legacy-restored")
+}
+
+func TestRunRestoreDoesNotFallbackOnOtherPublicErrors(t *testing.T) {
+	ctx, _ := restoreTestContext()
+	publicErr := &flaps.FlapsError{ResponseStatusCode: 422, OriginalError: errors.New("outside recovery window")}
+	legacyCalled := false
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+		RestoreManagedPostgresClusterFunc: func(context.Context, string, flaps.RestoreManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+			return flaps.ManagedPostgresCluster{}, publicErr
+		},
+	})
+	ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+		RestoreClusterBackupFunc: func(context.Context, string, mpgv2.RestoreClusterBackupInput) (mpgv2.RestoreClusterBackupResponse, error) {
+			legacyCalled = true
+			return mpgv2.RestoreClusterBackupResponse{}, nil
+		},
+	})
+
+	err := RunRestore(ctx, "mpg-source", "", "", "2026-06-01T12:02:30Z")
+	require.ErrorIs(t, err, publicErr)
+	require.ErrorContains(t, err, "failed to restore cluster: outside recovery window")
+	require.False(t, legacyCalled)
+}
+
+func TestRunRestorePreservesPublic404WhenFallbackFails(t *testing.T) {
+	ctx, _ := restoreTestContext()
+	publicErr := &flaps.FlapsError{ResponseStatusCode: 404, OriginalError: errors.New("backup not found")}
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+		RestoreManagedPostgresClusterFunc: func(context.Context, string, flaps.RestoreManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+			return flaps.ManagedPostgresCluster{}, publicErr
+		},
+	})
+	ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+		RestoreClusterBackupFunc: func(context.Context, string, mpgv2.RestoreClusterBackupInput) (mpgv2.RestoreClusterBackupResponse, error) {
+			return mpgv2.RestoreClusterBackupResponse{}, errors.New("legacy restore failed")
+		},
+	})
+
+	err := RunRestore(ctx, "mpg-source", "backup-1", "", "")
+	require.ErrorIs(t, err, publicErr)
+	require.EqualError(t, err, "failed to restore cluster: backup not found")
+}

--- a/internal/flapsutil/flaps_client.go
+++ b/internal/flapsutil/flaps_client.go
@@ -69,6 +69,7 @@ type FlapsClient interface {
 	NewRequest(ctx context.Context, method, path string, in any, headers map[string][]string) (*http.Request, error)
 	RefreshLease(ctx context.Context, appName, machineID string, ttl *int, nonce string) (*fly.MachineLease, error)
 	ReleaseLease(ctx context.Context, appName, machineID, nonce string) error
+	RestoreManagedPostgresCluster(ctx context.Context, id string, req flaps.RestoreManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error)
 	Restart(ctx context.Context, appName string, in fly.RestartMachineInput, nonce string) (err error)
 	SetAppSecret(ctx context.Context, appName, name string, value string) (*fly.SetAppSecretResp, error)
 	SetSecretKey(ctx context.Context, appName, name string, typ string, value []byte) (*fly.SetSecretKeyResp, error)

--- a/internal/inmem/flaps_client.go
+++ b/internal/inmem/flaps_client.go
@@ -291,6 +291,10 @@ func (m *FlapsClient) ReleaseLease(ctx context.Context, appName, machineID, nonc
 	panic("TODO")
 }
 
+func (m *FlapsClient) RestoreManagedPostgresCluster(ctx context.Context, id string, req flaps.RestoreManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+	panic("TODO")
+}
+
 func (m *FlapsClient) Restart(ctx context.Context, appName string, in fly.RestartMachineInput, nonce string) (err error) {
 	panic("TODO")
 }

--- a/internal/mock/flaps_client.go
+++ b/internal/mock/flaps_client.go
@@ -70,6 +70,7 @@ type FlapsClient struct {
 	NewRequestFunc                        func(ctx context.Context, method, path string, in any, headers map[string][]string) (*http.Request, error)
 	RefreshLeaseFunc                      func(ctx context.Context, appName, machineID string, ttl *int, nonce string) (*fly.MachineLease, error)
 	ReleaseLeaseFunc                      func(ctx context.Context, appName, machineID, nonce string) error
+	RestoreManagedPostgresClusterFunc     func(ctx context.Context, id string, req flaps.RestoreManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error)
 	RestartFunc                           func(ctx context.Context, appName string, in fly.RestartMachineInput, nonce string) (err error)
 	SetMetadataFunc                       func(ctx context.Context, appName, machineID, key, value string) error
 	SetAppSecretFunc                      func(ctx context.Context, appName, name string, value string) (*fly.SetAppSecretResp, error)
@@ -319,6 +320,10 @@ func (m *FlapsClient) RefreshLease(ctx context.Context, appName, machineID strin
 
 func (m *FlapsClient) ReleaseLease(ctx context.Context, appName, machineID, nonce string) error {
 	return m.ReleaseLeaseFunc(ctx, appName, machineID, nonce)
+}
+
+func (m *FlapsClient) RestoreManagedPostgresCluster(ctx context.Context, id string, req flaps.RestoreManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+	return m.RestoreManagedPostgresClusterFunc(ctx, id, req)
 }
 
 func (m *FlapsClient) Restart(ctx context.Context, appName string, in fly.RestartMachineInput, nonce string) (err error) {


### PR DESCRIPTION
## Summary

- route `fly mpg restore` for MPGv2 clusters through the typed Machines API
- retain the legacy MPGv2 restore endpoint as a 404 compatibility fallback without masking authoritative public errors
- preserve MPGv1 restore routing and update fly-go to v0.9.11

## Testing

- `GOWORK=off mise exec -- go test ./... -count=1`
- exercised real MPGv2 backup-ID and point-in-time restores through readiness
- verified restored database state across pre-write backup, post-write backup, and PITR boundaries
- verified requested and server-generated names, validation errors, public service errors, and MPGv1 routing
- confirmed all E2E-created clusters were deleted