### PR TITLE
Route MPGv2 detach through the Machines API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.1
 	github.com/superfly/client-signals/go v0.4.4
-	github.com/superfly/fly-go v0.9.12
+	github.com/superfly/fly-go v0.9.13
 	github.com/superfly/graphql v0.2.6
 	github.com/superfly/lfsc-go v0.1.1
 	github.com/superfly/macaroon v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -664,8 +664,8 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/superfly/client-signals/go v0.4.4 h1:btAouksYdwOkVCIqI/JI09bt17A6iIVuwVJGWndfmc8=
 github.com/superfly/client-signals/go v0.4.4/go.mod h1:FTpkC1/boj2Lez8w98k9Zs9ihtvz8a1VeGXDtaq7asY=
-github.com/superfly/fly-go v0.9.12 h1:LIUpcWtqoqdxPV/8v+J7AF0w4ZsUjrT30ZKJnyFZp1I=
-github.com/superfly/fly-go v0.9.12/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
+github.com/superfly/fly-go v0.9.13 h1:d5chrW/sFV8MJWevnqSs0HbVje2noflZKXD1Q+9BohU=
+github.com/superfly/fly-go v0.9.13/go.mod h1:GnCtCE8++DJL2JZhHCq+1+WOlQLjsdxxm1xRLoMTr8k=
 github.com/superfly/graphql v0.2.6 h1:zppbodNerWecoXEdjkhrqaNaSjGqobhXNlViHFuZzb4=
 github.com/superfly/graphql v0.2.6/go.mod h1:CVfDl31srm8HnJ9udwLu6hFNUW/P6GUM2dKcG1YQ8jc=
 github.com/superfly/lfsc-go v0.1.1 h1:dGjLgt81D09cG+aR9lJZIdmonjZSR5zYCi7s54+ZU2Q=

--- a/internal/build/imgsrc/flaps_mock_test.go
+++ b/internal/build/imgsrc/flaps_mock_test.go
@@ -335,6 +335,20 @@ func (mr *MockFlapsClientMockRecorder) DeleteIPAssignment(ctx, appName, ip any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteIPAssignment", reflect.TypeOf((*MockFlapsClient)(nil).DeleteIPAssignment), ctx, appName, ip)
 }
 
+// DeleteManagedPostgresAttachment mocks base method.
+func (m *MockFlapsClient) DeleteManagedPostgresAttachment(ctx context.Context, id, appName string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteManagedPostgresAttachment", ctx, id, appName)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteManagedPostgresAttachment indicates an expected call of DeleteManagedPostgresAttachment.
+func (mr *MockFlapsClientMockRecorder) DeleteManagedPostgresAttachment(ctx, id, appName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteManagedPostgresAttachment", reflect.TypeOf((*MockFlapsClient)(nil).DeleteManagedPostgresAttachment), ctx, id, appName)
+}
+
 // DeleteManagedPostgresCluster mocks base method.
 func (m *MockFlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()

--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -193,6 +193,10 @@ func (m *mockFlapsClient) DeleteCustomCertificate(ctx context.Context, appName, 
 	return fmt.Errorf("not implemented")
 }
 
+func (m *mockFlapsClient) DeleteManagedPostgresAttachment(ctx context.Context, id, appName string) error {
+	return fmt.Errorf("not implemented")
+}
+
 func (m *mockFlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id string) error {
 	return fmt.Errorf("not implemented")
 }

--- a/internal/command/mpg/v2/run_detach.go
+++ b/internal/command/mpg/v2/run_detach.go
@@ -2,20 +2,35 @@ package cmdv2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
 	"github.com/superfly/flyctl/iostreams"
 )
 
 func RunDetach(ctx context.Context, clusterID string, appName string) error {
-	io := iostreams.FromContext(ctx)
-	mpgClient := mpgv2.ClientFromContext(ctx)
+	var (
+		mpgClient    = flapsutil.ClientFromContext(ctx)
+		legacyClient = mpgv2.ClientFromContext(ctx)
+		io           = iostreams.FromContext(ctx)
+	)
 
-	// Delete the attachment record
-	_, err := mpgClient.DeleteAttachment(ctx, clusterID, appName)
-	if err != nil {
+	// Delete the attachment record. Prefer the public Machines API;
+	// fall back to the legacy MPGv2 client only when it returns a
+	// classified 404, signaling the endpoint isn't available on this
+	// API surface. Any other error is authoritative and must propagate.
+	err := mpgClient.DeleteManagedPostgresAttachment(ctx, clusterID, appName)
+	useLegacy := errors.Is(err, flaps.ErrFlapsNotFound)
+	if err != nil && !useLegacy {
 		return fmt.Errorf("failed to detach: %w", err)
+	}
+	if useLegacy {
+		if _, err := legacyClient.DeleteAttachment(ctx, clusterID, appName); err != nil {
+			return fmt.Errorf("failed to detach: %w", err)
+		}
 	}
 
 	fmt.Fprintf(io.Out, "\nPostgres cluster %s has been detached from %s\n", clusterID, appName)

--- a/internal/command/mpg/v2/run_detach_test.go
+++ b/internal/command/mpg/v2/run_detach_test.go
@@ -1,0 +1,102 @@
+package cmdv2
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/mock"
+	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+func detachTestContext(t *testing.T) (context.Context, *bytes.Buffer) {
+	t.Helper()
+
+	io, _, stdout, _ := iostreams.Test()
+
+	return iostreams.NewContext(context.Background(), io), stdout
+}
+
+func TestRunDetach(t *testing.T) {
+	const wantSuccessOutput = "\nPostgres cluster mpg-123 has been detached from my-app\n" +
+		"Note: This only removes the attachment record. Any secrets (like DATABASE_URL) are still set on the app.\n" +
+		"Use 'fly secrets unset DATABASE_URL -a my-app' to remove the connection string.\n"
+
+	tests := []struct {
+		name                 string
+		publicDeleteErr      error
+		legacyDeleteResponse mpgv2.DeleteAttachmentResponse
+		legacyDeleteErr      error
+		wantPublicDelete     bool
+		wantLegacy           bool
+		wantErr              string
+	}{
+		{
+			name:             "uses Machines API",
+			wantPublicDelete: true,
+		},
+		{
+			name:             "returns Machines API delete failure",
+			publicDeleteErr:  errors.New("delete failed"),
+			wantPublicDelete: true,
+			wantErr:          "failed to detach: delete failed",
+		},
+		{
+			name:             "falls back to legacy API on public not found",
+			publicDeleteErr:  flaps.ErrFlapsNotFound,
+			wantPublicDelete: true,
+			wantLegacy:       true,
+		},
+		{
+			name:             "returns legacy API delete failure",
+			publicDeleteErr:  flaps.ErrFlapsNotFound,
+			legacyDeleteErr:  errors.New("legacy delete failed"),
+			wantPublicDelete: true,
+			wantLegacy:       true,
+			wantErr:          "failed to detach: legacy delete failed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, stdout := detachTestContext(t)
+			publicDeleteCalled := false
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				DeleteManagedPostgresAttachmentFunc: func(_ context.Context, id, appName string) error {
+					publicDeleteCalled = true
+					require.Equal(t, "mpg-123", id)
+					require.Equal(t, "my-app", appName)
+
+					return test.publicDeleteErr
+				},
+			})
+
+			legacyCalled := false
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+				DeleteAttachmentFunc: func(_ context.Context, clusterID, appName string) (mpgv2.DeleteAttachmentResponse, error) {
+					legacyCalled = true
+					require.Equal(t, "mpg-123", clusterID)
+					require.Equal(t, "my-app", appName)
+
+					return test.legacyDeleteResponse, test.legacyDeleteErr
+				},
+			})
+
+			err := RunDetach(ctx, "mpg-123", "my-app")
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				require.Empty(t, stdout.String(), "no success output on error")
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, wantSuccessOutput, stdout.String(), "success output must be byte-identical")
+			}
+			require.Equal(t, test.wantPublicDelete, publicDeleteCalled)
+			require.Equal(t, test.wantLegacy, legacyCalled)
+		})
+	}
+}

