### PR TITLE
Carve out preflight tests into dedicated group.

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -21,7 +21,9 @@ jobs:
         group:
           - apps
           - deploy
+          - deploy-detach
           - deploy-fixtures
+          - deploy-machine-checks
           - bluegreen
           - launch
           - scale

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -57,12 +57,18 @@ if [[ -n "$group" ]]; then
             ;;
         deploy)
             test_pattern="^Test(FlyDeploy|Deploy)"
-            # Slow fixture and bluegreen tests have independent matrix jobs so
-            # they do not consume the shared deploy package timeout.
-            test_skip_pattern="^Test(Deploy$|FlyDeploy_BlueGreen)"
+            # Slow deploy tests have independent matrix jobs so they do not
+            # consume the shared deploy package timeout.
+            test_skip_pattern="^Test(Deploy$|DeployDetach$|FlyDeploy_BlueGreen|FlyDeploy_(DeployMachinesCheck|NoServiceDeployMachinesCheck)$)"
+            ;;
+        deploy-detach)
+            test_pattern="^TestDeployDetach$"
             ;;
         deploy-fixtures)
             test_pattern="^TestDeploy$"
+            ;;
+        deploy-machine-checks)
+            test_pattern="^TestFlyDeploy_(DeployMachinesCheck|NoServiceDeployMachinesCheck)$"
             ;;
         bluegreen)
             test_pattern="^TestFlyDeploy_BlueGreen"
@@ -105,7 +111,7 @@ if [[ -n "$group" ]]; then
             ;;
         *)
             echo "Unknown test group: $group"
-            echo "Available groups: apps, deploy, deploy-fixtures, bluegreen, launch, scale, volume, console, logs, machine, postgres, postgres-flex-failover, tokens, wireguard, misc"
+            echo "Available groups: apps, deploy, deploy-detach, deploy-fixtures, bluegreen, deploy-machine-checks, launch, scale, volume, console, logs, machine, postgres, postgres-flex-failover, tokens, wireguard, misc"
             exit 1
             ;;
     esac

--- a/test/preflight/fly_deploy_bluegreen_test.go
+++ b/test/preflight/fly_deploy_bluegreen_test.go
@@ -18,7 +18,7 @@ import (
 // integration test doesn't depend on the internal package.
 const flyctlBGLaunchIDMetadataKey = "fly_flyctl_bluegreen_launch_id"
 
-func TestFlyDeployBluegreenImplicitAppProcessGroup(t *testing.T) {
+func TestFlyDeploy_BlueGreen_ImplicitAppProcessGroup(t *testing.T) {
 	f := testlib.NewTestEnvFromEnv(t)
 	appName := f.CreateRandomAppMachines()
 


### PR DESCRIPTION
The "deploy" group is too large and regularly exceeds Go's 15-minute package timeout. This PR carves out some tests and moves them to a new test group, like we've done in the past. These new groups get their own 15-minute timeout, which should alleviate the pressure on the "deploy" group.
