### PR TITLE
Improve volume-related Machine placement errors

### DIFF
--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -156,6 +156,17 @@ func (md *machineDeployment) DeployMachinesApp(ctx context.Context) error {
 		}
 	}
 
+	return withVolumePlacementCapacitySuggestion(err)
+}
+
+const volumePlacementCapacitySuggestion = "There isn't enough capacity on the hosts holding the available volumes to create one or more Machines. " +
+	"Try again later, or use `fly volume create` to add a new, empty volume with the configured name in the affected region, then deploy again."
+
+func withVolumePlacementCapacitySuggestion(err error) error {
+	if flapsutil.HasErrorStatusCode(err, flapsutil.VolumePlacementCapacityStatus) {
+		return flyerr.WithSuggestion(err, volumePlacementCapacitySuggestion)
+	}
+
 	return err
 }
 

--- a/internal/command/deploy/machines_deploymachinesapp_test.go
+++ b/internal/command/deploy/machines_deploymachinesapp_test.go
@@ -2,14 +2,18 @@ package deploy
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/mock"
 	"github.com/superfly/flyctl/iostreams"
@@ -75,4 +79,28 @@ func TestDeployMachinesApp(t *testing.T) {
 	ctx = flapsutil.NewContextWithClient(ctx, client)
 	err := md.deployMachinesApp(ctx)
 	assert.NoError(t, err)
+}
+
+func TestVolumePlacementCapacitySuggestion(t *testing.T) {
+	placementErr := &flaps.FlapsError{
+		OriginalError: errors.New("failed_precondition: insufficient resources for volumes"),
+		ResponseBody:  []byte(`{"status":"volume_placement_capacity"}`),
+		FlyRequestId:  "request-id",
+	}
+
+	t.Run("adds deploy advice and preserves Flaps metadata", func(t *testing.T) {
+		err := withVolumePlacementCapacitySuggestion(fmt.Errorf("failed to create machine: %w", placementErr))
+
+		require.ErrorIs(t, err, placementErr)
+		require.Equal(t, "request-id", flaps.GetErrorRequestID(err))
+		require.Contains(t, flyerr.GetErrorSuggestion(err), "Try again later")
+		require.Contains(t, flyerr.GetErrorSuggestion(err), "fly volume create")
+		require.Contains(t, flyerr.GetErrorSuggestion(err), "empty volume")
+	})
+
+	t.Run("leaves unrelated errors unchanged", func(t *testing.T) {
+		err := errors.New("machine launch failed")
+
+		require.Same(t, err, withVolumePlacementCapacitySuggestion(err))
+	})
 }

--- a/internal/command/scale/count_machines.go
+++ b/internal/command/scale/count_machines.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superfly/flyctl/internal/command/ips"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
@@ -181,7 +182,7 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 
 	err = updatePool.Wait()
 	if err != nil {
-		return err
+		return withVolumePlacementCapacitySuggestion(err)
 	}
 
 	// Scaling may change the situation of app-scoped egress IPs in affected regions
@@ -192,6 +193,17 @@ func runMachinesScaleCount(ctx context.Context, appName string, appConfig *appco
 	ips.SanityCheckAppScopedEgressIps(ctx, regionMap, nil, nil, "")
 
 	return nil
+}
+
+const volumePlacementCapacitySuggestion = "There isn't enough capacity on the hosts holding the available volumes to create the remaining Machines. " +
+	"Try again later, or use --with-new-volumes to create new empty volumes on hosts with capacity."
+
+func withVolumePlacementCapacitySuggestion(err error) error {
+	if flapsutil.HasErrorStatusCode(err, flapsutil.VolumePlacementCapacityStatus) {
+		return flyerr.WithSuggestion(err, volumePlacementCapacitySuggestion)
+	}
+
+	return err
 }
 
 func launchMachine(ctx context.Context, appName string, action *planItem, idx int) (*fly.Machine, error) {

--- a/internal/command/scale/count_machines_test.go
+++ b/internal/command/scale/count_machines_test.go
@@ -3,6 +3,7 @@ package scale
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -10,8 +11,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/flyerr"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -119,6 +122,39 @@ func TestLaunchMachineVolumeSelection(t *testing.T) {
 		require.ErrorIs(t, err, client.launchErr)
 		require.Equal(t, 1, client.launchCalls)
 		require.Equal(t, "data", client.launchInput.Config.Mounts[0].Volume)
+	})
+}
+
+func TestVolumePlacementCapacitySuggestion(t *testing.T) {
+	placementErr := &flaps.FlapsError{
+		OriginalError: errors.New("failed_precondition: insufficient resources for volumes"),
+		ResponseBody:  []byte(`{"status":"volume_placement_capacity"}`),
+		FlyRequestId:  "request-id",
+	}
+
+	t.Run("adds scale advice and preserves Flaps metadata", func(t *testing.T) {
+		err := withVolumePlacementCapacitySuggestion(fmt.Errorf("failed to launch VM: %w", placementErr))
+
+		require.ErrorIs(t, err, placementErr)
+		require.Equal(t, "request-id", flaps.GetErrorRequestID(err))
+		require.Contains(t, flyerr.GetErrorSuggestion(err), "--with-new-volumes")
+		require.Contains(t, flyerr.GetErrorSuggestion(err), "empty volumes")
+	})
+
+	t.Run("finds the status after another joined Flaps error", func(t *testing.T) {
+		otherErr := &flaps.FlapsError{
+			OriginalError: errors.New("another failure"),
+			ResponseBody:  []byte(`{"status":"unknown"}`),
+		}
+		err := withVolumePlacementCapacitySuggestion(errors.Join(otherErr, placementErr))
+
+		require.Contains(t, flyerr.GetErrorSuggestion(err), "--with-new-volumes")
+	})
+
+	t.Run("leaves unrelated errors unchanged", func(t *testing.T) {
+		err := errors.New("machine launch failed")
+
+		require.Same(t, err, withVolumePlacementCapacitySuggestion(err))
 	})
 }
 

