### PR TITLE
Preserve host for WireGuard-less Docker clients.

### DIFF
--- a/internal/build/imgsrc/docker.go
+++ b/internal/build/imgsrc/docker.go
@@ -614,6 +614,7 @@ func buildWireguardlessClientOpts(ctx context.Context, host, appName string) ([]
 	}
 
 	opts := []dockerclient.Opt{
+		dockerclient.WithHost(host),
 		dockerclient.WithAPIVersionNegotiation(),
 		dockerclient.WithHTTPHeaders(map[string]string{
 			"Authorization": "Basic " + basicAuth(appName, config.Tokens(ctx).Docker()),


### PR DESCRIPTION
WireGuard-less builders used a custom dialer to reach the remote daemon, but left the Docker client's host set to the local Unix socket default. This made direct requests work while Pack's Moby client and lifecycle configuration were given the wrong daemon address.

Set the remote host explicitly so all buildpack operations target the remote builder consistently.

The bug can be reproduced with the following fly.toml file:

    app = "buildpack-repro"

    [build]
      builder = "heroku/builder:24"

A Dockerfile is not necessary. Then, run:

    fly deploy --depot --wg=false --recreate-builder

This will fail with:

    Error: failed to fetch an image or build from source: failed to fetch builder image 'index.docker.io/heroku/builder:24': failed to connect to the docker API at unix:///var/run/docker.sock: lookup /var/run/docker.sock: no such host