### PR TITLE
Disable brittle preflight test for now.

### DIFF
--- a/test/preflight/fly_postgres_test.go
+++ b/test/preflight/fly_postgres_test.go
@@ -159,6 +159,8 @@ func TestPostgres_autostart(t *testing.T) {
 }
 
 func TestPostgres_FlexFailover(t *testing.T) {
+	t.Skip("disabled until we synced the recently-published postgres-flex at digest f2aaf3666b0f")
+
 	if testing.Short() {
 		t.Skip()
 	}


### PR DESCRIPTION
Once we synced the image digest of the latest postgres-flex release, we should re-enable this test.