### PR TITLE
mpg: migrate attach to the Machines API

### DIFF
--- a/internal/build/imgsrc/flaps_mock_test.go
+++ b/internal/build/imgsrc/flaps_mock_test.go
@@ -162,6 +162,21 @@ func (mr *MockFlapsClientMockRecorder) CreateCustomCertificate(ctx, appName, req
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCustomCertificate", reflect.TypeOf((*MockFlapsClient)(nil).CreateCustomCertificate), ctx, appName, req)
 }
 
+// CreateManagedPostgresAttachment mocks base method.
+func (m *MockFlapsClient) CreateManagedPostgresAttachment(ctx context.Context, id string, req flaps.CreateManagedPostgresAttachmentRequest) (flaps.ManagedPostgresAttachment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateManagedPostgresAttachment", ctx, id, req)
+	ret0, _ := ret[0].(flaps.ManagedPostgresAttachment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateManagedPostgresAttachment indicates an expected call of CreateManagedPostgresAttachment.
+func (mr *MockFlapsClientMockRecorder) CreateManagedPostgresAttachment(ctx, id, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateManagedPostgresAttachment", reflect.TypeOf((*MockFlapsClient)(nil).CreateManagedPostgresAttachment), ctx, id, req)
+}
+
 // CreateManagedPostgresBackup mocks base method.
 func (m *MockFlapsClient) CreateManagedPostgresBackup(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error {
 	m.ctrl.T.Helper()

--- a/internal/command/deploy/mock_client_test.go
+++ b/internal/command/deploy/mock_client_test.go
@@ -165,6 +165,10 @@ func (m *mockFlapsClient) CreateManagedPostgresBackup(ctx context.Context, id st
 	return fmt.Errorf("not implemented")
 }
 
+func (m *mockFlapsClient) CreateManagedPostgresAttachment(ctx context.Context, id string, req flaps.CreateManagedPostgresAttachmentRequest) (flaps.ManagedPostgresAttachment, error) {
+	return flaps.ManagedPostgresAttachment{}, fmt.Errorf("not implemented")
+}
+
 func (m *mockFlapsClient) EnableManagedPostgresExtension(ctx context.Context, id, database string, req flaps.EnableManagedPostgresExtensionRequest) error {
 	return fmt.Errorf("not implemented")
 }

--- a/internal/command/mpg/v2/run_attach.go
+++ b/internal/command/mpg/v2/run_attach.go
@@ -2,9 +2,11 @@ package cmdv2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/appsecrets"
 	"github.com/superfly/flyctl/internal/flag"
@@ -14,25 +16,27 @@ import (
 	"github.com/superfly/flyctl/iostreams"
 )
 
+// RunAttach attaches a managed Postgres cluster to an app.
 func RunAttach(ctx context.Context, clusterID string) error {
 	var (
 		appName = appconfig.NameFromContext(ctx)
 		io      = iostreams.FromContext(ctx)
 	)
 
-	mpgClient := mpgv2.ClientFromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	legacyClient := mpgv2.ClientFromContext(ctx)
 
 	// Username selection: flag > prompt (if interactive) > empty (use default credentials)
 	username := flag.GetString(ctx, "username")
 	if username == "" && io.IsInteractive() {
 		// Prompt for user selection
-		usersResponse, err := mpgClient.ListUsers(ctx, clusterID)
+		users, err := listUsers(ctx, clusterID)
 		if err != nil {
 			return fmt.Errorf("failed to list users: %w", err)
 		}
 
 		var userOptions []string
-		for _, user := range usersResponse.Data {
+		for _, user := range users {
 			userOptions = append(userOptions, fmt.Sprintf("%s [%s]", user.Name, user.Role))
 		}
 		// Add option to create new user
@@ -57,7 +61,7 @@ func RunAttach(ctx context.Context, clusterID string) error {
 
 			// Prompt for role selection
 			var roleIndex int
-			roleOptions := []string{"schema_admin", "writer", "reader"}
+			roleOptions := managedPostgresUserRoleOptions
 			err = prompt.Select(ctx, &roleIndex, "Select user role:", "", roleOptions...)
 			if err != nil {
 				return err
@@ -66,37 +70,31 @@ func RunAttach(ctx context.Context, clusterID string) error {
 
 			fmt.Fprintf(io.Out, "Creating user %s with role %s...\n", userInput, role)
 
-			input := mpgv2.CreateUserWithRoleInput{
-				Username: userInput,
-				Role:     role,
-			}
-
-			createResponse, err := mpgClient.CreateUserWithRole(ctx, clusterID, input)
+			user, err := createUserPublicFirst(ctx, flapsClient, legacyClient, clusterID, userInput, role)
 			if err != nil {
 				return fmt.Errorf("failed to create user: %w", err)
 			}
 
 			fmt.Fprintf(io.Out, "User created successfully!\n")
-			username = createResponse.Data.Name
-		} else if len(usersResponse.Data) > 0 {
-			username = usersResponse.Data[userIndex].Name
+			username = user.Name
+		} else if len(users) > 0 {
+			username = users[userIndex].Name
 		}
-		// If no users found and create wasn't selected, username remains empty and will use default credentials.
+		// If no users found and create wasn't selected, username remains empty
+		// and will use default credentials.
 	}
 
-	// Database selection priority: flag > prompt result (if interactive) > credentials.DBName
-	var db string
-	if database := flag.GetString(ctx, "database"); database != "" {
-		db = database
-	} else if io.IsInteractive() {
+	// Database selection priority: flag > prompt result (if interactive) > empty (use default credentials from cluster).
+	db := flag.GetString(ctx, "database")
+	if db == "" && io.IsInteractive() {
 		// Prompt for database selection
-		databasesResponse, err := mpgClient.ListDatabases(ctx, clusterID)
+		databases, err := listDatabasesPublicFirst(ctx, flapsClient, legacyClient, clusterID)
 		if err != nil {
 			return fmt.Errorf("failed to list databases: %w", err)
 		}
 
 		var dbOptions []string
-		for _, database := range databasesResponse.Data {
+		for _, database := range databases {
 			dbOptions = append(dbOptions, database.Name)
 		}
 		// Add option to create new database
@@ -121,54 +119,55 @@ func RunAttach(ctx context.Context, clusterID string) error {
 
 			fmt.Fprintf(io.Out, "Creating database %s...\n", dbName)
 
-			input := mpgv2.CreateDatabaseInput{
-				Name: dbName,
-			}
-
-			err := mpgClient.CreateDatabase(ctx, clusterID, input)
+			err = createDatabasePublicFirst(ctx, flapsClient, legacyClient, clusterID, dbName)
 			if err != nil {
 				return fmt.Errorf("failed to create database: %w", err)
 			}
 
 			fmt.Fprintf(io.Out, "Database created successfully!\n")
 			db = dbName
-		} else if len(databasesResponse.Data) > 0 {
-			db = databasesResponse.Data[dbIndex].Name
+		} else if len(databases) > 0 {
+			db = databases[dbIndex].Name
 		}
 	}
 
-	// Get cluster details with credentials
-	response, err := mpgClient.GetClusterById(ctx, clusterID)
+	// Get cluster details and credentials. The public Machines API cluster show does
+	// not expose credentials, so we always use the legacy client for the connection
+	// URI and default DB name. This preserves the existing behavior.
+	clusterResp, err := legacyClient.GetClusterById(ctx, clusterID)
 	if err != nil {
 		return fmt.Errorf("failed retrieving cluster %s: %w", clusterID, err)
 	}
 
-	// Get credentials - use user-specific endpoint if username provided, otherwise use default
-	var credentials mpgv2.GetClusterCredentialsResponse
+	baseUri := clusterResp.Credentials.ConnectionUri
+	if baseUri == "" {
+		return fmt.Errorf("connection URI is empty; cannot attach without valid credentials")
+	}
+
+	var connectionUri string
+	var user, password string
+
 	if username != "" {
-		userCreds, err := mpgClient.GetUserCredentials(ctx, clusterID, username)
+		creds, err := getUserCredentialsPublicFirst(ctx, flapsClient, legacyClient, clusterID, username)
 		if err != nil {
 			return fmt.Errorf("failed retrieving credentials for user %s: %w", username, err)
 		}
-		// Convert user credentials to the standard format
-		credentials = mpgv2.GetClusterCredentialsResponse{
-			User:     userCreds.Data.User,
-			Password: userCreds.Data.Password,
-			DBName:   response.Credentials.DBName, // Use default DB name from cluster credentials
-		}
+		user = creds.User
+		password = creds.Password
 	} else {
-		credentials = response.Credentials
+		user = clusterResp.Credentials.User
+		password = clusterResp.Credentials.Password
 	}
 
-	// Use selected database or fall back to default from credentials
 	if db == "" {
-		db = credentials.DBName
+		db = clusterResp.Credentials.DBName
 	}
-
-	flapsClient := flapsutil.ClientFromContext(ctx)
+	connectionUri, err = buildConnectionUri(baseUri, user, password, db)
+	if err != nil {
+		return fmt.Errorf("failed to build connection URI: %w", err)
+	}
 
 	variableName := flag.GetString(ctx, "variable-name")
-
 	if variableName == "" {
 		variableName = "DATABASE_URL"
 	}
@@ -185,19 +184,7 @@ func RunAttach(ctx context.Context, clusterID string) error {
 		}
 	}
 
-	// Build connection URI with selected user and database
-	// Parse the base connection URI to extract host/port
-	baseUri := response.Credentials.ConnectionUri
-	parsedUri, err := url.Parse(baseUri)
-	if err != nil {
-		return fmt.Errorf("failed to parse connection URI: %w", err)
-	}
-
-	// Build new connection URI with selected user, password, and database
-	parsedUri.User = url.UserPassword(credentials.User, credentials.Password)
-	parsedUri.Path = "/" + db
-	connectionUri := parsedUri.String()
-
+	// Write the secret.
 	s := map[string]string{}
 	s[variableName] = connectionUri
 
@@ -205,17 +192,142 @@ func RunAttach(ctx context.Context, clusterID string) error {
 		return err
 	}
 
-	// Create attachment record to track the cluster-app relationship
+	// Create attachment record to track the cluster-app relationship.
 	attachInput := mpgv2.CreateAttachmentInput{
 		AppName: appName,
 	}
-	if _, err := mpgClient.CreateAttachment(ctx, clusterID, attachInput); err != nil {
-		// Log warning but don't fail - the secret was set successfully
+	err = createAttachmentPublicFirst(ctx, flapsClient, legacyClient, clusterID, attachInput)
+	if err != nil {
+		// Attachment is warning-only; the secret was set successfully.
 		fmt.Fprintf(io.ErrOut, "Warning: failed to create attachment record: %v\n", err)
 	}
 
 	fmt.Fprintf(io.Out, "\nPostgres cluster %s is being attached to %s\n", clusterID, appName)
 	fmt.Fprintf(io.Out, "The following secret was added to %s:\n  %s=%s\n", appName, variableName, connectionUri)
+
+	return nil
+}
+
+// createUserPublicFirst tries the public Machines API for user creation and
+// falls back to the legacy MPGv2 client on a classified 404.
+func createUserPublicFirst(ctx context.Context, flapsClient flapsutil.FlapsClient, legacyClient mpgv2.ClientV2, clusterID, username, role string) (mpgv2.User, error) {
+	req := flaps.CreateManagedPostgresUserRequest{
+		Username: username,
+		Role:     role,
+	}
+
+	created, err := flapsClient.CreateManagedPostgresUser(ctx, clusterID, req)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		input := mpgv2.CreateUserWithRoleInput{
+			Username: username,
+			Role:     role,
+		}
+		response, legacyErr := legacyClient.CreateUserWithRole(ctx, clusterID, input)
+		if legacyErr != nil {
+			return mpgv2.User{}, legacyErr
+		}
+
+		return mpgv2.User{Name: response.Data.Name, Role: response.Data.Role}, nil
+	}
+	if err != nil {
+		return mpgv2.User{}, err
+	}
+
+	return mpgv2.User{Name: created.Username, Role: string(created.Role)}, nil
+}
+
+// userCredentials is the internal shape used to carry user credentials through
+// the attach flow, compatible with the legacy response fields used elsewhere.
+type userCredentials struct {
+	User     string
+	Password string
+}
+
+// getUserCredentialsPublicFirst tries the public Machines API for user
+// credentials and falls back to the legacy MPGv2 client on a classified 404.
+func getUserCredentialsPublicFirst(ctx context.Context, flapsClient flapsutil.FlapsClient, legacyClient mpgv2.ClientV2, clusterID, username string) (userCredentials, error) {
+	creds, err := flapsClient.GetManagedPostgresUserCredentials(ctx, clusterID, username)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		response, legacyErr := legacyClient.GetUserCredentials(ctx, clusterID, username)
+		if legacyErr != nil {
+			return userCredentials{}, legacyErr
+		}
+
+		return userCredentials{User: response.Data.User, Password: response.Data.Password}, nil
+	}
+	if err != nil {
+		return userCredentials{}, err
+	}
+
+	return userCredentials{User: creds.Username, Password: creds.Password}, nil
+}
+
+// listDatabasesPublicFirst tries the public Machines API for database listing
+// and falls back to the legacy MPGv2 client on a classified 404.
+func listDatabasesPublicFirst(ctx context.Context, flapsClient flapsutil.FlapsClient, legacyClient mpgv2.ClientV2, clusterID string) ([]mpgv2.Database, error) {
+	databases, err := flapsClient.ListManagedPostgresDatabases(ctx, clusterID)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		response, legacyErr := legacyClient.ListDatabases(ctx, clusterID)
+		if legacyErr != nil {
+			return nil, legacyErr
+		}
+
+		return response.Data, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	dbs := make([]mpgv2.Database, 0, len(databases))
+	for _, d := range databases {
+		dbs = append(dbs, mpgv2.Database{Name: d.Name})
+	}
+
+	return dbs, nil
+}
+
+// createDatabasePublicFirst tries the public Machines API for database
+// creation and falls back to the legacy MPGv2 client on a classified 404.
+func createDatabasePublicFirst(ctx context.Context, flapsClient flapsutil.FlapsClient, legacyClient mpgv2.ClientV2, clusterID, dbName string) error {
+	req := flaps.CreateManagedPostgresDatabaseRequest{Name: dbName}
+
+	_, err := flapsClient.CreateManagedPostgresDatabase(ctx, clusterID, req)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		return legacyClient.CreateDatabase(ctx, clusterID, mpgv2.CreateDatabaseInput{Name: dbName})
+	}
+
+	return err
+}
+
+// buildConnectionUri parses the base URI and substitutes user, password, and
+// database to produce a complete connection string.
+func buildConnectionUri(baseUri, user, password, db string) (string, error) {
+	parsedURI, err := url.Parse(baseUri)
+	if err != nil {
+		return "", err
+	}
+	parsedURI.User = url.UserPassword(user, password)
+	parsedURI.Path = "/" + db
+
+	return parsedURI.String(), nil
+}
+
+// createAttachmentPublicFirst tries the public Machines API for attachment
+// creation and falls back to the legacy MPGv2 client on a classified 404.
+func createAttachmentPublicFirst(ctx context.Context, flapsClient flapsutil.FlapsClient, legacyClient mpgv2.ClientV2, clusterID string, input mpgv2.CreateAttachmentInput) error {
+	req := flaps.CreateManagedPostgresAttachmentRequest{
+		AppName: input.AppName,
+	}
+
+	_, err := flapsClient.CreateManagedPostgresAttachment(ctx, clusterID, req)
+	if errors.Is(err, flaps.ErrFlapsNotFound) {
+		_, err := legacyClient.CreateAttachment(ctx, clusterID, input)
+
+		return err
+	}
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/command/mpg/v2/run_attach_test.go
+++ b/internal/command/mpg/v2/run_attach_test.go
@@ -1,0 +1,553 @@
+package cmdv2
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	"github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/flyctl"
+	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/mock"
+	"github.com/superfly/flyctl/internal/state"
+	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+// attachTestContext builds a context with iostreams, app name, config directory,
+// and a fresh empty flag set that callers populate. The IOStreams returned by
+// iostreams.Test() are non-interactive, so RunAttach's interactive prompt
+// paths are skipped unless callers opt in.
+func attachTestContext(t *testing.T) (context.Context, *bytes.Buffer, *bytes.Buffer, *pflag.FlagSet) {
+	t.Helper()
+	io, _, stdout, stderr := iostreams.Test()
+	configDir := t.TempDir()
+	t.Setenv("FLY_CONFIG_DIR", configDir)
+	flyctl.InitConfig()
+	ctx := iostreams.NewContext(context.Background(), io)
+	ctx = appconfig.WithName(ctx, "my-app")
+	ctx = appconfig.WithConfig(ctx, &appconfig.Config{})
+	ctx = state.WithConfigDirectory(ctx, t.TempDir())
+	flags := pflag.NewFlagSet("attach-test", pflag.ContinueOnError)
+
+	return flagctx.NewContext(ctx, flags), stdout, stderr, flags
+}
+
+// addAttachFlags adds the username, database, and variable-name flags used by
+// RunAttach to fs.
+func addAttachFlags(fs *pflag.FlagSet) {
+	fs.String("username", "", "")
+	fs.String("database", "", "")
+	fs.String("variable-name", "", "")
+}
+
+// minimalAttachFlapsClient returns a mock FlapsClient with all methods needed
+// by RunAttach pre-set to succeed or return safe defaults. Callers override
+// specific Func fields as needed.
+func minimalAttachFlapsClient() *mock.FlapsClient {
+	return &mock.FlapsClient{
+		ListManagedPostgresUsersFunc: func(_ context.Context, id string) ([]flaps.ManagedPostgresUser, error) {
+			return []flaps.ManagedPostgresUser{{Username: "alice", Role: flaps.ManagedPostgresUserRoleWriter}}, nil
+		},
+		ListManagedPostgresDatabasesFunc: func(_ context.Context, id string) ([]flaps.ManagedPostgresDatabase, error) {
+			return []flaps.ManagedPostgresDatabase{{Name: "appdb"}}, nil
+		},
+		GetManagedPostgresUserCredentialsFunc: func(_ context.Context, id, username string) (flaps.ManagedPostgresUserCredentials, error) {
+			return flaps.ManagedPostgresUserCredentials{Username: username, Password: "alice-pass"}, nil
+		},
+		CreateManagedPostgresAttachmentFunc: func(_ context.Context, id string, req flaps.CreateManagedPostgresAttachmentRequest) (flaps.ManagedPostgresAttachment, error) {
+			return flaps.ManagedPostgresAttachment{}, nil
+		},
+		ListAppSecretsFunc: func(_ context.Context, appName string, version *uint64, show bool) ([]fly.AppSecret, error) {
+			return nil, nil
+		},
+		UpdateAppSecretsFunc: func(_ context.Context, appName string, values map[string]*string) (*fly.UpdateAppSecretsResp, error) {
+			return &fly.UpdateAppSecretsResp{Version: 1}, nil
+		},
+	}
+}
+
+// minimalAttachLegacyClient returns a mock MpgV2Client with the cluster
+// credentials needed by RunAttach pre-set. Callers override specific Func
+// fields as needed.
+func minimalAttachLegacyClient() *mock.MpgV2Client {
+	return &mock.MpgV2Client{
+		GetClusterByIdFunc: func(_ context.Context, id string) (mpgv2.GetClusterResponse, error) {
+			return mpgv2.GetClusterResponse{
+				Credentials: mpgv2.GetClusterCredentialsResponse{
+					User:          "default_user",
+					Password:      "default-pass",
+					DBName:        "default_db",
+					ConnectionUri: "postgres://default_user:default-pass@pooler.fly.dev:5432/default_db",
+				},
+			}, nil
+		},
+		GetUserCredentialsFunc: func(_ context.Context, id, username string) (mpgv2.GetUserCredentialsResponse, error) {
+			return mpgv2.GetUserCredentialsResponse{
+				Data: struct {
+					User     string `json:"username"`
+					Password string `json:"password"`
+				}{User: username, Password: "legacy-pass"},
+			}, nil
+		},
+		CreateAttachmentFunc: func(_ context.Context, clusterID string, input mpgv2.CreateAttachmentInput) (mpgv2.CreateAttachmentResponse, error) {
+			return mpgv2.CreateAttachmentResponse{}, nil
+		},
+	}
+}
+
+// wantSecretOutput returns the expected stdout for a successful attach.
+func wantSecretOutput(appName, varName, uri string) string {
+	return "\nPostgres cluster mpg-123 is being attached to " + appName + "\n" +
+		"The following secret was added to " + appName + ":\n" +
+		"  " + varName + "=" + uri + "\n"
+}
+
+func TestBuildConnectionUri_invalidBase(t *testing.T) {
+	_, err := buildConnectionUri("postgres://host:notaport/db", "user", "pass", "database")
+	require.Error(t, err)
+}
+
+// TestRunAttach_publicSuccess verifies the happy path using all public APIs
+func TestRunAttach_publicSuccess(t *testing.T) {
+	ctx, stdout, stderr, flags := attachTestContext(t)
+	addAttachFlags(flags)
+	require.NoError(t, flags.Set("username", "alice"))
+	require.NoError(t, flags.Set("database", "appdb"))
+
+	flapsClient := minimalAttachFlapsClient()
+	flapsClient.CreateManagedPostgresAttachmentFunc = func(_ context.Context, id string, req flaps.CreateManagedPostgresAttachmentRequest) (flaps.ManagedPostgresAttachment, error) {
+		require.Equal(t, "mpg-123", id)
+		require.Equal(t, "my-app", req.AppName)
+
+		return flaps.ManagedPostgresAttachment{PostgresClusterID: id, AppName: req.AppName, AttachedAt: "2024-01-01T00:00:00Z"}, nil
+	}
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
+	ctx = mpgv2.NewContextWithClient(ctx, minimalAttachLegacyClient())
+
+	err := RunAttach(ctx, "mpg-123")
+	require.NoError(t, err)
+
+	// URI: alice's credentials substituted from the public endpoint, path set to appdb.
+	wantUri := "postgres://alice:alice-pass@pooler.fly.dev:5432/appdb"
+	require.Equal(t, wantSecretOutput("my-app", "DATABASE_URL", wantUri), stdout.String())
+	require.Empty(t, stderr.String())
+}
+
+// TestRunAttach_usernameUsesClusterDatabase verifies that selecting a user without
+// --database still preserves the cluster credential DB name
+func TestRunAttach_usernameUsesClusterDatabase(t *testing.T) {
+	ctx, stdout, stderr, flags := attachTestContext(t)
+	addAttachFlags(flags)
+	require.NoError(t, flags.Set("username", "alice"))
+
+	ctx = flapsutil.NewContextWithClient(ctx, minimalAttachFlapsClient())
+	ctx = mpgv2.NewContextWithClient(ctx, minimalAttachLegacyClient())
+
+	require.NoError(t, RunAttach(ctx, "mpg-123"))
+	require.Equal(t, wantSecretOutput("my-app", "DATABASE_URL", "postgres://alice:alice-pass@pooler.fly.dev:5432/default_db"), stdout.String())
+	require.Empty(t, stderr.String())
+}
+
+// TestRunAttach_noUsernameDefaultCredentials verifies that when no username is provided,
+// the legacy cluster credentials are used directly
+func TestRunAttach_noUsernameDefaultCredentials(t *testing.T) {
+	ctx, stdout, stderr, flags := attachTestContext(t)
+	addAttachFlags(flags)
+	// No username or database flags set.
+
+	flapsClient := minimalAttachFlapsClient()
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
+	ctx = mpgv2.NewContextWithClient(ctx, minimalAttachLegacyClient())
+
+	err := RunAttach(ctx, "mpg-123")
+	require.NoError(t, err)
+
+	// Default credentials used; database defaults to default_db.
+	wantUri := "postgres://default_user:default-pass@pooler.fly.dev:5432/default_db"
+	require.Equal(t, wantSecretOutput("my-app", "DATABASE_URL", wantUri), stdout.String())
+	require.Empty(t, stderr.String())
+}
+
+// TestRunAttach_customVariableName verifies that a custom secret variable name is respected
+func TestRunAttach_customVariableName(t *testing.T) {
+	ctx, stdout, stderr, flags := attachTestContext(t)
+	addAttachFlags(flags)
+	require.NoError(t, flags.Set("variable-name", "MY_PG_URL"))
+	// No username or database.
+
+	flapsClient := minimalAttachFlapsClient()
+	flapsClient.UpdateAppSecretsFunc = func(_ context.Context, appName string, values map[string]*string) (*fly.UpdateAppSecretsResp, error) {
+		require.Contains(t, values, "MY_PG_URL")
+
+		return &fly.UpdateAppSecretsResp{Version: 1}, nil
+	}
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
+	ctx = mpgv2.NewContextWithClient(ctx, minimalAttachLegacyClient())
+
+	err := RunAttach(ctx, "mpg-123")
+	require.NoError(t, err)
+
+	wantUri := "postgres://default_user:default-pass@pooler.fly.dev:5432/default_db"
+	require.Equal(t, wantSecretOutput("my-app", "MY_PG_URL", wantUri), stdout.String())
+	require.Empty(t, stderr.String())
+}
+
+// TestRunAttach_secretAlreadySet verifies that an existing secret prevents overwrite
+func TestRunAttach_secretAlreadySet(t *testing.T) {
+	ctx, _, _, flags := attachTestContext(t)
+	addAttachFlags(flags)
+
+	flapsClient := minimalAttachFlapsClient()
+	flapsClient.ListAppSecretsFunc = func(_ context.Context, appName string, version *uint64, show bool) ([]fly.AppSecret, error) {
+		require.Equal(t, "my-app", appName)
+
+		return []fly.AppSecret{{Name: "DATABASE_URL"}}, nil
+	}
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
+	ctx = mpgv2.NewContextWithClient(ctx, minimalAttachLegacyClient())
+
+	err := RunAttach(ctx, "mpg-123")
+	require.ErrorContains(t, err, "already has DATABASE_URL set")
+}
+
+// TestRunAttach_invalidConnectionUriError verifies that an empty connection URI is rejected
+func TestRunAttach_invalidConnectionUriError(t *testing.T) {
+	ctx, _, _, flags := attachTestContext(t)
+	addAttachFlags(flags)
+	// No username.
+
+	flapsClient := minimalAttachFlapsClient()
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
+	ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+		GetClusterByIdFunc: func(_ context.Context, id string) (mpgv2.GetClusterResponse, error) {
+			return mpgv2.GetClusterResponse{
+				Credentials: mpgv2.GetClusterCredentialsResponse{
+					User:          "default_user",
+					Password:      "default-pass",
+					DBName:        "default_db",
+					ConnectionUri: "", // Empty: triggers error.
+				},
+			}, nil
+		},
+	})
+
+	err := RunAttach(ctx, "mpg-123")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connection URI is empty")
+}
+
+// TestRunAttach_attachmentWarningOnly verifies that a failed attachment creation produces
+// a warning but does not fail the overall attach
+func TestRunAttach_attachmentWarningOnly(t *testing.T) {
+	ctx, _, stderr, flags := attachTestContext(t)
+	addAttachFlags(flags)
+	require.NoError(t, flags.Set("username", "alice"))
+	require.NoError(t, flags.Set("database", "appdb"))
+
+	flapsClient := minimalAttachFlapsClient()
+	flapsClient.CreateManagedPostgresAttachmentFunc = func(_ context.Context, id string, req flaps.CreateManagedPostgresAttachmentRequest) (flaps.ManagedPostgresAttachment, error) {
+		return flaps.ManagedPostgresAttachment{}, errors.New("attachment failed")
+	}
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
+	ctx = mpgv2.NewContextWithClient(ctx, minimalAttachLegacyClient())
+
+	err := RunAttach(ctx, "mpg-123")
+	require.NoError(t, err, "attachment failure should be warning-only")
+	require.Contains(t, stderr.String(), "Warning: failed to create attachment record")
+}
+
+// TestRunAttach_attachmentFallbackOnNotFound verifies that a classified 404 from the public
+// attachment API falls back to the legacy client
+func TestRunAttach_attachmentFallbackOnNotFound(t *testing.T) {
+	ctx, _, stderr, flags := attachTestContext(t)
+	addAttachFlags(flags)
+	require.NoError(t, flags.Set("username", "alice"))
+	require.NoError(t, flags.Set("database", "appdb"))
+
+	flapsClient := minimalAttachFlapsClient()
+	flapsClient.CreateManagedPostgresAttachmentFunc = func(_ context.Context, id string, req flaps.CreateManagedPostgresAttachmentRequest) (flaps.ManagedPostgresAttachment, error) {
+		return flaps.ManagedPostgresAttachment{}, flaps.ErrFlapsNotFound
+	}
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
+
+	legacyCalled := false
+	legacyClient := minimalAttachLegacyClient()
+	legacyClient.CreateAttachmentFunc = func(_ context.Context, clusterID string, input mpgv2.CreateAttachmentInput) (mpgv2.CreateAttachmentResponse, error) {
+		legacyCalled = true
+		require.Equal(t, "mpg-123", clusterID)
+		require.Equal(t, "my-app", input.AppName)
+
+		return mpgv2.CreateAttachmentResponse{}, nil
+	}
+	ctx = mpgv2.NewContextWithClient(ctx, legacyClient)
+
+	err := RunAttach(ctx, "mpg-123")
+	require.NoError(t, err)
+	require.True(t, legacyCalled, "legacy CreateAttachment should be called after public 404")
+	require.Empty(t, stderr.String(), "no warning on successful fallback")
+}
+
+// TestRunAttach_userCredentialsFallback verifies that GetUserCredentials falls back to the
+// legacy client on a classified 404. This exercises the full RunAttach flow with the
+// username flag set
+func TestRunAttach_userCredentialsFallback(t *testing.T) {
+	ctx, stdout, stderr, flags := attachTestContext(t)
+	addAttachFlags(flags)
+	require.NoError(t, flags.Set("username", "alice"))
+	require.NoError(t, flags.Set("database", "appdb"))
+
+	flapsClient := minimalAttachFlapsClient()
+	flapsClient.GetManagedPostgresUserCredentialsFunc = func(_ context.Context, id, username string) (flaps.ManagedPostgresUserCredentials, error) {
+		return flaps.ManagedPostgresUserCredentials{}, flaps.ErrFlapsNotFound
+	}
+	ctx = flapsutil.NewContextWithClient(ctx, flapsClient)
+
+	legacyCalled := false
+	legacyClient := minimalAttachLegacyClient()
+	legacyClient.GetUserCredentialsFunc = func(_ context.Context, id, username string) (mpgv2.GetUserCredentialsResponse, error) {
+		legacyCalled = true
+		require.Equal(t, "mpg-123", id)
+		require.Equal(t, "alice", username)
+
+		return mpgv2.GetUserCredentialsResponse{
+			Data: struct {
+				User     string `json:"username"`
+				Password string `json:"password"`
+			}{User: "alice", Password: "legacy-alice-pass"},
+		}, nil
+	}
+	ctx = mpgv2.NewContextWithClient(ctx, legacyClient)
+
+	err := RunAttach(ctx, "mpg-123")
+	require.NoError(t, err)
+	require.True(t, legacyCalled, "legacy GetUserCredentials should be called after public 404")
+
+	// Verify the legacy password was used in the URI.
+	wantUri := "postgres://alice:legacy-alice-pass@pooler.fly.dev:5432/appdb"
+	require.Equal(t, wantSecretOutput("my-app", "DATABASE_URL", wantUri), stdout.String())
+	require.Empty(t, stderr.String())
+}
+
+// TestListDatabasesPublicFirst exercises the extracted helper directly
+func TestListDatabasesPublicFirst(t *testing.T) {
+	tests := []struct {
+		name            string
+		publicDatabases []flaps.ManagedPostgresDatabase
+		publicErr       error
+		legacyDatabases []mpgv2.Database
+		legacyErr       error
+		wantLegacy      bool
+		wantDatabases   []mpgv2.Database
+		wantErr         string
+	}{
+		{
+			name:            "uses Machines API",
+			publicDatabases: []flaps.ManagedPostgresDatabase{{Name: "appdb"}},
+			wantDatabases:   []mpgv2.Database{{Name: "appdb"}},
+		},
+		{
+			name:            "falls back to legacy on public 404",
+			publicErr:       flaps.ErrFlapsNotFound,
+			legacyDatabases: []mpgv2.Database{{Name: "legacy_db"}},
+			wantLegacy:      true,
+			wantDatabases:   []mpgv2.Database{{Name: "legacy_db"}},
+		},
+		{
+			name:      "propagates non-404 public error without fallback",
+			publicErr: errors.New("internal server error"),
+			wantErr:   "internal server error",
+		},
+		{
+			name:       "propagates legacy error after public 404 fallback",
+			publicErr:  flaps.ErrFlapsNotFound,
+			legacyErr:  errors.New("legacy boom"),
+			wantLegacy: true,
+			wantErr:    "legacy boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			publicCalls, legacyCalls := 0, 0
+			flapsClient := &mock.FlapsClient{
+				ListManagedPostgresDatabasesFunc: func(_ context.Context, id string) ([]flaps.ManagedPostgresDatabase, error) {
+					publicCalls++
+					require.Equal(t, "mpg-123", id)
+
+					return tt.publicDatabases, tt.publicErr
+				},
+			}
+			legacyClient := &mock.MpgV2Client{
+				ListDatabasesFunc: func(_ context.Context, id string) (mpgv2.ListDatabasesResponse, error) {
+					legacyCalls++
+					require.Equal(t, "mpg-123", id)
+
+					return mpgv2.ListDatabasesResponse{Data: tt.legacyDatabases}, tt.legacyErr
+				},
+			}
+
+			databases, err := listDatabasesPublicFirst(ctx, flapsClient, legacyClient, "mpg-123")
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantDatabases, databases)
+			}
+			require.Equal(t, 1, publicCalls)
+			require.Equal(t, tt.wantLegacy, legacyCalls == 1)
+		})
+	}
+}
+
+// TestCreateUserPublicFirst exercises the extracted helper directly
+func TestCreateUserPublicFirst(t *testing.T) {
+	tests := []struct {
+		name       string
+		publicUser flaps.ManagedPostgresUser
+		publicErr  error
+		legacyUser mpgv2.User
+		legacyErr  error
+		wantLegacy bool
+		wantUser   mpgv2.User
+		wantErr    string
+	}{
+		{
+			name:       "uses Machines API",
+			publicUser: flaps.ManagedPostgresUser{Username: "newuser", Role: flaps.ManagedPostgresUserRoleWriter},
+			wantUser:   mpgv2.User{Name: "newuser", Role: "writer"},
+		},
+		{
+			name:       "falls back to legacy on public 404",
+			publicErr:  flaps.ErrFlapsNotFound,
+			legacyUser: mpgv2.User{Name: "newuser", Role: "reader"},
+			wantLegacy: true,
+			wantUser:   mpgv2.User{Name: "newuser", Role: "reader"},
+		},
+		{
+			name:      "propagates non-404 public error without fallback",
+			publicErr: errors.New("conflict: user already exists"),
+			wantErr:   "conflict: user already exists",
+		},
+		{
+			name:       "propagates legacy error after public 404 fallback",
+			publicErr:  flaps.ErrFlapsNotFound,
+			legacyErr:  errors.New("legacy boom"),
+			wantLegacy: true,
+			wantErr:    "legacy boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			publicCalls, legacyCalls := 0, 0
+			flapsClient := &mock.FlapsClient{
+				CreateManagedPostgresUserFunc: func(_ context.Context, id string, req flaps.CreateManagedPostgresUserRequest) (flaps.ManagedPostgresUser, error) {
+					publicCalls++
+					require.Equal(t, "mpg-123", id)
+					require.Equal(t, "newuser", req.Username)
+					require.Equal(t, "writer", req.Role)
+
+					return tt.publicUser, tt.publicErr
+				},
+			}
+			legacyClient := &mock.MpgV2Client{
+				CreateUserWithRoleFunc: func(_ context.Context, id string, input mpgv2.CreateUserWithRoleInput) (mpgv2.CreateUserWithRoleResponse, error) {
+					legacyCalls++
+					require.Equal(t, "mpg-123", id)
+					require.Equal(t, "newuser", input.Username)
+					require.Equal(t, "writer", input.Role)
+
+					return mpgv2.CreateUserWithRoleResponse{Data: tt.legacyUser}, tt.legacyErr
+				},
+			}
+
+			user, err := createUserPublicFirst(ctx, flapsClient, legacyClient, "mpg-123", "newuser", "writer")
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantUser, user)
+			}
+			require.Equal(t, 1, publicCalls)
+			require.Equal(t, tt.wantLegacy, legacyCalls == 1)
+		})
+	}
+}
+
+// TestCreateDatabasePublicFirst exercises the extracted helper directly
+func TestCreateDatabasePublicFirst(t *testing.T) {
+	tests := []struct {
+		name       string
+		publicErr  error
+		legacyErr  error
+		wantLegacy bool
+		wantErr    string
+	}{
+		{
+			name: "uses Machines API",
+		},
+		{
+			name:       "falls back to legacy on public 404",
+			publicErr:  flaps.ErrFlapsNotFound,
+			wantLegacy: true,
+		},
+		{
+			name:      "propagates non-404 public error without fallback",
+			publicErr: errors.New("conflict: database already exists"),
+			wantErr:   "conflict: database already exists",
+		},
+		{
+			name:       "propagates legacy error after public 404 fallback",
+			publicErr:  flaps.ErrFlapsNotFound,
+			legacyErr:  errors.New("legacy boom"),
+			wantLegacy: true,
+			wantErr:    "legacy boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			publicCalls, legacyCalls := 0, 0
+			flapsClient := &mock.FlapsClient{
+				CreateManagedPostgresDatabaseFunc: func(_ context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error) {
+					publicCalls++
+					require.Equal(t, "mpg-123", id)
+					require.Equal(t, "newdb", req.Name)
+
+					return flaps.ManagedPostgresDatabase{Name: "newdb"}, tt.publicErr
+				},
+			}
+			legacyClient := &mock.MpgV2Client{
+				CreateDatabaseFunc: func(_ context.Context, id string, input mpgv2.CreateDatabaseInput) error {
+					legacyCalls++
+					require.Equal(t, "mpg-123", id)
+					require.Equal(t, "newdb", input.Name)
+
+					return tt.legacyErr
+				},
+			}
+
+			err := createDatabasePublicFirst(ctx, flapsClient, legacyClient, "mpg-123", "newdb")
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, 1, publicCalls)
+			require.Equal(t, tt.wantLegacy, legacyCalls == 1)
+		})
+	}
+}

