### PR TITLE
Handle eventual consistency in volume tests.

### DIFF
--- a/test/preflight/fly_deploy_test.go
+++ b/test/preflight/fly_deploy_test.go
@@ -46,8 +46,15 @@ func TestFlyDeployHA(t *testing.T) {
 	require.Contains(f, x.StdErrString(), `needs volumes with name 'data' to fulfill mounts defined in fly.toml`)
 
 	// Create two volumes because fly launch will start 2 machines because of HA setup
-	f.Fly("volume create -a %s -r %s -s 1 data -y", appName, f.PrimaryRegion())
-	f.Fly("volume create -a %s -r %s -s 1 data -y", appName, f.SecondaryRegion())
+	for _, region := range []string{f.PrimaryRegion(), f.SecondaryRegion()} {
+		var volume *fly.Volume
+		result := f.Fly("volume create -a %s -r %s -s 1 data -y --json", appName, region)
+		result.StdOutJSON(&volume)
+
+		require.Eventually(t, func() bool {
+			return f.FlyAllowExitFailure("volume show %s --app %s --json", volume.ID, appName).ExitCode() == 0
+		}, time.Minute, 2*time.Second, "volume %s never became readable", volume.ID)
+	}
 	f.Fly("deploy --buildkit --remote-only")
 }
 
@@ -75,7 +82,12 @@ func TestFlyDeploy_AddNewMount(t *testing.T) {
 	x := f.FlyAllowExitFailure("deploy --buildkit --remote-only")
 	require.Contains(f, x.StdErrString(), `needs volumes with name 'data' to fulfill mounts defined in fly.toml`)
 
-	f.Fly("volume create -a %s -r %s -s 1 data -y", appName, f.PrimaryRegion())
+	var volume *fly.Volume
+	result := f.Fly("volume create -a %s -r %s -s 1 data -y --json", appName, f.PrimaryRegion())
+	result.StdOutJSON(&volume)
+	require.Eventually(t, func() bool {
+		return f.FlyAllowExitFailure("volume show %s --app %s --json", volume.ID, appName).ExitCode() == 0
+	}, time.Minute, 2*time.Second, "volume %s never became readable", volume.ID)
 	f.Fly("deploy --buildkit --remote-only")
 }
 

--- a/test/preflight/fly_scale_test.go
+++ b/test/preflight/fly_scale_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/test/preflight/testlib"
 )
 
@@ -117,6 +118,16 @@ primary_region = "%s"
 
 	// Extend the volume because if not found, scaling will default to 1GB.
 	f.Fly("volume extend %s --size 4 --app %s", ml[0].Config.Mounts[0].Volume, appName)
+	require.Eventually(t, func() bool {
+		result := f.FlyAllowExitFailure("volume show %s --app %s --json", ml[0].Config.Mounts[0].Volume, appName)
+		if result.ExitCode() != 0 {
+			return false
+		}
+
+		var volume fly.Volume
+		result.StdOutJSON(&volume)
+		return volume.SizeGb == 4
+	}, time.Minute, 2*time.Second, "volume %s never reached 4 GB", ml[0].Config.Mounts[0].Volume)
 
 	f.Fly("scale count -y 2")
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/test/preflight/fly_volume_test.go
+++ b/test/preflight/fly_volume_test.go
@@ -94,6 +94,9 @@ func testVolumeLs(t *testing.T) {
 	var destroyed *fly.Volume
 	j = f.Fly("volume create test_destroy --size 1 --app %s --region %s --yes --json", appName, f.PrimaryRegion())
 	j.StdOutJSON(&destroyed)
+	require.Eventually(t, func() bool {
+		return f.FlyAllowExitFailure("volume show %s --app %s --json", destroyed.ID, appName).ExitCode() == 0
+	}, time.Minute, 2*time.Second, "volume %s never became readable", destroyed.ID)
 
 	// Now destroy a volume (remembering to specify the app name)
 	f.Fly("volume destroy %s --yes --app %s", destroyed.ID, appName)
@@ -132,6 +135,9 @@ func testVolumeFork(t *testing.T) {
 	var original *fly.Volume
 	j := f.Fly("volume create foobar --json --app %s --region %s --yes", appName, f.PrimaryRegion())
 	j.StdOutJSON(&original)
+	require.Eventually(t, func() bool {
+		return f.FlyAllowExitFailure("volume show %s --app %s --json", original.ID, appName).ExitCode() == 0
+	}, time.Minute, 2*time.Second, "volume %s never became readable", original.ID)
 
 	var fork *fly.Volume
 	j = f.Fly("volume fork --json --app %s --region %s %s", appName, f.PrimaryRegion(), original.ID)
@@ -148,6 +154,9 @@ func testVolumeCreateFromDestroyedVolSnapshot(tt *testing.T) {
 	createRes := f.Fly("volume create test_destroy --size 1 --app %s --region %s --yes --json", appName, f.PrimaryRegion())
 	var vol *fly.Volume
 	createRes.StdOutJSON(&vol)
+	require.Eventually(t, func() bool {
+		return f.FlyAllowExitFailure("volume show %s --app %s --json", vol.ID, appName).ExitCode() == 0
+	}, time.Minute, 2*time.Second, "volume %s never became readable", vol.ID)
 	t.Logf("Start a machine under app %s", appName)
 	f.Fly("m run --org %s -a %s -r %s -v %s:/data --build-remote-only nginx", f.OrgSlug(), appName, f.PrimaryRegion(), vol.ID)
 	machine := f.MachinesList(appName)[0]


### PR DESCRIPTION
Volume creation is eventually consistent, meaning that one may not be able to retrieve a volume immediately after its creation. Preflight tests haven't been taking this into account and therefore occasionally fail with "volume not found" errors.

This PR adds `require.Eventually` invocations to make these tests less brittle.