### PR TITLE
Don't run unit tests twice.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 on:
   push:
+    # The workflow in ci-dev.yml also runs unit tests, but on pull_request
+    # instead of on push. We therefore limit this workflow to master pushes
+    # so we don't run unit tests twice.
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
So far, unit tests would run once on `pull_request` and once on `push`. This PR changes the `push` event to trigger on `master` only, so we don't do the work twice.