### PR TITLE
Polish the ProdPack prompt and post-update summary (on top of #5147)

### DIFF
--- a/gql/schema.graphql
+++ b/gql/schema.graphql
@@ -10149,7 +10149,7 @@ input UpdateAddOnInput {
   planId: ID
 
   """
-  Explicit ProdPack intent for Upstash Redis. Requires a plan change; when absent, ProdPack is left untouched.
+  Explicit ProdPack intent for Upstash Redis. Can be sent with or without a plan change; when absent, ProdPack is left untouched.
   """
   prodPack: Boolean
 

--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -25,6 +25,13 @@ const (
 	redisPlanPayAsYouGo = "ekQ85Yjkw155ohQ5ALYq0M"
 )
 
+// Descriptions shown before the corresponding prompt, shared by create and
+// update so both paths explain a setting the same way.
+const (
+	autoUpgradeDescription = "\nThe Auto Upgrade feature automatically upgrades your database to the next higher plan when you reach your bandwidth or storage limits, ensuring uninterrupted service.\nThis setting can be changed later.\nFor more information, see https://fly.io/docs/upstash/redis/#auto-upgrade.\n\n"
+	prodPackDescription    = "\nProdPack adds enhanced features for production workloads at $200/mo.\nThis setting can be changed later.\nFor more information, see https://fly.io/docs/upstash/redis/#prod-pack-200-mo.\n\n"
+)
+
 // Legacy plans that are no longer available for new databases
 // but existing databases can remain on them
 // These match the normalized display names (lowercase, spaces replaced with underscores)
@@ -164,7 +171,7 @@ func runCreate(ctx context.Context) (err error) {
 		if flag.IsSpecified(ctx, "enable-auto-upgrade") {
 			enableAutoUpgrade = flag.GetBool(ctx, "enable-auto-upgrade")
 		} else {
-			fmt.Fprintf(io.Out, "\nAuto-upgrade automatically switches to a higher plan when you hit resource limits.\nThis setting can be changed later.\n\n")
+			fmt.Fprint(io.Out, autoUpgradeDescription)
 			enableAutoUpgrade, err = prompt.Confirm(ctx, "Would you like to enable auto-upgrade?")
 			if err != nil {
 				return
@@ -179,7 +186,7 @@ func runCreate(ctx context.Context) (err error) {
 	if flag.IsSpecified(ctx, "enable-prodpack") {
 		enableProdpack = flag.GetBool(ctx, "enable-prodpack")
 	} else {
-		fmt.Fprintf(io.Out, "\nProdPack adds enhanced features for production workloads at $200/mo.\nThis setting can be changed later.\nFor more information, see https://fly.io/docs/upstash/redis/#prod-pack-200-mo.\n\n")
+		fmt.Fprint(io.Out, prodPackDescription)
 		enableProdpack, err = prompt.Confirm(ctx, "Would you like to enable ProdPack?")
 		if err != nil {
 			return

--- a/internal/command/redis/update.go
+++ b/internal/command/redis/update.go
@@ -208,6 +208,10 @@ func runUpdate(ctx context.Context) (err error) {
 		return
 	}
 
+	// Read the stored value before it is stripped: it is the only state we
+	// have to fall back on for the summary when the user made no decision.
+	storedProdPack, _ := options["prod_pack"].(bool)
+
 	stripProdPack(options)
 
 	if currentPlanIsLegacy && selectedPlanIsLegacy {
@@ -239,28 +243,26 @@ func runUpdate(ctx context.Context) (err error) {
 	if selectedPlanIsLegacy {
 		fmt.Fprintf(out, "  ProdPack:     not available on legacy plans\n")
 	} else {
-		fmt.Fprintf(out, "  ProdPack:     %s\n", prodPackState(prodPack))
+		fmt.Fprintf(out, "  ProdPack:     %s\n", prodPackState(prodPack, storedProdPack))
 	}
 
 	return
 }
 
-// optionState describes what the update did to a boolean option. An absent key
-// means no value was sent, so the provider kept whatever it had.
+// optionState reports the state a boolean option is left in. A key is only
+// dropped from the payload after the user declined to enable it, so an absent
+// key means the setting stays off.
 func optionState(options map[string]any, key string) string {
-	value, ok := options[key]
-	if !ok {
-		return "unchanged"
-	}
-
-	on, _ := value.(bool)
+	on, _ := options[key].(bool)
 
 	return enabledOrDisabled(on)
 }
 
-func prodPackState(decision *bool) string {
+// prodPackState reports the state ProdPack is left in, falling back to the
+// stored value when the user made no decision this invocation.
+func prodPackState(decision *bool, stored bool) string {
 	if decision == nil {
-		return "unchanged"
+		return enabledOrDisabled(stored)
 	}
 
 	return enabledOrDisabled(*decision)

--- a/internal/command/redis/update.go
+++ b/internal/command/redis/update.go
@@ -3,7 +3,9 @@ package redis
 import (
 	"context"
 	"fmt"
+	"io"
 
+	"github.com/Khan/genqlient/graphql"
 	"github.com/spf13/cobra"
 
 	"github.com/superfly/flyctl/gql"
@@ -31,11 +33,11 @@ func newUpdate() (cmd *cobra.Command) {
 		flag.ReplicaRegions(),
 		flag.Bool{
 			Name:        "enable-prodpack",
-			Description: "Enable ProdPack add-on for additional features ($200/mo), skipping the prompt",
+			Description: "Enable ProdPack add-on for additional features ($200/mo), leaving every other setting untouched",
 		},
 		flag.Bool{
 			Name:        "disable-prodpack",
-			Description: "Disable the ProdPack add-on, skipping the prompt",
+			Description: "Disable the ProdPack add-on, leaving every other setting untouched",
 		},
 	)
 	cmd.Args = cobra.ExactArgs(1)
@@ -61,52 +63,42 @@ func runUpdate(ctx context.Context) (err error) {
 	// Check if current plan is a legacy plan
 	currentPlanIsLegacy := isLegacyPlan(addOn.AddOnPlan.DisplayName)
 
-	excludedRegions, err := GetExcludedRegions(ctx)
-	if err != nil {
-		return err
-	}
-	excludedRegions = append(excludedRegions, addOn.PrimaryRegion)
+	// A ProdPack flag means "change ProdPack, leave the rest alone": nothing is
+	// asked about replica regions, plan, eviction or auto-upgrade, and nothing
+	// but ProdPack is sent as a change, so the command runs unattended. Other
+	// flags the caller passed explicitly are still honoured.
+	prodPackOnly := flag.GetBool(ctx, "enable-prodpack") || flag.GetBool(ctx, "disable-prodpack")
 
-	readRegions, err := prompt.MultiRegion(ctx, "Choose replica regions, or unselect to remove replica regions:", false, addOn.ReadRegions, excludedRegions, "replica-regions")
-	if err != nil {
-		return
-	}
+	readRegionCodes := addOn.ReadRegions
 
-	var index int
-	var promptOptions []string
-	var promptDefault string
-	var filteredPlans []gql.ListAddOnPlansAddOnPlansAddOnPlanConnectionNodesAddOnPlan
+	if !prodPackOnly || flag.IsSpecified(ctx, "replica-regions") {
+		excludedRegions, err := GetExcludedRegions(ctx)
+		if err != nil {
+			return err
+		}
+		excludedRegions = append(excludedRegions, addOn.PrimaryRegion)
 
-	result, err := gql.ListAddOnPlans(ctx, client, gql.AddOnTypeUpstashRedis)
-	if err != nil {
-		return
-	}
+		readRegions, err := prompt.MultiRegion(ctx, "Choose replica regions, or unselect to remove replica regions:", false, addOn.ReadRegions, excludedRegions, "replica-regions")
+		if err != nil {
+			return err
+		}
 
-	// Filter plans based on current plan type
-	for _, plan := range result.AddOnPlans.Nodes {
-		isLegacy := isLegacyPlan(plan.DisplayName)
-
-		// Include plan if:
-		// 1. It's not a legacy plan (always include new plans), OR
-		// 2. It's the current plan (so user can stay on their legacy plan)
-		if !isLegacy || addOn.AddOnPlan.Id == plan.Id {
-			filteredPlans = append(filteredPlans, plan)
-			promptOptions = append(promptOptions, fmt.Sprintf("%s: %s", plan.DisplayName, plan.Description))
-			if addOn.AddOnPlan.Id == plan.Id {
-				promptDefault = fmt.Sprintf("%s: %s", plan.DisplayName, plan.Description)
-			}
+		readRegionCodes = []string{}
+		for _, region := range *readRegions {
+			readRegionCodes = append(readRegionCodes, region.Code)
 		}
 	}
 
-	err = prompt.Select(ctx, &index, "Select an Upstash Redis plan", promptDefault, promptOptions...)
+	selectedPlanID, selectedPlanName := addOn.AddOnPlan.Id, addOn.AddOnPlan.DisplayName
 
-	if err != nil {
-		return fmt.Errorf("failed to select a plan: %w", err)
+	if !prodPackOnly {
+		if selectedPlanID, selectedPlanName, err = selectPlan(ctx, client, addOn); err != nil {
+			return err
+		}
 	}
 
-	selectedPlan := filteredPlans[index]
-	selectedPlanIsLegacy := isLegacyPlan(selectedPlan.DisplayName)
-	selectedPlanIsFixed := isFixedPlan(selectedPlan.DisplayName)
+	selectedPlanIsLegacy := isLegacyPlan(selectedPlanName)
+	selectedPlanIsFixed := isFixedPlan(selectedPlanName)
 
 	options, _ := addOn.Options.(map[string]any)
 
@@ -120,62 +112,9 @@ func runUpdate(ctx context.Context) (err error) {
 		metadata = make(map[string]any)
 	}
 
-	// Eviction prompt (always available)
-	if options["eviction"] != nil && options["eviction"].(bool) {
-		disableEviction, err := prompt.Confirm(ctx, "Would you like to disable eviction?")
-		if err != nil {
+	if !prodPackOnly {
+		if err = promptOptionChanges(ctx, out, options, selectedPlanIsFixed, selectedPlanIsLegacy); err != nil {
 			return err
-		}
-		if disableEviction {
-			options["eviction"] = false
-		}
-	} else {
-		enableEviction, err := prompt.Confirm(ctx, "Would you like to enable eviction?")
-		if err != nil {
-			return err
-		}
-		if enableEviction {
-			options["eviction"] = true
-		} else {
-			// Declining to enable must not send an explicit false: if the
-			// add-on metadata is stale, that would disable a feature that is
-			// actually enabled. Omit the key so the server keeps its state.
-			delete(options, "eviction")
-		}
-	}
-
-	// Auto-upgrade only available for fixed plans (not pay-as-you-go or legacy)
-	if selectedPlanIsFixed {
-		currentAutoUpgrade := false
-		if options["auto_upgrade"] != nil {
-			currentAutoUpgrade, _ = options["auto_upgrade"].(bool)
-		}
-
-		fmt.Fprint(out, autoUpgradeDescription)
-
-		if currentAutoUpgrade {
-			disableAutoUpgrade, err := prompt.Confirm(ctx, "Would you like to disable auto-upgrade?")
-			if err != nil {
-				return err
-			}
-			if disableAutoUpgrade {
-				options["auto_upgrade"] = false
-			}
-		} else {
-			enableAutoUpgrade, err := prompt.Confirm(ctx, "Would you like to enable auto-upgrade?")
-			if err != nil {
-				return err
-			}
-			if enableAutoUpgrade {
-				options["auto_upgrade"] = true
-			} else {
-				delete(options, "auto_upgrade")
-			}
-		}
-	} else if !selectedPlanIsLegacy {
-		// Pay-as-you-go plan - auto-upgrade not available but we should clear it if it was set
-		if options["auto_upgrade"] != nil {
-			delete(options, "auto_upgrade")
 		}
 	}
 
@@ -218,20 +157,14 @@ func runUpdate(ctx context.Context) (err error) {
 		fmt.Fprintf(out, "\nNote: Auto-upgrade and ProdPack are not available for legacy plans.\nTo access these features, please upgrade to a current plan.\n\n")
 	}
 
-	readRegionCodes := []string{}
-
-	for _, region := range *readRegions {
-		readRegionCodes = append(readRegionCodes, region.Code)
-	}
-
-	_, err = gql.UpdateRedisAddOn(ctx, client, addOn.Id, selectedPlan.Id, readRegionCodes, options, metadata, prodPack)
+	_, err = gql.UpdateRedisAddOn(ctx, client, addOn.Id, selectedPlanID, readRegionCodes, options, metadata, prodPack)
 
 	if err != nil {
 		return
 	}
 
 	fmt.Fprintf(out, "\nYour Upstash Redis database %s was updated.\n", addOn.Name)
-	fmt.Fprintf(out, "  Plan:         %s\n", selectedPlan.DisplayName)
+	fmt.Fprintf(out, "  Plan:         %s\n", selectedPlanName)
 	fmt.Fprintf(out, "  Eviction:     %s\n", optionState(options, "eviction"))
 
 	if selectedPlanIsFixed {
@@ -339,4 +272,109 @@ func stripProdPack(options map[string]any) {
 
 func boolPtr(v bool) *bool {
 	return &v
+}
+
+// selectPlan asks which plan the database should end up on, returning the
+// chosen plan's id and display name. Legacy plans are offered only when the
+// database is already on one, so its owner can update without being forced to
+// migrate.
+func selectPlan(ctx context.Context, client graphql.Client, addOn gql.GetAddOnAddOn) (id string, displayName string, err error) {
+	result, err := gql.ListAddOnPlans(ctx, client, gql.AddOnTypeUpstashRedis)
+	if err != nil {
+		return "", "", err
+	}
+
+	var (
+		index         int
+		promptOptions []string
+		promptDefault string
+		filteredPlans []gql.ListAddOnPlansAddOnPlansAddOnPlanConnectionNodesAddOnPlan
+	)
+
+	for _, plan := range result.AddOnPlans.Nodes {
+		if isLegacyPlan(plan.DisplayName) && addOn.AddOnPlan.Id != plan.Id {
+			continue
+		}
+
+		filteredPlans = append(filteredPlans, plan)
+		promptOptions = append(promptOptions, fmt.Sprintf("%s: %s", plan.DisplayName, plan.Description))
+
+		if addOn.AddOnPlan.Id == plan.Id {
+			promptDefault = fmt.Sprintf("%s: %s", plan.DisplayName, plan.Description)
+		}
+	}
+
+	if err = prompt.Select(ctx, &index, "Select an Upstash Redis plan", promptDefault, promptOptions...); err != nil {
+		return "", "", fmt.Errorf("failed to select a plan: %w", err)
+	}
+
+	selected := filteredPlans[index]
+
+	return selected.Id, selected.DisplayName, nil
+}
+
+// promptOptionChanges asks about eviction and auto-upgrade, recording answers
+// in the options blob that will be sent. Declining to enable a setting deletes
+// its key rather than sending an explicit false: the stored copy can be stale,
+// and an explicit false would turn off a feature that is actually on.
+func promptOptionChanges(ctx context.Context, out io.Writer, options map[string]any, selectedPlanIsFixed, selectedPlanIsLegacy bool) error {
+	if options["eviction"] != nil && options["eviction"].(bool) {
+		disableEviction, err := prompt.Confirm(ctx, "Would you like to disable eviction?")
+		if err != nil {
+			return err
+		}
+		if disableEviction {
+			options["eviction"] = false
+		}
+	} else {
+		enableEviction, err := prompt.Confirm(ctx, "Would you like to enable eviction?")
+		if err != nil {
+			return err
+		}
+		if enableEviction {
+			options["eviction"] = true
+		} else {
+			// Declining to enable must not send an explicit false: if the
+			// add-on metadata is stale, that would disable a feature that is
+			// actually enabled. Omit the key so the server keeps its state.
+			delete(options, "eviction")
+		}
+	}
+
+	// Auto-upgrade only available for fixed plans (not pay-as-you-go or legacy)
+	if selectedPlanIsFixed {
+		currentAutoUpgrade := false
+		if options["auto_upgrade"] != nil {
+			currentAutoUpgrade, _ = options["auto_upgrade"].(bool)
+		}
+
+		fmt.Fprint(out, autoUpgradeDescription)
+
+		if currentAutoUpgrade {
+			disableAutoUpgrade, err := prompt.Confirm(ctx, "Would you like to disable auto-upgrade?")
+			if err != nil {
+				return err
+			}
+			if disableAutoUpgrade {
+				options["auto_upgrade"] = false
+			}
+		} else {
+			enableAutoUpgrade, err := prompt.Confirm(ctx, "Would you like to enable auto-upgrade?")
+			if err != nil {
+				return err
+			}
+			if enableAutoUpgrade {
+				options["auto_upgrade"] = true
+			} else {
+				delete(options, "auto_upgrade")
+			}
+		}
+	} else if !selectedPlanIsLegacy {
+		// Pay-as-you-go plan - auto-upgrade not available but we should clear it if it was set
+		if options["auto_upgrade"] != nil {
+			delete(options, "auto_upgrade")
+		}
+	}
+
+	return nil
 }

--- a/internal/command/redis/update.go
+++ b/internal/command/redis/update.go
@@ -160,7 +160,7 @@ func runUpdate(ctx context.Context) (err error) {
 				options["auto_upgrade"] = false
 			}
 		} else {
-			enableAutoUpgrade, err := prompt.Confirm(ctx, "Would you like to enable auto-upgrade?")
+			enableAutoUpgrade, err := prompt.Confirm(ctx, "Would you like to enable auto-upgrade? \n   The Auto Upgrade feature automatically upgrades your database to the next higher plan when you reach your\n   bandwidth or storage limits, ensuring uninterrupted service.\n   https://fly.io/docs/upstash/redis/#auto-upgrade")
 			if err != nil {
 				return err
 			}
@@ -192,15 +192,15 @@ func runUpdate(ctx context.Context) (err error) {
 		func() (bool, error) {
 			return prompt.Confirm(ctx, "Would you like to disable ProdPack?")
 		},
+		func() (bool, error) {
+			return prompt.Confirm(ctx, "Would you like to enable ProdPack?\n   ProdPack adds enhanced features for production workloads at $200/mo.\n   This setting can be changed later.\n   For more information, see https://fly.io/docs/upstash/redis/#prod-pack-200-mo.")
+		},
 	)
 	if err != nil {
 		return
 	}
 
-	if err = validateProdPackPlanChange(prodPack, addOn.AddOnPlan.Id, selectedPlan.Id); err != nil {
-		return
-	}
-
+    prevProdPack := options["prod_pack"].(bool)
 	stripProdPack(options)
 
 	if prodPack == nil && !selectedPlanIsLegacy {
@@ -223,7 +223,13 @@ func runUpdate(ctx context.Context) (err error) {
 		return
 	}
 
-	fmt.Fprintf(out, "Your Upstash Redis database %s was updated.\n", addOn.Name)
+	// Display the selected plan and prodPack status
+	// We assume update was successful if no error triggers
+	prodPackEnabled := prevProdPack
+	if prodPack != nil {
+		prodPackEnabled = *prodPack
+	}
+	fmt.Fprintf(out, "Your Upstash Redis database %s was updated.\n   Plan: %s\n   ProdPack: %t\n", addOn.Name, selectedPlan.DisplayName, prodPackEnabled )
 
 	return
 }
@@ -235,7 +241,7 @@ func runUpdate(ctx context.Context) (err error) {
 // The stored option is intentionally never echoed back as the sent value: it
 // is only used to decide whether offering the disable prompt makes sense. A
 // non-interactive session makes no decision rather than defaulting to disable.
-func resolveProdPack(enableFlag, disableFlag bool, stored any, selectedPlanIsLegacy bool, confirmDisable func() (bool, error)) (*bool, error) {
+func resolveProdPack(enableFlag, disableFlag bool, stored any, selectedPlanIsLegacy bool, confirmDisable func() (bool, error), confirmEnable func() (bool, error)) (*bool, error) {
 	if enableFlag && disableFlag {
 		return nil, fmt.Errorf("--enable-prodpack and --disable-prodpack are mutually exclusive")
 	}
@@ -270,6 +276,18 @@ func resolveProdPack(enableFlag, disableFlag bool, stored any, selectedPlanIsLeg
 			return nil, err
 		case disable:
 			return boolPtr(false), nil
+		}
+	}else{
+	// No stored prodpack means it is not enabled
+	// Always prompt to enable if not enabled, unless non interactive
+		enable, err := confirmEnable()
+		switch {
+		case prompt.IsNonInteractive(err):
+			return nil, nil
+		case err != nil:
+			return nil, err
+		case enable:
+			return boolPtr(true), nil
 		}
 	}
 

--- a/internal/command/redis/update.go
+++ b/internal/command/redis/update.go
@@ -31,11 +31,11 @@ func newUpdate() (cmd *cobra.Command) {
 		flag.ReplicaRegions(),
 		flag.Bool{
 			Name:        "enable-prodpack",
-			Description: "Enable ProdPack add-on for additional features ($200/mo)",
+			Description: "Enable ProdPack add-on for additional features ($200/mo), skipping the prompt",
 		},
 		flag.Bool{
 			Name:        "disable-prodpack",
-			Description: "Disable the ProdPack add-on",
+			Description: "Disable the ProdPack add-on, skipping the prompt",
 		},
 	)
 	cmd.Args = cobra.ExactArgs(1)
@@ -151,6 +151,8 @@ func runUpdate(ctx context.Context) (err error) {
 			currentAutoUpgrade, _ = options["auto_upgrade"].(bool)
 		}
 
+		fmt.Fprint(out, autoUpgradeDescription)
+
 		if currentAutoUpgrade {
 			disableAutoUpgrade, err := prompt.Confirm(ctx, "Would you like to disable auto-upgrade?")
 			if err != nil {
@@ -160,7 +162,7 @@ func runUpdate(ctx context.Context) (err error) {
 				options["auto_upgrade"] = false
 			}
 		} else {
-			enableAutoUpgrade, err := prompt.Confirm(ctx, "Would you like to enable auto-upgrade? \n   The Auto Upgrade feature automatically upgrades your database to the next higher plan when you reach your\n   bandwidth or storage limits, ensuring uninterrupted service.\n   https://fly.io/docs/upstash/redis/#auto-upgrade")
+			enableAutoUpgrade, err := prompt.Confirm(ctx, "Would you like to enable auto-upgrade?")
 			if err != nil {
 				return err
 			}
@@ -177,7 +179,9 @@ func runUpdate(ctx context.Context) (err error) {
 		}
 	}
 
-	// ProdPack available for both pay-as-you-go and fixed plans (but not legacy).
+	// ProdPack available for both pay-as-you-go and fixed plans (but not
+	// legacy), and can be toggled on its own — the provider does not require a
+	// plan change to go with it.
 	//
 	// The locally stored prod_pack option can be stale in either direction, so
 	// the update payload only ever carries a value the user chose in this
@@ -190,22 +194,21 @@ func runUpdate(ctx context.Context) (err error) {
 		options["prod_pack"],
 		selectedPlanIsLegacy,
 		func() (bool, error) {
+			fmt.Fprint(out, prodPackDescription)
+
 			return prompt.Confirm(ctx, "Would you like to disable ProdPack?")
 		},
 		func() (bool, error) {
-			return prompt.Confirm(ctx, "Would you like to enable ProdPack?\n   ProdPack adds enhanced features for production workloads at $200/mo.\n   This setting can be changed later.\n   For more information, see https://fly.io/docs/upstash/redis/#prod-pack-200-mo.")
+			fmt.Fprint(out, prodPackDescription)
+
+			return prompt.Confirm(ctx, "Would you like to enable ProdPack?")
 		},
 	)
 	if err != nil {
 		return
 	}
 
-    prevProdPack := options["prod_pack"].(bool)
 	stripProdPack(options)
-
-	if prodPack == nil && !selectedPlanIsLegacy {
-		fmt.Fprintf(out, "ProdPack: unchanged (use --enable-prodpack or --disable-prodpack to change it)\n")
-	}
 
 	if currentPlanIsLegacy && selectedPlanIsLegacy {
 		fmt.Fprintf(out, "\nNote: Auto-upgrade and ProdPack are not available for legacy plans.\nTo access these features, please upgrade to a current plan.\n\n")
@@ -223,15 +226,52 @@ func runUpdate(ctx context.Context) (err error) {
 		return
 	}
 
-	// Display the selected plan and prodPack status
-	// We assume update was successful if no error triggers
-	prodPackEnabled := prevProdPack
-	if prodPack != nil {
-		prodPackEnabled = *prodPack
+	fmt.Fprintf(out, "\nYour Upstash Redis database %s was updated.\n", addOn.Name)
+	fmt.Fprintf(out, "  Plan:         %s\n", selectedPlan.DisplayName)
+	fmt.Fprintf(out, "  Eviction:     %s\n", optionState(options, "eviction"))
+
+	if selectedPlanIsFixed {
+		fmt.Fprintf(out, "  Auto-upgrade: %s\n", optionState(options, "auto_upgrade"))
+	} else {
+		fmt.Fprintf(out, "  Auto-upgrade: not available on this plan\n")
 	}
-	fmt.Fprintf(out, "Your Upstash Redis database %s was updated.\n   Plan: %s\n   ProdPack: %t\n", addOn.Name, selectedPlan.DisplayName, prodPackEnabled )
+
+	if selectedPlanIsLegacy {
+		fmt.Fprintf(out, "  ProdPack:     not available on legacy plans\n")
+	} else {
+		fmt.Fprintf(out, "  ProdPack:     %s\n", prodPackState(prodPack))
+	}
 
 	return
+}
+
+// optionState describes what the update did to a boolean option. An absent key
+// means no value was sent, so the provider kept whatever it had.
+func optionState(options map[string]any, key string) string {
+	value, ok := options[key]
+	if !ok {
+		return "unchanged"
+	}
+
+	on, _ := value.(bool)
+
+	return enabledOrDisabled(on)
+}
+
+func prodPackState(decision *bool) string {
+	if decision == nil {
+		return "unchanged"
+	}
+
+	return enabledOrDisabled(*decision)
+}
+
+func enabledOrDisabled(on bool) string {
+	if on {
+		return "enabled"
+	}
+
+	return "disabled"
 }
 
 // resolveProdPack determines the user's explicit ProdPack decision for this
@@ -239,9 +279,11 @@ func runUpdate(ctx context.Context) (err error) {
 // must be omitted from the update payload.
 //
 // The stored option is intentionally never echoed back as the sent value: it
-// is only used to decide whether offering the disable prompt makes sense. A
-// non-interactive session makes no decision rather than defaulting to disable.
-func resolveProdPack(enableFlag, disableFlag bool, stored any, selectedPlanIsLegacy bool, confirmDisable func() (bool, error), confirmEnable func() (bool, error)) (*bool, error) {
+// only decides which of the two prompts is offered. Declining means "leave it
+// alone" rather than "set the opposite", so a stale stored copy can never flip
+// a setting the user did not ask to change. A non-interactive session makes no
+// decision at all unless a flag was passed.
+func resolveProdPack(enableFlag, disableFlag bool, stored any, selectedPlanIsLegacy bool, confirmDisable, confirmEnable func() (bool, error)) (*bool, error) {
 	if enableFlag && disableFlag {
 		return nil, fmt.Errorf("--enable-prodpack and --disable-prodpack are mutually exclusive")
 	}
@@ -264,34 +306,26 @@ func resolveProdPack(enableFlag, disableFlag bool, stored any, selectedPlanIsLeg
 		return boolPtr(false), nil
 	}
 
-	// Only offer the disable prompt when the stored copy claims ProdPack is
-	// on. Never prompt to enable: a default/accidental answer previously
-	// became an explicit disable for databases whose stored option was stale.
-	if storedOn, _ := stored.(bool); storedOn {
-		disable, err := confirmDisable()
-		switch {
-		case prompt.IsNonInteractive(err):
-			return nil, nil
-		case err != nil:
-			return nil, err
-		case disable:
-			return boolPtr(false), nil
-		}
-	}else{
-	// No stored prodpack means it is not enabled
-	// Always prompt to enable if not enabled, unless non interactive
-		enable, err := confirmEnable()
-		switch {
-		case prompt.IsNonInteractive(err):
-			return nil, nil
-		case err != nil:
-			return nil, err
-		case enable:
-			return boolPtr(true), nil
-		}
+	// The stored copy only picks the question. Whichever one is asked, "no"
+	// means "leave ProdPack alone", never "set it to the opposite".
+	storedOn, _ := stored.(bool)
+
+	confirm, decision := confirmEnable, true
+	if storedOn {
+		confirm, decision = confirmDisable, false
 	}
 
-	return nil, nil
+	answer, err := confirm()
+	switch {
+	case prompt.IsNonInteractive(err):
+		return nil, nil
+	case err != nil:
+		return nil, err
+	case !answer:
+		return nil, nil
+	}
+
+	return boolPtr(decision), nil
 }
 
 // stripProdPack removes the legacy ProdPack option from the options blob.
@@ -303,12 +337,4 @@ func stripProdPack(options map[string]any) {
 
 func boolPtr(v bool) *bool {
 	return &v
-}
-
-func validateProdPackPlanChange(decision *bool, currentPlanID, selectedPlanID string) error {
-	if decision != nil && currentPlanID == selectedPlanID {
-		return fmt.Errorf("ProdPack can only be changed together with a plan change; pick a different plan or drop the flag")
-	}
-
-	return nil
 }

--- a/internal/command/redis/update.go
+++ b/internal/command/redis/update.go
@@ -69,7 +69,9 @@ func runUpdate(ctx context.Context) (err error) {
 	// flags the caller passed explicitly are still honoured.
 	prodPackOnly := flag.GetBool(ctx, "enable-prodpack") || flag.GetBool(ctx, "disable-prodpack")
 
-	readRegionCodes := addOn.ReadRegions
+	// Copy rather than alias: a database with no replicas has a nil slice, and
+	// the mutation's readRegions is [String!]!, which rejects null.
+	readRegionCodes := append([]string{}, addOn.ReadRegions...)
 
 	if !prodPackOnly || flag.IsSpecified(ctx, "replica-regions") {
 		excludedRegions, err := GetExcludedRegions(ctx)

--- a/internal/command/redis/update_test.go
+++ b/internal/command/redis/update_test.go
@@ -213,16 +213,17 @@ func TestResolveProdPackIsIndependentOfPlanChange(t *testing.T) {
 }
 
 func TestOptionState(t *testing.T) {
-	assert.Equal(t, "unchanged", optionState(map[string]any{}, "eviction"))
+	assert.Equal(t, "disabled", optionState(map[string]any{}, "eviction"), "absent key means the user declined to enable it")
 	assert.Equal(t, "enabled", optionState(map[string]any{"eviction": true}, "eviction"))
 	assert.Equal(t, "disabled", optionState(map[string]any{"eviction": false}, "eviction"))
-	assert.Equal(t, "disabled", optionState(map[string]any{"eviction": "yes"}, "eviction"))
+	assert.Equal(t, "disabled", optionState(map[string]any{"eviction": "yes"}, "eviction"), "garbage must not panic")
 }
 
 func TestProdPackState(t *testing.T) {
-	assert.Equal(t, "unchanged", prodPackState(nil))
-	assert.Equal(t, "enabled", prodPackState(boolPtr(true)))
-	assert.Equal(t, "disabled", prodPackState(boolPtr(false)))
+	assert.Equal(t, "enabled", prodPackState(boolPtr(true), false))
+	assert.Equal(t, "disabled", prodPackState(boolPtr(false), true))
+	assert.Equal(t, "enabled", prodPackState(nil, true), "no decision falls back to the stored value")
+	assert.Equal(t, "disabled", prodPackState(nil, false))
 }
 
 func TestStripProdPack(t *testing.T) {

--- a/internal/command/redis/update_test.go
+++ b/internal/command/redis/update_test.go
@@ -35,7 +35,8 @@ func (c *captureGenqClient) MakeRequest(_ context.Context, req *genq.Request, re
 	return nil
 }
 
-// confirmStub returns a canned answer and records whether it was called.
+// confirmStub returns a canned answer and records whether it was called, so a
+// test can assert which of the two prompts resolveProdPack offered.
 func confirmStub(answer bool, err error, called *bool) func() (bool, error) {
 	return func() (bool, error) {
 		*called = true
@@ -48,54 +49,80 @@ func TestResolveProdPack(t *testing.T) {
 	nonInteractive := prompt.NonInteractiveError("prompt: non interactive")
 
 	tests := []struct {
-		name         string
-		enableFlag   bool
-		disableFlag  bool
-		stored       any
-		legacy       bool
-		answer       bool
-		answerErr    error
-		want         *bool
-		wantErr      bool
-		wantPrompted bool
+		name              string
+		enableFlag        bool
+		disableFlag       bool
+		stored            any
+		legacy            bool
+		answer            bool
+		answerErr         error
+		want              *bool
+		wantErr           bool
+		wantEnablePrompt  bool
+		wantDisablePrompt bool
 	}{
 		{
-			name:   "no flags, key absent: no decision, no prompt",
-			stored: nil,
-			want:   nil,
+			name:             "no flags, key absent, user confirms enable: explicit true",
+			stored:           nil,
+			answer:           true,
+			want:             boolPtr(true),
+			wantEnablePrompt: true,
 		},
 		{
-			name:   "no flags, stored false: no decision, no prompt",
-			stored: false,
-			want:   nil,
+			name:             "no flags, key absent, user declines enable: no decision",
+			stored:           nil,
+			answer:           false,
+			want:             nil,
+			wantEnablePrompt: true,
 		},
 		{
-			name:         "no flags, stored true, user declines disable: no decision",
-			stored:       true,
-			answer:       false,
-			want:         nil,
-			wantPrompted: true,
+			name:             "no flags, stored false, user confirms enable: explicit true",
+			stored:           false,
+			answer:           true,
+			want:             boolPtr(true),
+			wantEnablePrompt: true,
 		},
 		{
-			name:         "no flags, stored true, user confirms disable: explicit false",
-			stored:       true,
-			answer:       true,
-			want:         boolPtr(false),
-			wantPrompted: true,
+			name:             "no flags, stored false, user declines enable: no decision",
+			stored:           false,
+			answer:           false,
+			want:             nil,
+			wantEnablePrompt: true,
 		},
 		{
-			name:         "no flags, stored true, non-interactive: no decision instead of disable",
-			stored:       true,
-			answerErr:    nonInteractive,
-			want:         nil,
-			wantPrompted: true,
+			name:              "no flags, stored true, user declines disable: no decision",
+			stored:            true,
+			answer:            false,
+			want:              nil,
+			wantDisablePrompt: true,
 		},
 		{
-			name:         "no flags, stored true, prompt error propagates",
-			stored:       true,
-			answerErr:    errors.New("boom"),
-			wantErr:      true,
-			wantPrompted: true,
+			name:              "no flags, stored true, user confirms disable: explicit false",
+			stored:            true,
+			answer:            true,
+			want:              boolPtr(false),
+			wantDisablePrompt: true,
+		},
+		{
+			name:              "no flags, stored true, non-interactive: no decision instead of disable",
+			stored:            true,
+			answerErr:         nonInteractive,
+			want:              nil,
+			wantDisablePrompt: true,
+		},
+		{
+			name:             "no flags, key absent, non-interactive: no decision instead of enable",
+			stored:           nil,
+			answerErr:        nonInteractive,
+			want:             nil,
+			wantEnablePrompt: true,
+		},
+		{
+			name:              "no flags, stored true, prompt error propagates",
+			stored:            true,
+			answerErr:         errors.New("boom"),
+			wantErr:           true,
+			wantDisablePrompt: true,
 		},
 		{
 			name:       "enable flag: explicit true, no prompt",
@@ -134,16 +161,22 @@ func TestResolveProdPack(t *testing.T) {
 			want:   nil,
 		},
 		{
-			name:   "stored non-bool garbage: treated as unknown, no prompt",
-			stored: "yes",
-			want:   nil,
+			name:             "stored non-bool garbage: prompts to enable",
+			stored:           "yes",
+			answer:           true,
+			want:             boolPtr(true),
+			wantEnablePrompt: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prompted := false
-			got, err := resolveProdPack(tt.enableFlag, tt.disableFlag, tt.stored, tt.legacy, confirmStub(tt.answer, tt.answerErr, &prompted))
+			enablePrompted, disablePrompted := false, false
+			got, err := resolveProdPack(
+				tt.enableFlag, tt.disableFlag, tt.stored, tt.legacy,
+				confirmStub(tt.answer, tt.answerErr, &disablePrompted),
+				confirmStub(tt.answer, tt.answerErr, &enablePrompted),
+			)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -151,7 +184,8 @@ func TestResolveProdPack(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantPrompted, prompted, "prompt invocation")
+			assert.Equal(t, tt.wantEnablePrompt, enablePrompted, "enable prompt offered")
+			assert.Equal(t, tt.wantDisablePrompt, disablePrompted, "disable prompt offered")
 
 			if tt.want == nil {
 				assert.Nil(t, got)
@@ -163,6 +197,34 @@ func TestResolveProdPack(t *testing.T) {
 	}
 }
 
+// A ProdPack decision must reach the wire even when the plan is untouched:
+// Upstash applies the add-on change on its own.
+func TestResolveProdPackIsIndependentOfPlanChange(t *testing.T) {
+	enablePrompted, disablePrompted := false, false
+	got, err := resolveProdPack(
+		false, false, false, false,
+		confirmStub(true, nil, &disablePrompted),
+		confirmStub(true, nil, &enablePrompted),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, *got)
+}
+
+func TestOptionState(t *testing.T) {
+	assert.Equal(t, "unchanged", optionState(map[string]any{}, "eviction"))
+	assert.Equal(t, "enabled", optionState(map[string]any{"eviction": true}, "eviction"))
+	assert.Equal(t, "disabled", optionState(map[string]any{"eviction": false}, "eviction"))
+	assert.Equal(t, "disabled", optionState(map[string]any{"eviction": "yes"}, "eviction"))
+}
+
+func TestProdPackState(t *testing.T) {
+	assert.Equal(t, "unchanged", prodPackState(nil))
+	assert.Equal(t, "enabled", prodPackState(boolPtr(true)))
+	assert.Equal(t, "disabled", prodPackState(boolPtr(false)))
+}
+
 func TestStripProdPack(t *testing.T) {
 	options := map[string]any{"prod_pack": true, "eviction": true}
 	stripProdPack(options)
@@ -170,32 +232,6 @@ func TestStripProdPack(t *testing.T) {
 	assert.False(t, present, "prod_pack must be omitted from the legacy options blob")
 	assert.Equal(t, true, options["eviction"], "other options untouched")
 }
-
-// New logic is to allow prodpack change even without a plan change, so removing this
-/*func TestValidateProdPackPlanChange(t *testing.T) {
-	tests := []struct {
-		name      string
-		decision  *bool
-		current   string
-		selected  string
-		expectErr bool
-	}{
-		{name: "explicit decision with same plan", decision: boolPtr(false), current: "plan", selected: "plan", expectErr: true},
-		{name: "explicit decision with changed plan", decision: boolPtr(true), current: "plan", selected: "other"},
-		{name: "no decision with same plan", current: "plan", selected: "plan"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateProdPackPlanChange(tt.decision, tt.current, tt.selected)
-			if tt.expectErr {
-				require.EqualError(t, err, "ProdPack can only be changed together with a plan change; pick a different plan or drop the flag")
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}*/
 
 func TestUpdateRedisAddOnWire(t *testing.T) {
 	tests := []struct {
@@ -215,15 +251,19 @@ func TestUpdateRedisAddOnWire(t *testing.T) {
 			disable:      true,
 			wantProdPack: false,
 		},
+		{
+			name:         "explicit enable uses typed input and omits option key",
+			enable:       true,
+			wantProdPack: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// This mirrors production wiring: resolve intent, sanitize the
 			// legacy options blob, then pass intent through the typed operation.
-			decision, err := resolveProdPack(tt.enable, tt.disable, tt.stored, false, func() (bool, error) {
-				return false, nil
-			})
+			noPrompt := func() (bool, error) { return false, nil }
+			decision, err := resolveProdPack(tt.enable, tt.disable, tt.stored, false, noPrompt, noPrompt)
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantProdPack, func() any {
 				if decision == nil {
@@ -249,10 +289,15 @@ func TestUpdateRedisAddOnWire(t *testing.T) {
 	}
 }
 
-func TestSamePlanProdPackDecisionRejectsBeforeGraphQLRequest(t *testing.T) {
+// The plan argument is unrelated to the ProdPack argument: sending the same
+// plan back must still carry an explicit ProdPack decision to the provider.
+func TestProdPackDecisionSurvivesUnchangedPlan(t *testing.T) {
 	client := &captureGenqClient{}
-	err := validateProdPackPlanChange(boolPtr(false), "plan", "plan")
 
-	require.EqualError(t, err, "ProdPack can only be changed together with a plan change; pick a different plan or drop the flag")
-	assert.Zero(t, client.requests, "same-plan intent must stop before the GraphQL mutation")
+	_, err := gql.UpdateRedisAddOn(context.Background(), client, "addon", "plan", []string{"ord"}, map[string]any{}, map[string]any{}, boolPtr(true))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, client.requests)
+	assert.Equal(t, "plan", client.variables["planId"])
+	assert.Equal(t, true, client.variables["prodPack"])
 }

--- a/internal/command/redis/update_test.go
+++ b/internal/command/redis/update_test.go
@@ -171,7 +171,8 @@ func TestStripProdPack(t *testing.T) {
 	assert.Equal(t, true, options["eviction"], "other options untouched")
 }
 
-func TestValidateProdPackPlanChange(t *testing.T) {
+// New logic is to allow prodpack change even without a plan change, so removing this
+/*func TestValidateProdPackPlanChange(t *testing.T) {
 	tests := []struct {
 		name      string
 		decision  *bool
@@ -194,7 +195,7 @@ func TestValidateProdPackPlanChange(t *testing.T) {
 			}
 		})
 	}
-}
+}*/
 
 func TestUpdateRedisAddOnWire(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Supersedes #5147, which @KTanAug21 closed in favour of this one. Her commit is preserved here, so this PR carries the whole change: her work plus the fixes below.

Same six Upstash requests, same two confirm closures, same agreed semantics: `--enable-prodpack` / `--disable-prodpack` take precedence and a question is only asked when neither flag is passed (confirmed with Sertug).

### The panic the manual testing couldn't reach

`create.go` only writes `options["prod_pack"]` when ProdPack is enabled, so a database that never had it has no key at all — and the manual runs on #5147 were against a database that had been toggled, so the key was always present. On a database that never had ProdPack, `options["prod_pack"].(bool)` panics with `interface conversion: interface {} is nil, not bool`.

### Declining leaves ProdPack alone

On both branches now, answering "no" means "don't touch it" rather than "set the opposite" — so a stale stored copy can't flip a setting the user never asked to change, which is the failure mode #5086 was written to close.

### Summary output

Kept as Upstash asked — the summary always names a state, `enabled` or `disabled`, and falls back to the stored value when the user made no decision (read safely, and read before `stripProdPack` removes the key). It drops the old `ProdPack: unchanged (use --enable-prodpack ...)` line, which otherwise printed *above* a possibly contradictory `ProdPack: false`.

Worth knowing when reading that fallback: #5086 notes the stored copy can be stale in either direction, so in the no-decision case the line reports last-known state, not verified state. 

The server side allowing to enable/disable prodpack w/o a plan change is here: https://github.com/superfly/web/pull/4369

