### PR TITLE
Use the Flaps app lookup instead of the full GraphQL GetApp query

### DIFF
--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -66,6 +66,7 @@ func Run(ctx context.Context, opt Options) (err error) {
 		runCtx:                ctx,
 		currentChange:         latestChangeAt,
 		tunnels:               make(map[tunnelKey]*wg.Tunnel),
+		slugAliases:           make(map[string]string),
 		tokens:                toks,
 		cancelTokenMonitoring: cancelMonitor,
 	}).serve(ctx, l)
@@ -124,10 +125,14 @@ type server struct {
 
 	listener net.Listener
 
-	runCtx                context.Context
-	mu                    sync.Mutex
-	currentChange         time.Time
-	tunnels               map[tunnelKey]*wg.Tunnel
+	runCtx        context.Context
+	mu            sync.Mutex
+	currentChange time.Time
+	tunnels       map[tunnelKey]*wg.Tunnel
+	// slugAliases maps every slug a client has used for an organization to
+	// the slug tunnels are keyed by. Clients may name the personal org by
+	// its raw slug (as Flaps does) or by the "personal" alias (as web does).
+	slugAliases           map[string]string
 	tokens                *tokens.Tokens
 	cancelTokenMonitoring func()
 }
@@ -314,11 +319,30 @@ func (s *server) fetchInstances(ctx context.Context, tunnel *wg.Tunnel, app stri
 	return ret, nil
 }
 
+// rememberSlug records that slug names the organization whose tunnels are
+// keyed by canonical.
+func (s *server) rememberSlug(slug, canonical string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.slugAliases[slug] = canonical
+}
+
+// canonicalSlugUnlocked returns the slug tunnels are keyed by for a slug a
+// client sent. Callers must hold s.mu.
+func (s *server) canonicalSlugUnlocked(slug string) string {
+	if canonical, ok := s.slugAliases[slug]; ok {
+		return canonical
+	}
+
+	return slug
+}
+
 func (s *server) tunnelFor(slug, network string) *wg.Tunnel {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	tk := tunnelKey{orgSlug: slug, networkName: network}
+	tk := tunnelKey{orgSlug: s.canonicalSlugUnlocked(slug), networkName: network}
 
 	return s.tunnels[tk]
 }

--- a/agent/server/session.go
+++ b/agent/server/session.go
@@ -205,9 +205,13 @@ func (s *session) fetchOrg(ctx context.Context, slug string) (*fly.Organization,
 		return nil, err
 	}
 
