### PR TITLE
Make Requested changes by Upstash on "fly redis update" 

### DIFF
--- a/internal/command/redis/update.go
+++ b/internal/command/redis/update.go
@@ -160,7 +160,7 @@ func runUpdate(ctx context.Context) (err error) {
 				options["auto_upgrade"] = false
 			}
 		} else {
-			enableAutoUpgrade, err := prompt.Confirm(ctx, "Would you like to enable auto-upgrade?")
+			enableAutoUpgrade, err := prompt.Confirm(ctx, "Would you like to enable auto-upgrade? \n   The Auto Upgrade feature automatically upgrades your database to the next higher plan when you reach your\n   bandwidth or storage limits, ensuring uninterrupted service.\n   https://fly.io/docs/upstash/redis/#auto-upgrade")
 			if err != nil {
 				return err
 			}
@@ -192,15 +192,15 @@ func runUpdate(ctx context.Context) (err error) {
 		func() (bool, error) {
 			return prompt.Confirm(ctx, "Would you like to disable ProdPack?")
 		},
+		func() (bool, error) {
+			return prompt.Confirm(ctx, "Would you like to enable ProdPack?\n   ProdPack adds enhanced features for production workloads at $200/mo.\n   This setting can be changed later.\n   For more information, see https://fly.io/docs/upstash/redis/#prod-pack-200-mo.")
+		},
 	)
 	if err != nil {
 		return
 	}
 
-	if err = validateProdPackPlanChange(prodPack, addOn.AddOnPlan.Id, selectedPlan.Id); err != nil {
-		return
-	}
-
+    prevProdPack := options["prod_pack"].(bool)
 	stripProdPack(options)
 
 	if prodPack == nil && !selectedPlanIsLegacy {
@@ -223,7 +223,13 @@ func runUpdate(ctx context.Context) (err error) {
 		return
 	}
 
-	fmt.Fprintf(out, "Your Upstash Redis database %s was updated.\n", addOn.Name)
+	// Display the selected plan and prodPack status
+	// We assume update was successful if no error triggers
+	prodPackEnabled := prevProdPack
+	if prodPack != nil {
+		prodPackEnabled = *prodPack
+	}
+	fmt.Fprintf(out, "Your Upstash Redis database %s was updated.\n   Plan: %s\n   ProdPack: %t\n", addOn.Name, selectedPlan.DisplayName, prodPackEnabled )
 
 	return
 }
@@ -235,7 +241,7 @@ func runUpdate(ctx context.Context) (err error) {
 // The stored option is intentionally never echoed back as the sent value: it
 // is only used to decide whether offering the disable prompt makes sense. A
 // non-interactive session makes no decision rather than defaulting to disable.
-func resolveProdPack(enableFlag, disableFlag bool, stored any, selectedPlanIsLegacy bool, confirmDisable func() (bool, error)) (*bool, error) {
+func resolveProdPack(enableFlag, disableFlag bool, stored any, selectedPlanIsLegacy bool, confirmDisable func() (bool, error), confirmEnable func() (bool, error)) (*bool, error) {
 	if enableFlag && disableFlag {
 		return nil, fmt.Errorf("--enable-prodpack and --disable-prodpack are mutually exclusive")
 	}
@@ -270,6 +276,18 @@ func resolveProdPack(enableFlag, disableFlag bool, stored any, selectedPlanIsLeg
 			return nil, err
 		case disable:
 			return boolPtr(false), nil
+		}
+	}else{
+	// No stored prodpack means it is not enabled
+	// Always prompt to enable if not enabled, unless non interactive
+		enable, err := confirmEnable()
+		switch {
+		case prompt.IsNonInteractive(err):
+			return nil, nil
+		case err != nil:
+			return nil, err
+		case enable:
+			return boolPtr(true), nil
 		}
 	}
 

--- a/internal/command/redis/update_test.go
+++ b/internal/command/redis/update_test.go
@@ -171,7 +171,8 @@ func TestStripProdPack(t *testing.T) {
 	assert.Equal(t, true, options["eviction"], "other options untouched")
 }
 
-func TestValidateProdPackPlanChange(t *testing.T) {
+// New logic is to allow prodpack change even without a plan change, so removing this
+/*func TestValidateProdPackPlanChange(t *testing.T) {
 	tests := []struct {
 		name      string
 		decision  *bool
@@ -194,7 +195,7 @@ func TestValidateProdPackPlanChange(t *testing.T) {
 			}
 		})
 	}
-}
+}*/
 
 func TestUpdateRedisAddOnWire(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
### Change Summary

**What and Why:**
Upstash requested changes to be made last Aug 28 2026, see [reference](https://app.plain.com/workspace/w_01J30S94JDD57QXMT9Q47J928E/thread/th_01KZY1WJNJB9PTB34V10KZ0DZJ/)

**How:**
**1. User should be able to enable/disable prod pack without changing the plan**
- [x] Remove triggering [validateProdPackPlanChange ](https://github.com/superfly/flyctl/blob/a70abbb7b7dade47bb7c8180fc1a7d7cf71db3f9/internal/command/redis/update.go#L200-L202) 
- [X]  [Remove the test](https://github.com/superfly/flyctl/blob/a70abbb7b7dade47bb7c8180fc1a7d7cf71db3f9/internal/command/redis/update_test.go#L174-L197) that validates prevention of prodPack change when no plan change is made
- [ ] *Still needs an update from web to remove server validation!*

**2. Auto upgrade option should have an explanation:**
- [X] Updated the [prompt](https://github.com/superfly/flyctl/blob/a70abbb7b7dade47bb7c8180fc1a7d7cf71db3f9/internal/command/redis/update.go#L163) to contain the [added explanation](https://github.com/superfly/flyctl/blob/132fa780b38bd151b700a221e62ede96d17cb8c3/internal/command/redis/update.go#L163)

**3. After update is complete, it would be better to show which plan the db is on, and a confirmation that prod pack is enabled/disabled**
- [X] Displayed the [selected plan and prodPack status](https://github.com/superfly/flyctl/blob/132fa780b38bd151b700a221e62ede96d17cb8c3/internal/command/redis/update.go#L226-L232) ( selected or retained if no change ) with the assumption that the update is successful if no error is triggered for the update 

**6. Show question to enable prodpack if no flag passed**
- [X] Prompt the user [about enabling prodpack](https://github.com/superfly/flyctl/blob/132fa780b38bd151b700a221e62ede96d17cb8c3/internal/command/redis/update.go#L195-L197) if: no --enable-prodpack/disable-prodpack flag was passed or it is disabled [here](https://github.com/superfly/flyctl/blob/132fa780b38bd151b700a221e62ede96d17cb8c3/internal/command/redis/update.go#L280-L292)

Related to:
https://app.plain.com/workspace/w_01J30S94JDD57QXMT9Q47J928E/thread/th_01KZY1WJNJB9PTB34V10KZ0DZJ/
---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [ ] n/a
