### PR TITLE
Re-enable Postgres-flex test.

### DIFF
--- a/test/preflight/fly_postgres_test.go
+++ b/test/preflight/fly_postgres_test.go
@@ -159,8 +159,6 @@ func TestPostgres_autostart(t *testing.T) {
 }
 
 func TestPostgres_FlexFailover(t *testing.T) {
-	t.Skip("disabled until we synced the recently-published postgres-flex at digest f2aaf3666b0f")
-
 	if testing.Short() {
 		t.Skip()
 	}


### PR DESCRIPTION
This test should now be using the latest postgres-flex image, which comes with a fix for a leadership election race: https://github.com/fly-apps/postgres-flex/pull/371