### PR TITLE
Make app cleanup idempotent on deletion.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,8 @@ linters:
             - github.com/superfly/flyctl/render.Printf
             - github.com/superfly/flyctl/render.Detailf
             - github.com/superfly/flyctl/render.Donef
+    nlreturn:
+      block-size: 5
     staticcheck:
       checks:
         - all

--- a/scripts/clean-up-preflight-apps/main.go
+++ b/scripts/clean-up-preflight-apps/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/google/shlex"
@@ -58,8 +61,9 @@ func run() error {
 				return err
 			}
 			cmd := exec.CommandContext(ctx, flyctlBin, cmdParts[1:]...)
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = io.MultiWriter(os.Stdout, &stdout)
+			cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
 			cmd.Env = append(cmd.Env, os.Environ()...)
 			cmd.Env = append(cmd.Env, fmt.Sprintf("FLY_API_TOKEN=%s", os.Getenv("FLY_PREFLIGHT_TEST_ACCESS_TOKEN")))
 			fmt.Fprintln(os.Stderr, cmdStr)
@@ -69,10 +73,19 @@ func run() error {
 			}
 			err = cmd.Wait()
 			if err != nil {
+				if isAppNotFound(stdout.String(), stderr.String()) {
+					fmt.Fprintf(os.Stderr, "app %s is already gone; continuing cleanup\n", app.Id)
+					continue
+				}
 				return err
 			}
 		}
 	}
 
 	return nil
+}
+
+func isAppNotFound(stdout, stderr string) bool {
+	output := strings.ToLower(stdout + "\n" + stderr)
+	return strings.Contains(output, "app not found")
 }


### PR DESCRIPTION
Our preflight tests create a bunch of apps. Tests tend to clean up after themselves but we also have a cleanup tool that deletes all apps older than 30 minutes. This can result in a deletion race. To fix that, we make deletion idempotent. If it fails, we ignore the error.