### PR TITLE
Start builder machine if it's currently stopped.

### DIFF
--- a/internal/build/imgsrc/ensure_builder.go
+++ b/internal/build/imgsrc/ensure_builder.go
@@ -115,7 +115,7 @@ func (p *Provisioner) EnsureBuilder(ctx context.Context, region string, recreate
 		}
 
 		if validateBuilderErr == BuilderMachineNotStarted {
-			err := restartBuilderMachine(ctx, builderApp.Name, builderMachine)
+			err := startOrRestartBuilderMachine(ctx, builderApp.Name, builderMachine)
 			switch {
 			case errors.Is(err, ShouldReplaceBuilderMachine):
 				span.AddEvent("recreating builder due to resource reservation error")
@@ -574,15 +574,21 @@ func createFlyManagedBuilder(ctx context.Context, orgSlug string, region string)
 	return builderApp, machine, nil
 }
 
-func restartBuilderMachine(ctx context.Context, appName string, builderMachine *fly.Machine) error {
+func startOrRestartBuilderMachine(ctx context.Context, appName string, builderMachine *fly.Machine) error {
 	ctx, span := tracing.GetTracer().Start(ctx, "restart_builder_machine")
 	defer span.End()
 
 	flapsClient := flapsutil.ClientFromContext(ctx)
 
-	if err := flapsClient.Restart(ctx, appName, fly.RestartMachineInput{
-		ID: builderMachine.ID,
-	}, ""); err != nil {
+	var err error
+	if builderMachine.State == "stopped" {
+		_, err = flapsClient.Start(ctx, appName, builderMachine.ID, "")
+	} else {
+		err = flapsClient.Restart(ctx, appName, fly.RestartMachineInput{
+			ID: builderMachine.ID,
+		}, "")
+	}
+	if err != nil {
 		if strings.Contains(err.Error(), "could not reserve resource for machine") ||
 			strings.Contains(err.Error(), "deploys to this host are temporarily disabled") {
 			span.RecordError(err)

--- a/internal/build/imgsrc/ensure_builder_test.go
+++ b/internal/build/imgsrc/ensure_builder_test.go
@@ -309,12 +309,17 @@ func TestCreateBuilder(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestRestartBuilderMachine(t *testing.T) {
+func TestStartOrRestartBuilderMachine(t *testing.T) {
 	t.Parallel()
 	ctx := testingContext(t)
 
 	couldNotReserveResources := false
+	started := false
 	flapsClient := mock.FlapsClient{
+		StartFunc: func(ctx context.Context, appName, machineID string, nonce string) (*fly.MachineStartResponse, error) {
+			started = true
+			return nil, nil
+		},
 		RestartFunc: func(ctx context.Context, appName string, input fly.RestartMachineInput, nonce string) error {
 			if couldNotReserveResources {
 				return &flaps.FlapsError{
@@ -330,11 +335,14 @@ func TestRestartBuilderMachine(t *testing.T) {
 	}
 
 	ctx = flapsutil.NewContextWithClient(ctx, &flapsClient)
-	err := restartBuilderMachine(ctx, "", &fly.Machine{ID: "bigmachine"})
+	err := startOrRestartBuilderMachine(ctx, "", &fly.Machine{ID: "bigmachine"})
 	assert.NoError(t, err)
+	err = startOrRestartBuilderMachine(ctx, "", &fly.Machine{ID: "bigmachine", State: "stopped"})
+	assert.NoError(t, err)
+	assert.True(t, started)
 
 	couldNotReserveResources = true
-	err = restartBuilderMachine(ctx, "", &fly.Machine{ID: "bigmachine"})
+	err = startOrRestartBuilderMachine(ctx, "", &fly.Machine{ID: "bigmachine"})
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ShouldReplaceBuilderMachine)
 }


### PR DESCRIPTION
Previously, `EnsureBuilder` always attempted to restart a non-running builder machine. This doesn't work for machines that are in "stopped" state, which is common for auto-stopped preflight builders.