--- a/internal/flapsutil/error_status.go
+++ b/internal/flapsutil/error_status.go
@@ -1,0 +1,29 @@
+package flapsutil
+
+import "github.com/superfly/fly-go/flaps"
+
+const VolumePlacementCapacityStatus = flaps.StatusCode("volume_placement_capacity")
+
+// HasErrorStatusCode reports whether err or any error it wraps carries status.
+// Error pools can join several Flaps errors, so errors.As alone is insufficient:
+// it can stop at an earlier Flaps error with a different status.
+func HasErrorStatusCode(err error, status flaps.StatusCode) bool {
+	if statusErr, ok := err.(flaps.ErrorStatusCode); ok {
+		if actual := statusErr.StatusCode(); actual != nil && *actual == status {
+			return true
+		}
+	}
+
+	switch err := err.(type) {
+	case interface{ Unwrap() []error }:
+		for _, inner := range err.Unwrap() {
+			if HasErrorStatusCode(inner, status) {
+				return true
+			}
+		}
+	case interface{ Unwrap() error }:
+		return HasErrorStatusCode(err.Unwrap(), status)
+	}
+
+	return false
+}

--- a/internal/flapsutil/error_status_test.go
+++ b/internal/flapsutil/error_status_test.go
@@ -1,0 +1,28 @@
+package flapsutil
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/superfly/fly-go/flaps"
+)
+
+func TestHasErrorStatusCode(t *testing.T) {
+	placementErr := &flaps.FlapsError{
+		OriginalError: errors.New("volume placement failed"),
+		ResponseBody:  []byte(`{"status":"volume_placement_capacity"}`),
+	}
+	otherFlapsErr := &flaps.FlapsError{
+		OriginalError: errors.New("another failure"),
+		ResponseBody:  []byte(`{"status":"unknown"}`),
+	}
+
+	assert.True(t, HasErrorStatusCode(placementErr, VolumePlacementCapacityStatus))
+	assert.True(t, HasErrorStatusCode(fmt.Errorf("launch failed: %w", placementErr), VolumePlacementCapacityStatus))
+	assert.True(t, HasErrorStatusCode(errors.Join(otherFlapsErr, placementErr), VolumePlacementCapacityStatus))
+	assert.False(t, HasErrorStatusCode(otherFlapsErr, VolumePlacementCapacityStatus))
+	assert.False(t, HasErrorStatusCode(errors.New("not a Flaps error"), VolumePlacementCapacityStatus))
+	assert.False(t, HasErrorStatusCode(nil, VolumePlacementCapacityStatus))
+}

--- a/internal/flyerr/flyerr.go
+++ b/internal/flyerr/flyerr.go
@@ -15,6 +15,33 @@ type GenericErr struct {
 	DocUrl   string
 }
 
+type suggestedError struct {
+	err        error
+	suggestion string
+}
+
+func (e suggestedError) Error() string {
+	return e.err.Error()
+}
+
+func (e suggestedError) Unwrap() error {
+	return e.err
+}
+
+func (e suggestedError) Suggestion() string {
+	return e.suggestion
+}
+
+// WithSuggestion decorates err with user-facing advice while preserving its
+// wrapping chain. A nil error or empty suggestion is returned unchanged.
+func WithSuggestion(err error, suggestion string) error {
+	if err == nil || suggestion == "" {
+		return err
+	}
+
+	return suggestedError{err: err, suggestion: suggestion}
+}
+
 func (e GenericErr) Error() string {
 	return e.Err
 }

--- a/internal/flyerr/flyerr_test.go
+++ b/internal/flyerr/flyerr_test.go
@@ -1,0 +1,19 @@
+package flyerr
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithSuggestion(t *testing.T) {
+	underlying := errors.New("launch failed")
+	err := WithSuggestion(underlying, "try again")
+
+	require.EqualError(t, err, underlying.Error())
+	require.ErrorIs(t, err, underlying)
+	require.Equal(t, "try again", GetErrorSuggestion(err))
+	require.Nil(t, WithSuggestion(nil, "try again"))
+	require.Same(t, underlying, WithSuggestion(underlying, ""))
+}


### PR DESCRIPTION
### Change Summary

What and Why:

Add suggestions for `deploy` and `scale count` failures related to volumes and host capacity.

How:

Detect the new `volume_placement_capacity` status code from the API.

Related to:
* https://github.com/superfly/machines-meta/issues/9
* https://github.com/superfly/flyctl/pull/5125
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a