### PR TITLE
Preserve builder app during connection retries.

### DIFF
--- a/internal/build/imgsrc/buildkit_builder.go
+++ b/internal/build/imgsrc/buildkit_builder.go
@@ -131,9 +131,10 @@ func (r *BuildkitBuilder) buildWithBuildkit(ctx context.Context, streams *iostre
 func (r *BuildkitBuilder) connectClient(ctx context.Context, app *flaps.App, appName string) (*client.Client, error) {
 	recreateBuilder := flag.GetRecreateBuilder(ctx)
 	ensureBuilder := false
+	var err error
 	if r.addr == "" || recreateBuilder {
 		updateProgress(ctx, "Updating remote builder...")
-		_, app, err := r.provisioner.EnsureBuilder(
+		_, app, err = r.provisioner.EnsureBuilder(
 			ctx, os.Getenv("FLY_REMOTE_BUILDER_REGION"), recreateBuilder,
 		)
 		if err != nil {


### PR DESCRIPTION
Avoid shadowing the builder app returned by `EnsureBuilder`. The retry path needs that app's organization and network to establish the WireGuard dialer; losing it caused retries to skip WireGuard and retry forever.