### PR TITLE
Route MPGv2 user and extension commands through the Machines API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.1
 	github.com/superfly/client-signals/go v0.4.4
-	github.com/superfly/fly-go v0.9.11
+	github.com/superfly/fly-go v0.9.12
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -664,7 +664,6 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVuwVJGWndfmc8=
 github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
-github.com/superfly/fly-go v0.9.11/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
 github.com/superfly/fly-go v0.9.12 h1:LIUpcWtqoqdxPV/8v+J7AF0w4ZsUjrT30ZKJnyFZp1I=
 github.com/superfly/fly-go v0.9.12/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=

--- a/go.sum
+++ b/go.sum
@@ -666,6 +666,8 @@ github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVu
 github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
 github.com/superfly/fly-go v0.9.11 h1:Yfkxwm93+YWfLgdsoAnOtjN89zurnaQAUILDPPiWKKU=
 github.com/superfly/fly-go v0.9.11/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
+github.com/superfly/fly-go v0.9.12 h1:LIUpcWtqoqdxPV/8v+J7AF0w4ZsUjrT30ZKJnyFZp1I=
+github.com/superfly/fly-go v0.9.12/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/go.sum
+++ b/go.sum
@@ -664,7 +664,6 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVuwVJGWndfmc8=
 github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
-github.com/superfly/fly-go v0.9.11 h1:Yfkxwm93+YWfLgdsoAnOtjN89zurnaQAUILDPPiWKKU=
 github.com/superfly/fly-go v0.9.11/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
 github.com/superfly/fly-go v0.9.12 h1:LIUpcWtqoqdxPV/8v+J7AF0w4ZsUjrT30ZKJnyFZp1I=
 github.com/superfly/fly-go v0.9.12/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=

--- a/internal/build/imgsrc/flaps_mock_test.go
+++ b/internal/build/imgsrc/flaps_mock_test.go
@@ -206,6 +206,21 @@ func (mr *MockFlapsClientMockRecorder) CreateManagedPostgresDatabase(ctx, id, re
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateManagedPostgresDatabase", reflect.TypeOf((*MockFlapsClient)(nil).CreateManagedPostgresDatabase), ctx, id, req)
 }
 
