### PR TITLE
Take organization GraphQL IDs from ui-ex for app-scoped commands

### DIFF
--- a/internal/command/console/console.go
+++ b/internal/command/console/console.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/shlex"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/uiexutil"
 
@@ -176,16 +177,15 @@ func runConsole(ctx context.Context) error {
 		apiClient = flyutil.ClientFromContext(ctx)
 	)
 
-	app, err := apiClient.GetAppCompact(ctx, appName)
+	app, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("failed to get app: %w", err)
 	}
 
-	flapsApp, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, app.Name)
+	org, err := uiexutil.AppOrganization(ctx, app)
 	if err != nil {
-		return fmt.Errorf("failed to get app network: %w", err)
+		return err
 	}
-	network := flapsutil.NetworkName(flapsApp)
 
 	appConfig := appconfig.ConfigFromContext(ctx)
 	if appConfig == nil {
@@ -210,14 +210,14 @@ func runConsole(ctx context.Context) error {
 		defer cleanup()
 	}
 
-	_, dialer, err := agent.BringUpAgent(ctx, apiClient, app, network, false)
+	_, dialer, err := agent.BringUpAgentOrgSlug(ctx, apiClient, app.Organization.Slug, flapsutil.NetworkName(app), false)
 	if err != nil {
 		return err
 	}
 
 	params := &ssh.ConnectParams{
 		Ctx:            ctx,
-		Org:            app.Organization,
+		Org:            org,
 		Dialer:         dialer,
 		Username:       flag.GetString(ctx, "user"),
 		DisableSpinner: false,
@@ -238,7 +238,7 @@ func runConsole(ctx context.Context) error {
 	return ssh.Console(ctx, sshClient, consoleCommand, true, ssh.SessionTarget{Container: params.Container})
 }
 
-func selectMachine(ctx context.Context, app *fly.AppCompact, appConfig *appconfig.Config) (*fly.Machine, func(), error) {
+func selectMachine(ctx context.Context, app *flaps.App, appConfig *appconfig.Config) (*fly.Machine, func(), error) {
 	if flag.GetBool(ctx, "select") {
 		return promptForMachine(ctx, app, appConfig)
 	} else if flag.IsSpecified(ctx, "machine") {
@@ -253,7 +253,7 @@ func selectMachine(ctx context.Context, app *fly.AppCompact, appConfig *appconfi
 	}
 }
 
-func promptForMachine(ctx context.Context, app *fly.AppCompact, appConfig *appconfig.Config) (*fly.Machine, func(), error) {
+func promptForMachine(ctx context.Context, app *flaps.App, appConfig *appconfig.Config) (*fly.Machine, func(), error) {
 	if flag.IsSpecified(ctx, "machine") {
 		return nil, nil, errors.New("--machine can't be used with -s/--select")
 	}
@@ -317,7 +317,7 @@ func getMachineByID(ctx context.Context, appName string) (*fly.Machine, func(), 
 	return machine, nil, nil
 }
 
-func makeEphemeralConsoleMachine(ctx context.Context, app *fly.AppCompact, appConfig *appconfig.Config, guest *fly.MachineGuest) (*fly.Machine, func(), error) {
+func makeEphemeralConsoleMachine(ctx context.Context, app *flaps.App, appConfig *appconfig.Config, guest *fly.MachineGuest) (*fly.Machine, func(), error) {
 	currentRelease, err := uiexutil.LatestRelease(ctx, uiexutil.ClientFromContext(ctx), app.Name)
 	if err != nil {
 		return nil, nil, err

--- a/internal/command/launch/launch_frameworks.go
+++ b/internal/command/launch/launch_frameworks.go
@@ -21,6 +21,7 @@ import (
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/scanner"
 )
@@ -48,19 +49,24 @@ func (state *launchState) setupGitHubActions(ctx context.Context, appName string
 
 			expiry := "999999h"
 
-			app, err := apiClient.GetAppCompact(ctx, appName)
+			app, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, appName)
 			if err != nil {
 				return fmt.Errorf("failed retrieving app %s: %w", appName, err)
+			}
+
+			org, err := uiexutil.AppOrganization(ctx, app)
+			if err != nil {
+				return err
 			}
 
 			resp, err := gql.CreateLimitedAccessToken(
 				ctx,
 				apiClient.GenqClient(),
 				appName,
-				app.Organization.ID,
+				org.ID,
 				"deploy",
 				&gql.LimitedAccessTokenOptions{
-					"app_id": app.ID,
+					"app_id": app.Name,
 				},
 				expiry,
 			)

--- a/internal/command/postgres/barman.go
+++ b/internal/command/postgres/barman.go
@@ -10,6 +10,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/appsecrets"
@@ -23,6 +24,7 @@ import (
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/sentry"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/ip"
 )
@@ -96,7 +98,6 @@ func newCreateBarman() *cobra.Command {
 func runBarmanCreate(ctx context.Context) error {
 	var (
 		io      = iostreams.FromContext(ctx)
-		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 
@@ -105,22 +106,27 @@ func runBarmanCreate(ctx context.Context) error {
 	// pre-fetch platform regions for later use
 	prompt.PlatformRegions(ctx)
 
-	app, err := client.GetAppCompact(ctx, appName)
+	app, err := flapsClient.GetApp(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("failed retrieving app %s: %w", appName, err)
 	}
 
-	if !app.IsPostgresApp() {
+	if !flapsutil.IsPostgresApp(app) {
 		return fmt.Errorf("app %s is not a postgres app", appName)
 	}
 
-	ctx, err = apps.BuildContext(ctx, app)
+	org, err := uiexutil.AppOrganization(ctx, app)
+	if err != nil {
+		return err
+	}
+
+	ctx, err = apps.BuildContextForApp(ctx, app)
 	if err != nil {
 		return err
 	}
 
 	var region *fly.Region
-	region, err = prompt.Region(ctx, !app.Organization.PaidPlan, prompt.RegionParams{
+	region, err = prompt.Region(ctx, !org.PaidPlan, prompt.RegionParams{
 		Message: "Select a region. Prefer closer to the primary",
 	})
 	if err != nil {
@@ -192,7 +198,7 @@ func runBarmanCreate(ctx context.Context) error {
 
 	imageRepo := "flyio/postgres-flex"
 
-	imageRef, err := client.GetLatestImageTag(ctx, imageRepo, nil)
+	imageRef, err := flyutil.ClientFromContext(ctx).GetLatestImageTag(ctx, imageRepo, nil)
 	if err != nil {
 		return err
 	}
@@ -389,7 +395,7 @@ func newBarmanRecover() *cobra.Command {
 	return cmd
 }
 
-func captureError(ctx context.Context, err error, app *fly.AppCompact) {
+func captureError(ctx context.Context, err error, app *flaps.App) {
 	// ignore cancelled errors
 	if errors.Is(err, context.Canceled) {
 		return
@@ -468,12 +474,17 @@ func runConsole(ctx context.Context, cmd string) error {
 	client := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 
-	app, err := client.GetAppCompact(ctx, appName)
+	app, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("get app: %w", err)
 	}
 
-	agentclient, dialer, err := agent.BringUpAgent(ctx, client, app, "", false)
+	org, err := uiexutil.AppOrganization(ctx, app)
+	if err != nil {
+		return err
+	}
+
+	agentclient, dialer, err := agent.BringUpAgentOrgSlug(ctx, client, app.Organization.Slug, flapsutil.NetworkName(app), false)
 	if err != nil {
 		return err
 	}
@@ -485,7 +496,7 @@ func runConsole(ctx context.Context, cmd string) error {
 
 	params := &ssh.ConnectParams{
 		Ctx:            ctx,
-		Org:            app.Organization,
+		Org:            org,
 		Dialer:         dialer,
 		Username:       "root",
 		DisableSpinner: false,
@@ -507,7 +518,7 @@ func runConsole(ctx context.Context, cmd string) error {
 	return nil
 }
 
-func lookupAddress(ctx context.Context, cli *agent.Client, dialer agent.Dialer, app *fly.AppCompact, console bool) (addr string, err error) {
+func lookupAddress(ctx context.Context, cli *agent.Client, dialer agent.Dialer, app *flaps.App, console bool) (addr string, err error) {
 	addr, err = addrForMachines(ctx, app, console)
 
 	if err != nil {
@@ -526,7 +537,7 @@ func lookupAddress(ctx context.Context, cli *agent.Client, dialer agent.Dialer, 
 	return
 }
 
-func addrForMachines(ctx context.Context, app *fly.AppCompact, console bool) (addr string, err error) {
+func addrForMachines(ctx context.Context, app *flaps.App, console bool) (addr string, err error) {
 	// out := iostreams.FromContext(ctx).Out
 	flapsClient := flapsutil.ClientFromContext(ctx)
 

--- a/internal/command/postgres/connect.go
+++ b/internal/command/postgres/connect.go
@@ -8,7 +8,7 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/mattn/go-colorable"
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command"
@@ -16,7 +16,8 @@ import (
 	"github.com/superfly/flyctl/internal/command/ssh"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
-	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/internal/uiexutil"
 )
 
 func newConnect() *cobra.Command {
@@ -58,29 +59,31 @@ func newConnect() *cobra.Command {
 }
 
 func runConnect(ctx context.Context) error {
-	var (
-		client  = flyutil.ClientFromContext(ctx)
-		appName = appconfig.NameFromContext(ctx)
-	)
+	appName := appconfig.NameFromContext(ctx)
 
-	app, err := client.GetAppCompact(ctx, appName)
+	app, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("failed retrieving app %s: %w", appName, err)
 	}
 
-	if !app.IsPostgresApp() {
+	if !flapsutil.IsPostgresApp(app) {
 		return fmt.Errorf("app %s is not a postgres app", appName)
 	}
 
-	ctx, err = apps.BuildContext(ctx, app)
+	org, err := uiexutil.AppOrganization(ctx, app)
 	if err != nil {
 		return err
 	}
 
-	return runMachineConnect(ctx, app)
+	ctx, err = apps.BuildContextForApp(ctx, app)
+	if err != nil {
+		return err
+	}
+
+	return runMachineConnect(ctx, app, org)
 }
 
-func runMachineConnect(ctx context.Context, app *fly.AppCompact) error {
+func runMachineConnect(ctx context.Context, app *flaps.App, org *uiex.Organization) error {
 	var (
 		MinPostgresHaVersion         = "0.0.9"
 		MinPostgresFlexVersion       = "0.0.3"
@@ -109,7 +112,7 @@ func runMachineConnect(ctx context.Context, app *fly.AppCompact) error {
 
 	return ssh.SSHConnect(&ssh.SSHParams{
 		Ctx:      ctx,
-		Org:      app.Organization,
+		Org:      org,
 		Dialer:   agent.DialerFromContext(ctx),
 		App:      app.Name,
 		Username: ssh.DefaultSshUsername,

--- a/internal/command/postgres/detach.go
+++ b/internal/command/postgres/detach.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/agent"
 	"github.com/superfly/flyctl/flypg"
 	"github.com/superfly/flyctl/internal/appconfig"
@@ -44,25 +45,23 @@ func newDetach() *cobra.Command {
 
 func runDetach(ctx context.Context) error {
 	var (
-		client = flyutil.ClientFromContext(ctx)
-
 		pgAppName = flag.FirstArg(ctx)
 		appName   = appconfig.NameFromContext(ctx)
 	)
 
-	app, err := client.GetAppCompact(ctx, appName)
+	appFlapsClient := flapsutil.ClientFromContext(ctx)
+
+	app, err := appFlapsClient.GetApp(ctx, appName)
 	if err != nil {
 		return err
 	}
 
-	appFlapsClient := flapsutil.ClientFromContext(ctx)
-
-	pgApp, err := client.GetAppCompact(ctx, pgAppName)
+	pgApp, err := appFlapsClient.GetApp(ctx, pgAppName)
 	if err != nil {
 		return fmt.Errorf("get postgres app: %w", err)
 	}
 
-	ctx, err = apps.BuildContext(ctx, pgApp)
+	ctx, err = apps.BuildContextForApp(ctx, pgApp)
 	if err != nil {
 		return err
 	}
@@ -70,7 +69,7 @@ func runDetach(ctx context.Context) error {
 	return runMachineDetach(ctx, appFlapsClient, app, pgApp)
 }
 
-func runMachineDetach(ctx context.Context, appFlapsClient flapsutil.FlapsClient, app *fly.AppCompact, pgApp *fly.AppCompact) error {
+func runMachineDetach(ctx context.Context, appFlapsClient flapsutil.FlapsClient, app *flaps.App, pgApp *flaps.App) error {
 	var (
 		MinPostgresHaVersion         = "0.0.19"
 		MinPostgresFlexVersion       = "0.0.3"
@@ -99,14 +98,15 @@ func runMachineDetach(ctx context.Context, appFlapsClient flapsutil.FlapsClient,
 }
 
 // TODO - This process needs to be re-written to suppport non-interactive terminals.
-func detachAppFromPostgres(ctx context.Context, leaderIP string, appFlapsClient flapsutil.FlapsClient, app *fly.AppCompact, pgApp *fly.AppCompact) error {
+func detachAppFromPostgres(ctx context.Context, leaderIP string, appFlapsClient flapsutil.FlapsClient, app *flaps.App, pgApp *flaps.App) error {
 	var (
 		client = flyutil.ClientFromContext(ctx)
 		dialer = agent.DialerFromContext(ctx)
 		io     = iostreams.FromContext(ctx)
 	)
 
-	attachments, err := client.ListPostgresClusterAttachments(ctx, app.ID, pgApp.ID)
+	// The GraphQL app ID is the app name.
+	attachments, err := client.ListPostgresClusterAttachments(ctx, app.Name, pgApp.Name)
 	if err != nil {
 		return err
 	}

--- a/internal/command/postgres/failover.go
+++ b/internal/command/postgres/failover.go
@@ -21,8 +21,9 @@ import (
 	"github.com/superfly/flyctl/internal/command/ssh"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
-	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/internal/watch"
 	"github.com/superfly/flyctl/iostreams"
 )
@@ -65,20 +66,24 @@ func runFailover(ctx context.Context) (err error) {
 		MinPostgresStandaloneVersion = "0.0.7"
 
 		io      = iostreams.FromContext(ctx)
-		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 	)
 
-	app, err := client.GetAppCompact(ctx, appName)
+	app, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("get app: %w", err)
 	}
 
-	if !app.IsPostgresApp() {
+	if !flapsutil.IsPostgresApp(app) {
 		return fmt.Errorf("app %s is not a Postgres app", app.Name)
 	}
 
-	ctx, err = apps.BuildContext(ctx, app)
+	org, err := uiexutil.AppOrganization(ctx, app)
+	if err != nil {
+		return err
+	}
+
+	ctx, err = apps.BuildContextForApp(ctx, app)
 	if err != nil {
 		return err
 	}
@@ -107,7 +112,7 @@ func runFailover(ctx context.Context) (err error) {
 		force := flag.GetBool(ctx, "force")
 		allowSecondaryRegion := flag.GetBool(ctx, "allow-secondary-region")
 
-		if failoverErr := flexFailover(ctx, machines, app, force, allowSecondaryRegion); failoverErr != nil {
+		if failoverErr := flexFailover(ctx, machines, app, org, force, allowSecondaryRegion); failoverErr != nil {
 			if err := handleFlexFailoverFail(ctx, app, machines); err != nil {
 				fmt.Fprintf(io.ErrOut, "Failed to handle failover failure, please manually configure PG cluster primary")
 			}
@@ -156,7 +161,7 @@ func runFailover(ctx context.Context) (err error) {
 	return
 }
 
-func flexFailover(ctx context.Context, machines []*fly.Machine, app *fly.AppCompact, force, allowSecondaryRegion bool) error {
+func flexFailover(ctx context.Context, machines []*fly.Machine, app *flaps.App, org *uiex.Organization, force, allowSecondaryRegion bool) error {
 	if len(machines) < 3 {
 		return fmt.Errorf("Not enough machines to meet quorum requirements")
 	}
@@ -207,7 +212,7 @@ func flexFailover(ctx context.Context, machines []*fly.Machine, app *fly.AppComp
 		return fmt.Errorf("Could not find primary region for app")
 	}
 
-	newLeader, err := pickNewLeader(ctx, app, primaryCandidates, secondaryCandidates, allowSecondaryRegion)
+	newLeader, err := pickNewLeader(ctx, app, org, primaryCandidates, secondaryCandidates, allowSecondaryRegion)
 	if err != nil {
 		return err
 	}
@@ -239,7 +244,7 @@ func flexFailover(ctx context.Context, machines []*fly.Machine, app *fly.AppComp
 	fmt.Println("Promoting new leader... ", newLeader.ID)
 	err = ssh.SSHConnect(&ssh.SSHParams{
 		Ctx:      ctx,
-		Org:      app.Organization,
+		Org:      org,
 		App:      app.Name,
 		Username: "postgres",
 		Dialer:   agent.DialerFromContext(ctx),
@@ -297,7 +302,7 @@ func flexFailover(ctx context.Context, machines []*fly.Machine, app *fly.AppComp
 	return nil
 }
 
-func handleFlexFailoverFail(ctx context.Context, app *fly.AppCompact, machines []*fly.Machine) (err error) {
+func handleFlexFailoverFail(ctx context.Context, app *flaps.App, machines []*fly.Machine) (err error) {
 	io := iostreams.FromContext(ctx)
 	flapsClient := flapsutil.ClientFromContext(ctx)
 
@@ -367,7 +372,7 @@ func handleFlexFailoverFail(ctx context.Context, app *fly.AppCompact, machines [
 	return nil
 }
 
-func pickNewLeader(ctx context.Context, app *fly.AppCompact, primaryCandidates []*fly.Machine, secondaryCandidates []*fly.Machine, allowSecondaryRegion bool) (*fly.Machine, error) {
+func pickNewLeader(ctx context.Context, app *flaps.App, org *uiex.Organization, primaryCandidates []*fly.Machine, secondaryCandidates []*fly.Machine, allowSecondaryRegion bool) (*fly.Machine, error) {
 	machineReasons := make(map[string]string)
 
 	// We should go for the primary canddiates first, but the secondary candidates are also valid
@@ -386,7 +391,7 @@ func pickNewLeader(ctx context.Context, app *fly.AppCompact, primaryCandidates [
 		} else if !machine.AllHealthChecks().AllPassing() {
 			isValid = false
 			machineReasons[machine.ID] = "1+ health checks are not passing"
-		} else if !passesDryRun(ctx, app, machine) {
+		} else if !passesDryRun(ctx, app, org, machine) {
 			isValid = false
 			machineReasons[machine.ID] = fmt.Sprintf("Running a dry run of `repmgr standby switchover` failed. Try running `fly ssh console -u postgres -C 'repmgr standby switchover -f /data/repmgr.conf --dry-run' -s -a %s` for more information. This was most likely due to the requirements for quorum not being met.", app.Name)
 		}
@@ -411,10 +416,10 @@ func pickNewLeader(ctx context.Context, app *fly.AppCompact, primaryCandidates [
 }
 
 // Before doing anything that might mess up, it's useful to check if a dry run of the failover command will work, since that allows repmgr to do some checks
-func passesDryRun(ctx context.Context, app *fly.AppCompact, machine *fly.Machine) bool {
+func passesDryRun(ctx context.Context, app *flaps.App, org *uiex.Organization, machine *fly.Machine) bool {
 	err := ssh.SSHConnect(&ssh.SSHParams{
 		Ctx:      ctx,
-		Org:      app.Organization,
+		Org:      org,
 		App:      app.Name,
 		Username: "postgres",
 		Dialer:   agent.DialerFromContext(ctx),

--- a/internal/command/postgres/import.go
+++ b/internal/command/postgres/import.go
@@ -20,6 +20,7 @@ import (
 	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/internal/uiexutil"
 )
 
 func newImport() *cobra.Command {
@@ -77,7 +78,6 @@ func newImport() *cobra.Command {
 
 func runImport(ctx context.Context) error {
 	var (
-		client  = flyutil.ClientFromContext(ctx)
 		appName = appconfig.NameFromContext(ctx)
 
 		sourceURI = flag.FirstArg(ctx)
@@ -88,16 +88,20 @@ func runImport(ctx context.Context) error {
 	// pre-fetch platform regions for later use
 	prompt.PlatformRegions(ctx)
 
-	apiClient := flyutil.ClientFromContext(ctx)
-	app, err := apiClient.GetAppCompact(ctx, appName)
+	flapsClient := flapsutil.ClientFromContext(ctx)
+
+	app, err := flapsClient.GetApp(ctx, appName)
 	if err != nil {
 		return err
 	}
 
-	flapsClient := flapsutil.ClientFromContext(ctx)
-
-	if !app.IsPostgresApp() {
+	if !flapsutil.IsPostgresApp(app) {
 		return fmt.Errorf("The target app must be a Postgres app")
+	}
+
+	org, err := uiexutil.AppOrganization(ctx, app)
+	if err != nil {
+		return err
 	}
 
 	machines, err := flapsClient.ListActive(ctx, appName)
@@ -115,7 +119,7 @@ func runImport(ctx context.Context) error {
 	machineID := leader.ID
 
 	// Resolve region
-	region, err := prompt.Region(ctx, !app.Organization.PaidPlan, prompt.RegionParams{
+	region, err := prompt.Region(ctx, !org.PaidPlan, prompt.RegionParams{
 		Message: "Choose a region to deploy the migration machine:",
 	})
 	if err != nil {
@@ -135,7 +139,7 @@ func runImport(ctx context.Context) error {
 		return fmt.Errorf("failed to set secrets: %s", err)
 	}
 
-	ctx, err = apps.BuildContext(ctx, app)
+	ctx, err = apps.BuildContextForApp(ctx, app)
 	if err != nil {
 		return fmt.Errorf("failed to build context: %s", err)
 	}
@@ -161,7 +165,7 @@ func runImport(ctx context.Context) error {
 
 	// If a custom migration image is not specified, resolve latest managed image.
 	if imageRef == "" {
-		imageRef, err = client.GetLatestImageTag(ctx, "flyio/postgres-importer", nil)
+		imageRef, err = flyutil.ClientFromContext(ctx).GetLatestImageTag(ctx, "flyio/postgres-importer", nil)
 		if err != nil {
 			return err
 		}
@@ -192,7 +196,7 @@ func runImport(ctx context.Context) error {
 	// Initiate migration process
 	err = ssh.SSHConnect(&ssh.SSHParams{
 		Ctx:      ctx,
-		Org:      app.Organization,
+		Org:      org,
 		Dialer:   agent.DialerFromContext(ctx),
 		App:      app.Name,
 		Username: ssh.DefaultSshUsername,

--- a/internal/command/postgres/renew_certs.go
+++ b/internal/command/postgres/renew_certs.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/appsecrets"
 	"github.com/superfly/flyctl/internal/command"
@@ -16,6 +16,8 @@ import (
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 	mach "github.com/superfly/flyctl/internal/machine"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -49,27 +51,31 @@ func runRefreshSSHCerts(ctx context.Context) error {
 		appName = appconfig.NameFromContext(ctx)
 	)
 
-	apiClient := flyutil.ClientFromContext(ctx)
-	app, err := apiClient.GetAppCompact(ctx, appName)
+	flapsClient := flapsutil.ClientFromContext(ctx)
+
+	app, err := flapsClient.GetApp(ctx, appName)
 	if err != nil {
 		return err
 	}
 
-	flapsClient := flapsutil.ClientFromContext(ctx)
-
-	if !app.IsPostgresApp() {
+	if !flapsutil.IsPostgresApp(app) {
 		return fmt.Errorf("app %s is not a postgres app", appName)
 	}
 
-	ctx, err = apps.BuildContext(ctx, app)
+	org, err := uiexutil.AppOrganization(ctx, app)
 	if err != nil {
 		return err
 	}
 
-	return refreshSSHCerts(ctx, flapsClient, app)
+	ctx, err = apps.BuildContextForApp(ctx, app)
+	if err != nil {
+		return err
+	}
+
+	return refreshSSHCerts(ctx, flapsClient, app, org)
 }
 
-func refreshSSHCerts(ctx context.Context, flapsClient flapsutil.FlapsClient, app *fly.AppCompact) error {
+func refreshSSHCerts(ctx context.Context, flapsClient flapsutil.FlapsClient, app *flaps.App, org *uiex.Organization) error {
 	var (
 		io        = iostreams.FromContext(ctx)
 		client    = flyutil.ClientFromContext(ctx)
@@ -98,7 +104,7 @@ func refreshSSHCerts(ctx context.Context, flapsClient flapsutil.FlapsClient, app
 	}
 
 	validHours := validDays * 24
-	cert, err := client.IssueSSHCertificate(ctx, app.Organization.GetID(), []string{"root", "fly", "postgres"}, []string{app.Name}, &validHours, pub)
+	cert, err := client.IssueSSHCertificate(ctx, org.ID, []string{"root", "fly", "postgres"}, []string{app.Name}, &validHours, pub)
 	if err != nil {
 		return fmt.Errorf("failed to issue ssh certificate: %w", err)
 	}

--- a/internal/command/registry/args.go
+++ b/internal/command/registry/args.go
@@ -13,12 +13,13 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
-	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/spinner"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -67,11 +68,10 @@ func SortedKeys[V any](m map[ImgInfo]V) []ImgInfo {
 	return keys
 }
 
-// argsGetAppCompact returns the AppCompact for the selected app, using `app`.
-func argsGetAppCompact(ctx context.Context) (*fly.AppCompact, error) {
+// argsGetApp returns the selected app, using `app`.
+func argsGetApp(ctx context.Context) (*flaps.App, error) {
 	appName := appconfig.NameFromContext(ctx)
-	apiClient := flyutil.ClientFromContext(ctx)
-	app, err := apiClient.GetAppCompact(ctx, appName)
+	app, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, appName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get app: %w", err)
 	}
@@ -80,7 +80,7 @@ func argsGetAppCompact(ctx context.Context) (*fly.AppCompact, error) {
 }
 
 // argsGetMachine returns the selected machine, using `app`, `select` and `machine`.
-func argsGetMachine(ctx context.Context, app *fly.AppCompact) (*fly.Machine, error) {
+func argsGetMachine(ctx context.Context, app *flaps.App) (*fly.Machine, error) {
 	if flag.IsSpecified(ctx, "machine") {
 		if flag.IsSpecified(ctx, "select") {
 			return nil, errors.New("--machine can't be used with -s/--select")
@@ -95,7 +95,7 @@ func argsGetMachine(ctx context.Context, app *fly.AppCompact) (*fly.Machine, err
 // argsSelectMachine lets the user select a machine if there are multiple machines and
 // the user specified "-s". Otherwise it returns the first machine for an app.
 // Using `select`.
-func argsSelectMachine(ctx context.Context, app *fly.AppCompact) (*fly.Machine, error) {
+func argsSelectMachine(ctx context.Context, app *flaps.App) (*fly.Machine, error) {
 	anyMachine := !flag.GetBool(ctx, "select")
 
 	flapsClient := flapsutil.ClientFromContext(ctx)
@@ -128,7 +128,7 @@ func argsSelectMachine(ctx context.Context, app *fly.AppCompact) (*fly.Machine, 
 }
 
 // argsGetMachineByID returns an app's machine using the `machine` argument.
-func argsGetMachineByID(ctx context.Context, app *fly.AppCompact) (*fly.Machine, error) {
+func argsGetMachineByID(ctx context.Context, app *flaps.App) (*fly.Machine, error) {
 	flapsClient := flapsutil.ClientFromContext(ctx)
 
 	machineID := flag.GetString(ctx, "machine")
@@ -143,7 +143,12 @@ func argsGetMachineByID(ctx context.Context, app *fly.AppCompact) (*fly.Machine,
 // argsGetImgPath returns an image path and its OrgID from the command line or from a
 // selected app machine, using `app`, `image`, `select`, and `machine`.
 func argsGetImgPath(ctx context.Context) (string, string, error) {
-	app, err := argsGetAppCompact(ctx)
+	app, err := argsGetApp(ctx)
+	if err != nil {
+		return "", "", err
+	}
+
+	org, err := uiexutil.AppOrganization(ctx, app)
 	if err != nil {
 		return "", "", err
 	}
@@ -155,7 +160,7 @@ func argsGetImgPath(ctx context.Context) (string, string, error) {
 
 		path := flag.GetString(ctx, "image")
 
-		return path, app.Organization.ID, nil
+		return path, org.ID, nil
 	}
 
 	machine, err := argsGetMachine(ctx, app)
@@ -163,7 +168,7 @@ func argsGetImgPath(ctx context.Context) (string, string, error) {
 		return "", "", err
 	}
 
-	return imageRefPath(&machine.ImageRef), app.Organization.ID, nil
+	return imageRefPath(&machine.ImageRef), org.ID, nil
 }
 
 // argsGetImages returns a list of images in ImgInfo format from
@@ -187,13 +192,12 @@ func argsGetImages(ctx context.Context) (map[ImgInfo]Unit, error) {
 // argsGetOrgImages returns a list of images for an org in ImgInfo format
 // from `running`.
 func argsGetOrgImages(ctx context.Context, orgName string) (map[ImgInfo]Unit, error) {
-	client := flyutil.ClientFromContext(ctx)
-	org, err := client.GetOrganizationBySlug(ctx, orgName)
+	org, err := uiexutil.ClientFromContext(ctx).GetOrganization(ctx, orgName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get org %q: %w", orgName, err)
 	}
 
-	apps, err := client.GetAppsForOrganization(ctx, org.ID)
+	apps, err := flapsutil.ClientFromContext(ctx).ListApps(ctx, flaps.ListAppsRequest{OrgSlug: orgName})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list apps for %q: %w", orgName, err)
 	}
@@ -227,13 +231,15 @@ func argsGetOrgImages(ctx context.Context, orgName string) (map[ImgInfo]Unit, er
 // argsGetAppImages returns a list of images for an app in ImgInfo format
 // from `running`.
 func argsGetAppImages(ctx context.Context, appName string) (map[ImgInfo]Unit, error) {
-	apiClient := flyutil.ClientFromContext(ctx)
-	app, err := apiClient.GetAppCompact(ctx, appName)
+	app, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, appName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get app %q: %w", appName, err)
 	}
 
-	org := app.Organization
+	org, err := uiexutil.AppOrganization(ctx, app)
+	if err != nil {
+		return nil, err
+	}
 
 	return argsGetOrgAppImages(ctx, org.Name, org.ID, app.Name)
 }

--- a/internal/command/ssh/console.go
+++ b/internal/command/ssh/console.go
@@ -23,6 +23,7 @@ import (
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/sentry"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/ip"
 	"github.com/superfly/flyctl/ssh"
@@ -88,7 +89,7 @@ func quiet(ctx context.Context) bool {
 	return flag.GetBool(ctx, "quiet")
 }
 
-func lookupAddressAndContainer(ctx context.Context, cli *agent.Client, dialer agent.Dialer, app *fly.AppCompact, console bool) (addr string, container string, err error) {
+func lookupAddressAndContainer(ctx context.Context, cli *agent.Client, dialer agent.Dialer, app *flaps.App, console bool) (addr string, container string, err error) {
 	selectedMachine, err := selectMachine(ctx, app)
 	if err != nil {
 		return "", "", err
@@ -142,7 +143,7 @@ func newConsole() *cobra.Command {
 // SessionTarget selects where a session runs on the remote machine.
 type SessionTarget = ssh.SessionTarget
 
-func captureError(ctx context.Context, err error, app *fly.AppCompact) {
+func captureError(ctx context.Context, err error, app *flaps.App) {
 	// ignore cancelled errors
 	if errors.Is(err, context.Canceled) {
 		return
@@ -170,17 +171,17 @@ func runConsole(ctx context.Context) error {
 		terminal.Debugf("Retrieving app info for %s\n", appName)
 	}
 
-	app, err := client.GetAppCompact(ctx, appName)
+	app, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("get app: %w", err)
 	}
 
-	flapsApp, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, app.Name)
+	org, err := uiexutil.AppOrganization(ctx, app)
 	if err != nil {
-		return fmt.Errorf("get app network: %w", err)
+		return err
 	}
 
-	agentclient, dialer, err := agent.BringUpAgent(ctx, client, app, flapsutil.NetworkName(flapsApp), quiet(ctx))
+	agentclient, dialer, err := agent.BringUpAgentOrgSlug(ctx, client, app.Organization.Slug, flapsutil.NetworkName(app), quiet(ctx))
 	if err != nil {
 		return err
 	}
@@ -203,7 +204,7 @@ func runConsole(ctx context.Context) error {
 
 	params := &ConnectParams{
 		Ctx:            ctx,
-		Org:            app.Organization,
+		Org:            org,
 		Dialer:         dialer,
 		Username:       flag.GetString(ctx, "user"),
 		DisableSpinner: quiet(ctx),
@@ -258,7 +259,7 @@ func Console(ctx context.Context, sshClient *ssh.Client, cmd string, allocPTY bo
 	return err
 }
 
-func selectMachine(ctx context.Context, app *fly.AppCompact) (machine *fly.Machine, err error) {
+func selectMachine(ctx context.Context, app *flaps.App) (machine *fly.Machine, err error) {
 	out := iostreams.FromContext(ctx).Out
 	flapsClient := flapsutil.ClientFromContext(ctx)
 

--- a/internal/command/ssh/sftp.go
+++ b/internal/command/ssh/sftp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/uiexutil"
 
 	"github.com/chzyer/readline"
 	"github.com/google/shlex"
@@ -133,17 +134,17 @@ func newSFTPConnection(ctx context.Context) (*sftp.Client, error) {
 	client := flyutil.ClientFromContext(ctx)
 	appName := appconfig.NameFromContext(ctx)
 
-	app, err := client.GetAppCompact(ctx, appName)
+	app, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, appName)
 	if err != nil {
 		return nil, fmt.Errorf("get app: %w", err)
 	}
 
-	flapsApp, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, appName)
+	org, err := uiexutil.AppOrganization(ctx, app)
 	if err != nil {
-		return nil, fmt.Errorf("get app network: %w", err)
+		return nil, err
 	}
 
-	agentclient, dialer, err := agent.BringUpAgent(ctx, client, app, flapsutil.NetworkName(flapsApp), quiet(ctx))
+	agentclient, dialer, err := agent.BringUpAgentOrgSlug(ctx, client, app.Organization.Slug, flapsutil.NetworkName(app), quiet(ctx))
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +156,7 @@ func newSFTPConnection(ctx context.Context) (*sftp.Client, error) {
 
 	params := &ConnectParams{
 		Ctx:            ctx,
-		Org:            app.Organization,
+		Org:            org,
 		Dialer:         dialer,
 		Username:       DefaultSshUsername,
 		DisableSpinner: true,

--- a/internal/command/tokens/create.go
+++ b/internal/command/tokens/create.go
@@ -10,8 +10,10 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command/orgs"
 	"github.com/superfly/flyctl/internal/config"
+	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/macaroon"
 	"github.com/superfly/macaroon/flyio"
@@ -309,14 +311,19 @@ func runSSH(ctx context.Context) error {
 
 	appName := appconfig.NameFromContext(ctx)
 
-	app, err := apiClient.GetAppCompact(ctx, appName)
+	app, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("failed retrieving app %s: %w", appName, err)
 	}
 
+	org, err := uiexutil.AppOrganization(ctx, app)
+	if err != nil {
+		return err
+	}
+
 	// start with app deploy token and then pare it down.
-	resp, err := makeToken(ctx, apiClient, app.Organization.ID, expiry, "deploy", &gql.LimitedAccessTokenOptions{
-		"app_id": app.ID,
+	resp, err := makeToken(ctx, apiClient, org.ID, expiry, "deploy", &gql.LimitedAccessTokenOptions{
+		"app_id": app.Name,
 	})
 	if err != nil {
 		return err
@@ -478,13 +485,18 @@ func runDeploy(ctx context.Context) (err error) {
 
 	appName := appconfig.NameFromContext(ctx)
 
-	app, err := apiClient.GetAppCompact(ctx, appName)
+	app, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("failed retrieving app %s: %w", appName, err)
 	}
 
-	resp, err := makeToken(ctx, apiClient, app.Organization.ID, expiry, "deploy", &gql.LimitedAccessTokenOptions{
-		"app_id": app.ID,
+	org, err := uiexutil.AppOrganization(ctx, app)
+	if err != nil {
+		return err
+	}
+
+	resp, err := makeToken(ctx, apiClient, org.ID, expiry, "deploy", &gql.LimitedAccessTokenOptions{
+		"app_id": app.Name,
 	})
 	if err != nil {
 		return err
@@ -513,13 +525,18 @@ func runMachineExec(ctx context.Context) error {
 
 	appName := appconfig.NameFromContext(ctx)
 
-	app, err := apiClient.GetAppCompact(ctx, appName)
+	app, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, appName)
 	if err != nil {
 		return fmt.Errorf("failed retrieving app %s: %w", appName, err)
 	}
 
-	resp, err := makeToken(ctx, apiClient, app.Organization.ID, expiry, "deploy", &gql.LimitedAccessTokenOptions{
-		"app_id": app.ID,
+	org, err := uiexutil.AppOrganization(ctx, app)
+	if err != nil {
+		return err
+	}
+
+	resp, err := makeToken(ctx, apiClient, org.ID, expiry, "deploy", &gql.LimitedAccessTokenOptions{
+		"app_id": app.Name,
 	})
 	if err != nil {
 		return err

--- a/internal/metrics/synthetics/token.go
+++ b/internal/metrics/synthetics/token.go
@@ -4,17 +4,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/macaroon"
 	"github.com/superfly/macaroon/flyio"
 )
 
 func generateSyntheticsToken(ctx context.Context) (token string, err error) {
-	client := flyutil.ClientFromContext(ctx)
-	var orgs []fly.Organization
-	if orgs, err = client.GetOrganizations(ctx); err != nil {
+	var orgs []uiex.Organization
+	if orgs, err = uiexutil.ClientFromContext(ctx).ListOrganizations(ctx, false); err != nil {
 		return
 	}
 
@@ -52,7 +52,7 @@ func GetSyntheticsToken(ctx context.Context) (token string, err error) {
 	return token, nil
 }
 
-func getOrgReadOnlyToken(ctx context.Context, org fly.Organization) ([][]byte, error) {
+func getOrgReadOnlyToken(ctx context.Context, org uiex.Organization) ([][]byte, error) {
 	var (
 		token     string
 		apiClient = flyutil.ClientFromContext(ctx)

--- a/internal/metrics/token.go
+++ b/internal/metrics/token.go
@@ -10,6 +10,8 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/state"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/terminal"
 )
 
@@ -22,7 +24,14 @@ func queryMetricsToken(ctx context.Context) (string, error) {
 		Tokens: cfg.Tokens,
 	})
 
-	personal, err := apiClient.GetOrganizationBySlug(ctx, "personal")
+	uiexClient, err := uiexutil.NewClientWithOptions(ctx, uiex.NewClientOpts{
+		Tokens: cfg.Tokens,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	personal, err := uiexClient.GetOrganization(ctx, "personal")
 	if err != nil {
 		return "", err
 	}

--- a/internal/uiex/organizations.go
+++ b/internal/uiex/organizations.go
@@ -117,3 +117,16 @@ func (c *Client) GetOrganization(ctx context.Context, orgSlug string) (*Organiza
 		return nil, fmt.Errorf("failed to get organization %s (status %d): %s", orgSlug, res.StatusCode, string(body))
 	}
 }
+
+// GetID returns the organization's GraphQL global ID. Together with GetSlug it
+// lets an Organization stand in wherever an org is needed for GraphQL
+// mutations such as SSH certificate issuance.
+func (o *Organization) GetID() string {
+	return o.ID
+}
+
+// GetSlug returns the organization's slug as the API reports it to this user,
+// which is "personal" for their personal organization.
+func (o *Organization) GetSlug() string {
+	return o.Slug
+}

--- a/internal/uiexutil/organizations.go
+++ b/internal/uiexutil/organizations.go
@@ -1,0 +1,20 @@
+package uiexutil
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/uiex"
+)
+
+// AppOrganization returns the organization that owns app, looked up by the
+// org slug Flaps reports for it.
+func AppOrganization(ctx context.Context, app *flaps.App) (*uiex.Organization, error) {
+	org, err := ClientFromContext(ctx).GetOrganization(ctx, app.Organization.Slug)
+	if err != nil {
+		return nil, fmt.Errorf("failed retrieving organization for app %s: %w", app.Name, err)
+	}
+
+	return org, nil
+}


### PR DESCRIPTION
The ui-ex organization endpoint reports the same global ID the GraphQL API does, so commands that only fetched a GraphQL app to reach its organization ID can fetch the app through Flaps and the organization through ui-ex instead. Add GetID and GetSlug to uiex.Organization so it satisfies the ssh package's organization interface, and a uiexutil.AppOrganization helper for the Flaps-slug-to-org hop.

Convert ssh console, ssh sftp, console, the Postgres connect, failover, import, barman, renew-certs, and detach commands, the app-scoped token creation paths, the metrics and synthetics token helpers, and the registry image listing.

The GraphQL app ID is the app name, and the Deploy token profile and the Postgres attachments query both resolve it by name, so those sites pass the name directly.


Claude-Session: https://claude.ai/code/session_01DMttEkUAVhL7YZFRFjhHwB
