### PR TITLE
fix(auth): re-fetch all org tokens after re-login

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -695,6 +695,9 @@ func handleReLogin(ctx context.Context, reason string) (context.Context, error) 
 			return nil, err
 		}
 
+		// Fetch organization tokens and discharge any third-party caveats
+		config.MonitorTokens(ctx, config.Tokens(ctx), tryOpenUserURL)
+
 		return ctx, nil
 	} else {
 		return nil, fly.ErrNoAuthToken


### PR DESCRIPTION
### Change Summary

What and Why:

When a flyctl session expires, flyctl prompts the user to sign in again. The re-login path reloads the user token but doesn't fetch missing organization tokens or discharge third-party caveats. As a result, the first command after re-login could fail with a permission error for users in multiple organizations or organizations using SSO.

How:

Adding missing org token check to the re-login path.

---

### Documentation

- [ ] Fresh Produce
- [ ] In superfly/docs, or asked for help from docs team
- [x] n/a
