### PR TITLE
Show warning after login if new token is shadowed.

### DIFF
--- a/internal/build/imgsrc/ensure_builder_test.go
+++ b/internal/build/imgsrc/ensure_builder_test.go
@@ -318,6 +318,7 @@ func TestStartOrRestartBuilderMachine(t *testing.T) {
 	flapsClient := mock.FlapsClient{
 		StartFunc: func(ctx context.Context, appName, machineID string, nonce string) (*fly.MachineStartResponse, error) {
 			started = true
+
 			return nil, nil
 		},
 		RestartFunc: func(ctx context.Context, appName string, input fly.RestartMachineInput, nonce string) error {

--- a/internal/command/auth/login.go
+++ b/internal/command/auth/login.go
@@ -98,6 +98,12 @@ func loginTokenOverrideWarning() string {
 		if token == "" {
 			return ""
 		}
+		if apiToken := os.Getenv(config.APITokenEnvKey); apiToken != "" {
+			return fmt.Sprintf(
+				"Environment variables %s and %s are set. flyctl will continue using these instead of the credentials just saved. Unset both variables to use the new credentials.",
+				config.AccessTokenEnvKey, config.APITokenEnvKey,
+			)
+		}
 
 		return warnFor(config.AccessTokenEnvKey)
 	}

--- a/internal/command/auth/login.go
+++ b/internal/command/auth/login.go
@@ -98,6 +98,7 @@ func loginTokenOverrideWarning() string {
 		if token == "" {
 			return ""
 		}
+
 		return warnFor(config.AccessTokenEnvKey)
 	}
 

--- a/internal/command/auth/login.go
+++ b/internal/command/auth/login.go
@@ -3,14 +3,17 @@ package auth
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/superfly/flyctl/internal/command/auth/webauth"
 
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/iostreams"
 )
 
 func newLogin() *cobra.Command {
@@ -68,7 +71,41 @@ func runLogin(ctx context.Context) error {
 		return err
 	}
 
-	return webauth.SaveToken(ctx, token)
+	if err := webauth.SaveToken(ctx, token); err != nil {
+		return err
+	}
+
+	if warning := loginTokenOverrideWarning(); warning != "" {
+		io := iostreams.FromContext(ctx)
+		colorize := io.ColorScheme()
+		fmt.Fprintf(iostreams.FromContext(ctx).ErrOut, "\n%s %s\n", colorize.WarningIcon(), colorize.Yellow(warning))
+	}
+
+	return nil
+}
+
+func loginTokenOverrideWarning() string {
+	warnFor := func(envVar string) string {
+		return fmt.Sprintf(
+			"Environment variable %s is set, so flyctl will continue using it instead of the credentials just saved. Unset %s to use the new credentials.",
+			envVar, envVar,
+		)
+	}
+
+	// Keep this precedence in sync with config.applyEnv. An explicitly empty
+	// FLY_ACCESS_TOKEN prevents FLY_API_TOKEN from being selected.
+	if token, ok := os.LookupEnv(config.AccessTokenEnvKey); ok {
+		if token == "" {
+			return ""
+		}
+		return warnFor(config.AccessTokenEnvKey)
+	}
+
+	if token := os.Getenv(config.APITokenEnvKey); token != "" {
+		return warnFor(config.APITokenEnvKey)
+	}
+
+	return ""
 }
 
 type requiredWhenNonInteractive string


### PR DESCRIPTION
There's a UX footgun where a user runs `fly auth login` successfully but subsequent commands still fail because an invalid `FLY_API_TOKEN` is set, which takes precedence over the newly obtained token.

This PR teaches `fly auth login` to print a warning if either `FLY_API_TOKEN` or `FLY_ACCESS_TOKEN` is set.