### PR TITLE
Don't build executable twice.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: '21 */2 * * *'
   push:
+    branches:
+      - master
   pull_request:
 
 concurrency:


### PR DESCRIPTION
So far, the `test_build` job would run both on the `pull_request` event and the `push` event. This PR makes the job only trigger if we pushed to master, so we don't build unnecessarily.