--- a/internal/flapsutil/flaps_client.go
+++ b/internal/flapsutil/flaps_client.go
@@ -22,6 +22,7 @@ type FlapsClient interface {
 	CreateManagedPostgresDatabase(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error)
 	CreateManagedPostgresUser(ctx context.Context, id string, req flaps.CreateManagedPostgresUserRequest) (flaps.ManagedPostgresUser, error)
 	CreateManagedPostgresBackup(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error
+	CreateManagedPostgresAttachment(ctx context.Context, id string, req flaps.CreateManagedPostgresAttachmentRequest) (flaps.ManagedPostgresAttachment, error)
 	EnableManagedPostgresExtension(ctx context.Context, id, database string, req flaps.EnableManagedPostgresExtensionRequest) error
 	CreateVolume(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error)
 	CreateVolumeSnapshot(ctx context.Context, appName, volumeId string) error

--- a/internal/inmem/flaps_client.go
+++ b/internal/inmem/flaps_client.go
@@ -181,6 +181,10 @@ func (m *FlapsClient) CreateManagedPostgresBackup(ctx context.Context, id string
 	panic("TODO")
 }
 
+func (m *FlapsClient) CreateManagedPostgresAttachment(ctx context.Context, id string, req flaps.CreateManagedPostgresAttachmentRequest) (flaps.ManagedPostgresAttachment, error) {
+	panic("TODO")
+}
+
 func (m *FlapsClient) EnableManagedPostgresExtension(ctx context.Context, id, database string, req flaps.EnableManagedPostgresExtensionRequest) error {
 	panic("TODO")
 }

--- a/internal/mock/flaps_client.go
+++ b/internal/mock/flaps_client.go
@@ -23,6 +23,7 @@ type FlapsClient struct {
 	CreateManagedPostgresDatabaseFunc     func(ctx context.Context, id string, req flaps.CreateManagedPostgresDatabaseRequest) (flaps.ManagedPostgresDatabase, error)
 	CreateManagedPostgresUserFunc         func(ctx context.Context, id string, req flaps.CreateManagedPostgresUserRequest) (flaps.ManagedPostgresUser, error)
 	CreateManagedPostgresBackupFunc       func(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error
+	CreateManagedPostgresAttachmentFunc   func(ctx context.Context, id string, req flaps.CreateManagedPostgresAttachmentRequest) (flaps.ManagedPostgresAttachment, error)
 	EnableManagedPostgresExtensionFunc    func(ctx context.Context, id, database string, req flaps.EnableManagedPostgresExtensionRequest) error
 	CreateVolumeFunc                      func(ctx context.Context, appName string, req fly.CreateVolumeRequest) (*fly.Volume, error)
 	CreateVolumeSnapshotFunc              func(ctx context.Context, appName, volumeId string) error
@@ -136,6 +137,10 @@ func (m *FlapsClient) CreateManagedPostgresUser(ctx context.Context, id string, 
 
 func (m *FlapsClient) CreateManagedPostgresBackup(ctx context.Context, id string, req flaps.CreateManagedPostgresBackupRequest) error {
 	return m.CreateManagedPostgresBackupFunc(ctx, id, req)
+}
+
+func (m *FlapsClient) CreateManagedPostgresAttachment(ctx context.Context, id string, req flaps.CreateManagedPostgresAttachmentRequest) (flaps.ManagedPostgresAttachment, error) {
+	return m.CreateManagedPostgresAttachmentFunc(ctx, id, req)
 }
 
 func (m *FlapsClient) EnableManagedPostgresExtension(ctx context.Context, id, database string, req flaps.EnableManagedPostgresExtensionRequest) error {


### PR DESCRIPTION
## Summary

- Make the public Machines API the primary path for `fly mpg attach`.
- Preserve compatibility with existing MPG service behavior when required.
- Reuse the existing Flaps client for secret operations.
- Add coverage for public-path success and compatibility fallback behavior.
- Cover the interactive attach flow with a manual personal-org E2E test.

## Validation

- `go test ./internal/command/mpg/v2/...` and touched packages
- Local `flyctl` build from this worktree
- Manual personal-org attach/detach E2E using a disposable app
- `go vet` on affected packages
- `golangci-lint run ./internal/command/mpg/v2/...`
- `git diff --check`

The base connection URI, default database name, and default cluster credentials still come from the existing MPG service path because the public cluster API does not expose them. Named-user credentials are public-first, with compatibility fallback when required. The interactive E2E was manual; the preflight E2E tests remain separate.