### PR TITLE
Route MPGv2 create through the Machines API

### DIFF
--- a/internal/command/mpg/v2/run_create.go
+++ b/internal/command/mpg/v2/run_create.go
@@ -3,14 +3,15 @@ package cmdv2
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strconv"
 	"time"
 
-	"github.com/superfly/fly-go"
-	regionsv2 "github.com/superfly/flyctl/internal/command/mpg/v2/regions"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/flag"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/mpgutil"
 	"github.com/superfly/flyctl/internal/prompt"
-	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -30,12 +31,35 @@ type CreatePlanDisplay struct {
 	PricePerMo int
 }
 
-func RunCreate(ctx context.Context, orgRawSlug string, params *CreateClusterParams, planDisplay *CreatePlanDisplay) error {
-	io := iostreams.FromContext(ctx)
-	mpgClient := mpgv2.ClientFromContext(ctx)
+// flyUser and flyDB are the fixed credentials used by the public
+// Machines API's create/credentials response. The public credentials
+// endpoint carries no database name, so the connection URI is composed
+// against the literal "fly-db" database.
+const (
+	flyUser = "fly-user"
+	flyDB   = "fly-db"
+)
 
-	// Get available MPG regions from API
-	mpgRegions, err := regionsv2.GetAvailableMPGRegions(ctx, orgRawSlug)
+// RunCreate provisions a new Managed Postgres cluster via the public
+// Machines API (flaps) and prints the connection string once ready.
+//
+// Unlike the other migrated MPG commands, this one deliberately does NOT
+// fall back to the private client on a failed or ambiguous create call:
+// retrying a mutating create against a different backend risks
+// double-provisioning a cluster. Errors from CreateManagedPostgresCluster
+// are propagated to the caller as-is.
+//
+// orgRawSlug is accepted for API parity with the previous implementation;
+// region discovery is now driven by the non-org-scoped Machines API region
+// list (mpgutil.AvailableRegions).
+func RunCreate(ctx context.Context, orgRawSlug string, params *CreateClusterParams, planDisplay *CreatePlanDisplay) error {
+	_ = orgRawSlug
+
+	io := iostreams.FromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
+
+	// Get available MPG regions from the public Machines API region list.
+	mpgRegions, err := mpgutil.AvailableRegions(ctx)
 	if err != nil {
 		return err
 	}
@@ -46,19 +70,24 @@ func RunCreate(ctx context.Context, orgRawSlug string, params *CreateClusterPara
 
 	// Check if region was specified via flag
 	regionCode := flag.GetString(ctx, "region")
-	var selectedRegion *fly.Region
+	var selectedRegionCode string
 
 	if regionCode != "" {
 		// Find the specified region in the allowed regions
+		var matched bool
 		for _, region := range mpgRegions {
 			if region.Code == regionCode {
-				selectedRegion = &region
+				selectedRegionCode = region.Code
+				matched = true
 
 				break
 			}
 		}
-		if selectedRegion == nil {
-			availableCodes, _ := regionsv2.GetAvailableMPGRegionCodes(ctx, params.OrgSlug)
+		if !matched {
+			availableCodes := make([]string, len(mpgRegions))
+			for i, region := range mpgRegions {
+				availableCodes[i] = region.Code
+			}
 
 			return fmt.Errorf("region %s is not available for Managed Postgres. Available regions: %v", regionCode, availableCodes)
 		}
@@ -74,25 +103,25 @@ func RunCreate(ctx context.Context, orgRawSlug string, params *CreateClusterPara
 			return err
 		}
 
-		selectedRegion = &mpgRegions[selectedIndex]
+		selectedRegionCode = mpgRegions[selectedIndex].Code
 	}
 
-	input := mpgv2.CreateClusterInput{
+	createReq := flaps.CreateManagedPostgresClusterRequest{
 		Name:           params.Name,
-		Region:         selectedRegion.Code,
+		Region:         selectedRegionCode,
 		Plan:           params.Plan,
 		OrgSlug:        params.OrgSlug,
-		StorageInGb:    params.StorageInGb,
-		PostGISEnabled: params.PostGISEnabled,
+		DiskSizeGB:     params.StorageInGb,
 		PGMajorVersion: strconv.Itoa(params.PGMajorVersion),
+		PostGISEnabled: params.PostGISEnabled,
 	}
 
-	response, err := mpgClient.CreateCluster(ctx, input)
+	cluster, err := flapsClient.CreateManagedPostgresCluster(ctx, createReq)
 	if err != nil {
 		return fmt.Errorf("failed creating managed postgres cluster: %w", err)
 	}
 
-	clusterID := response.Data.Id
+	clusterID := cluster.ID
 
 	var connectionURI string
 
@@ -108,26 +137,38 @@ func RunCreate(ctx context.Context, orgRawSlug string, params *CreateClusterPara
 	fmt.Fprintf(io.Out, "You can cancel this wait with Ctrl+C - the cluster will continue provisioning in the background.\n")
 	fmt.Fprintf(io.Out, "Once ready, you can connect to the database with: fly mpg connect %s\n\n", clusterID)
 	for {
-		res, err := mpgClient.GetClusterById(ctx, clusterID)
+		res, err := flapsClient.GetManagedPostgresCluster(ctx, clusterID)
 		if err != nil {
 			return fmt.Errorf("failed checking cluster status: %w", err)
 		}
 
-		cluster := res.Data
-		credentials := res.Credentials
-
-		if cluster.Id == "" {
+		if res.ID == "" {
 			return fmt.Errorf("invalid cluster response: no cluster ID")
 		}
 
-		if cluster.Status == "ready" {
-			connectionURI = credentials.ConnectionUri
+		switch res.Status {
+		case flaps.ManagedPostgresStatusReady:
+			creds, credErr := flapsClient.GetManagedPostgresUserCredentials(ctx, clusterID, flyUser)
+			if credErr != nil {
+				return fmt.Errorf("failed retrieving credentials for cluster %s: %w", clusterID, credErr)
+			}
 
-			break
+			// The connection URI's username is the fixed "fly-user" the plan
+			// requested credentials for, NOT whatever Username the credentials
+			// response carries — invariant #6 keeps the URI user stable
+			// regardless of any unexpected payload drift.
+			uri, buildErr := buildConnectionURI(res.Endpoints.Primary.Pooler, flyUser, creds.Password, flyDB)
+			if buildErr != nil {
+				return fmt.Errorf("failed to build connection URI for cluster %s: %w", clusterID, buildErr)
+			}
+			connectionURI = uri
+
+		case flaps.ManagedPostgresStatusFailed, flaps.ManagedPostgresStatusError:
+			return fmt.Errorf("cluster creation failed")
 		}
 
-		if cluster.Status == "error" {
-			return fmt.Errorf("cluster creation failed")
+		if connectionURI != "" {
+			break
 		}
 
 		time.Sleep(5 * time.Second)
@@ -137,11 +178,36 @@ func RunCreate(ctx context.Context, orgRawSlug string, params *CreateClusterPara
 	fmt.Fprintf(io.Out, "  ID: %s\n", clusterID)
 	fmt.Fprintf(io.Out, "  Name: %s\n", params.Name)
 	fmt.Fprintf(io.Out, "  Organization: %s\n", params.OrgSlug)
-	fmt.Fprintf(io.Out, "  Region: %s\n", response.Data.Region)
+	fmt.Fprintf(io.Out, "  Region: %s\n", cluster.Region)
 	fmt.Fprintf(io.Out, "  Plan: %s\n", params.Plan)
-	fmt.Fprintf(io.Out, "  Disk: %dGB\n", response.Data.Disk)
-	fmt.Fprintf(io.Out, "  PostGIS: %t\n", response.Data.PostGISEnabled)
+	fmt.Fprintf(io.Out, "  Disk: %dGB\n", cluster.DiskSizeGB)
+	fmt.Fprintf(io.Out, "  PostGIS: %t\n", cluster.PostGISEnabled)
 	fmt.Fprintf(io.Out, "  Connection string: %s\n", connectionURI)
 
 	return nil
+}
+
+// buildConnectionURI composes a pooled (PgBouncer-style) connection URI for
+// the given endpoint + credentials. The password is URL-escaped via
+// url.UserPassword so that reserved characters in the password do not corrupt
+// the URI.
+//
+// The endpoint Host/Port are validated before composition: a cluster that
+// reports status "ready" can still carry a zero-valued pooler endpoint during
+// the propagation-lag race between readiness and endpoint population. Without
+// this check, the function would silently return a broken URI such as
+// "postgres://fly-user:secret@:0/fly-db" with a nil error.
+func buildConnectionURI(endpoint flaps.ManagedPostgresEndpoint, username, password, dbName string) (string, error) {
+	if endpoint.Host == "" || endpoint.Port == 0 {
+		return "", fmt.Errorf("cluster ready but pooler endpoint not yet available")
+	}
+
+	u := &url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(username, password),
+		Host:   fmt.Sprintf("%s:%d", endpoint.Host, endpoint.Port),
+		Path:   "/" + dbName,
+	}
+
+	return u.String(), nil
 }

--- a/internal/command/mpg/v2/run_create_test.go
+++ b/internal/command/mpg/v2/run_create_test.go
@@ -1,0 +1,589 @@
+package cmdv2
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/require"
+	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flag/flagctx"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/mock"
+	"github.com/superfly/flyctl/internal/prompt"
+	mpgv2 "github.com/superfly/flyctl/internal/uiex/mpg/v2"
+	"github.com/superfly/flyctl/iostreams"
+)
+
+// createTestContext builds a context carrying a --region flag and an
+// iostream suitable for the create command's expectations. If region is
+// the empty string, --region is left unset (so the command takes the
+// interactive-prompt branch instead).
+func createTestContext(t *testing.T, region string) (context.Context, *bytes.Buffer) {
+	t.Helper()
+
+	io, _, stdout, _ := iostreams.Test()
+	ctx := iostreams.NewContext(context.Background(), io)
+
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	flags.String("region", "", "")
+	if region != "" {
+		require.NoError(t, flags.Set("region", region))
+	}
+
+	return flagctx.NewContext(ctx, flags), stdout
+}
+
+func sampleParams() *CreateClusterParams {
+	return &CreateClusterParams{
+		Name:           "my-cluster",
+		OrgSlug:        "my-org",
+		Plan:           "basic",
+		StorageInGb:    10,
+		PGMajorVersion: 16,
+		PostGISEnabled: true,
+	}
+}
+
+func samplePlan() *CreatePlanDisplay {
+	return &CreatePlanDisplay{
+		Name:       "Basic",
+		CPU:        "1",
+		Memory:     "256MB",
+		PricePerMo: 5,
+	}
+}
+
+// sampleRegions returns the region list returned by the mocked GetRegions
+// call. Codes here drive the explicit --region validation, the empty-list
+// short-circuit, and the interactive-prompt option list.
+func sampleRegions() []fly.Region {
+	return []fly.Region{
+		{Code: "iad", Name: "Ashburn, Virginia (US)", MPGAvailable: true},
+		{Code: "lax", Name: "Los Angeles, California (US)", MPGAvailable: true},
+	}
+}
+
+// poolerEndpoints builds the inline-struct Endpoints value used by the
+// credentials/URI tests. Tests that exercise the credentials branch set the
+// cluster's Endpoints.Primary.Pooler so the expected URI is
+// "postgres://fly-user:<password>@pooler.example.test:6432/fly-db".
+func poolerEndpoints() flaps.ManagedPostgresEndpoints {
+	return flaps.ManagedPostgresEndpoints{
+		Primary: struct {
+			Direct flaps.ManagedPostgresEndpoint `json:"direct"`
+			Pooler flaps.ManagedPostgresEndpoint `json:"pooler"`
+		}{
+			Pooler: flaps.ManagedPostgresEndpoint{Host: "pooler.example.test", Port: 6432},
+		},
+	}
+}
+
+// assertNoLegacyCreate wires the MpgV2Client mock such that any call to the
+// private CreateCluster fails the test. The no-create-fallback invariant
+// (invariant #1 in the plan) requires that RunCreate never touch the
+// private client for cluster creation.
+func assertNoLegacyCreate(t *testing.T, ctx context.Context) context.Context {
+	t.Helper()
+
+	return mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+		CreateClusterFunc: func(context.Context, mpgv2.CreateClusterInput) (mpgv2.CreateClusterResponse, error) {
+			t.Fatal("mpgv2.CreateCluster must not be called by the public-API create path")
+
+			return mpgv2.CreateClusterResponse{}, nil
+		},
+	})
+}
+
+// TestRunCreate_RegionDiscovery covers the regionsv2 -> mpgutil.AvailableRegions
+// swap: explicit --region validation, empty-list short-circuit, and the
+// invalid-region error's codes content.
+func TestRunCreate_RegionDiscovery(t *testing.T) {
+	tests := []struct {
+		name          string
+		regionFlag    string
+		regions       []fly.Region
+		regionsErr    error
+		wantErr       string
+		wantCreateHit bool
+	}{
+		{
+			name:          "explicit valid region is selected and proceeds to create",
+			regionFlag:    "lax",
+			regions:       sampleRegions(),
+			wantCreateHit: true,
+		},
+		{
+			name:       "explicit invalid region returns error with available codes from the same call",
+			regionFlag: "sfo",
+			regions:    sampleRegions(),
+			wantErr:    "region sfo is not available for Managed Postgres. Available regions: [iad lax]",
+		},
+		{
+			name:    "empty region list returns legacy error unchanged",
+			regions: nil,
+			wantErr: "no valid regions found for Managed Postgres",
+		},
+		{
+			name:       "regions retrieval failure is propagated",
+			regionsErr: errors.New("regions boom"),
+			wantErr:    "regions boom",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, _ := createTestContext(t, test.regionFlag)
+			createCalled := false
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				GetRegionsFunc: func(context.Context) (*flaps.RegionData, error) {
+					if test.regionsErr != nil {
+						return nil, test.regionsErr
+					}
+
+					return &flaps.RegionData{Regions: test.regions}, nil
+				},
+				CreateManagedPostgresClusterFunc: func(_ context.Context, req flaps.CreateManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+					createCalled = true
+					require.Equal(t, "basic", req.Plan)
+					require.Equal(t, "my-org", req.OrgSlug)
+					require.Equal(t, "16", req.PGMajorVersion)
+					require.Equal(t, 10, req.DiskSizeGB)
+					require.Equal(t, "my-cluster", req.Name)
+					require.Equal(t, "lax", req.Region)
+					require.True(t, req.PostGISEnabled)
+
+					return flaps.ManagedPostgresCluster{ID: "mpg-123", Region: req.Region, DiskSizeGB: req.DiskSizeGB, PostGISEnabled: req.PostGISEnabled}, nil
+				},
+				GetManagedPostgresClusterFunc: func(context.Context, string) (flaps.ManagedPostgresCluster, error) {
+					return flaps.ManagedPostgresCluster{ID: "mpg-123", Status: flaps.ManagedPostgresStatusReady, Endpoints: poolerEndpoints()}, nil
+				},
+				GetManagedPostgresUserCredentialsFunc: func(context.Context, string, string) (flaps.ManagedPostgresUserCredentials, error) {
+					return flaps.ManagedPostgresUserCredentials{Username: "fly-user", Password: "secret"}, nil
+				},
+			})
+			ctx = assertNoLegacyCreate(t, ctx)
+
+			err := RunCreate(ctx, "my-org", sampleParams(), samplePlan())
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.wantCreateHit, createCalled)
+		})
+	}
+}
+
+// TestRunCreate_InteractivePromptRegion verifies that when --region is not
+// set, the region options are built from mpgutil.AvailableRegions (so the
+// prompt path is wired to the same data source as the explicit path). In
+// non-interactive test mode prompt.Select returns prompt.ErrNonInteractive;
+// that is sufficient proof that the option list flowed through to survey.
+func TestRunCreate_InteractivePromptRegion(t *testing.T) {
+	ctx, _ := createTestContext(t, "" /* no --region */)
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+		GetRegionsFunc: func(context.Context) (*flaps.RegionData, error) {
+			return &flaps.RegionData{Regions: sampleRegions()}, nil
+		},
+	})
+	ctx = assertNoLegacyCreate(t, ctx)
+
+	err := RunCreate(ctx, "my-org", sampleParams(), samplePlan())
+	require.Error(t, err)
+	require.True(t, prompt.IsNonInteractive(err), "expected prompt.ErrNonInteractive, got: %v", err)
+}
+
+// TestRunCreate_PollLoop covers the two terminal-failure statuses documented
+// for this endpoint ("failed" canonical, "error" backend-reported), the
+// malformed-response guard, and a transient poll error.
+func TestRunCreate_PollLoop(t *testing.T) {
+	tests := []struct {
+		name    string
+		polls   []flaps.ManagedPostgresCluster
+		pollErr error
+		wantErr string
+	}{
+		{
+			name: "ready on first poll proceeds to credentials",
+			polls: []flaps.ManagedPostgresCluster{
+				{ID: "mpg-123", Status: flaps.ManagedPostgresStatusReady, Endpoints: poolerEndpoints()},
+			},
+		},
+		{
+			name: "transient provisioning status keeps polling then succeeds",
+			polls: []flaps.ManagedPostgresCluster{
+				{ID: "mpg-123", Status: "creating"},
+				{ID: "mpg-123", Status: flaps.ManagedPostgresStatusReady, Endpoints: poolerEndpoints()},
+			},
+		},
+		{
+			// Propagation-lag race between a cluster becoming ready and its
+			// endpoint data being populated. The pooler endpoint is zero-valued
+			// (no Host, no Port) but Status is still "ready". RunCreate must
+			// surface this as an error from buildConnectionURI rather than
+			// silently printing a broken URI such as
+			// "postgres://fly-user:secret@:0/fly-db" as if the cluster had been
+			// created successfully.
+			name: "ready status with zero-value pooler endpoint returns an error (propagation-lag race)",
+			polls: []flaps.ManagedPostgresCluster{
+				{ID: "mpg-123", Status: flaps.ManagedPostgresStatusReady, Endpoints: flaps.ManagedPostgresEndpoints{}},
+			},
+			wantErr: "failed to build connection URI for cluster mpg-123: cluster ready but pooler endpoint not yet available",
+		},
+		{
+			name: "failed status is terminal failure",
+			polls: []flaps.ManagedPostgresCluster{
+				{ID: "mpg-123", Status: flaps.ManagedPostgresStatusFailed},
+			},
+			wantErr: "cluster creation failed",
+		},
+		{
+			name: "error status is also terminal failure (backend-reported spelling)",
+			polls: []flaps.ManagedPostgresCluster{
+				{ID: "mpg-123", Status: flaps.ManagedPostgresStatusError},
+			},
+			wantErr: "cluster creation failed",
+		},
+		{
+			name:    "transient poll error is a hard error (no retry)",
+			pollErr: errors.New("net down"),
+			wantErr: "failed checking cluster status: net down",
+		},
+		{
+			name: "missing cluster ID in poll response is a hard error",
+			polls: []flaps.ManagedPostgresCluster{
+				{ID: "", Status: "creating"},
+			},
+			wantErr: "invalid cluster response: no cluster ID",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, _ := createTestContext(t, "iad")
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				GetRegionsFunc: func(context.Context) (*flaps.RegionData, error) {
+					return &flaps.RegionData{Regions: sampleRegions()}, nil
+				},
+				CreateManagedPostgresClusterFunc: func(context.Context, flaps.CreateManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+					return flaps.ManagedPostgresCluster{ID: "mpg-123", Region: "iad", DiskSizeGB: 10, PostGISEnabled: true}, nil
+				},
+				GetManagedPostgresClusterFunc: func(_ context.Context, id string) (flaps.ManagedPostgresCluster, error) {
+					require.Equal(t, "mpg-123", id)
+					if test.pollErr != nil {
+						return flaps.ManagedPostgresCluster{}, test.pollErr
+					}
+					if len(test.polls) == 0 {
+						t.Fatal("test setup error: no poll responses configured")
+
+						return flaps.ManagedPostgresCluster{}, nil
+					}
+					p := test.polls[0]
+					test.polls = test.polls[1:]
+
+					return p, nil
+				},
+				GetManagedPostgresUserCredentialsFunc: func(context.Context, string, string) (flaps.ManagedPostgresUserCredentials, error) {
+					return flaps.ManagedPostgresUserCredentials{Username: "fly-user", Password: "secret"}, nil
+				},
+			})
+			ctx = assertNoLegacyCreate(t, ctx)
+
+			err := RunCreate(ctx, "my-org", sampleParams(), samplePlan())
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestRunCreate_CreateError covers the no-fallback invariant: any error from
+// CreateManagedPostgresCluster is returned to the caller without a private
+// retry that could double-provision the cluster.
+func TestRunCreate_CreateError(t *testing.T) {
+	ctx, _ := createTestContext(t, "iad")
+	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+		GetRegionsFunc: func(context.Context) (*flaps.RegionData, error) {
+			return &flaps.RegionData{Regions: sampleRegions()}, nil
+		},
+		CreateManagedPostgresClusterFunc: func(context.Context, flaps.CreateManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+			return flaps.ManagedPostgresCluster{}, errors.New("quota exceeded")
+		},
+	})
+	ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{
+		CreateClusterFunc: func(context.Context, mpgv2.CreateClusterInput) (mpgv2.CreateClusterResponse, error) {
+			t.Fatal("create error must never trigger a legacy fallback that risks double-provisioning")
+
+			return mpgv2.CreateClusterResponse{}, nil
+		},
+	})
+
+	err := RunCreate(ctx, "my-org", sampleParams(), samplePlan())
+	require.ErrorContains(t, err, "failed creating managed postgres cluster: quota exceeded")
+}
+
+// TestRunCreate_RequestMapping verifies the CreateClusterParams -> request
+// field mapping, including the int -> string conversion of PG major version
+// and the direct copy of storage GB.
+func TestRunCreate_RequestMapping(t *testing.T) {
+	tests := []struct {
+		name       string
+		params     *CreateClusterParams
+		regionFlag string
+		want       flaps.CreateManagedPostgresClusterRequest
+	}{
+		{
+			name: "all fields populated",
+			params: &CreateClusterParams{
+				Name: "my-cluster", OrgSlug: "my-org", Plan: "performance",
+				StorageInGb: 50, PGMajorVersion: 17, PostGISEnabled: true,
+			},
+			regionFlag: "iad",
+			want: flaps.CreateManagedPostgresClusterRequest{
+				Name: "my-cluster", OrgSlug: "my-org", Plan: "performance",
+				Region: "iad", DiskSizeGB: 50, PGMajorVersion: "17", PostGISEnabled: true,
+			},
+		},
+		{
+			name: "postgis disabled and pg16",
+			params: &CreateClusterParams{
+				Name: "tiny", OrgSlug: "acme", Plan: "basic",
+				StorageInGb: 1, PGMajorVersion: 16, PostGISEnabled: false,
+			},
+			regionFlag: "lax",
+			want: flaps.CreateManagedPostgresClusterRequest{
+				Name: "tiny", OrgSlug: "acme", Plan: "basic",
+				Region: "lax", DiskSizeGB: 1, PGMajorVersion: "16", PostGISEnabled: false,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, _ := createTestContext(t, test.regionFlag)
+			var got flaps.CreateManagedPostgresClusterRequest
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				GetRegionsFunc: func(context.Context) (*flaps.RegionData, error) {
+					return &flaps.RegionData{Regions: sampleRegions()}, nil
+				},
+				CreateManagedPostgresClusterFunc: func(_ context.Context, req flaps.CreateManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+					got = req
+
+					return flaps.ManagedPostgresCluster{ID: "mpg-123", Region: req.Region, DiskSizeGB: req.DiskSizeGB, PostGISEnabled: req.PostGISEnabled}, nil
+				},
+				GetManagedPostgresClusterFunc: func(context.Context, string) (flaps.ManagedPostgresCluster, error) {
+					return flaps.ManagedPostgresCluster{ID: "mpg-123", Status: flaps.ManagedPostgresStatusReady, Endpoints: poolerEndpoints()}, nil
+				},
+				GetManagedPostgresUserCredentialsFunc: func(context.Context, string, string) (flaps.ManagedPostgresUserCredentials, error) {
+					return flaps.ManagedPostgresUserCredentials{Username: "fly-user", Password: "secret"}, nil
+				},
+			})
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{})
+
+			require.NoError(t, RunCreate(ctx, "my-org", test.params, samplePlan()))
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+// TestRunCreate_Credentials covers the post-ready branch: fetching the
+// fly-user credentials, composing the connection URI from the pooler
+// endpoint, and erroring when the credentials fetch fails (no retry).
+func TestRunCreate_Credentials(t *testing.T) {
+	tests := []struct {
+		name           string
+		password       string
+		credsUsername  string
+		credsErr       error
+		wantInOutput   []string
+		wantNotInOut   []string
+		wantErr        string
+		wantCredsCalls int
+	}{
+		{
+			name:           "happy path prints pooler-based URI",
+			password:       "secret",
+			credsUsername:  "fly-user",
+			wantInOutput:   []string{"postgres://fly-user:secret@pooler.example.test:6432/fly-db", "Connection string: "},
+			wantCredsCalls: 1,
+		},
+		{
+			name:          "password containing reserved URI characters is escaped",
+			password:      "p@ss:wo/rd%",
+			credsUsername: "fly-user",
+			// url.UserPassword percent-escapes '@', ':', '/', '%' (and others)
+			// when rendering the userinfo, so the raw password must NOT appear
+			// inside the printed URI.
+			wantInOutput: []string{
+				"postgres://fly-user:" + url.QueryEscape("p@ss:wo/rd%") + "@pooler.example.test:6432/fly-db",
+			},
+			wantNotInOut:   []string{"fly-user:p@ss:wo/rd%@"},
+			wantCredsCalls: 1,
+		},
+		{
+			name:     "unexpected username in credentials response is ignored; URI keeps fixed fly-user",
+			password: "secret",
+			// The plan pins the URI username to the literal "fly-user" regardless
+			// of any Username value the credentials endpoint echoes back; this
+			// guards against a regression where the URI user drifts to the
+			// payload-supplied value (e.g. "unexpected-user").
+			credsUsername: "unexpected-user",
+			wantInOutput: []string{
+				"postgres://fly-user:secret@pooler.example.test:6432/fly-db",
+			},
+			wantNotInOut: []string{
+				"postgres://unexpected-user:secret@",
+			},
+			wantCredsCalls: 1,
+		},
+		{
+			name:          "empty username in credentials response is ignored; URI keeps fixed fly-user",
+			password:      "secret",
+			credsUsername: "",
+			wantInOutput: []string{
+				"postgres://fly-user:secret@pooler.example.test:6432/fly-db",
+			},
+			wantCredsCalls: 1,
+		},
+		{
+			name:           "credentials fetch failure is a hard error with no retry",
+			credsErr:       errors.New("creds 500"),
+			wantErr:        "failed retrieving credentials for cluster mpg-123: creds 500",
+			wantCredsCalls: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, stdout := createTestContext(t, "iad")
+			credsCalls := 0
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				GetRegionsFunc: func(context.Context) (*flaps.RegionData, error) {
+					return &flaps.RegionData{Regions: sampleRegions()}, nil
+				},
+				CreateManagedPostgresClusterFunc: func(context.Context, flaps.CreateManagedPostgresClusterRequest) (flaps.ManagedPostgresCluster, error) {
+					return flaps.ManagedPostgresCluster{ID: "mpg-123", Region: "iad", DiskSizeGB: 10, PostGISEnabled: true}, nil
+				},
+				GetManagedPostgresClusterFunc: func(context.Context, string) (flaps.ManagedPostgresCluster, error) {
+					return flaps.ManagedPostgresCluster{ID: "mpg-123", Status: flaps.ManagedPostgresStatusReady, Endpoints: poolerEndpoints()}, nil
+				},
+				GetManagedPostgresUserCredentialsFunc: func(_ context.Context, id, username string) (flaps.ManagedPostgresUserCredentials, error) {
+					credsCalls++
+					require.Equal(t, "mpg-123", id)
+					require.Equal(t, "fly-user", username)
+					if test.credsErr != nil {
+						return flaps.ManagedPostgresUserCredentials{}, test.credsErr
+					}
+
+					return flaps.ManagedPostgresUserCredentials{Username: test.credsUsername, Password: test.password}, nil
+				},
+			})
+			ctx = mpgv2.NewContextWithClient(ctx, &mock.MpgV2Client{})
+
+			err := RunCreate(ctx, "my-org", sampleParams(), samplePlan())
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				require.Equal(t, test.wantCredsCalls, credsCalls)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.wantCredsCalls, credsCalls)
+
+			out := stdout.String()
+			for _, want := range test.wantInOutput {
+				require.True(t, strings.Contains(out, want), "stdout must contain %q\nstdout: %s", want, out)
+			}
+			for _, miss := range test.wantNotInOut {
+				require.False(t, strings.Contains(out, miss), "stdout must not contain unescaped %q\nstdout: %s", miss, out)
+			}
+		})
+	}
+}
+
+// TestBuildConnectionURI is a focused unit test for the URL-construction
+// helper. It pins down the exact escape behavior so a regression in
+// url.UserPassword's output (or a switch away from it) is caught even if
+// RunCreate's larger wiring changes.
+func TestBuildConnectionURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint flaps.ManagedPostgresEndpoint
+		user     string
+		pass     string
+		db       string
+		want     string
+		wantErr  string
+	}{
+		{
+			name:     "plain credentials",
+			endpoint: flaps.ManagedPostgresEndpoint{Host: "h.test", Port: 5432},
+			user:     "u",
+			pass:     "p",
+			db:       "d",
+			want:     "postgres://u:p@h.test:5432/d",
+		},
+		{
+			name:     "reserved URI characters in password are escaped",
+			endpoint: flaps.ManagedPostgresEndpoint{Host: "h.test", Port: 5432},
+			user:     "u",
+			pass:     "p@ss:wo/rd%",
+			db:       "d",
+			// url.UserPassword escapes '@', ':', '/', '%' — which would otherwise
+			// corrupt the URI's userinfo, host, path, or percent-decoding.
+			want: "postgres://u:" + url.QueryEscape("p@ss:wo/rd%") + "@h.test:5432/d",
+		},
+		{
+			// Propagation-lag race: a cluster can report status "ready" before
+			// its pooler endpoint data is populated. Without this guard,
+			// buildConnectionURI would silently return a broken URI such as
+			// "postgres://fly-user:secret@:0/fly-db" with a nil error and
+			// RunCreate would print it as if the cluster had been created
+			// successfully.
+			name:     "zero-value pooler endpoint (empty host, zero port) returns error instead of broken URI",
+			endpoint: flaps.ManagedPostgresEndpoint{},
+			user:     "fly-user",
+			pass:     "secret",
+			db:       "fly-db",
+			wantErr:  "cluster ready but pooler endpoint not yet available",
+		},
+		{
+			name:     "missing host with non-zero port returns error",
+			endpoint: flaps.ManagedPostgresEndpoint{Port: 6432},
+			user:     "u",
+			pass:     "p",
+			db:       "d",
+			wantErr:  "cluster ready but pooler endpoint not yet available",
+		},
+		{
+			name:     "host with zero port returns error",
+			endpoint: flaps.ManagedPostgresEndpoint{Host: "h.test"},
+			user:     "u",
+			pass:     "p",
+			db:       "d",
+			wantErr:  "cluster ready but pooler endpoint not yet available",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := buildConnectionURI(test.endpoint, test.user, test.pass, test.db)
+			if test.wantErr != "" {
+				require.EqualError(t, err, test.wantErr)
+				require.Empty(t, got, "buildConnectionURI must not return a URI when it returns an error")
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
`fly mpg create` for MPGv2 now uses the public Machines API instead of the private MPG client.

- Region discovery uses `mpgutil.AvailableRegions` and public `GetRegions`, selecting non-deprecated MPG-available regions. Explicit `--region` validation, interactive prompting, and existing error messages are unchanged.
- Creation uses `CreateManagedPostgresCluster`. Errors do not fall back because retrying a mutating request against another backend could create a duplicate cluster.
- Readiness polling uses `GetManagedPostgresCluster`; `failed` and `error` are terminal.
- After readiness, `GetManagedPostgresUserCredentials` retrieves `fly-user` credentials. The connection string uses the primary pooler endpoint, `fly-user`, `fly-db`, and a password escaped with `url.UserPassword`. An empty endpoint fails instead of reporting success with a broken URI during propagation lag.
- No fly-go update required; v0.9.15 already has these methods.

## Test plan

- Unit coverage: explicit, interactive, empty, and invalid region discovery; request mapping; terminal statuses; polling errors; missing IDs; credential failures; unavailable endpoints; reserved-character passwords.
- `go build`, `go vet`, `gofmt -l`, `git diff --check` pass.
- Live test: this binary created a cluster in a personal org and returned a working connection string. A sibling `connect`/`proxy` migration binary connected and wrote data. Valid, invalid, and interactive region selection were tested against the live API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)