### PR TITLE
Run Buildpack preflight test using local Docker.

### DIFF
--- a/internal/build/imgsrc/ensure_builder_test.go
+++ b/internal/build/imgsrc/ensure_builder_test.go
@@ -318,6 +318,7 @@ func TestStartOrRestartBuilderMachine(t *testing.T) {
 	flapsClient := mock.FlapsClient{
 		StartFunc: func(ctx context.Context, appName, machineID string, nonce string) (*fly.MachineStartResponse, error) {
 			started = true
+
 			return nil, nil
 		},
 		RestartFunc: func(ctx context.Context, appName string, input fly.RestartMachineInput, nonce string) error {

--- a/test/preflight/fly_deploy_test.go
+++ b/test/preflight/fly_deploy_test.go
@@ -482,18 +482,21 @@ func testDeploy(t *testing.T, appDir string, builderFlag string) {
 func TestDeploy(t *testing.T) {
 	t.Run("Buildpack", func(t *testing.T) {
 		if testing.Short() {
-			t.Skip("Skipping buildpack test in CI: buildpacks require wireguard connectivity which is not available in CI environment")
+			t.Skip("Skipping in short mode: buildpack test is covered by full preflight runs")
 		}
 		t.Parallel()
-		// Buildpacks cannot use BuildKit, so they use Depot (which falls back to remote builders)
-		testDeploy(t, filepath.Join(testlib.RepositoryRoot(), "test", "preflight", "fixtures", "example-buildpack"), "--depot")
+		// Buildpacks are built using the pack tool, which requires a Docker API.
+		// Use the CI runner's Docker daemon so this test does not share the
+		// organization's remote builder with the BuildKit test because they are
+		// API-incompatible.
+		testDeploy(t, filepath.Join(testlib.RepositoryRoot(), "test", "preflight", "fixtures", "example-buildpack"), "--local-only")
 	})
 	t.Run("Dockerfile", func(t *testing.T) {
 		if testing.Short() {
-			t.Skip("Skipping in short mode: test suite approaches 15m timeout with this test included")
+			t.Skip("Skipping in short mode: buildkit test is covered by full preflight runs")
 		}
 		t.Parallel()
-		// Dockerfiles explicitly use BuildKit with remote building
+		// Explicitly use flyctl's remote BuildKit builder app for the Dockerfile.
 		testDeploy(t, filepath.Join(testlib.RepositoryRoot(), "test", "preflight", "fixtures", "example"), "--buildkit --remote-only")
 	})
 }


### PR DESCRIPTION
Preflight tests share an organization-wide remote builder app. This causes a conflict for the `TestDeploy` preflight test: The "Buildpack" test wants a remote Docker/RCHAB builder whereas the "Dockerfile" test wants a BuildKit builder. Both use the "remote-docker-builder" app role despite exposing incompatible APIs and that has been causing problems when both tests run in parallel.

To fix this, use `--local-only` for the Buildpack test. This should fix the builder app race but it comes at the cost of losing some test coverage. We need to re-architect preflight tests to safely test these two different build paths.