+	// The personal org is "personal" by Slug and its real name by RawSlug;
+	// clients may send either. Tunnels are keyed by Slug, so remember the
+	// alias for later lookups that only carry the slug the client used.
 	for _, org := range orgs {
-		if org.Slug == slug {
+		if org.Slug == slug || org.RawSlug == slug {
 			no := org // copy
+			s.srv.rememberSlug(slug, org.Slug)
 
 			return &no, nil
 		}

--- a/internal/command/apps/apps.go
+++ b/internal/command/apps/apps.go
@@ -8,8 +8,10 @@ import (
 	"github.com/spf13/cobra"
 
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/command"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 )
 
@@ -47,8 +49,14 @@ func BuildContext(ctx context.Context, app *fly.AppCompact) (context.Context, er
 	return BuildContextForNetwork(ctx, app.Organization.Slug, app.Network)
 }
 
+// BuildContextForApp is BuildContext for an app fetched through Flaps.
+func BuildContextForApp(ctx context.Context, app *flaps.App) (context.Context, error) {
+	return BuildContextForNetwork(ctx, app.Organization.Slug, flapsutil.NetworkName(app))
+}
+
 // BuildContextForNetwork establishes an agent tunnel into the given org network
-// and stores the resulting dialer in the context.
+// and stores the resulting dialer in the context. network is the name the web
+// API uses for the network, which is empty for the org's default network.
 func BuildContextForNetwork(ctx context.Context, orgSlug, network string) (context.Context, error) {
 	client := flyutil.ClientFromContext(ctx)
 

--- a/internal/command/apps/apps.go
+++ b/internal/command/apps/apps.go
@@ -44,6 +44,12 @@ func New() *cobra.Command {
 
 // BuildContext is a helper that builds out commonly required context requirements
 func BuildContext(ctx context.Context, app *fly.AppCompact) (context.Context, error) {
+	return BuildContextForNetwork(ctx, app.Organization.Slug, app.Network)
+}
+
+// BuildContextForNetwork establishes an agent tunnel into the given org network
+// and stores the resulting dialer in the context.
+func BuildContextForNetwork(ctx context.Context, orgSlug, network string) (context.Context, error) {
 	client := flyutil.ClientFromContext(ctx)
 
 	agentclient, err := agent.Establish(ctx, client)
@@ -51,9 +57,9 @@ func BuildContext(ctx context.Context, app *fly.AppCompact) (context.Context, er
 		return nil, fmt.Errorf("can't establish agent %w", err)
 	}
 
-	dialer, err := agentclient.Dialer(ctx, app.Organization.Slug, app.Network)
+	dialer, err := agentclient.Dialer(ctx, orgSlug, network)
 	if err != nil {
-		return nil, fmt.Errorf("can't build tunnel for %s: %s", app.Organization.Slug, err)
+		return nil, fmt.Errorf("can't build tunnel for %s: %s", orgSlug, err)
 	}
 	ctx = agent.DialerWithContext(ctx, dialer)
 

--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -73,7 +73,7 @@ func RunDestroy(ctx context.Context) error {
 			}
 		}
 
-		app, err := client.GetApp(ctx, appName)
+		app, err := flapsClient.GetApp(ctx, appName)
 		if err != nil {
 			return err
 		}

--- a/internal/command/apps/move.go
+++ b/internal/command/apps/move.go
@@ -72,7 +72,9 @@ func RunMove(ctx context.Context) error {
 		return err
 	}
 
-	if app.Organization.Slug == org.Slug {
+	// Flaps reports the raw org slug, while the org picked by the user may
+	// carry the "personal" alias.
+	if app.Organization.Slug == org.RawSlug || app.Organization.Slug == org.Slug {
 		fmt.Fprintln(io.Out, "No changes to apply")
 
 		return nil
@@ -106,7 +108,7 @@ func runMoveAppOnMachines(ctx context.Context, app *flaps.App, targetOrg *fly.Or
 		skipHealthChecks = flag.GetBool(ctx, "skip-health-checks")
 	)
 
-	ctx, err := BuildContextForNetwork(ctx, app.Organization.Slug, app.Network)
+	ctx, err := BuildContextForApp(ctx, app)
 	if err != nil {
 		return err
 	}

--- a/internal/command/apps/move.go
+++ b/internal/command/apps/move.go
@@ -8,9 +8,11 @@ import (
 	"github.com/superfly/flyctl/internal/appsecrets"
 	"github.com/superfly/flyctl/internal/command/deploy/statics"
 	"github.com/superfly/flyctl/internal/flag/completion"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/logger"
@@ -52,14 +54,14 @@ For details, see https://fly.io/docs/apps/move-app-org/.`
 // TODO: make internal once the move package is removed
 func RunMove(ctx context.Context) error {
 	var (
-		appName  = flag.FirstArg(ctx)
-		client   = flyutil.ClientFromContext(ctx)
-		io       = iostreams.FromContext(ctx)
-		colorize = io.ColorScheme()
-		logger   = logger.FromContext(ctx)
+		appName     = flag.FirstArg(ctx)
+		flapsClient = flapsutil.ClientFromContext(ctx)
+		io          = iostreams.FromContext(ctx)
+		colorize    = io.ColorScheme()
+		logger      = logger.FromContext(ctx)
 	)
 
-	app, err := client.GetApp(ctx, appName)
+	app, err := flapsClient.GetApp(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("failed fetching app: %w", err)
 	}
@@ -97,14 +99,14 @@ Please confirm whether you wish to restart this app now.`
 	return runMoveAppOnMachines(ctx, app, org)
 }
 
-func runMoveAppOnMachines(ctx context.Context, app *fly.App, targetOrg *fly.Organization) error {
+func runMoveAppOnMachines(ctx context.Context, app *flaps.App, targetOrg *fly.Organization) error {
 	var (
 		client           = flyutil.ClientFromContext(ctx)
 		io               = iostreams.FromContext(ctx)
 		skipHealthChecks = flag.GetBool(ctx, "skip-health-checks")
 	)
 
-	ctx, err := BuildContext(ctx, app.Compact())
+	ctx, err := BuildContextForNetwork(ctx, app.Organization.Slug, app.Network)
 	if err != nil {
 		return err
 	}
@@ -130,7 +132,14 @@ func runMoveAppOnMachines(ctx context.Context, app *fly.App, targetOrg *fly.Orga
 	}
 
 	if oldStaticsBucket != nil {
-		err := statics.MoveBucket(ctx, oldStaticsBucket, oldOrg, app, targetOrg, machines)
+		releaseVersion := 0
+		if release, err := client.GetAppCurrentReleaseMachines(ctx, app.Name); err != nil {
+			return fmt.Errorf("failed to find app's current release: %w", err)
+		} else if release != nil {
+			releaseVersion = release.Version
+		}
+
+		err := statics.MoveBucket(ctx, oldStaticsBucket, oldOrg, app, targetOrg, releaseVersion, machines)
 		if err != nil {
 			return fmt.Errorf("failed to move statics bucket: %w", err)
 		}

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -54,16 +54,12 @@ func (md *machineDeployment) DeployMachinesApp(ctx context.Context) error {
 	//                the app's services (if one exists).
 	if md.staticsUseTigris(ctx) {
 
-		fullApp, err := md.apiClient.GetApp(ctx, md.app.Name)
-		if err != nil {
-			return err
-		}
 		fullOrg, err := md.apiClient.GetOrganizationBySlug(ctx, md.app.Organization.Slug)
 		if err != nil {
 			return err
 		}
 
-		md.tigrisStatics = statics.Deployer(md.appConfig, fullApp, fullOrg, md.releaseVersion)
+		md.tigrisStatics = statics.Deployer(md.appConfig, md.app, fullOrg, md.releaseVersion)
 		if err := md.tigrisStatics.Configure(ctx); err != nil {
 			return err
 		}

--- a/internal/command/deploy/statics/addon.go
+++ b/internal/command/deploy/statics/addon.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/gql"
 	extensions "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flyutil"
@@ -21,7 +22,7 @@ import (
 
 // FindBucket finds the tigris statics bucket for the given app and org.
 // Returns nil, nil if no bucket is found.
-func FindBucket(ctx context.Context, app *fly.App, org *fly.Organization) (*gql.StaticsAddOn, error) {
+func FindBucket(ctx context.Context, app *flaps.App, org *fly.Organization) (*gql.StaticsAddOn, error) {
 	client := flyutil.ClientFromContext(ctx)
 	gqlClient := client.GenqClient()
 

--- a/internal/command/deploy/statics/deployer.go
+++ b/internal/command/deploy/statics/deployer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/samber/lo"
 	"github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/terminal"
@@ -40,7 +41,7 @@ const staticsKeepVersions = 3
 
 type DeployerState struct {
 	// State that's pulled from the larger machines deployment
-	app            *fly.App
+	app            *flaps.App
 	org            *fly.Organization
 	appConfig      *appconfig.Config
 	releaseVersion int
@@ -52,7 +53,7 @@ type DeployerState struct {
 	originalStatics []appconfig.Static
 }
 
-func Deployer(appConfig *appconfig.Config, app *fly.App, org *fly.Organization, releaseVersion int) *DeployerState {
+func Deployer(appConfig *appconfig.Config, app *flaps.App, org *fly.Organization, releaseVersion int) *DeployerState {
 	return &DeployerState{
 		app:            app,
 		appConfig:      appConfig,

--- a/internal/command/deploy/statics/move.go
+++ b/internal/command/deploy/statics/move.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/samber/lo"
 	"github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flyutil"
@@ -21,8 +22,9 @@ func MoveBucket(
 	ctx context.Context,
 	prevBucket *gql.StaticsAddOn,
 	prevOrg *fly.Organization,
-	app *fly.App,
+	app *flaps.App,
 	targetOrg *fly.Organization,
+	releaseVersion int,
 	machines []*fly.Machine,
 ) error {
 
@@ -45,7 +47,7 @@ func MoveBucket(
 
 	prevBucketName := prevBucketMeta[staticsMetaBucketName].(string)
 
-	deployer := Deployer(appConfig, app, targetOrg, app.CurrentRelease.Version)
+	deployer := Deployer(appConfig, app, targetOrg, releaseVersion)
 	err = deployer.Configure(ctx)
 	if err != nil {
 		return err

--- a/internal/command/deploy/web_client.go
+++ b/internal/command/deploy/web_client.go
@@ -16,7 +16,6 @@ type webClient interface {
 	CreateRelease(ctx context.Context, input fly.CreateReleaseInput) (*fly.CreateReleaseResponse, error)
 	UpdateRelease(ctx context.Context, input fly.UpdateReleaseInput) (*fly.UpdateReleaseResponse, error)
 
-	GetApp(ctx context.Context, appName string) (*fly.App, error)
 	GetOrganizationBySlug(ctx context.Context, slug string) (*fly.Organization, error)
 
 	logs.WebClient

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -312,14 +312,14 @@ func buildManifest(ctx context.Context, parentConfig *appconfig.Config, recovera
 // Returns an error only if the prompt library encounters an error. (this should never occur)
 func nudgeTowardsDeploy(ctx context.Context, appName string) (bool, error) {
 
-	client := flyutil.ClientFromContext(ctx)
+	flapsClient := flapsutil.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 
 	if flag.GetYes(ctx) {
 		return false, nil
 	}
 
-	if _, err := client.GetApp(ctx, appName); err != nil {
+	if _, err := flapsClient.GetApp(ctx, appName); err != nil {
 		// The user can't see the app. Let them proceed.
 		return false, nil
 	}

--- a/internal/command/mcp/destroy.go
+++ b/internal/command/mcp/destroy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
-	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/flapsutil"
 )
 
 func NewDestroy() *cobra.Command {
@@ -78,8 +78,8 @@ func runDestroy(ctx context.Context) error {
 		}
 	}
 
-	client := flyutil.ClientFromContext(ctx)
-	_, err := client.GetApp(ctx, appName)
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	_, err := flapsClient.GetApp(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("app not found: %w", err)
 	}
@@ -95,7 +95,7 @@ func runDestroy(ctx context.Context) error {
 		return fmt.Errorf("failed to destroy app': %w", err)
 	}
 
-	_, err = client.GetApp(ctx, appName)
+	_, err = flapsClient.GetApp(ctx, appName)
 	if err == nil {
 		return fmt.Errorf("app not destroyed: %s", appName)
 	}

--- a/internal/flapsutil/app.go
+++ b/internal/flapsutil/app.go
@@ -1,0 +1,19 @@
+package flapsutil
+
+import "github.com/superfly/fly-go/flaps"
+
+// DefaultNetwork is the name Flaps reports for an organization's default
+// network. The web API and WireGuard tunnels identify that network by an
+// empty name instead.
+const DefaultNetwork = "default"
+
+// NetworkName returns the app's network name in the form the web API and
+// WireGuard tunnels expect: empty for the organization's default network,
+// and the custom network's name otherwise.
+func NetworkName(app *flaps.App) string {
+	if app == nil || app.Network == DefaultNetwork {
+		return ""
+	}
+
+	return app.Network
+}


### PR DESCRIPTION
The fly-go GetApp GraphQL query fetches every field on an app, including the full config of every machine, but the flyctl callers only read the app name, the organization slug, and the internal numeric ID. All of those are returned by the Flaps GET /apps/{name} endpoint, which flyctl already calls elsewhere.

Switch `apps destroy`, `apps move`, `mcp destroy`, the launch existence check, and the Tigris statics deployer to the Flaps app. The statics package now takes a *flaps.App, and MoveBucket takes the release version explicitly; `apps move` fetches it with the small current-release query only when there is a bucket to move.

`apps move` no longer goes through App.Compact() to build the agent tunnel. That copy never carried the app network because the GraphQL query did not fetch it, so apps on custom networks now dial correctly.

The only remaining caller of the full query is `apps create --json`, which renders the whole struct as output.


Claude-Session: https://claude.ai/code/session_01DMttEkUAVhL7YZFRFjhHwB