+// CreateManagedPostgresUser mocks base method.
+func (m *MockFlapsClient) CreateManagedPostgresUser(ctx context.Context, id string, req flaps.CreateManagedPostgresUserRequest) (flaps.ManagedPostgresUser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateManagedPostgresUser", ctx, id, req)
+	ret0, _ := ret[0].(flaps.ManagedPostgresUser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateManagedPostgresUser indicates an expected call of CreateManagedPostgresUser.
+func (mr *MockFlapsClientMockRecorder) CreateManagedPostgresUser(ctx, id, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateManagedPostgresUser", reflect.TypeOf((*MockFlapsClient)(nil).CreateManagedPostgresUser), ctx, id, req)
+}
+
 // CreateVolume mocks base method.
 func (m *MockFlapsClient) CreateVolume(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error) {
 	m.ctrl.T.Helper()
@@ -332,6 +347,20 @@ func (m *MockFlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id s
 func (mr *MockFlapsClientMockRecorder) DeleteManagedPostgresCluster(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteManagedPostgresCluster", reflect.TypeOf((*MockFlapsClient)(nil).DeleteManagedPostgresCluster), ctx, id)
+}
+
+// DeleteManagedPostgresUser mocks base method.
+func (m *MockFlapsClient) DeleteManagedPostgresUser(ctx context.Context, id, username string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteManagedPostgresUser", ctx, id, username)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteManagedPostgresUser indicates an expected call of DeleteManagedPostgresUser.
+func (mr *MockFlapsClientMockRecorder) DeleteManagedPostgresUser(ctx, id, username any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteManagedPostgresUser", reflect.TypeOf((*MockFlapsClient)(nil).DeleteManagedPostgresUser), ctx, id, username)
 }
 
 // DeleteMetadata mocks base method.
@@ -842,6 +871,21 @@ func (mr *MockFlapsClientMockRecorder) ListManagedPostgresDatabases(ctx, id any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListManagedPostgresDatabases", reflect.TypeOf((*MockFlapsClient)(nil).ListManagedPostgresDatabases), ctx, id)
 }
 
+// ListManagedPostgresUsers mocks base method.
+func (m *MockFlapsClient) ListManagedPostgresUsers(ctx context.Context, id string) ([]flaps.ManagedPostgresUser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListManagedPostgresUsers", ctx, id)
+	ret0, _ := ret[0].([]flaps.ManagedPostgresUser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListManagedPostgresUsers indicates an expected call of ListManagedPostgresUsers.
+func (mr *MockFlapsClientMockRecorder) ListManagedPostgresUsers(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListManagedPostgresUsers", reflect.TypeOf((*MockFlapsClient)(nil).ListManagedPostgresUsers), ctx, id)
+}
+
 // ListSecretKeys mocks base method.
 func (m *MockFlapsClient) ListSecretKeys(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error) {
 	m.ctrl.T.Helper()
@@ -1059,6 +1103,20 @@ func (m *MockFlapsClient) UpdateAppSecrets(ctx context.Context, appName string, 
 func (mr *MockFlapsClientMockRecorder) UpdateAppSecrets(ctx, appName, values any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAppSecrets", reflect.TypeOf((*MockFlapsClient)(nil).UpdateAppSecrets), ctx, appName, values)
+}
+
+// UpdateManagedPostgresUserRole mocks base method.
+func (m *MockFlapsClient) UpdateManagedPostgresUserRole(ctx context.Context, id, username string, req flaps.UpdateManagedPostgresUserRoleRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateManagedPostgresUserRole", ctx, id, username, req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateManagedPostgresUserRole indicates an expected call of UpdateManagedPostgresUserRole.
+func (mr *MockFlapsClientMockRecorder) UpdateManagedPostgresUserRole(ctx, id, username, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateManagedPostgresUserRole", reflect.TypeOf((*MockFlapsClient)(nil).UpdateManagedPostgresUserRole), ctx, id, username, req)
 }
 
 // UpdateVolume mocks base method.

--- a/internal/build/imgsrc/flaps_mock_test.go
+++ b/internal/build/imgsrc/flaps_mock_test.go
@@ -406,6 +406,34 @@ func (mr *MockFlapsClientMockRecorder) DeleteVolume(ctx, appName, volumeId any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockFlapsClient)(nil).DeleteVolume), ctx, appName, volumeId)
 }
 
+// DisableManagedPostgresExtension mocks base method.
+func (m *MockFlapsClient) DisableManagedPostgresExtension(ctx context.Context, id, database, name string, force bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DisableManagedPostgresExtension", ctx, id, database, name, force)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DisableManagedPostgresExtension indicates an expected call of DisableManagedPostgresExtension.
+func (mr *MockFlapsClientMockRecorder) DisableManagedPostgresExtension(ctx, id, database, name, force any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableManagedPostgresExtension", reflect.TypeOf((*MockFlapsClient)(nil).DisableManagedPostgresExtension), ctx, id, database, name, force)
+}
+
+// EnableManagedPostgresExtension mocks base method.
+func (m *MockFlapsClient) EnableManagedPostgresExtension(ctx context.Context, id, database string, req flaps.EnableManagedPostgresExtensionRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnableManagedPostgresExtension", ctx, id, database, req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnableManagedPostgresExtension indicates an expected call of EnableManagedPostgresExtension.
+func (mr *MockFlapsClientMockRecorder) EnableManagedPostgresExtension(ctx, id, database, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableManagedPostgresExtension", reflect.TypeOf((*MockFlapsClient)(nil).EnableManagedPostgresExtension), ctx, id, database, req)
+}
+
 // Destroy mocks base method.
 func (m *MockFlapsClient) Destroy(ctx context.Context, appName string, input fly.RemoveMachineInput, nonce string) error {
 	m.ctrl.T.Helper()
@@ -884,6 +912,21 @@ func (m *MockFlapsClient) ListManagedPostgresUsers(ctx context.Context, id strin
 func (mr *MockFlapsClientMockRecorder) ListManagedPostgresUsers(ctx, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListManagedPostgresUsers", reflect.TypeOf((*MockFlapsClient)(nil).ListManagedPostgresUsers), ctx, id)
+}
+
+// ListManagedPostgresExtensions mocks base method.
+func (m *MockFlapsClient) ListManagedPostgresExtensions(ctx context.Context, id, database string) ([]flaps.ManagedPostgresExtension, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListManagedPostgresExtensions", ctx, id, database)
+	ret0, _ := ret[0].([]flaps.ManagedPostgresExtension)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListManagedPostgresExtensions indicates an expected call of ListManagedPostgresExtensions.
+func (mr *MockFlapsClientMockRecorder) ListManagedPostgresExtensions(ctx, id, database any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListManagedPostgresExtensions", reflect.TypeOf((*MockFlapsClient)(nil).ListManagedPostgresExtensions), ctx, id, database)
 }
 
 // ListSecretKeys mocks base method.

--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -165,6 +165,10 @@ func (m *mockFlapsClient) CreateManagedPostgresBackup(ctx context.Context, id st
 	return fmt.Errorf("not implemented")
 }
 
+func (m *mockFlapsClient) EnableManagedPostgresExtension(ctx context.Context, id, database string, req flaps.EnableManagedPostgresExtensionRequest) error {
+	return fmt.Errorf("not implemented")
+}
+
 func (m *mockFlapsClient) CreateVolume(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error) {
 	return nil, fmt.Errorf("failed to create volume %s", req.Name)
 }
@@ -194,6 +198,10 @@ func (m *mockFlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id s
 }
 
 func (m *mockFlapsClient) DeleteManagedPostgresUser(ctx context.Context, id, username string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockFlapsClient) DisableManagedPostgresExtension(ctx context.Context, id, database, name string, force bool) error {
 	return fmt.Errorf("not implemented")
 }
 
@@ -472,6 +480,10 @@ func (m *mockFlapsClient) ListManagedPostgresUsers(ctx context.Context, id strin
 }
 
 func (m *mockFlapsClient) ListManagedPostgresBackups(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockFlapsClient) ListManagedPostgresExtensions(ctx context.Context, id, database string) ([]flaps.ManagedPostgresExtension, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -157,6 +157,10 @@ func (m *mockFlapsClient) CreateManagedPostgresDatabase(ctx context.Context, id 
 	return flaps.ManagedPostgresDatabase{}, fmt.Errorf("not implemented")
 }
 
+func (m *mockFlapsClient) CreateManagedPostgresUser(ctx context.Context, id string, req flaps.CreateManagedPostgresUserRequest) (flaps.ManagedPostgresUser, error) {
+	return flaps.ManagedPostgresUser{}, fmt.Errorf("not implemented")
+}
+
 func (m *mockFlapsClient) CreateManagedPostgresBackup(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error {
 	return fmt.Errorf("not implemented")
 }
@@ -186,6 +190,10 @@ func (m *mockFlapsClient) DeleteCustomCertificate(ctx context.Context, appName, 
 }
 
 func (m *mockFlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (m *mockFlapsClient) DeleteManagedPostgresUser(ctx context.Context, id, username string) error {
 	return fmt.Errorf("not implemented")
 }
 
@@ -459,6 +467,10 @@ func (m *mockFlapsClient) ListManagedPostgresDatabases(ctx context.Context, id s
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (m *mockFlapsClient) ListManagedPostgresUsers(ctx context.Context, id string) ([]flaps.ManagedPostgresUser, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func (m *mockFlapsClient) ListManagedPostgresBackups(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error) {
 	return nil, fmt.Errorf("not implemented")
 }
@@ -607,6 +619,10 @@ func (m *mockFlapsClient) Update(ctx context.Context, appName string, builder fl
 
 func (m *mockFlapsClient) UpdateAppSecrets(ctx context.Context, appName string, values map[string]*string) (*fly.UpdateAppSecretsResp, error) {
 	return nil, fmt.Errorf("failed to update app secret %v", values)
+}
+
+func (m *mockFlapsClient) UpdateManagedPostgresUserRole(ctx context.Context, id, username string, req flaps.UpdateManagedPostgresUserRoleRequest) error {
+	return fmt.Errorf("not implemented")
 }
 
 func (m *mockFlapsClient) UpdateVolume(ctx context.Context, appName, volumeId string, req fly.UpdateVolumeRequest) (*fly.Volume, error) {

--- a/internal/command/mpg/v2/run_extensions.go
+++ b/internal/command/mpg/v2/run_extensions.go
@@ -2,9 +2,12 @@ package cmdv2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
 	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
@@ -14,24 +17,35 @@ import (
 func RunExtensionsList(ctx context.Context, clusterID, database string) error {
 	cfg := config.FromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
-	mpgClient := mpgv2.ClientFromContext(ctx)
 
 	database, err := resolveDatabase(ctx, clusterID, database)
 	if err != nil {
 		return err
 	}
 
-	resp, err := mpgClient.ListExtensions(ctx, clusterID, database)
-	if err != nil {
+	extensions, err := flapsutil.ClientFromContext(ctx).ListManagedPostgresExtensions(ctx, clusterID, database)
+	var outputExtensions []mpgv2.Extension
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		resp, legacyErr := mpgv2.ClientFromContext(ctx).ListExtensions(ctx, clusterID, database)
+		if legacyErr != nil {
+			return fmt.Errorf("failed to list extensions for database %s: %w", database, legacyErr)
+		}
+		outputExtensions = resp.Data
+	} else if err != nil {
 		return fmt.Errorf("failed to list extensions for database %s: %w", database, err)
+	} else {
+		outputExtensions = make([]mpgv2.Extension, 0, len(extensions))
+		for _, ext := range extensions {
+			outputExtensions = append(outputExtensions, extensionForOutput(ext))
+		}
 	}
 
 	if cfg.JSONOutput {
-		return render.JSON(out, resp.Data)
+		return render.JSON(out, outputExtensions)
 	}
 
-	rows := make([][]string, 0, len(resp.Data))
-	for _, ext := range resp.Data {
+	rows := make([][]string, 0, len(outputExtensions))
+	for _, ext := range outputExtensions {
 		installed := "no"
 		version := ""
 		schema := ""
@@ -55,7 +69,6 @@ func RunExtensionsList(ctx context.Context, clusterID, database string) error {
 
 func RunExtensionsEnable(ctx context.Context, clusterID, database, name, schema string, createSchema bool) error {
 	out := iostreams.FromContext(ctx).Out
-	mpgClient := mpgv2.ClientFromContext(ctx)
 
 	database, err := resolveDatabase(ctx, clusterID, database)
 	if err != nil {
@@ -69,13 +82,21 @@ func RunExtensionsEnable(ctx context.Context, clusterID, database, name, schema 
 		createSchema = true
 	}
 
-	input := mpgv2.EnableExtensionInput{
-		Name:                 name,
-		Schema:               schema,
-		CreateSchemaIfNeeded: createSchema,
+	input := flaps.EnableManagedPostgresExtensionRequest{
+		Name:         name,
+		Schema:       schema,
+		CreateSchema: createSchema,
 	}
 
-	if err := mpgClient.EnableExtension(ctx, clusterID, database, input); err != nil {
+	err = flapsutil.ClientFromContext(ctx).EnableManagedPostgresExtension(ctx, clusterID, database, input)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		err = mpgv2.ClientFromContext(ctx).EnableExtension(ctx, clusterID, database, mpgv2.EnableExtensionInput{
+			Name:                 name,
+			Schema:               schema,
+			CreateSchemaIfNeeded: createSchema,
+		})
+	}
+	if err != nil {
 		return err
 	}
 
@@ -86,20 +107,48 @@ func RunExtensionsEnable(ctx context.Context, clusterID, database, name, schema 
 
 func RunExtensionsDisable(ctx context.Context, clusterID, database, name string, force bool) error {
 	out := iostreams.FromContext(ctx).Out
-	mpgClient := mpgv2.ClientFromContext(ctx)
 
 	database, err := resolveDatabase(ctx, clusterID, database)
 	if err != nil {
 		return err
 	}
 
-	if err := mpgClient.DisableExtension(ctx, clusterID, database, name, force); err != nil {
+	err = flapsutil.ClientFromContext(ctx).DisableManagedPostgresExtension(ctx, clusterID, database, name, force)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		err = mpgv2.ClientFromContext(ctx).DisableExtension(ctx, clusterID, database, name, force)
+	}
+	if err != nil {
 		return err
 	}
 
 	fmt.Fprintf(out, "Extension %s disabled on database %s.\n", name, database)
 
 	return nil
+}
+
+func extensionForOutput(ext flaps.ManagedPostgresExtension) mpgv2.Extension {
+	legacy := mpgv2.Extension{
+		Name:           ext.Name,
+		Description:    optionalString(ext.Description),
+		DefaultVersion: optionalString(ext.DefaultVersion),
+		IsSystem:       ext.System,
+	}
+	if ext.Installed != nil {
+		legacy.Installed = &mpgv2.InstalledExtension{
+			Version: ext.Installed.Version,
+			Schema:  ext.Installed.Schema,
+		}
+	}
+
+	return legacy
+}
+
+func optionalString(value *string) string {
+	if value == nil {
+		return ""
+	}
+
+	return *value
 }
 
 // resolveDatabase returns the database to target: the explicit flag value if
@@ -111,18 +160,26 @@ func resolveDatabase(ctx context.Context, clusterID, database string) (string, e
 		return database, nil
 	}
 
-	mpgClient := mpgv2.ClientFromContext(ctx)
-	dbs, err := mpgClient.ListDatabases(ctx, clusterID)
-	if err != nil {
+	databases, err := flapsutil.ClientFromContext(ctx).ListManagedPostgresDatabases(ctx, clusterID)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		response, legacyErr := mpgv2.ClientFromContext(ctx).ListDatabases(ctx, clusterID)
+		if legacyErr != nil {
+			return "", fmt.Errorf("failed to list databases: %w", legacyErr)
+		}
+		databases = make([]flaps.ManagedPostgresDatabase, 0, len(response.Data))
+		for _, database := range response.Data {
+			databases = append(databases, flaps.ManagedPostgresDatabase{Name: database.Name})
+		}
+	} else if err != nil {
 		return "", fmt.Errorf("failed to list databases: %w", err)
 	}
 
-	if len(dbs.Data) == 0 {
+	if len(databases) == 0 {
 		return "", fmt.Errorf("no databases found in cluster %s", clusterID)
 	}
 
-	if len(dbs.Data) == 1 {
-		return dbs.Data[0].Name, nil
+	if len(databases) == 1 {
+		return databases[0].Name, nil
 	}
 
 	io := iostreams.FromContext(ctx)
@@ -130,8 +187,8 @@ func resolveDatabase(ctx context.Context, clusterID, database string) (string, e
 		return "", prompt.NonInteractiveError("the cluster has multiple databases; pass --database to choose one")
 	}
 
-	options := make([]string, 0, len(dbs.Data))
-	for _, db := range dbs.Data {
+	options := make([]string, 0, len(databases))
+	for _, db := range databases {
 		options = append(options, db.Name)
 	}
 
@@ -140,5 +197,5 @@ func resolveDatabase(ctx context.Context, clusterID, database string) (string, e
 		return "", err
 	}
 
-	return dbs.Data[idx].Name, nil
+	return databases[idx].Name, nil
 }

--- a/internal/command/mpg/v2/run_extensions_test.go
+++ b/internal/command/mpg/v2/run_extensions_test.go
@@ -139,6 +139,7 @@ func TestRunExtensionsList(t *testing.T) {
 					require.Equal(t, []map[string]any{{
 						"name": "hstore", "description": "", "docs_url": "", "default_version": "", "is_system": false, "installed": nil,
 					}}, got)
+
 					return
 				}
 				docsURL := ""
@@ -285,6 +286,7 @@ func TestResolveDatabaseUsesPublicAPIWithLegacyFallback(t *testing.T) {
 		ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
 			ListManagedPostgresDatabasesFunc: func(_ context.Context, id string) ([]flaps.ManagedPostgresDatabase, error) {
 				require.Equal(t, "mpg-123", id)
+
 				return []flaps.ManagedPostgresDatabase{{Name: "only-db"}}, nil
 			},
 		})
@@ -305,6 +307,7 @@ func TestResolveDatabaseUsesPublicAPIWithLegacyFallback(t *testing.T) {
 			ListDatabasesFunc: func(_ context.Context, id string) (mpgv2.ListDatabasesResponse, error) {
 				legacyCalls++
 				require.Equal(t, "mpg-123", id)
+
 				return mpgv2.ListDatabasesResponse{Data: []mpgv2.Database{{Name: "legacy-db"}}}, nil
 			},
 		})

--- a/internal/command/mpg/v2/run_extensions_test.go
+++ b/internal/command/mpg/v2/run_extensions_test.go
@@ -1,0 +1,327 @@
+package cmdv2
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/mock"
+	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func extensionsTestContext(t *testing.T, jsonOutput bool) (context.Context, *bytes.Buffer) {
+	t.Helper()
+
+	io, _, stdout, _ := iostreams.Test()
+	ctx := iostreams.NewContext(context.Background(), io)
+	ctx = config.NewContext(ctx, &config.Config{JSONOutput: jsonOutput})
+
+	return ctx, stdout
+}
+
+func TestRunExtensionsList(t *testing.T) {
+	publicExtensions := []flaps.ManagedPostgresExtension{
+		{Name: "pg_trgm", Description: stringPointer("text similarity"), DefaultVersion: stringPointer("1.6")},
+		{Name: "plpgsql", Description: stringPointer("PL/pgSQL"), DefaultVersion: stringPointer("1.0"), System: true, Installed: &flaps.ManagedPostgresInstalledExtension{Version: "1.0", Schema: "pg_catalog"}},
+	}
+	nullMetadataExtensions := []flaps.ManagedPostgresExtension{{Name: "hstore"}}
+	legacyExtensions := []mpgv2.Extension{
+		{Name: "pg_trgm", Description: "text similarity", DocsURL: "https://example.test/pg_trgm", DefaultVersion: "1.6"},
+		{Name: "plpgsql", Description: "PL/pgSQL", DefaultVersion: "1.0", IsSystem: true, Installed: &mpgv2.InstalledExtension{Version: "1.0", Schema: "pg_catalog"}},
+	}
+
+	tests := []struct {
+		name             string
+		jsonOutput       bool
+		nullMetadata     bool
+		publicExtensions []flaps.ManagedPostgresExtension
+		publicErr        error
+		legacyExtensions []mpgv2.Extension
+		legacyErr        error
+		wantLegacyCalls  int
+		wantErr          string
+		wantOutput       []string
+	}{
+		{
+			name:             "public success renders installed and uninstalled table rows",
+			publicExtensions: publicExtensions,
+			wantOutput:       []string{"Extensions in database app", "pg_trgm", "no", "plpgsql", "yes", "1.0", "pg_catalog", "PL/pgSQL"},
+		},
+		{
+			name:             "public success preserves legacy JSON shape",
+			jsonOutput:       true,
+			publicExtensions: publicExtensions,
+		},
+		{
+			name:             "public null metadata renders blank table fields",
+			publicExtensions: nullMetadataExtensions,
+			wantOutput:       []string{"Extensions in database app", "hstore", "no"},
+		},
+		{
+			name:             "public null metadata preserves legacy JSON shape",
+			jsonOutput:       true,
+			nullMetadata:     true,
+			publicExtensions: nullMetadataExtensions,
+		},
+		{
+			name:             "classified 404 falls back",
+			publicErr:        fmt.Errorf("wrapped: %w", flaps.ErrFlapsNotFound),
+			legacyExtensions: legacyExtensions,
+			wantLegacyCalls:  1,
+			wantOutput:       []string{"pg_trgm", "plpgsql", "yes", "pg_catalog"},
+		},
+		{
+			name:             "classified 404 preserves legacy JSON fields",
+			jsonOutput:       true,
+			publicErr:        flaps.ErrFlapsNotFound,
+			legacyExtensions: legacyExtensions,
+			wantLegacyCalls:  1,
+		},
+		{
+			name:            "fallback preserves legacy error",
+			publicErr:       flaps.ErrFlapsNotFound,
+			legacyErr:       errors.New("legacy denied"),
+			wantLegacyCalls: 1,
+			wantErr:         "failed to list extensions for database app: legacy denied",
+		},
+		{
+			name:      "non-404 public error is authoritative",
+			publicErr: errors.New("public unavailable"),
+			wantErr:   "failed to list extensions for database app: public unavailable",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, stdout := extensionsTestContext(t, test.jsonOutput)
+			publicCalls := 0
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				ListManagedPostgresExtensionsFunc: func(_ context.Context, id, database string) ([]flaps.ManagedPostgresExtension, error) {
+					publicCalls++
+					require.Equal(t, "mpg-123", id)
+					require.Equal(t, "app", database)
+
+					return test.publicExtensions, test.publicErr
+				},
+			})
+			legacyCalls := 0
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+				ListExtensionsFunc: func(_ context.Context, id, database string) (mpgv2.ListExtensionsResponse, error) {
+					legacyCalls++
+					require.Equal(t, "mpg-123", id)
+					require.Equal(t, "app", database)
+
+					return mpgv2.ListExtensionsResponse{Data: test.legacyExtensions}, test.legacyErr
+				},
+			})
+
+			err := RunExtensionsList(ctx, "mpg-123", "app")
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, 1, publicCalls)
+			require.Equal(t, test.wantLegacyCalls, legacyCalls)
+
+			if test.jsonOutput {
+				var got []map[string]any
+				require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+				if test.nullMetadata {
+					require.Equal(t, []map[string]any{{
+						"name": "hstore", "description": "", "docs_url": "", "default_version": "", "is_system": false, "installed": nil,
+					}}, got)
+					return
+				}
+				docsURL := ""
+				if test.wantLegacyCalls == 1 {
+					docsURL = "https://example.test/pg_trgm"
+				}
+				require.Equal(t, []map[string]any{
+					{"name": "pg_trgm", "description": "text similarity", "docs_url": docsURL, "default_version": "1.6", "is_system": false, "installed": nil},
+					{"name": "plpgsql", "description": "PL/pgSQL", "docs_url": "", "default_version": "1.0", "is_system": true, "installed": map[string]any{"version": "1.0", "schema": "pg_catalog"}},
+				}, got)
+			}
+			for _, want := range test.wantOutput {
+				require.Contains(t, stdout.String(), want)
+			}
+		})
+	}
+}
+
+func stringPointer(value string) *string {
+	return &value
+}
+
+func TestRunExtensionsEnable(t *testing.T) {
+	tests := []struct {
+		name            string
+		extension       string
+		schema          string
+		createSchema    bool
+		publicErr       error
+		legacyErr       error
+		wantPublicReq   flaps.EnableManagedPostgresExtensionRequest
+		wantLegacyCalls int
+		wantErr         string
+	}{
+		{name: "maps public request options", extension: "hstore", schema: "addons", createSchema: true, wantPublicReq: flaps.EnableManagedPostgresExtensionRequest{Name: "hstore", Schema: "addons", CreateSchema: true}},
+		{name: "defaults postgis topology schema", extension: "postgis_topology", wantPublicReq: flaps.EnableManagedPostgresExtensionRequest{Name: "postgis_topology", Schema: "topology", CreateSchema: true}},
+		{name: "classified 404 falls back with legacy request mapping", extension: "hstore", schema: "addons", createSchema: true, publicErr: flaps.ErrFlapsNotFound, wantPublicReq: flaps.EnableManagedPostgresExtensionRequest{Name: "hstore", Schema: "addons", CreateSchema: true}, wantLegacyCalls: 1},
+		{name: "fallback returns legacy error", extension: "hstore", publicErr: flaps.ErrFlapsNotFound, legacyErr: errors.New("legacy denied"), wantPublicReq: flaps.EnableManagedPostgresExtensionRequest{Name: "hstore"}, wantLegacyCalls: 1, wantErr: "legacy denied"},
+		{name: "non-404 public error is authoritative", extension: "hstore", publicErr: errors.New("public denied"), wantPublicReq: flaps.EnableManagedPostgresExtensionRequest{Name: "hstore"}, wantErr: "public denied"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, stdout := extensionsTestContext(t, false)
+			publicCalls := 0
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				EnableManagedPostgresExtensionFunc: func(_ context.Context, id, database string, req flaps.EnableManagedPostgresExtensionRequest) error {
+					publicCalls++
+					require.Equal(t, "mpg-123", id)
+					require.Equal(t, "app", database)
+					require.Equal(t, test.wantPublicReq, req)
+
+					return test.publicErr
+				},
+			})
+			legacyCalls := 0
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+				EnableExtensionFunc: func(_ context.Context, id, database string, input mpgv2.EnableExtensionInput) error {
+					legacyCalls++
+					require.Equal(t, test.wantPublicReq.Name, input.Name)
+					require.Equal(t, test.wantPublicReq.Schema, input.Schema)
+					require.Equal(t, test.wantPublicReq.CreateSchema, input.CreateSchemaIfNeeded)
+
+					return test.legacyErr
+				},
+			})
+
+			err := RunExtensionsEnable(ctx, "mpg-123", "app", test.extension, test.schema, test.createSchema)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Contains(t, stdout.String(), "Extension "+test.extension+" enabled on database app.")
+			}
+			require.Equal(t, 1, publicCalls)
+			require.Equal(t, test.wantLegacyCalls, legacyCalls)
+		})
+	}
+}
+
+func TestRunExtensionsDisable(t *testing.T) {
+	tests := []struct {
+		name            string
+		force           bool
+		publicErr       error
+		legacyErr       error
+		wantLegacyCalls int
+		wantErr         string
+	}{
+		{name: "public success maps force", force: true},
+		{name: "classified 404 falls back", force: true, publicErr: flaps.ErrFlapsNotFound, wantLegacyCalls: 1},
+		{name: "fallback returns legacy error", publicErr: flaps.ErrFlapsNotFound, legacyErr: errors.New("legacy denied"), wantLegacyCalls: 1, wantErr: "legacy denied"},
+		{name: "non-404 public error is authoritative", publicErr: errors.New("public denied"), wantErr: "public denied"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, stdout := extensionsTestContext(t, false)
+			publicCalls := 0
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				DisableManagedPostgresExtensionFunc: func(_ context.Context, id, database, name string, force bool) error {
+					publicCalls++
+					require.Equal(t, "mpg-123", id)
+					require.Equal(t, "app", database)
+					require.Equal(t, "hstore", name)
+					require.Equal(t, test.force, force)
+
+					return test.publicErr
+				},
+			})
+			legacyCalls := 0
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+				DisableExtensionFunc: func(_ context.Context, id, database, name string, force bool) error {
+					legacyCalls++
+					require.Equal(t, test.force, force)
+
+					return test.legacyErr
+				},
+			})
+
+			err := RunExtensionsDisable(ctx, "mpg-123", "app", "hstore", test.force)
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Contains(t, stdout.String(), "Extension hstore disabled on database app.")
+			}
+			require.Equal(t, 1, publicCalls)
+			require.Equal(t, test.wantLegacyCalls, legacyCalls)
+		})
+	}
+}
+
+func TestResolveDatabaseUsesPublicAPIWithLegacyFallback(t *testing.T) {
+	t.Run("explicit database skips resolution", func(t *testing.T) {
+		ctx, _ := extensionsTestContext(t, false)
+		database, err := resolveDatabase(ctx, "mpg-123", "explicit-db")
+		require.NoError(t, err)
+		require.Equal(t, "explicit-db", database)
+	})
+
+	t.Run("public success", func(t *testing.T) {
+		ctx, _ := extensionsTestContext(t, false)
+		ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+			ListManagedPostgresDatabasesFunc: func(_ context.Context, id string) ([]flaps.ManagedPostgresDatabase, error) {
+				require.Equal(t, "mpg-123", id)
+				return []flaps.ManagedPostgresDatabase{{Name: "only-db"}}, nil
+			},
+		})
+		database, err := resolveDatabase(ctx, "mpg-123", "")
+		require.NoError(t, err)
+		require.Equal(t, "only-db", database)
+	})
+
+	t.Run("classified 404 falls back", func(t *testing.T) {
+		ctx, _ := extensionsTestContext(t, false)
+		ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+			ListManagedPostgresDatabasesFunc: func(context.Context, string) ([]flaps.ManagedPostgresDatabase, error) {
+				return nil, flaps.ErrFlapsNotFound
+			},
+		})
+		legacyCalls := 0
+		ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+			ListDatabasesFunc: func(_ context.Context, id string) (mpgv2.ListDatabasesResponse, error) {
+				legacyCalls++
+				require.Equal(t, "mpg-123", id)
+				return mpgv2.ListDatabasesResponse{Data: []mpgv2.Database{{Name: "legacy-db"}}}, nil
+			},
+		})
+		database, err := resolveDatabase(ctx, "mpg-123", "")
+		require.NoError(t, err)
+		require.Equal(t, "legacy-db", database)
+		require.Equal(t, 1, legacyCalls)
+	})
+
+	t.Run("non-404 public error is authoritative", func(t *testing.T) {
+		ctx, _ := extensionsTestContext(t, false)
+		ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+			ListManagedPostgresDatabasesFunc: func(context.Context, string) ([]flaps.ManagedPostgresDatabase, error) {
+				return nil, errors.New("public denied")
+			},
+		})
+		_, err := resolveDatabase(ctx, "mpg-123", "")
+		require.ErrorContains(t, err, "failed to list databases: public denied")
+	})
+}

--- a/internal/command/mpg/v2/run_users.go
+++ b/internal/command/mpg/v2/run_users.go
@@ -2,38 +2,76 @@ package cmdv2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
 	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
 	"github.com/superfly/flyctl/iostreams"
 )
 
+// managedPostgresUserRoleOptions lists the roles the CLI exposes to the user
+// when prompting interactively, in the order they are presented. Keeping this
+// derived from the flaps package constants ensures the prompt and the request
+// body cannot drift from the API's accepted set.
+var managedPostgresUserRoleOptions = []string{
+	string(flaps.ManagedPostgresUserRoleSchemaAdmin),
+	string(flaps.ManagedPostgresUserRoleWriter),
+	string(flaps.ManagedPostgresUserRoleReader),
+}
+
+// publicUserToLegacy converts the public response to the legacy output shape.
+func publicUserToLegacy(u flaps.ManagedPostgresUser) mpgv2.User {
+	return mpgv2.User{Name: u.Username, Role: string(u.Role)}
+}
+
+func listUsers(ctx context.Context, clusterID string) ([]mpgv2.User, error) {
+	publicUsers, err := flapsutil.ClientFromContext(ctx).ListManagedPostgresUsers(ctx, clusterID)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		response, legacyErr := mpgv2.ClientFromContext(ctx).ListUsers(ctx, clusterID)
+		if legacyErr != nil {
+			return nil, legacyErr
+		}
+
+		return response.Data, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	users := make([]mpgv2.User, 0, len(publicUsers))
+	for _, user := range publicUsers {
+		users = append(users, publicUserToLegacy(user))
+	}
+
+	return users, nil
+}
+
 func RunUsersList(ctx context.Context, clusterID string) error {
 	cfg := config.FromContext(ctx)
 	out := iostreams.FromContext(ctx).Out
-	mpgClient := mpgv2.ClientFromContext(ctx)
-
-	users, err := mpgClient.ListUsers(ctx, clusterID)
+	users, err := listUsers(ctx, clusterID)
 	if err != nil {
 		return fmt.Errorf("failed to list users for cluster %s: %w", clusterID, err)
 	}
 
-	if len(users.Data) == 0 {
+	if len(users) == 0 {
 		fmt.Fprintf(out, "No users found for cluster %s\n", clusterID)
 
 		return nil
 	}
 
 	if cfg.JSONOutput {
-		return render.JSON(out, users.Data)
+		return render.JSON(out, users)
 	}
 
-	rows := make([][]string, 0, len(users.Data))
-	for _, user := range users.Data {
+	rows := make([][]string, 0, len(users))
+	for _, user := range users {
 		rows = append(rows, []string{
 			user.Name,
 			user.Role,
@@ -45,7 +83,7 @@ func RunUsersList(ctx context.Context, clusterID string) error {
 
 func RunUsersCreate(ctx context.Context, clusterID string) error {
 	out := iostreams.FromContext(ctx).Out
-	mpgClient := mpgv2.ClientFromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	username := flag.GetString(ctx, "username")
 	if username == "" {
@@ -64,9 +102,9 @@ func RunUsersCreate(ctx context.Context, clusterID string) error {
 
 	role := flag.GetString(ctx, "role")
 	validRoles := map[string]bool{
-		"schema_admin": true,
-		"writer":       true,
-		"reader":       true,
+		string(flaps.ManagedPostgresUserRoleSchemaAdmin): true,
+		string(flaps.ManagedPostgresUserRoleWriter):      true,
+		string(flaps.ManagedPostgresUserRoleReader):      true,
 	}
 
 	if role == "" {
@@ -76,38 +114,46 @@ func RunUsersCreate(ctx context.Context, clusterID string) error {
 		}
 		// Prompt for role selection
 		var roleIndex int
-		roleOptions := []string{"schema_admin", "writer", "reader"}
-		err := prompt.Select(ctx, &roleIndex, "Select user role:", "", roleOptions...)
+		err := prompt.Select(ctx, &roleIndex, "Select user role:", "", managedPostgresUserRoleOptions...)
 		if err != nil {
 			return err
 		}
-		role = roleOptions[roleIndex]
+		role = managedPostgresUserRoleOptions[roleIndex]
 	} else if !validRoles[role] {
-		return fmt.Errorf("invalid role %q. Must be one of: schema_admin, writer, reader", role)
+		return fmt.Errorf("invalid role %q. Must be one of: %s, %s, %s", role, flaps.ManagedPostgresUserRoleSchemaAdmin, flaps.ManagedPostgresUserRoleWriter, flaps.ManagedPostgresUserRoleReader)
 	}
 
 	fmt.Fprintf(out, "Creating user %s with role %s in cluster %s...\n", username, role, clusterID)
 
-	input := mpgv2.CreateUserWithRoleInput{
+	input := flaps.CreateManagedPostgresUserRequest{
 		Username: username,
 		Role:     role,
 	}
 
-	response, err := mpgClient.CreateUserWithRole(ctx, clusterID, input)
-	if err != nil {
+	response, err := flapsClient.CreateManagedPostgresUser(ctx, clusterID, input)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		legacyResponse, legacyErr := mpgv2.ClientFromContext(ctx).CreateUserWithRole(ctx, clusterID, mpgv2.CreateUserWithRoleInput(input))
+		if legacyErr != nil {
+			return fmt.Errorf("failed to create user: %w", legacyErr)
+		}
+		response = flaps.ManagedPostgresUser{
+			Username: legacyResponse.Data.Name,
+			Role:     flaps.ManagedPostgresUserRole(legacyResponse.Data.Role),
+		}
+	} else if err != nil {
 		return fmt.Errorf("failed to create user: %w", err)
 	}
 
 	fmt.Fprintf(out, "User created successfully!\n")
-	fmt.Fprintf(out, "  Name: %s\n", response.Data.Name)
-	fmt.Fprintf(out, "  Role: %s\n", response.Data.Role)
+	fmt.Fprintf(out, "  Name: %s\n", response.Username)
+	fmt.Fprintf(out, "  Role: %s\n", string(response.Role))
 
 	return nil
 }
 
 func RunUsersSetRole(ctx context.Context, clusterID string) error {
 	out := iostreams.FromContext(ctx).Out
-	mpgClient := mpgv2.ClientFromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	username := flag.GetString(ctx, "username")
 	if username == "" {
@@ -117,18 +163,18 @@ func RunUsersSetRole(ctx context.Context, clusterID string) error {
 		}
 
 		// Get list of users to prompt from
-		usersResponse, err := mpgClient.ListUsers(ctx, clusterID)
+		users, err := listUsers(ctx, clusterID)
 		if err != nil {
 			return fmt.Errorf("failed to list users: %w", err)
 		}
 
-		if len(usersResponse.Data) == 0 {
+		if len(users) == 0 {
 			return fmt.Errorf("no users found in cluster %s", clusterID)
 		}
 
 		// Format users as options: "username [role]"
 		var userOptions []string
-		for _, user := range usersResponse.Data {
+		for _, user := range users {
 			userOptions = append(userOptions, fmt.Sprintf("%s [%s]", user.Name, user.Role))
 		}
 
@@ -138,14 +184,14 @@ func RunUsersSetRole(ctx context.Context, clusterID string) error {
 			return err
 		}
 
-		username = usersResponse.Data[userIndex].Name
+		username = users[userIndex].Name
 	}
 
 	role := flag.GetString(ctx, "role")
 	validRoles := map[string]bool{
-		"schema_admin": true,
-		"writer":       true,
-		"reader":       true,
+		string(flaps.ManagedPostgresUserRoleSchemaAdmin): true,
+		string(flaps.ManagedPostgresUserRoleWriter):      true,
+		string(flaps.ManagedPostgresUserRoleReader):      true,
 	}
 
 	if role == "" {
@@ -155,23 +201,25 @@ func RunUsersSetRole(ctx context.Context, clusterID string) error {
 		}
 		// Prompt for role selection
 		var roleIndex int
-		roleOptions := []string{"schema_admin", "writer", "reader"}
-		err := prompt.Select(ctx, &roleIndex, "Select user role:", "", roleOptions...)
+		err := prompt.Select(ctx, &roleIndex, "Select user role:", "", managedPostgresUserRoleOptions...)
 		if err != nil {
 			return err
 		}
-		role = roleOptions[roleIndex]
+		role = managedPostgresUserRoleOptions[roleIndex]
 	} else if !validRoles[role] {
-		return fmt.Errorf("invalid role %q. Must be one of: schema_admin, writer, reader", role)
+		return fmt.Errorf("invalid role %q. Must be one of: %s, %s, %s", role, flaps.ManagedPostgresUserRoleSchemaAdmin, flaps.ManagedPostgresUserRoleWriter, flaps.ManagedPostgresUserRoleReader)
 	}
 
 	fmt.Fprintf(out, "Updating user %s role to %s in cluster %s...\n", username, role, clusterID)
 
-	input := mpgv2.UpdateUserRoleInput{
+	input := flaps.UpdateManagedPostgresUserRoleRequest{
 		Role: role,
 	}
 
-	err := mpgClient.UpdateUserRole(ctx, clusterID, username, input)
+	err := flapsClient.UpdateManagedPostgresUserRole(ctx, clusterID, username, input)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		err = mpgv2.ClientFromContext(ctx).UpdateUserRole(ctx, clusterID, username, mpgv2.UpdateUserRoleInput(input))
+	}
 	if err != nil {
 		return fmt.Errorf("failed to update user role: %w", err)
 	}
@@ -187,7 +235,7 @@ func RunUsersDelete(ctx context.Context, clusterID string) error {
 	out := iostreams.FromContext(ctx).Out
 	io := iostreams.FromContext(ctx)
 	colorize := io.ColorScheme()
-	mpgClient := mpgv2.ClientFromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	username := flag.GetString(ctx, "username")
 	if username == "" {
@@ -196,18 +244,18 @@ func RunUsersDelete(ctx context.Context, clusterID string) error {
 		}
 
 		// Get list of users to prompt from
-		usersResponse, err := mpgClient.ListUsers(ctx, clusterID)
+		users, err := listUsers(ctx, clusterID)
 		if err != nil {
 			return fmt.Errorf("failed to list users: %w", err)
 		}
 
-		if len(usersResponse.Data) == 0 {
+		if len(users) == 0 {
 			return fmt.Errorf("no users found in cluster %s", clusterID)
 		}
 
 		// Format users as options: "username [role]"
 		var userOptions []string
-		for _, user := range usersResponse.Data {
+		for _, user := range users {
 			userOptions = append(userOptions, fmt.Sprintf("%s [%s]", user.Name, user.Role))
 		}
 
@@ -217,7 +265,7 @@ func RunUsersDelete(ctx context.Context, clusterID string) error {
 			return err
 		}
 
-		username = usersResponse.Data[userIndex].Name
+		username = users[userIndex].Name
 	}
 
 	if !flag.GetYes(ctx) {
@@ -238,7 +286,10 @@ func RunUsersDelete(ctx context.Context, clusterID string) error {
 
 	fmt.Fprintf(out, "Deleting user %s from cluster %s...\n", username, clusterID)
 
-	err := mpgClient.DeleteUser(ctx, clusterID, username)
+	err := flapsClient.DeleteManagedPostgresUser(ctx, clusterID, username)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		err = mpgv2.ClientFromContext(ctx).DeleteUser(ctx, clusterID, username)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to delete user: %w", err)
 	}

--- a/internal/command/mpg/v2/run_users_test.go
+++ b/internal/command/mpg/v2/run_users_test.go
@@ -1,0 +1,279 @@
+package cmdv2
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/mock"
+	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+// usersTestContext builds a context that mirrors the shape used by the mpg/v2
+// command package: a flag set for the user/role/yes flags, an iostreams pair
+// for table/JSON output, and the JSON output toggle carried on the config.
+func usersTestContext(t *testing.T, jsonOutput bool) (context.Context, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+
+	io, _, stdout, stderr := iostreams.Test()
+	ctx := iostreams.NewContext(context.Background(), io)
+	ctx = config.NewContext(ctx, &config.Config{JSONOutput: jsonOutput})
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("username", "", "")
+	flags.String("role", "", "")
+	flags.Bool("yes", false, "")
+
+	return flagctx.NewContext(ctx, flags), stdout, stderr
+}
+
+func wrappedNotFound() error {
+	return fmt.Errorf("public users: %w", &flaps.FlapsError{
+		ResponseStatusCode: 404,
+		OriginalError:      errors.New("not found"),
+	})
+}
+
+func TestRunUsersList(t *testing.T) {
+	tests := []struct {
+		name         string
+		jsonOutput   bool
+		publicUsers  []flaps.ManagedPostgresUser
+		publicErr    error
+		legacyUsers  []mpgv2.User
+		legacyErr    error
+		wantLegacy   bool
+		wantErr      string
+		wantContains []string
+		wantJSON     string
+	}{
+		{name: "public table", publicUsers: []flaps.ManagedPostgresUser{{Username: "app_user", Role: flaps.ManagedPostgresUserRoleWriter}}, wantContains: []string{"NAME", "ROLE", "app_user", "writer"}},
+		{name: "public JSON keeps legacy name shape", jsonOutput: true, publicUsers: []flaps.ManagedPostgresUser{{Username: "app_user", Role: flaps.ManagedPostgresUserRoleReader}}, wantJSON: `[{"name":"app_user","role":"reader"}]`},
+		{name: "public empty", wantContains: []string{"No users found for cluster mpg-123"}},
+		{name: "wrapped 404 fallback", publicErr: wrappedNotFound(), legacyUsers: []mpgv2.User{{Name: "legacy_user", Role: "schema_admin"}}, wantLegacy: true, wantContains: []string{"legacy_user", "schema_admin"}},
+		{name: "non-404 authoritative", publicErr: &flaps.FlapsError{ResponseStatusCode: 422, OriginalError: errors.New("invalid")}, wantErr: "failed to list users for cluster mpg-123", wantLegacy: false},
+		{name: "legacy failure", publicErr: flaps.ErrFlapsNotFound, legacyErr: errors.New("legacy boom"), wantLegacy: true, wantErr: "failed to list users for cluster mpg-123: legacy boom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, stdout, _ := usersTestContext(t, tt.jsonOutput)
+			publicCalls, legacyCalls := 0, 0
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{ListManagedPostgresUsersFunc: func(_ context.Context, id string) ([]flaps.ManagedPostgresUser, error) {
+				publicCalls++
+				require.Equal(t, "mpg-123", id)
+
+				return tt.publicUsers, tt.publicErr
+			}})
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{ListUsersFunc: func(_ context.Context, id string) (mpgv2.ListUsersResponse, error) {
+				legacyCalls++
+				require.Equal(t, "mpg-123", id)
+
+				return mpgv2.ListUsersResponse{Data: tt.legacyUsers}, tt.legacyErr
+			}})
+
+			err := RunUsersList(ctx, "mpg-123")
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, 1, publicCalls)
+			require.Equal(t, tt.wantLegacy, legacyCalls == 1)
+			for _, want := range tt.wantContains {
+				require.Contains(t, stdout.String(), want)
+			}
+			if tt.wantJSON != "" {
+				var got, want any
+				require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+				require.NoError(t, json.Unmarshal([]byte(tt.wantJSON), &want))
+				require.Equal(t, want, got)
+				require.NotContains(t, stdout.String(), "username")
+			}
+			require.NotContains(t, strings.ToLower(stdout.String()), "password")
+			require.NotContains(t, strings.ToLower(stdout.String()), "credential")
+		})
+	}
+}
+
+func TestRunUsersCreateRoutingAndValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		username   string
+		role       string
+		publicErr  error
+		legacyErr  error
+		wantPublic bool
+		wantLegacy bool
+		wantErr    string
+	}{
+		{name: "public success", username: "new_user", role: "writer", wantPublic: true},
+		{name: "wrapped 404 fallback", username: "new_user", role: "reader", publicErr: wrappedNotFound(), wantPublic: true, wantLegacy: true},
+		{name: "conflict authoritative", username: "new_user", role: "writer", publicErr: &flaps.FlapsError{ResponseStatusCode: 409, OriginalError: errors.New("exists")}, wantPublic: true, wantErr: "failed to create user"},
+		{name: "username required first", role: "writer", wantErr: "username must be specified"},
+		{name: "role required", username: "new_user", wantErr: "user role must be specified"},
+		{name: "role validated before API", username: "new_user", role: "owner", wantErr: `invalid role "owner"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, stdout, _ := usersTestContext(t, false)
+			if tt.username != "" {
+				require.NoError(t, flag.SetString(ctx, "username", tt.username))
+			}
+			if tt.role != "" {
+				require.NoError(t, flag.SetString(ctx, "role", tt.role))
+			}
+			publicCalls, legacyCalls := 0, 0
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{CreateManagedPostgresUserFunc: func(_ context.Context, id string, req flaps.CreateManagedPostgresUserRequest) (flaps.ManagedPostgresUser, error) {
+				publicCalls++
+				require.Equal(t, "mpg-123", id)
+				require.Equal(t, flaps.CreateManagedPostgresUserRequest{Username: tt.username, Role: tt.role}, req)
+
+				return flaps.ManagedPostgresUser{Username: tt.username, Role: flaps.ManagedPostgresUserRole(tt.role)}, tt.publicErr
+			}})
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{CreateUserWithRoleFunc: func(_ context.Context, id string, input mpgv2.CreateUserWithRoleInput) (mpgv2.CreateUserWithRoleResponse, error) {
+				legacyCalls++
+				require.Equal(t, mpgv2.CreateUserWithRoleInput{Username: tt.username, Role: tt.role}, input)
+
+				return mpgv2.CreateUserWithRoleResponse{Data: mpgv2.User{Name: tt.username, Role: tt.role}}, tt.legacyErr
+			}})
+			err := RunUsersCreate(ctx, "mpg-123")
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Contains(t, stdout.String(), "User created successfully!")
+			}
+			require.Equal(t, tt.wantPublic, publicCalls == 1)
+			require.Equal(t, tt.wantLegacy, legacyCalls == 1)
+		})
+	}
+}
+
+func TestRunUsersSetRoleRouting(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		publicErr    error
+		legacyErr    error
+		wantLegacy   bool
+		wantErr      string
+		wantExactErr string
+	}{
+		{name: "public success"},
+		{name: "wrapped 404 fallback", publicErr: wrappedNotFound(), wantLegacy: true},
+		{name: "wrapped 404 legacy failure", publicErr: wrappedNotFound(), legacyErr: errors.New("legacy update boom"), wantLegacy: true, wantExactErr: "failed to update user role: legacy update boom"},
+		{name: "server error authoritative", publicErr: &flaps.FlapsError{ResponseStatusCode: 500, OriginalError: errors.New("boom")}, wantErr: "failed to update user role"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, stdout, _ := usersTestContext(t, false)
+			require.NoError(t, flag.SetString(ctx, "username", "app_user"))
+			require.NoError(t, flag.SetString(ctx, "role", "reader"))
+			publicCalls, legacyCalls := 0, 0
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{UpdateManagedPostgresUserRoleFunc: func(_ context.Context, id, username string, req flaps.UpdateManagedPostgresUserRoleRequest) error {
+				publicCalls++
+				require.Equal(t, "mpg-123", id)
+				require.Equal(t, "app_user", username)
+				require.Equal(t, "reader", req.Role)
+
+				return tt.publicErr
+			}})
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{UpdateUserRoleFunc: func(_ context.Context, id, username string, input mpgv2.UpdateUserRoleInput) error {
+				legacyCalls++
+				require.Equal(t, "reader", input.Role)
+
+				return tt.legacyErr
+			}})
+			err := RunUsersSetRole(ctx, "mpg-123")
+			if tt.wantExactErr != "" {
+				require.EqualError(t, err, tt.wantExactErr)
+				require.NotContains(t, stdout.String(), "User role updated successfully!")
+			} else if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Contains(t, stdout.String(), "User role updated successfully!")
+			}
+			require.Equal(t, 1, publicCalls)
+			require.Equal(t, tt.wantLegacy, legacyCalls == 1)
+		})
+	}
+}
+
+func TestRunUsersDeleteRoutingAndYes(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		publicErr    error
+		legacyErr    error
+		wantLegacy   bool
+		wantErr      string
+		wantExactErr string
+	}{
+		{name: "public success"},
+		{name: "classified 404 fallback", publicErr: flaps.ErrFlapsNotFound, wantLegacy: true},
+		{name: "wrapped 404 legacy failure", publicErr: wrappedNotFound(), legacyErr: errors.New("legacy delete boom"), wantLegacy: true, wantExactErr: "failed to delete user: legacy delete boom"},
+		{name: "gone authoritative", publicErr: &flaps.FlapsError{ResponseStatusCode: 410, OriginalError: errors.New("gone")}, wantErr: "failed to delete user"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, stdout, stderr := usersTestContext(t, false)
+			require.NoError(t, flag.SetString(ctx, "username", "old_user"))
+			require.NoError(t, flag.FromContext(ctx).Set("yes", "true"))
+			publicCalls, legacyCalls := 0, 0
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{DeleteManagedPostgresUserFunc: func(_ context.Context, id, username string) error {
+				publicCalls++
+				require.Equal(t, "mpg-123", id)
+				require.Equal(t, "old_user", username)
+
+				return tt.publicErr
+			}})
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{DeleteUserFunc: func(_ context.Context, id, username string) error {
+				legacyCalls++
+
+				return tt.legacyErr
+			}})
+			err := RunUsersDelete(ctx, "mpg-123")
+			if tt.wantExactErr != "" {
+				require.EqualError(t, err, tt.wantExactErr)
+				require.NotContains(t, stdout.String(), "deleted successfully")
+			} else if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Contains(t, stdout.String(), "User old_user deleted successfully from cluster mpg-123")
+			}
+			require.Empty(t, stderr.String())
+			require.Equal(t, 1, publicCalls)
+			require.Equal(t, tt.wantLegacy, legacyCalls == 1)
+		})
+	}
+}
+
+func TestUsersInteractiveListUsesSameFallbackPolicy(t *testing.T) {
+	ctx, _, _ := usersTestContext(t, false)
+	publicCalls, legacyCalls := 0, 0
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{ListManagedPostgresUsersFunc: func(context.Context, string) ([]flaps.ManagedPostgresUser, error) {
+		publicCalls++
+
+		return nil, wrappedNotFound()
+	}})
+	ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{ListUsersFunc: func(context.Context, string) (mpgv2.ListUsersResponse, error) {
+		legacyCalls++
+
+		return mpgv2.ListUsersResponse{Data: []mpgv2.User{{Name: "select_user", Role: "writer"}}}, nil
+	}})
+	users, err := listUsers(ctx, "mpg-123")
+	require.NoError(t, err)
+	require.Equal(t, []mpgv2.User{{Name: "select_user", Role: "writer"}}, users)
+	require.Equal(t, 1, publicCalls)
+	require.Equal(t, 1, legacyCalls)
+}

--- a/internal/flapsutil/flaps_client.go
+++ b/internal/flapsutil/flaps_client.go
@@ -20,6 +20,7 @@ type FlapsClient interface {
 	CreateACMECertificate(ctx context.Context, appName string, req fly.CreateCertificateRequest) (*fly.CertificateDetailResponse, error)
 	CreateManagedPostgresCluster(ctx context.Context, req flaps.CreateManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error)
 	CreateManagedPostgresDatabase(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error)
+	CreateManagedPostgresUser(ctx context.Context, id string, req flaps.CreateManagedPostgresUserRequest) (flaps.ManagedPostgresUser, error)
 	CreateManagedPostgresBackup(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error
 	CreateVolume(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error)
 	CreateVolumeSnapshot(ctx context.Context, appName, volumeId string) error
@@ -28,6 +29,7 @@ type FlapsClient interface {
 	DeleteCertificate(ctx context.Context, appName, hostname string) error
 	DeleteCustomCertificate(ctx context.Context, appName, hostname string) error
 	DeleteManagedPostgresCluster(ctx context.Context, id string) error
+	DeleteManagedPostgresUser(ctx context.Context, id, username string) error
 	DeleteMetadata(ctx context.Context, appName, machineID, key string) error
 	DeleteAppSecret(ctx context.Context, appName, name string) (*fly.DeleteAppSecretResp, error)
 	DeleteIPAssignment(ctx context.Context, appName, ip string) (err error)
@@ -64,6 +66,7 @@ type FlapsClient interface {
 	ListFlyAppsMachines(ctx context.Context, appName string) ([]*fly.Machine, *fly.Machine, error)
 	ListManagedPostgresClusters(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error)
 	ListManagedPostgresDatabases(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error)
+	ListManagedPostgresUsers(ctx context.Context, id string) ([]flaps.ManagedPostgresUser, error)
 	ListManagedPostgresBackups(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error)
 	ListSecretKeys(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error)
 	NewRequest(ctx context.Context, method, path string, in any, headers map[string][]string) (*http.Request, error)
@@ -80,6 +83,7 @@ type FlapsClient interface {
 	Uncordon(ctx context.Context, appName, machineID string, nonce string) (err error)
 	Update(ctx context.Context, appName string, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error)
 	UpdateAppSecrets(ctx context.Context, appName string, values map[string]*string) (*fly.UpdateAppSecretsResp, error)
+	UpdateManagedPostgresUserRole(ctx context.Context, id, username string, req flaps.UpdateManagedPostgresUserRoleRequest) error
 	UpdateVolume(ctx context.Context, appName, volumeId string, req fly.UpdateVolumeRequest) (*fly.Volume, error)
 	Wait(ctx context.Context, appName string, machineID string, waitOpts ...flaps.WaitOption) (err error)
 	WaitForApp(ctx context.Context, name string) error

--- a/internal/flapsutil/flaps_client.go
+++ b/internal/flapsutil/flaps_client.go
@@ -22,6 +22,7 @@ type FlapsClient interface {
 	CreateManagedPostgresDatabase(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error)
 	CreateManagedPostgresUser(ctx context.Context, id string, req flaps.CreateManagedPostgresUserRequest) (flaps.ManagedPostgresUser, error)
 	CreateManagedPostgresBackup(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error
+	EnableManagedPostgresExtension(ctx context.Context, id, database string, req flaps.EnableManagedPostgresExtensionRequest) error
 	CreateVolume(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error)
 	CreateVolumeSnapshot(ctx context.Context, appName, volumeId string) error
 	DeleteApp(ctx context.Context, name string) error
@@ -30,6 +31,7 @@ type FlapsClient interface {
 	DeleteCustomCertificate(ctx context.Context, appName, hostname string) error
 	DeleteManagedPostgresCluster(ctx context.Context, id string) error
 	DeleteManagedPostgresUser(ctx context.Context, id, username string) error
+	DisableManagedPostgresExtension(ctx context.Context, id, database, name string, force bool) error
 	DeleteMetadata(ctx context.Context, appName, machineID, key string) error
 	DeleteAppSecret(ctx context.Context, appName, name string) (*fly.DeleteAppSecretResp, error)
 	DeleteIPAssignment(ctx context.Context, appName, ip string) (err error)
@@ -68,6 +70,7 @@ type FlapsClient interface {
 	ListManagedPostgresDatabases(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error)
 	ListManagedPostgresUsers(ctx context.Context, id string) ([]flaps.ManagedPostgresUser, error)
 	ListManagedPostgresBackups(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error)
+	ListManagedPostgresExtensions(ctx context.Context, id, database string) ([]flaps.ManagedPostgresExtension, error)
 	ListSecretKeys(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error)
 	NewRequest(ctx context.Context, method, path string, in any, headers map[string][]string) (*http.Request, error)
 	RefreshLease(ctx context.Context, appName, machineID string, ttl *int, nonce string) (*fly.MachineLease, error)

--- a/internal/inmem/flaps_client.go
+++ b/internal/inmem/flaps_client.go
@@ -80,6 +80,10 @@ func (m *FlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id strin
 	panic("TODO")
 }
 
+func (m *FlapsClient) DeleteManagedPostgresUser(ctx context.Context, id, username string) error {
+	panic("TODO")
+}
+
 func (m *FlapsClient) DeleteMetadata(ctx context.Context, appName, machineID, key string) error {
 	panic("TODO")
 }
@@ -158,6 +162,10 @@ func (m *FlapsClient) CreateManagedPostgresCluster(ctx context.Context, req flap
 }
 
 func (m *FlapsClient) CreateManagedPostgresDatabase(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) CreateManagedPostgresUser(ctx context.Context, id string, req flaps.CreateManagedPostgresUserRequest) (flaps.ManagedPostgresUser, error) {
 	panic("TODO")
 }
 
@@ -271,6 +279,10 @@ func (m *FlapsClient) ListManagedPostgresDatabases(ctx context.Context, id strin
 	panic("TODO")
 }
 
+func (m *FlapsClient) ListManagedPostgresUsers(ctx context.Context, id string) ([]flaps.ManagedPostgresUser, error) {
+	panic("TODO")
+}
+
 func (m *FlapsClient) ListManagedPostgresBackups(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error) {
 	panic("TODO")
 }
@@ -332,6 +344,10 @@ func (m *FlapsClient) Update(ctx context.Context, appName string, builder fly.La
 }
 
 func (m *FlapsClient) UpdateAppSecrets(ctx context.Context, appName string, values map[string]*string) (*fly.UpdateAppSecretsResp, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) UpdateManagedPostgresUserRole(ctx context.Context, id, username string, req flaps.UpdateManagedPostgresUserRoleRequest) error {
 	panic("TODO")
 }
 

--- a/internal/inmem/flaps_client.go
+++ b/internal/inmem/flaps_client.go
@@ -84,6 +84,10 @@ func (m *FlapsClient) DeleteManagedPostgresUser(ctx context.Context, id, usernam
 	panic("TODO")
 }
 
+func (m *FlapsClient) DisableManagedPostgresExtension(ctx context.Context, id, database, name string, force bool) error {
+	panic("TODO")
+}
+
 func (m *FlapsClient) DeleteMetadata(ctx context.Context, appName, machineID, key string) error {
 	panic("TODO")
 }
@@ -170,6 +174,10 @@ func (m *FlapsClient) CreateManagedPostgresUser(ctx context.Context, id string, 
 }
 
 func (m *FlapsClient) CreateManagedPostgresBackup(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error {
+	panic("TODO")
+}
+
+func (m *FlapsClient) EnableManagedPostgresExtension(ctx context.Context, id, database string, req flaps.EnableManagedPostgresExtensionRequest) error {
 	panic("TODO")
 }
 
@@ -284,6 +292,10 @@ func (m *FlapsClient) ListManagedPostgresUsers(ctx context.Context, id string) (
 }
 
 func (m *FlapsClient) ListManagedPostgresBackups(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error) {
+	panic("TODO")
+}
+
+func (m *FlapsClient) ListManagedPostgresExtensions(ctx context.Context, id, database string) ([]flaps.ManagedPostgresExtension, error) {
 	panic("TODO")
 }
 

--- a/internal/mock/flaps_client.go
+++ b/internal/mock/flaps_client.go
@@ -23,6 +23,7 @@ type FlapsClient struct {
 	CreateManagedPostgresDatabaseFunc     func(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error)
 	CreateManagedPostgresUserFunc         func(ctx context.Context, id string, req flaps.CreateManagedPostgresUserRequest) (flaps.ManagedPostgresUser, error)
 	CreateManagedPostgresBackupFunc       func(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error
+	EnableManagedPostgresExtensionFunc    func(ctx context.Context, id, database string, req flaps.EnableManagedPostgresExtensionRequest) error
 	CreateVolumeFunc                      func(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error)
 	CreateVolumeSnapshotFunc              func(ctx context.Context, appName, volumeId string) error
 	DeleteAppFunc                         func(ctx context.Context, name string) error
@@ -31,6 +32,7 @@ type FlapsClient struct {
 	DeleteCustomCertificateFunc           func(ctx context.Context, appName, hostname string) error
 	DeleteManagedPostgresClusterFunc      func(ctx context.Context, id string) error
 	DeleteManagedPostgresUserFunc         func(ctx context.Context, id, username string) error
+	DisableManagedPostgresExtensionFunc   func(ctx context.Context, id, database, name string, force bool) error
 	DeleteMetadataFunc                    func(ctx context.Context, appName, machineID, key string) error
 	DeleteAppSecretFunc                   func(ctx context.Context, appName, name string) (*fly.DeleteAppSecretResp, error)
 	DeleteIPAssignmentFunc                func(ctx context.Context, appName, ip string) (err error)
@@ -69,6 +71,7 @@ type FlapsClient struct {
 	ListManagedPostgresDatabasesFunc      func(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error)
 	ListManagedPostgresUsersFunc          func(ctx context.Context, id string) ([]flaps.ManagedPostgresUser, error)
 	ListManagedPostgresBackupsFunc        func(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error)
+	ListManagedPostgresExtensionsFunc     func(ctx context.Context, id, database string) ([]flaps.ManagedPostgresExtension, error)
 	ListSecretKeysFunc                    func(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error)
 	NewRequestFunc                        func(ctx context.Context, method, path string, in any, headers map[string][]string) (*http.Request, error)
 	RefreshLeaseFunc                      func(ctx context.Context, appName, machineID string, ttl *int, nonce string) (*fly.MachineLease, error)
@@ -134,6 +137,10 @@ func (m *FlapsClient) CreateManagedPostgresBackup(ctx context.Context, id string
 	return m.CreateManagedPostgresBackupFunc(ctx, id, req)
 }
 
+func (m *FlapsClient) EnableManagedPostgresExtension(ctx context.Context, id, database string, req flaps.EnableManagedPostgresExtensionRequest) error {
+	return m.EnableManagedPostgresExtensionFunc(ctx, id, database, req)
+}
+
 func (m *FlapsClient) CreateVolume(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error) {
 	return m.CreateVolumeFunc(ctx, appName, req)
 }
@@ -168,6 +175,10 @@ func (m *FlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id strin
 
 func (m *FlapsClient) DeleteManagedPostgresUser(ctx context.Context, id, username string) error {
 	return m.DeleteManagedPostgresUserFunc(ctx, id, username)
+}
+
+func (m *FlapsClient) DisableManagedPostgresExtension(ctx context.Context, id, database, name string, force bool) error {
+	return m.DisableManagedPostgresExtensionFunc(ctx, id, database, name, force)
 }
 
 func (m *FlapsClient) DeleteMetadata(ctx context.Context, appName, machineID, key string) error {
@@ -320,6 +331,10 @@ func (m *FlapsClient) ListManagedPostgresUsers(ctx context.Context, id string) (
 
 func (m *FlapsClient) ListManagedPostgresBackups(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error) {
 	return m.ListManagedPostgresBackupsFunc(ctx, id)
+}
+
+func (m *FlapsClient) ListManagedPostgresExtensions(ctx context.Context, id, database string) ([]flaps.ManagedPostgresExtension, error) {
+	return m.ListManagedPostgresExtensionsFunc(ctx, id, database)
 }
 
 func (m *FlapsClient) ListSecretKeys(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error) {

--- a/internal/mock/flaps_client.go
+++ b/internal/mock/flaps_client.go
@@ -21,6 +21,7 @@ type FlapsClient struct {
 	CreateACMECertificateFunc             func(ctx context.Context, appName string, req fly.CreateCertificateRequest) (*fly.CertificateDetailResponse, error)
 	CreateManagedPostgresClusterFunc      func(ctx context.Context, req flaps.CreateManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error)
 	CreateManagedPostgresDatabaseFunc     func(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error)
+	CreateManagedPostgresUserFunc         func(ctx context.Context, id string, req flaps.CreateManagedPostgresUserRequest) (flaps.ManagedPostgresUser, error)
 	CreateManagedPostgresBackupFunc       func(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error
 	CreateVolumeFunc                      func(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error)
 	CreateVolumeSnapshotFunc              func(ctx context.Context, appName, volumeId string) error
@@ -29,6 +30,7 @@ type FlapsClient struct {
 	DeleteCertificateFunc                 func(ctx context.Context, appName, hostname string) error
 	DeleteCustomCertificateFunc           func(ctx context.Context, appName, hostname string) error
 	DeleteManagedPostgresClusterFunc      func(ctx context.Context, id string) error
+	DeleteManagedPostgresUserFunc         func(ctx context.Context, id, username string) error
 	DeleteMetadataFunc                    func(ctx context.Context, appName, machineID, key string) error
 	DeleteAppSecretFunc                   func(ctx context.Context, appName, name string) (*fly.DeleteAppSecretResp, error)
 	DeleteIPAssignmentFunc                func(ctx context.Context, appName, ip string) (err error)
@@ -65,6 +67,7 @@ type FlapsClient struct {
 	ListFlyAppsMachinesFunc               func(ctx context.Context, appName string) ([]*fly.Machine, *fly.Machine, error)
 	ListManagedPostgresClustersFunc       func(ctx context.Context, req flaps.ListManagedPostgresClustersRequest) ([]flaps.ManagedPostgresClusterSummary, error)
 	ListManagedPostgresDatabasesFunc      func(ctx context.Context, id string) ([]flaps.ManagedPostgresDatabase, error)
+	ListManagedPostgresUsersFunc          func(ctx context.Context, id string) ([]flaps.ManagedPostgresUser, error)
 	ListManagedPostgresBackupsFunc        func(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error)
 	ListSecretKeysFunc                    func(ctx context.Context, appName string, version *uint64) ([]fly.SecretKey, error)
 	NewRequestFunc                        func(ctx context.Context, method, path string, in any, headers map[string][]string) (*http.Request, error)
@@ -81,6 +84,7 @@ type FlapsClient struct {
 	UncordonFunc                          func(ctx context.Context, appName, machineID string, nonce string) (err error)
 	UpdateFunc                            func(ctx context.Context, appName string, builder fly.LaunchMachineInput, nonce string) (out *fly.Machine, err error)
 	UpdateAppSecretsFunc                  func(ctx context.Context, appName string, values map[string]*string) (*fly.UpdateAppSecretsResp, error)
+	UpdateManagedPostgresUserRoleFunc     func(ctx context.Context, id, username string, req flaps.UpdateManagedPostgresUserRoleRequest) error
 	UpdateVolumeFunc                      func(ctx context.Context, appName, volumeId string, req fly.UpdateVolumeRequest) (*fly.Volume, error)
 	WaitFunc                              func(ctx context.Context, appName string, machineID string, waitOpts ...flaps.WaitOption) (err error)
 	WaitForAppFunc                        func(ctx context.Context, name string) error
@@ -122,6 +126,10 @@ func (m *FlapsClient) CreateManagedPostgresDatabase(ctx context.Context, id stri
 	return m.CreateManagedPostgresDatabaseFunc(ctx, id, req)
 }
 
+func (m *FlapsClient) CreateManagedPostgresUser(ctx context.Context, id string, req flaps.CreateManagedPostgresUserRequest) (flaps.ManagedPostgresUser, error) {
+	return m.CreateManagedPostgresUserFunc(ctx, id, req)
+}
+
 func (m *FlapsClient) CreateManagedPostgresBackup(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error {
 	return m.CreateManagedPostgresBackupFunc(ctx, id, req)
 }
@@ -156,6 +164,10 @@ func (m *FlapsClient) DeleteCustomCertificate(ctx context.Context, appName, host
 
 func (m *FlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id string) error {
 	return m.DeleteManagedPostgresClusterFunc(ctx, id)
+}
+
+func (m *FlapsClient) DeleteManagedPostgresUser(ctx context.Context, id, username string) error {
+	return m.DeleteManagedPostgresUserFunc(ctx, id, username)
 }
 
 func (m *FlapsClient) DeleteMetadata(ctx context.Context, appName, machineID, key string) error {
@@ -302,6 +314,10 @@ func (m *FlapsClient) ListManagedPostgresDatabases(ctx context.Context, id strin
 	return m.ListManagedPostgresDatabasesFunc(ctx, id)
 }
 
+func (m *FlapsClient) ListManagedPostgresUsers(ctx context.Context, id string) ([]flaps.ManagedPostgresUser, error) {
+	return m.ListManagedPostgresUsersFunc(ctx, id)
+}
+
 func (m *FlapsClient) ListManagedPostgresBackups(ctx context.Context, id string) ([]flaps.ManagedPostgresBackup, error) {
 	return m.ListManagedPostgresBackupsFunc(ctx, id)
 }
@@ -364,6 +380,10 @@ func (m *FlapsClient) Update(ctx context.Context, appName string, builder fly.La
 
 func (m *FlapsClient) UpdateAppSecrets(ctx context.Context, appName string, values map[string]*string) (*fly.UpdateAppSecretsResp, error) {
 	return m.UpdateAppSecretsFunc(ctx, appName, values)
+}
+
+func (m *FlapsClient) UpdateManagedPostgresUserRole(ctx context.Context, id, username string, req flaps.UpdateManagedPostgresUserRoleRequest) error {
+	return m.UpdateManagedPostgresUserRoleFunc(ctx, id, username, req)
 }
 
 func (m *FlapsClient) UpdateVolume(ctx context.Context, appName, volumeId string, req fly.UpdateVolumeRequest) (*fly.Volume, error) {


### PR DESCRIPTION
Moves the MPG v2 user and extension commands to the public Machines API.

- lists, creates, updates, and deletes users
- lists, enables, and disables extensions
- resolves databases through the Machines API
- falls back to the legacy API only for classified 404 responses
- preserves existing flyctl output and error behavior
- uses fly-go v0.9.12

Adds coverage for public routing, 404 fallback, non-404 errors, request mapping, and output compatibility.

The public extension API does not provide `docs_url`, so it is empty in JSON output on the public path.