### PR TITLE
Limit `flyctl` command timeout in preflight tests.

### DIFF
--- a/test/preflight/fly_deploy_test.go
+++ b/test/preflight/fly_deploy_test.go
@@ -581,7 +581,7 @@ func TestFlyDeploy_BlueGreen_StoppedMachines(t *testing.T) {
 `
 		f.WriteFlyToml("%s", appConfig)
 
-		deployRes := f.FlyAllowExitFailure("deploy --remote-only --strategy bluegreen")
+		deployRes := f.FlyAllowExitFailure("deploy --remote-only --strategy bluegreen --wait-timeout 1m")
 		require.NotEqual(t, 0, deployRes.ExitCode(),
 			"bluegreen deploy must fail when the app crashes, not silently report success;\nstdout:\n%s\nstderr:\n%s",
 			deployRes.StdOutString(), deployRes.StdErrString())

--- a/test/preflight/testlib/test_env.go
+++ b/test/preflight/testlib/test_env.go
@@ -198,7 +198,7 @@ func (f *FlyctlTestEnv) Fly(flyctlCmd string, vals ...interface{}) *FlyctlResult
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(f.t.Context(), defaultFlyctlCommandTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultFlyctlCommandTimeout)
 	defer cancel()
 
 	return f.FlyContextAndConfig(ctx, FlyCmdConfig{}, flyctlCmd, vals...)
@@ -207,7 +207,7 @@ func (f *FlyctlTestEnv) Fly(flyctlCmd string, vals ...interface{}) *FlyctlResult
 // FlyAllowExitFailure runs flyctl command and returns the result.
 // It does not fail the test even if the command exits with a non-zero status
 func (f *FlyctlTestEnv) FlyAllowExitFailure(flyctlCmd string, vals ...interface{}) *FlyctlResult {
-	ctx, cancel := context.WithTimeout(f.t.Context(), defaultFlyctlCommandTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultFlyctlCommandTimeout)
 	defer cancel()
 
 	return f.FlyContextAndConfig(ctx, FlyCmdConfig{NoAssertSuccessfulExit: true}, flyctlCmd, vals...)

--- a/test/preflight/testlib/test_env.go
+++ b/test/preflight/testlib/test_env.go
@@ -36,6 +36,11 @@ type FlyctlTestEnv struct {
 	VMSize              string
 }
 
+// Preflight flyctl commands are not supposed to take more than five minutes.
+// If they do take more time, we cancel them, to give the remaining tests more
+// time against the 15m Go package test timeout.
+const defaultFlyctlCommandTimeout = 5 * time.Minute
+
 func (f *FlyctlTestEnv) OrgSlug() string {
 	return f.orgSlug
 }
@@ -193,13 +198,19 @@ func (f *FlyctlTestEnv) Fly(flyctlCmd string, vals ...interface{}) *FlyctlResult
 		}
 	}
 
-	return f.FlyContextAndConfig(context.TODO(), FlyCmdConfig{}, flyctlCmd, vals...)
+	ctx, cancel := context.WithTimeout(f.t.Context(), defaultFlyctlCommandTimeout)
+	defer cancel()
+
+	return f.FlyContextAndConfig(ctx, FlyCmdConfig{}, flyctlCmd, vals...)
 }
 
 // FlyAllowExitFailure runs flyctl command and returns the result.
 // It does not fail the test even if the command exits with a non-zero status
 func (f *FlyctlTestEnv) FlyAllowExitFailure(flyctlCmd string, vals ...interface{}) *FlyctlResult {
-	return f.FlyContextAndConfig(context.TODO(), FlyCmdConfig{NoAssertSuccessfulExit: true}, flyctlCmd, vals...)
+	ctx, cancel := context.WithTimeout(f.t.Context(), defaultFlyctlCommandTimeout)
+	defer cancel()
+
+	return f.FlyContextAndConfig(ctx, FlyCmdConfig{NoAssertSuccessfulExit: true}, flyctlCmd, vals...)
 }
 
 type FlyCmdConfig struct {
@@ -241,6 +252,9 @@ func (f *FlyctlTestEnv) FlyContextAndConfig(ctx context.Context, cfg FlyCmdConfi
 		f.Fatalf("failed to start command: %s [error]: %s", res.cmdStr, err)
 	}
 	err = cmd.Wait()
+	if err != nil && ctx.Err() != nil {
+		f.Fatalf("command exceeded its deadline: %s [context error]: %v [stdout]: %s [stderr]: %s", res.cmdStr, ctx.Err(), res.stdOut.String(), res.stdErr.String())
+	}
 	if err == nil {
 		res.exitCode = 0
 	} else if exitErr, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
`flyctl` commands in preflight tests are not supposed to take more than five minutes, so this PR cancels any test that takes longer. That gives the remaining tests a larger time budget against Go's 15-minute test timeout.