--- a/internal/flapsutil/flaps_client.go
+++ b/internal/flapsutil/flaps_client.go
@@ -29,6 +29,7 @@ type FlapsClient interface {
 	DeleteACMECertificate(ctx context.Context, appName, hostname string) error
 	DeleteCertificate(ctx context.Context, appName, hostname string) error
 	DeleteCustomCertificate(ctx context.Context, appName, hostname string) error
+	DeleteManagedPostgresAttachment(ctx context.Context, id, appName string) error
 	DeleteManagedPostgresCluster(ctx context.Context, id string) error
 	DeleteManagedPostgresUser(ctx context.Context, id, username string) error
 	DisableManagedPostgresExtension(ctx context.Context, id, database, name string, force bool) error

--- a/internal/inmem/flaps_client.go
+++ b/internal/inmem/flaps_client.go
@@ -76,6 +76,10 @@ func (m *FlapsClient) DeleteCustomCertificate(ctx context.Context, appName, host
 	panic("TODO")
 }
 
+func (m *FlapsClient) DeleteManagedPostgresAttachment(ctx context.Context, id, appName string) error {
+	panic("TODO")
+}
+
 func (m *FlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id string) error {
 	panic("TODO")
 }

--- a/internal/mock/flaps_client.go
+++ b/internal/mock/flaps_client.go
@@ -30,6 +30,7 @@ type FlapsClient struct {
 	DeleteACMECertificateFunc             func(ctx context.Context, appName, hostname string) error
 	DeleteCertificateFunc                 func(ctx context.Context, appName, hostname string) error
 	DeleteCustomCertificateFunc           func(ctx context.Context, appName, hostname string) error
+	DeleteManagedPostgresAttachmentFunc   func(ctx context.Context, id, appName string) error
 	DeleteManagedPostgresClusterFunc      func(ctx context.Context, id string) error
 	DeleteManagedPostgresUserFunc         func(ctx context.Context, id, username string) error
 	DisableManagedPostgresExtensionFunc   func(ctx context.Context, id, database, name string, force bool) error
@@ -167,6 +168,10 @@ func (m *FlapsClient) DeleteCertificate(ctx context.Context, appName, hostname s
 
 func (m *FlapsClient) DeleteCustomCertificate(ctx context.Context, appName, hostname string) error {
 	return m.DeleteCustomCertificateFunc(ctx, appName, hostname)
+}
+
+func (m *FlapsClient) DeleteManagedPostgresAttachment(ctx context.Context, id, appName string) error {
+	return m.DeleteManagedPostgresAttachmentFunc(ctx, id, appName)
 }
 
 func (m *FlapsClient) DeleteManagedPostgresCluster(ctx context.Context, id string) error {


### PR DESCRIPTION
## Summary

- route `fly mpg detach` through the public Machines API
- fall back to the legacy MPGv2 API only for classified 404 responses
- preserve existing detach output and secret-warning behavior
- update the fly-go dependency to released `v0.9.13`
- add coverage for public success, classified-404 fallback, fallback errors, and authoritative public errors

## Testing

- `go test ./internal/command/mpg/v2 -run Detach -count=1`
- `go test ./internal/command/mpg/... -count=1`
- `go mod tidy -diff`
- `go mod verify`
- `go vet ./...`
- `gofmt -l .`
- `git diff --check`
- real disposable personal-org validation with a local build of this branch
