### PR TITLE
Select organizations through ui-ex instead of GraphQL

### DIFF
--- a/agent/server/server.go
+++ b/agent/server/server.go
@@ -246,7 +246,7 @@ func (s *server) buildTunnel(ctx context.Context, org *fly.Organization, reestab
 	}
 
 	var state *wg.WireGuardState
-	if state, err = wireguard.StateForOrg(ctx, client, org, os.Getenv("FLY_AGENT_WG_REGION"), "", reestablish, network); err != nil {
+	if state, err = wireguard.StateForOrg(ctx, client, org.ID, org.Slug, os.Getenv("FLY_AGENT_WG_REGION"), "", reestablish, network); err != nil {
 		return
 	}
 

--- a/flypg/launcher.go
+++ b/flypg/launcher.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/ssh"
 
 	fly "github.com/superfly/fly-go"
@@ -46,7 +47,7 @@ type CreateClusterInput struct {
 	ConsulURL          string
 	ImageRef           string
 	InitialClusterSize int
-	Organization       *fly.Organization
+	Organization       *uiex.Organization
 	Password           string
 	Region             string
 	VolumeSize         *int

--- a/internal/command/apps/destroy.go
+++ b/internal/command/apps/destroy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superfly/flyctl/internal/flag/completion"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/uiexutil"
 
 	"github.com/superfly/flyctl/iostreams"
 
@@ -77,7 +78,7 @@ func RunDestroy(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		org, err := client.GetOrganizationBySlug(ctx, app.Organization.Slug)
+		org, err := uiexutil.AppOrganization(ctx, app)
 		if err != nil {
 			return err
 		}

--- a/internal/command/apps/list.go
+++ b/internal/command/apps/list.go
@@ -1,19 +1,25 @@
 package apps
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/sort"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
-	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/format"
 	"github.com/superfly/flyctl/internal/render"
 )
@@ -49,17 +55,7 @@ Apps on a non-default network also show the network name.
 func runList(ctx context.Context) (err error) {
 	silence := flag.GetBool(ctx, "quiet")
 	cfg := config.FromContext(ctx)
-	org, err := getOrg(ctx)
-	if err != nil {
-		return fmt.Errorf("error getting organization: %w", err)
-	}
-
-	var orgID *string
-	if org != nil {
-		orgID = &org.ID
-	}
-
-	apps, err := getApps(ctx, orgID)
+	apps, err := getApps(ctx, flag.GetOrg(ctx))
 	if err != nil {
 		return
 	}
@@ -129,75 +125,70 @@ func runList(ctx context.Context) (err error) {
 	return
 }
 
-// getApps mirrors fly-go's GetApps/GetAppsForOrganization but also requests
-// the network field, which those queries omit.
-func getApps(ctx context.Context, orgID *string) ([]fly.App, error) {
-	client := flyutil.ClientFromContext(ctx)
+// getApps lists the apps the user can see, or only those in orgSlug when it
+// is set, through Flaps. The latest deploy time comes from the ui-ex
+// current-release timestamps, which cover every app in one request.
+func getApps(ctx context.Context, orgSlug string) ([]fly.App, error) {
+	flapsClient := flapsutil.ClientFromContext(ctx)
+	uiexClient := uiexutil.ClientFromContext(ctx)
 
-	query := `
-		query($org: ID, $after: String) {
-			apps(type: "container", first: 200, after: $after, organizationId: $org) {
-				pageInfo {
-					hasNextPage
-					endCursor
-				}
-				nodes {
-					id
-					name
-					deployed
-					hostname
-					platformVersion
-					network
-					organization {
-						slug
-						name
-					}
-					currentRelease {
-						createdAt
-						status
-					}
-					status
-				}
-			}
+	// Flaps reports raw org slugs; show the slug the user knows the org by,
+	// which is "personal" for their personal org, as the GraphQL listing did.
+	var orgs []uiex.Organization
+	if orgSlug == "" {
+		var err error
+		if orgs, err = uiexClient.ListOrganizations(ctx, false); err != nil {
+			return nil, err
 		}
-	`
-
-	apps := []fly.App{}
-	var after *string
-
-	for {
-		req := client.NewRequest(query)
-		if orgID != nil {
-			req.Var("org", *orgID)
-		}
-		if after != nil {
-			req.Var("after", *after)
-		}
-
-		data, err := client.RunWithContext(ctx, req)
+	} else {
+		org, err := uiexClient.GetOrganization(ctx, orgSlug)
 		if err != nil {
 			return nil, err
 		}
+		orgs = []uiex.Organization{*org}
+	}
+	// The GraphQL listing grouped apps by org, personal org first, and
+	// sorted by name within each org; keep that order.
+	sort.OrganizationsByTypeAndName(orgs)
+	slugByRawSlug := make(map[string]string, len(orgs))
+	for _, org := range orgs {
+		slugByRawSlug[org.RawSlug] = org.Slug
+	}
 
-		apps = append(apps, data.Apps.Nodes...)
+	releaseTimes, err := uiexClient.GetAllAppsCurrentReleaseTimestamps(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-		if !data.Apps.PageInfo.HasNextPage {
-			break
+	apps := []fly.App{}
+	for _, org := range orgs {
+		flapsApps, err := flapsClient.ListApps(ctx, flaps.ListAppsRequest{OrgSlug: org.Slug})
+		if err != nil {
+			return nil, err
 		}
-		after = &data.Apps.PageInfo.EndCursor
+		slices.SortFunc(flapsApps, func(a, b flaps.App) int { return cmp.Compare(a.Name, b.Name) })
+
+		for _, app := range flapsApps {
+			// The GraphQL app ID is the app name.
+			out := fly.App{
+				ID:       app.Name,
+				Name:     app.Name,
+				Deployed: app.Deployed(),
+				Status:   app.Status,
+				Network:  flapsutil.NetworkName(&app),
+				Organization: fly.Organization{
+					Slug: cmp.Or(slugByRawSlug[app.Organization.Slug], app.Organization.Slug),
+					Name: app.Organization.Name,
+				},
+			}
+			if releaseTimes != nil {
+				if createdAt, ok := (*releaseTimes)[app.Name]; ok && !createdAt.IsZero() {
+					out.CurrentRelease = &fly.Release{CreatedAt: createdAt}
+				}
+			}
+			apps = append(apps, out)
+		}
 	}
 
 	return apps, nil
-}
-
-func getOrg(ctx context.Context) (*fly.Organization, error) {
-	client := flyutil.ClientFromContext(ctx)
-
-	orgName := flag.GetOrg(ctx)
-
-	if orgName == "" {
-		return nil, nil
-	}
-
-	return client.GetOrganizationBySlug(ctx, orgName)
 }

--- a/internal/command/apps/list_test.go
+++ b/internal/command/apps/list_test.go
@@ -2,17 +2,18 @@ package apps
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
-	fly "github.com/superfly/fly-go"
+	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
-	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/mock"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -41,20 +42,28 @@ func TestRunListEmptyApps(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				require.Equal(t, http.MethodPost, r.Method)
-				require.Equal(t, "/graphql", r.URL.Path)
-				fmt.Fprint(w, `{"data":{"apps":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}`)
-			}))
-			t.Cleanup(server.Close)
-
 			io, _, out, _ := iostreams.Test()
 			ctx := iostreams.NewContext(context.Background(), io)
 			ctx = config.NewContext(ctx, &config.Config{JSONOutput: tt.jsonOutput})
 			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
 			flags.Bool("quiet", tt.quiet, "")
+			flags.String("org", "", "")
 			ctx = flag.NewContext(ctx, flags)
-			ctx = flyutil.NewContextWithClient(ctx, flyutil.NewClientFromOptions(ctx, fly.ClientOptions{BaseURL: server.URL}))
+			ctx = uiexutil.NewContextWithClient(ctx, &mock.UiexClient{
+				ListOrganizationsFunc: func(ctx context.Context, admin bool) ([]uiex.Organization, error) {
+					return []uiex.Organization{{Slug: "personal", RawSlug: "raw-personal", Personal: true}}, nil
+				},
+				GetAllAppsCurrentReleaseTimestampsFunc: func(ctx context.Context) (*map[string]time.Time, error) {
+					return &map[string]time.Time{}, nil
+				},
+			})
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				ListAppsFunc: func(ctx context.Context, req flaps.ListAppsRequest) ([]flaps.App, error) {
+					require.Equal(t, "personal", req.OrgSlug)
+
+					return nil, nil
+				},
+			})
 
 			require.NoError(t, runList(ctx))
 			require.Equal(t, tt.want, out.String())

--- a/internal/command/apps/move.go
+++ b/internal/command/apps/move.go
@@ -10,6 +10,7 @@ import (
 	"github.com/superfly/flyctl/internal/flag/completion"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/internal/uiexutil"
 
 	fly "github.com/superfly/fly-go"
@@ -102,7 +103,7 @@ Please confirm whether you wish to restart this app now.`
 	return runMoveAppOnMachines(ctx, app, org)
 }
 
-func runMoveAppOnMachines(ctx context.Context, app *flaps.App, targetOrg *fly.Organization) error {
+func runMoveAppOnMachines(ctx context.Context, app *flaps.App, targetOrg *uiex.Organization) error {
 	var (
 		client           = flyutil.ClientFromContext(ctx)
 		io               = iostreams.FromContext(ctx)
@@ -120,7 +121,7 @@ func runMoveAppOnMachines(ctx context.Context, app *flaps.App, targetOrg *fly.Or
 		return err
 	}
 
-	oldOrg, err := client.GetOrganizationBySlug(ctx, app.Organization.Slug)
+	oldOrg, err := uiexutil.AppOrganization(ctx, app)
 	if err != nil {
 		return fmt.Errorf("failed to find app's original organization: %w", err)
 	}

--- a/internal/command/deploy/machines_deploymachinesapp.go
+++ b/internal/command/deploy/machines_deploymachinesapp.go
@@ -54,7 +54,7 @@ func (md *machineDeployment) DeployMachinesApp(ctx context.Context) error {
 	//                the app's services (if one exists).
 	if md.staticsUseTigris(ctx) {
 
-		fullOrg, err := md.apiClient.GetOrganizationBySlug(ctx, md.app.Organization.Slug)
+		fullOrg, err := md.uiexClient.GetOrganization(ctx, md.app.Organization.Slug)
 		if err != nil {
 			return err
 		}

--- a/internal/command/deploy/statics/addon.go
+++ b/internal/command/deploy/statics/addon.go
@@ -8,12 +8,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/gql"
 	extensions "github.com/superfly/flyctl/internal/command/extensions/core"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/haikunator"
+	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/macaroon/flyio"
 	"github.com/superfly/macaroon/resset"
@@ -22,7 +22,7 @@ import (
 
 // FindBucket finds the tigris statics bucket for the given app and org.
 // Returns nil, nil if no bucket is found.
-func FindBucket(ctx context.Context, app *flaps.App, org *fly.Organization) (*gql.StaticsAddOn, error) {
+func FindBucket(ctx context.Context, app *flaps.App, org *uiex.Organization) (*gql.StaticsAddOn, error) {
 	client := flyutil.ClientFromContext(ctx)
 	gqlClient := client.GenqClient()
 
@@ -151,10 +151,7 @@ func (deployer *DeployerState) ensureBucketCreated(ctx context.Context) (tokeniz
 
 func (deployer *DeployerState) tokenizeTigrisSecrets(secrets map[string]any) (string, error) {
 
-	orgId, err := strconv.ParseUint(deployer.org.InternalNumericID, 10, 64)
-	if err != nil {
-		return "", fmt.Errorf("failed to decode org ID for %s: %w", deployer.org.Slug, err)
-	}
+	orgId := deployer.org.InternalNumericID
 
 	secret := &tokenizer.Secret{
 		AuthConfig: &tokenizer.FlyioMacaroonAuthConfig{Access: flyio.Access{

--- a/internal/command/deploy/statics/deployer.go
+++ b/internal/command/deploy/statics/deployer.go
@@ -12,9 +12,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/samber/lo"
-	"github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
 	"github.com/superfly/flyctl/internal/appconfig"
+	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/terminal"
 )
@@ -42,7 +42,7 @@ const staticsKeepVersions = 3
 type DeployerState struct {
 	// State that's pulled from the larger machines deployment
 	app            *flaps.App
-	org            *fly.Organization
+	org            *uiex.Organization
 	appConfig      *appconfig.Config
 	releaseVersion int
 
@@ -53,7 +53,7 @@ type DeployerState struct {
 	originalStatics []appconfig.Static
 }
 
-func Deployer(appConfig *appconfig.Config, app *flaps.App, org *fly.Organization, releaseVersion int) *DeployerState {
+func Deployer(appConfig *appconfig.Config, app *flaps.App, org *uiex.Organization, releaseVersion int) *DeployerState {
 	return &DeployerState{
 		app:            app,
 		appConfig:      appConfig,

--- a/internal/command/deploy/statics/move.go
+++ b/internal/command/deploy/statics/move.go
@@ -12,6 +12,7 @@ import (
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -21,9 +22,9 @@ import (
 func MoveBucket(
 	ctx context.Context,
 	prevBucket *gql.StaticsAddOn,
-	prevOrg *fly.Organization,
+	prevOrg *uiex.Organization,
 	app *flaps.App,
-	targetOrg *fly.Organization,
+	targetOrg *uiex.Organization,
 	releaseVersion int,
 	machines []*fly.Machine,
 ) error {

--- a/internal/command/deploy/statics/util.go
+++ b/internal/command/deploy/statics/util.go
@@ -10,9 +10,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/tokenizer"
 )
 
@@ -49,7 +49,7 @@ func spawnWorkers(ctx context.Context, n int, f func(context.Context) error) fun
 	}
 }
 
-func getPushToken(ctx context.Context, org *fly.Organization) (string, error) {
+func getPushToken(ctx context.Context, org *uiex.Organization) (string, error) {
 	client := flyutil.ClientFromContext(ctx)
 
 	resp, err := gql.CreateLimitedAccessToken(
@@ -68,7 +68,7 @@ func getPushToken(ctx context.Context, org *fly.Organization) (string, error) {
 	return resp.CreateLimitedAccessToken.LimitedAccessToken.TokenHeader, nil
 }
 
-func s3ClientWithAuth(ctx context.Context, auth string, org *fly.Organization) (*s3.Client, error) {
+func s3ClientWithAuth(ctx context.Context, auth string, org *uiex.Organization) (*s3.Client, error) {
 
 	s3Config, err := config.LoadDefaultConfig(ctx,
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("tokenizer-access-key", "tokenizer-secret-key", "")),

--- a/internal/command/deploy/web_client.go
+++ b/internal/command/deploy/web_client.go
@@ -14,8 +14,6 @@ type webClient interface {
 	CreateRelease(ctx context.Context, input fly.CreateReleaseInput) (*fly.CreateReleaseResponse, error)
 	UpdateRelease(ctx context.Context, input fly.UpdateReleaseInput) (*fly.UpdateReleaseResponse, error)
 
-	GetOrganizationBySlug(ctx context.Context, slug string) (*fly.Organization, error)
-
 	logs.WebClient
 	blueGreenWebClient
 }

--- a/internal/command/extensions/core/core.go
+++ b/internal/command/extensions/core/core.go
@@ -13,13 +13,13 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/samber/lo"
 	"github.com/skratchdot/open-golang/open"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/render"
+	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/scanner"
 )
@@ -32,7 +32,7 @@ type Extension struct {
 
 type ExtensionParams struct {
 	AppName              string
-	Organization         *fly.Organization
+	Organization         *uiex.Organization
 	Provider             string
 	PlanID               string
 	OrganizationPlanID   string

--- a/internal/command/launch/plan_builder.go
+++ b/internal/command/launch/plan_builder.go
@@ -22,10 +22,10 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyerr"
-	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/haikunator"
 	"github.com/superfly/flyctl/internal/launchdarkly"
 	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 	"github.com/superfly/flyctl/scanner"
@@ -677,30 +677,31 @@ func appNameTaken(ctx context.Context, name string) (bool, error) {
 }
 
 // determineOrg returns the org specified on the command line, or the personal org if left unspecified
-func determineOrg(ctx context.Context, config *appconfig.Config) (*fly.Organization, string, error) {
-	client := flyutil.ClientFromContext(ctx)
+func determineOrg(ctx context.Context, config *appconfig.Config) (*uiex.Organization, string, error) {
+	uiexClient := uiexutil.ClientFromContext(ctx)
 
 	if flag.GetBool(ctx, "attach") && config != nil && config.AppName != "" {
-		org, err := client.GetOrganizationByApp(ctx, config.AppName)
-		if err == nil {
-			return org, fmt.Sprintf("from %s app", config.AppName), nil
+		if app, err := flapsutil.ClientFromContext(ctx).GetApp(ctx, config.AppName); err == nil {
+			if org, err := uiexClient.GetOrganization(ctx, app.Organization.Slug); err == nil {
+				return org, fmt.Sprintf("from %s app", config.AppName), nil
+			}
 		}
 	}
 
-	orgs, err := client.GetOrganizations(ctx)
+	orgs, err := uiexClient.ListOrganizations(ctx, false)
 	if err != nil {
 		return nil, "", err
 	}
 
-	bySlug := make(map[string]fly.Organization, len(orgs))
+	bySlug := make(map[string]uiex.Organization, len(orgs))
 	for _, o := range orgs {
 		bySlug[o.Slug] = o
 	}
-	byRawSlug := make(map[string]fly.Organization, len(orgs))
+	byRawSlug := make(map[string]uiex.Organization, len(orgs))
 	for _, o := range orgs {
 		byRawSlug[o.RawSlug] = o
 	}
-	byName := make(map[string]fly.Organization, len(orgs))
+	byName := make(map[string]uiex.Organization, len(orgs))
 	for _, o := range orgs {
 		byName[o.Name] = o
 	}

--- a/internal/command/launch/plan_builder_test.go
+++ b/internal/command/launch/plan_builder_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/flag/flagctx"
 	"github.com/superfly/flyctl/internal/flapsutil"
-	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/mock"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -71,25 +71,24 @@ func TestAppNameTaken(t *testing.T) {
 }
 
 func TestDetermineOrg(t *testing.T) {
-	personalOrg := fly.Organization{
-		ID:      "org-id-personal",
-		Slug:    "personal",
-		RawSlug: "lubien-org-339",
-		Name:    "Lubien Org",
-		Type:    "PERSONAL",
+	personalOrg := uiex.Organization{
+		ID:       "org-id-personal",
+		Slug:     "personal",
+		RawSlug:  "lubien-org-339",
+		Name:     "Lubien Org",
+		Personal: true,
 	}
-	teamOrg := fly.Organization{
+	teamOrg := uiex.Organization{
 		ID:      "org-id-team",
 		Slug:    "my-team",
 		RawSlug: "my-team",
 		Name:    "My Team",
-		Type:    "SHARED",
 	}
-	orgs := []fly.Organization{personalOrg, teamOrg}
+	orgs := []uiex.Organization{personalOrg, teamOrg}
 
-	makeClient := func() *mock.Client {
-		return &mock.Client{
-			GetOrganizationsFunc: func(ctx context.Context, filters ...fly.OrganizationFilter) ([]fly.Organization, error) {
+	makeClient := func() *mock.UiexClient {
+		return &mock.UiexClient{
+			ListOrganizationsFunc: func(ctx context.Context, admin bool) ([]uiex.Organization, error) {
 				return orgs, nil
 			},
 		}
@@ -97,7 +96,7 @@ func TestDetermineOrg(t *testing.T) {
 
 	t.Run("no org flag defaults to personal", func(t *testing.T) {
 		ctx := newDetermineOrgCtx(t, "")
-		ctx = flyutil.NewContextWithClient(ctx, makeClient())
+		ctx = uiexutil.NewContextWithClient(ctx, makeClient())
 
 		org, _, err := determineOrg(ctx, nil)
 		require.NoError(t, err)
@@ -107,7 +106,7 @@ func TestDetermineOrg(t *testing.T) {
 
 	t.Run("canonical personal slug", func(t *testing.T) {
 		ctx := newDetermineOrgCtx(t, "personal")
-		ctx = flyutil.NewContextWithClient(ctx, makeClient())
+		ctx = uiexutil.NewContextWithClient(ctx, makeClient())
 
 		org, _, err := determineOrg(ctx, nil)
 		require.NoError(t, err)
@@ -117,7 +116,7 @@ func TestDetermineOrg(t *testing.T) {
 
 	t.Run("real raw slug of personal org", func(t *testing.T) {
 		ctx := newDetermineOrgCtx(t, "lubien-org-339")
-		ctx = flyutil.NewContextWithClient(ctx, makeClient())
+		ctx = uiexutil.NewContextWithClient(ctx, makeClient())
 
 		org, _, err := determineOrg(ctx, nil)
 		require.NoError(t, err)
@@ -127,7 +126,7 @@ func TestDetermineOrg(t *testing.T) {
 
 	t.Run("team org by slug", func(t *testing.T) {
 		ctx := newDetermineOrgCtx(t, "my-team")
-		ctx = flyutil.NewContextWithClient(ctx, makeClient())
+		ctx = uiexutil.NewContextWithClient(ctx, makeClient())
 
 		org, _, err := determineOrg(ctx, nil)
 		require.NoError(t, err)
@@ -136,7 +135,7 @@ func TestDetermineOrg(t *testing.T) {
 
 	t.Run("org by display name", func(t *testing.T) {
 		ctx := newDetermineOrgCtx(t, "My Team")
-		ctx = flyutil.NewContextWithClient(ctx, makeClient())
+		ctx = uiexutil.NewContextWithClient(ctx, makeClient())
 
 		org, _, err := determineOrg(ctx, nil)
 		require.NoError(t, err)
@@ -145,7 +144,7 @@ func TestDetermineOrg(t *testing.T) {
 
 	t.Run("unknown org returns error and falls back to personal", func(t *testing.T) {
 		ctx := newDetermineOrgCtx(t, "does-not-exist")
-		ctx = flyutil.NewContextWithClient(ctx, makeClient())
+		ctx = uiexutil.NewContextWithClient(ctx, makeClient())
 
 		org, _, err := determineOrg(ctx, nil)
 		assert.Error(t, err)

--- a/internal/command/launch/state.go
+++ b/internal/command/launch/state.go
@@ -11,7 +11,6 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/command/launch/plan"
 	"github.com/superfly/flyctl/internal/flapsutil"
-	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
@@ -77,19 +76,17 @@ func cacheGrab[T any](cache map[string]any, key string, cb func() (T, error)) (T
 }
 
 func (state *launchState) orgCompact(ctx context.Context) (*uiex.Organization, error) {
-	org, err := uiexutil.ClientFromContext(ctx).GetOrganization(ctx, state.Plan.OrgSlug)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get org %q for state: %w", state.Plan.OrgSlug, err)
-	}
-
-	return org, nil
+	return state.Org(ctx)
 }
 
-func (state *launchState) Org(ctx context.Context) (*fly.Organization, error) {
-	apiClient := flyutil.ClientFromContext(ctx)
+func (state *launchState) Org(ctx context.Context) (*uiex.Organization, error) {
+	return cacheGrab(state.cache, "org,"+state.Plan.OrgSlug, func() (*uiex.Organization, error) {
+		org, err := uiexutil.ClientFromContext(ctx).GetOrganization(ctx, state.Plan.OrgSlug)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get org %q for state: %w", state.Plan.OrgSlug, err)
+		}
 
-	return cacheGrab(state.cache, "org,"+state.Plan.OrgSlug, func() (*fly.Organization, error) {
-		return apiClient.GetOrganizationBySlug(ctx, state.Plan.OrgSlug)
+		return org, nil
 	})
 }
 

--- a/internal/command/machine/run.go
+++ b/internal/command/machine/run.go
@@ -543,12 +543,14 @@ func getOrCreateEphemeralShellApp(ctx context.Context, client flyutil.Client) (*
 		return nil, fmt.Errorf("create interactive shell app: %w", err)
 	}
 
-	apps, err := client.GetAppsForOrganization(ctx, org.ID)
+	flapsClient := flapsutil.ClientFromContext(ctx)
+
+	apps, err := flapsClient.ListApps(ctx, flaps.ListAppsRequest{OrgSlug: org.Slug})
 	if err != nil {
 		return nil, fmt.Errorf("create interactive shell app: %w", err)
 	}
 
-	var appc *fly.App
+	var appc *flaps.App
 
 	for appi, appt := range apps {
 		if strings.HasPrefix(appt.Name, "flyctl-interactive-shells-") {
@@ -561,7 +563,6 @@ func getOrCreateEphemeralShellApp(ctx context.Context, client flyutil.Client) (*
 	if appc == nil {
 		shellAppName := fmt.Sprintf("flyctl-interactive-shells-%s-%d", strings.ToLower(org.ID), rand.Intn(1_000_000))
 		shellAppName = strings.TrimRight(shellAppName[:min(len(shellAppName), 63)], "-")
-		flapsClient := flapsutil.ClientFromContext(ctx)
 		createdApp, err := flapsClient.CreateApp(ctx, flaps.CreateAppRequest{
 			Org: org.Slug,
 			// I'll never find love again like the kind you give like the kind you send
@@ -574,7 +575,7 @@ func getOrCreateEphemeralShellApp(ctx context.Context, client flyutil.Client) (*
 		if err := flapsClient.WaitForApp(ctx, createdApp.Name); err != nil {
 			return nil, err
 		}
-		appc = &fly.App{Name: createdApp.Name}
+		appc = createdApp
 	}
 
 	// this app handle won't have all the metadata attached, so grab it

--- a/internal/command/mpg/list_test.go
+++ b/internal/command/mpg/list_test.go
@@ -5,36 +5,18 @@ import (
 	"encoding/json"
 	"testing"
 
-	genq "github.com/Khan/genqlient/graphql"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/fly-go/flaps"
-	"github.com/superfly/flyctl/gql"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag/flagctx"
 	"github.com/superfly/flyctl/internal/flapsutil"
-	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/mock"
+	"github.com/superfly/flyctl/internal/uiex"
 	mpgv1 "github.com/superfly/flyctl/internal/uiex/mpg/v1"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 )
-
-type organizationGraphQLClient struct{}
-
-func (organizationGraphQLClient) MakeRequest(_ context.Context, _ *genq.Request, response *genq.Response) error {
-	data := response.Data.(*gql.GetOrganizationResponse)
-	data.Organization.OrganizationData = gql.OrganizationData{
-		Id:       "org-id",
-		Slug:     "personal",
-		RawSlug:  "raw-personal",
-		PaidPlan: true,
-		Name:     "Personal",
-		Billable: true,
-	}
-
-	return nil
-}
 
 func TestRunListUsesMergedMachinesAndLegacyResults(t *testing.T) {
 	io, _, stdout, _ := iostreams.Test()
@@ -45,14 +27,11 @@ func TestRunListUsesMergedMachinesAndLegacyResults(t *testing.T) {
 	flags.Bool("deleted", false, "")
 	ctx = flagctx.NewContext(ctx, flags)
 
-	ctx = flyutil.NewContextWithClient(ctx, &mock.Client{
-		GetOrganizationBySlugFunc: func(_ context.Context, slug string) (*fly.Organization, error) {
+	ctx = uiexutil.NewContextWithClient(ctx, &mock.UiexClient{
+		GetOrganizationFunc: func(_ context.Context, slug string) (*uiex.Organization, error) {
 			require.Equal(t, "personal", slug)
 
-			return &fly.Organization{Slug: slug, RawSlug: "raw-personal"}, nil
-		},
-		GenqClientFunc: func() genq.Client {
-			return organizationGraphQLClient{}
+			return &uiex.Organization{Slug: slug, RawSlug: "raw-personal"}, nil
 		},
 	})
 	ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{

--- a/internal/command/orgs/cross_network_replays.go
+++ b/internal/command/orgs/cross_network_replays.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -52,7 +51,7 @@ func newCrossNetworkReplaysStatus() *cobra.Command {
 func runCrossNetworkReplaysStatus(ctx context.Context) error {
 	client := flyutil.ClientFromContext(ctx)
 
-	org, err := OrgFromFlagOrSelect(ctx, fly.AdminOnly)
+	org, err := OrgFromFlagOrSelect(ctx, AdminOnly)
 	if err != nil {
 		return err
 	}
@@ -95,7 +94,7 @@ func newCrossNetworkReplaysEnable() *cobra.Command {
 }
 
 func runCrossNetworkReplaysEnable(ctx context.Context) error {
-	org, err := OrgFromFlagOrSelect(ctx, fly.AdminOnly)
+	org, err := OrgFromFlagOrSelect(ctx, AdminOnly)
 	if err != nil {
 		return err
 	}
@@ -146,7 +145,7 @@ func newCrossNetworkReplaysDisable() *cobra.Command {
 }
 
 func runCrossNetworkReplaysDisable(ctx context.Context) error {
-	org, err := OrgFromFlagOrSelect(ctx, fly.AdminOnly)
+	org, err := OrgFromFlagOrSelect(ctx, AdminOnly)
 	if err != nil {
 		return err
 	}

--- a/internal/command/orgs/delete.go
+++ b/internal/command/orgs/delete.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flyutil"
@@ -35,7 +34,7 @@ func newDelete() *cobra.Command {
 }
 
 func runDelete(ctx context.Context) error {
-	org, err := OrgFromEnvVarOrFirstArgOrSelect(ctx, fly.AdminOnly)
+	org, err := OrgFromEnvVarOrFirstArgOrSelect(ctx, AdminOnly)
 	if err != nil {
 		return err
 	}

--- a/internal/command/orgs/invite.go
+++ b/internal/command/orgs/invite.go
@@ -39,7 +39,7 @@ sent, and the user will be pending until they respond.
 func runInvite(ctx context.Context) error {
 	client := flyutil.ClientFromContext(ctx)
 
-	org, err := OrgFromEnvVarOrFirstArgOrSelect(ctx, fly.AdminOnly)
+	org, err := OrgFromEnvVarOrFirstArgOrSelect(ctx, AdminOnly)
 	if err != nil {
 		return nil
 	}

--- a/internal/command/orgs/list.go
+++ b/internal/command/orgs/list.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
-	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/render"
 )
 
@@ -34,9 +34,7 @@ func newList() *cobra.Command {
 }
 
 func runList(ctx context.Context) error {
-	client := flyutil.ClientFromContext(ctx)
-
-	orgs, err := client.GetOrganizations(ctx)
+	orgs, err := uiexutil.ClientFromContext(ctx).ListOrganizations(ctx, false)
 	if err != nil {
 		return err
 	}

--- a/internal/command/orgs/orgs.go
+++ b/internal/command/orgs/orgs.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
-	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
 	"github.com/superfly/flyctl/internal/sort"
 )
@@ -63,7 +64,15 @@ func emailFromSecondArgOrPrompt(ctx context.Context) (email string, err error) {
 
 var errSlugArgMustBeSpecified = prompt.NonInteractiveError("slug argument must be specified when not running interactively")
 
-func slugFromArgOrSelect(ctx context.Context, orgSlug string, filters ...fly.OrganizationFilter) (slug string, err error) {
+// Filter narrows the organizations offered when prompting for one.
+type Filter int
+
+const (
+	// AdminOnly limits the choice to organizations the user administers.
+	AdminOnly Filter = iota
+)
+
+func slugFromArgOrSelect(ctx context.Context, orgSlug string, filters ...Filter) (slug string, err error) {
 	if orgSlug != "" {
 		return orgSlug, nil
 	}
@@ -79,15 +88,15 @@ func slugFromArgOrSelect(ctx context.Context, orgSlug string, filters ...fly.Org
 		return
 	}
 
-	client := flyutil.ClientFromContext(ctx)
+	adminOnly := slices.Contains(filters, AdminOnly)
 
-	var orgs []fly.Organization
-	if orgs, err = client.GetOrganizations(ctx, filters...); err != nil {
+	var orgs []uiex.Organization
+	if orgs, err = uiexutil.ClientFromContext(ctx).ListOrganizations(ctx, adminOnly); err != nil {
 		return
 	}
 	sort.OrganizationsByTypeAndName(orgs)
 
-	var org *fly.Organization
+	var org *uiex.Organization
 	if org, err = prompt.SelectOrg(ctx, orgs); prompt.IsNonInteractive(err) {
 		err = errSlugArgMustBeSpecified
 	} else if err == nil {
@@ -97,7 +106,7 @@ func slugFromArgOrSelect(ctx context.Context, orgSlug string, filters ...fly.Org
 	return
 }
 
-func OrgFromEnvVarOrFirstArgOrSelect(ctx context.Context, filters ...fly.OrganizationFilter) (*fly.Organization, error) {
+func OrgFromEnvVarOrFirstArgOrSelect(ctx context.Context, filters ...Filter) (*uiex.Organization, error) {
 	slug := flag.GetOrg(ctx)
 	if slug == "" {
 		var err error
@@ -110,7 +119,7 @@ func OrgFromEnvVarOrFirstArgOrSelect(ctx context.Context, filters ...fly.Organiz
 	return OrgFromSlug(ctx, slug)
 }
 
-func OrgFromFlagOrSelect(ctx context.Context, filters ...fly.OrganizationFilter) (*fly.Organization, error) {
+func OrgFromFlagOrSelect(ctx context.Context, filters ...Filter) (*uiex.Organization, error) {
 	slug, err := slugFromArgOrSelect(ctx, flag.GetOrg(ctx), filters...)
 	if err != nil {
 		return nil, err
@@ -119,10 +128,8 @@ func OrgFromFlagOrSelect(ctx context.Context, filters ...fly.OrganizationFilter)
 	return OrgFromSlug(ctx, slug)
 }
 
-func OrgFromSlug(ctx context.Context, slug string) (*fly.Organization, error) {
-	client := flyutil.ClientFromContext(ctx)
-
-	org, err := client.GetOrganizationBySlug(ctx, slug)
+func OrgFromSlug(ctx context.Context, slug string) (*uiex.Organization, error) {
+	org, err := uiexutil.ClientFromContext(ctx).GetOrganization(ctx, slug)
 	if err != nil {
 		return nil, fmt.Errorf("failed retrieving organization with slug %s: %w", slug, err)
 	}
@@ -130,11 +137,16 @@ func OrgFromSlug(ctx context.Context, slug string) (*fly.Organization, error) {
 	return org, nil
 }
 
-func printOrg(w io.Writer, org *fly.Organization, headers bool) {
+func printOrg(w io.Writer, org *uiex.Organization, headers bool) {
 	if headers {
 		fmt.Fprintln(w, "Name\tSlug\tType")
 		fmt.Fprintln(w, "----\t----\t----")
 	}
 
-	fmt.Fprintf(w, "%s\t%s\t%s\n", org.Name, org.Slug, org.Type)
+	orgType := "SHARED"
+	if org.Personal {
+		orgType = "PERSONAL"
+	}
+
+	fmt.Fprintf(w, "%s\t%s\t%s\n", org.Name, org.Slug, orgType)
 }

--- a/internal/command/orgs/remove.go
+++ b/internal/command/orgs/remove.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
@@ -33,7 +32,7 @@ invitation to join (if not, see orgs revoke).
 
 func runRemove(ctx context.Context) error {
 	client := flyutil.ClientFromContext(ctx)
-	selectedOrg, err := OrgFromEnvVarOrFirstArgOrSelect(ctx, fly.AdminOnly)
+	selectedOrg, err := OrgFromEnvVarOrFirstArgOrSelect(ctx, AdminOnly)
 	if err != nil {
 		return nil
 	}

--- a/internal/command/orgs/replay_sources_add.go
+++ b/internal/command/orgs/replay_sources_add.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -41,7 +41,7 @@ func runReplaySourcesAdd(ctx context.Context) error {
 	client := flyutil.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 
-	org, err := OrgFromFlagOrSelect(ctx, fly.AdminOnly)
+	org, err := OrgFromFlagOrSelect(ctx, AdminOnly)
 	if err != nil {
 		return err
 	}
@@ -51,7 +51,7 @@ func runReplaySourcesAdd(ctx context.Context) error {
 
 	if len(args) == 0 {
 		// Interactive mode: show multi-select of available orgs
-		userOrgs, err := client.GetOrganizations(ctx)
+		userOrgs, err := uiexutil.ClientFromContext(ctx).ListOrganizations(ctx, false)
 		if err != nil {
 			return fmt.Errorf("failed to get organizations: %w", err)
 		}

--- a/internal/command/orgs/replay_sources_list.go
+++ b/internal/command/orgs/replay_sources_list.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
@@ -35,7 +34,7 @@ func newReplaySourcesList() *cobra.Command {
 func runReplaySourcesList(ctx context.Context) error {
 	client := flyutil.ClientFromContext(ctx)
 
-	org, err := OrgFromFlagOrSelect(ctx, fly.AdminOnly)
+	org, err := OrgFromFlagOrSelect(ctx, AdminOnly)
 	if err != nil {
 		return err
 	}

--- a/internal/command/orgs/replay_sources_remove.go
+++ b/internal/command/orgs/replay_sources_remove.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -42,12 +42,12 @@ func runReplaySourcesRemove(ctx context.Context) error {
 	client := flyutil.ClientFromContext(ctx)
 	io := iostreams.FromContext(ctx)
 
-	org, err := OrgFromFlagOrSelect(ctx, fly.AdminOnly)
+	org, err := OrgFromFlagOrSelect(ctx, AdminOnly)
 	if err != nil {
 		return err
 	}
 
-	userOrgs, err := client.GetOrganizations(ctx)
+	userOrgs, err := uiexutil.ClientFromContext(ctx).ListOrganizations(ctx, false)
 	if err != nil {
 		return fmt.Errorf("failed to get user organizations: %w", err)
 	}

--- a/internal/command/postgres/backup.go
+++ b/internal/command/postgres/backup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/superfly/flyctl/internal/appconfig"
 	"github.com/superfly/flyctl/internal/appsecrets"
 	"github.com/superfly/flyctl/internal/flapsutil"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
@@ -143,7 +144,11 @@ func runBackupRestore(ctx context.Context) error {
 	restoreSecret += resolveRestoreTarget(ctx)
 
 	// Resolve organization
-	org, err := client.GetOrganizationByApp(ctx, appName)
+	app, err := flapsClient.GetApp(ctx, appName)
+	if err != nil {
+		return err
+	}
+	org, err := uiexutil.AppOrganization(ctx, app)
 	if err != nil {
 		return err
 	}

--- a/internal/command/postgres/create.go
+++ b/internal/command/postgres/create.go
@@ -18,6 +18,7 @@ import (
 	"github.com/superfly/flyctl/internal/haikunator"
 	mach "github.com/superfly/flyctl/internal/machine"
 	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -123,7 +124,7 @@ func run(ctx context.Context) (err error) {
 		}
 	}
 
-	var org *fly.Organization
+	var org *uiex.Organization
 	org, err = prompt.Org(ctx)
 	if err != nil {
 		return
@@ -266,7 +267,7 @@ func run(ctx context.Context) (err error) {
 }
 
 // CreateCluster creates a Postgres cluster with an optional name. The name will be prompted for if not supplied.
-func CreateCluster(ctx context.Context, org *fly.Organization, region *fly.Region, params *ClusterParams) (err error) {
+func CreateCluster(ctx context.Context, org *uiex.Organization, region *fly.Region, params *ClusterParams) (err error) {
 	var (
 		client = flyutil.ClientFromContext(ctx)
 		io     = iostreams.FromContext(ctx)

--- a/internal/command/redis/create.go
+++ b/internal/command/redis/create.go
@@ -11,6 +11,7 @@ import (
 
 	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/gql"
+	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/iostreams"
 
 	"github.com/superfly/flyctl/internal/command"
@@ -198,7 +199,7 @@ func runCreate(ctx context.Context) (err error) {
 	return err
 }
 
-func Create(ctx context.Context, org *fly.Organization, name string, region *fly.Region, plan *gql.ListAddOnPlansAddOnPlansAddOnPlanConnectionNodesAddOnPlan, disallowReplicas bool, enableEviction bool, enableAutoUpgrade bool, enableProdpack bool, readRegions *[]fly.Region) (addOn *gql.AddOn, err error) {
+func Create(ctx context.Context, org *uiex.Organization, name string, region *fly.Region, plan *gql.ListAddOnPlansAddOnPlansAddOnPlanConnectionNodesAddOnPlan, disallowReplicas bool, enableEviction bool, enableAutoUpgrade bool, enableProdpack bool, readRegions *[]fly.Region) (addOn *gql.AddOn, err error) {
 	var (
 		io       = iostreams.FromContext(ctx)
 		colorize = io.ColorScheme()
@@ -270,7 +271,7 @@ type RedisConfiguration struct {
 	ProdPack      bool
 }
 
-func ProvisionDatabase(ctx context.Context, org *fly.Organization, config RedisConfiguration) (addOn *gql.AddOn, err error) {
+func ProvisionDatabase(ctx context.Context, org *uiex.Organization, config RedisConfiguration) (addOn *gql.AddOn, err error) {
 	client := flyutil.ClientFromContext(ctx).GenqClient()
 
 	var readRegionCodes []string

--- a/internal/command/wireguard/others.go
+++ b/internal/command/wireguard/others.go
@@ -13,6 +13,8 @@ import (
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/prompt"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -31,7 +33,7 @@ func argOrPrompt(ctx context.Context, nth int, prompt string) (string, error) {
 	return val, err
 }
 
-func orgByArg(ctx context.Context) (*fly.Organization, error) {
+func orgByArg(ctx context.Context) (*uiex.Organization, error) {
 	args := flag.Args(ctx)
 
 	if len(args) == 0 {
@@ -43,9 +45,7 @@ func orgByArg(ctx context.Context) (*fly.Organization, error) {
 		return org, nil
 	}
 
-	apiClient := flyutil.ClientFromContext(ctx)
-
-	return apiClient.GetOrganizationBySlug(ctx, args[0])
+	return uiexutil.ClientFromContext(ctx).GetOrganization(ctx, args[0])
 }
 
 func resolveOutputWriter(ctx context.Context, idx int, prompt string) (w io.WriteCloser, mustClose bool, err error) {

--- a/internal/command/wireguard/wireguard.go
+++ b/internal/command/wireguard/wireguard.go
@@ -141,7 +141,7 @@ func runWireguardCreate(ctx context.Context) error {
 
 	network := flag.GetString(ctx, "network")
 
-	state, err := wireguard.Create(apiClient, org, region, name, network, "static")
+	state, err := wireguard.Create(apiClient, org.ID, org.Slug, region, name, network, "static")
 	if err != nil {
 		return err
 	}

--- a/internal/flag/completion/completions.go
+++ b/internal/flag/completion/completions.go
@@ -13,6 +13,8 @@ import (
 	"github.com/superfly/flyctl/internal/flag/flagnames"
 	"github.com/superfly/flyctl/internal/flapsutil"
 	"github.com/superfly/flyctl/internal/flyutil"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/internal/uiexutil"
 )
 
 func CompleteApps(
@@ -76,13 +78,11 @@ func CompleteOrgs(
 	args []string,
 	partial string,
 ) ([]string, error) {
-	client := flyutil.ClientFromContext(ctx)
-
-	format := func(org fly.Organization) string {
+	format := func(org uiex.Organization) string {
 		return fmt.Sprintf("%s\t%s", org.Slug, org.Name)
 	}
 
-	orgs, err := client.GetOrganizations(ctx)
+	orgs, err := uiexutil.ClientFromContext(ctx).ListOrganizations(ctx, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -19,9 +19,10 @@ import (
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flag"
 	"github.com/superfly/flyctl/internal/flapsutil"
-	"github.com/superfly/flyctl/internal/flyutil"
 	"github.com/superfly/flyctl/internal/future"
 	"github.com/superfly/flyctl/internal/sort"
+	"github.com/superfly/flyctl/internal/uiex"
+	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
 )
 
@@ -246,12 +247,12 @@ var errOrgSlugRequired = NonInteractiveError("org slug must be specified when no
 
 // Org returns the Organization the user has passed in via flag or prompts the
 // user for one.
-func Org(ctx context.Context) (*fly.Organization, error) {
-	client := flyutil.ClientFromContext(ctx)
+func Org(ctx context.Context) (*uiex.Organization, error) {
+	client := uiexutil.ClientFromContext(ctx)
 
 	slug := config.FromContext(ctx).Organization
 
-	orgs, err := client.GetOrganizations(ctx)
+	orgs, err := client.ListOrganizations(ctx, false)
 	if err != nil {
 		return nil, err
 	}
@@ -260,9 +261,8 @@ func Org(ctx context.Context) (*fly.Organization, error) {
 	io := iostreams.FromContext(ctx)
 
 	switch {
-	case slug == "" && len(orgs) == 1 && orgs[0].Type == "PERSONAL":
-		fmt.Fprintf(io.ErrOut, "automatically selected %s organization: %s\n",
-			strings.ToLower(orgs[0].Type), orgs[0].Name)
+	case slug == "" && len(orgs) == 1 && orgs[0].Personal:
+		fmt.Fprintf(io.ErrOut, "automatically selected personal organization: %s\n", orgs[0].Name)
 
 		return &orgs[0], nil
 	case slug != "":
@@ -285,11 +285,11 @@ func Org(ctx context.Context) (*fly.Organization, error) {
 	}
 }
 
-func SelectOrg(ctx context.Context, orgs []fly.Organization) (org *fly.Organization, err error) {
+func SelectOrg(ctx context.Context, orgs []uiex.Organization) (org *uiex.Organization, err error) {
 	var options []string
 	for _, org := range orgs {
 		personalCallout := ""
-		if org.Type == "PERSONAL" && org.Slug != "personal" {
+		if org.Personal && org.Slug != "personal" {
 			personalCallout = " [personal]"
 		}
 		options = append(options, fmt.Sprintf("%s (%s)%s", org.Name, org.Slug, personalCallout))

--- a/internal/sort/sort.go
+++ b/internal/sort/sort.go
@@ -5,12 +5,17 @@ import (
 	"sort"
 
 	fly "github.com/superfly/fly-go"
+	"github.com/superfly/flyctl/internal/uiex"
 )
 
 // OrganizationsByTypeAndName sorts orgs by their type and name.
-func OrganizationsByTypeAndName(orgs []fly.Organization) {
+func OrganizationsByTypeAndName(orgs []uiex.Organization) {
 	sort.Slice(orgs, func(i, j int) bool {
-		return orgs[i].Type < orgs[j].Type || orgs[i].Name < orgs[j].Name
+		if orgs[i].Personal != orgs[j].Personal {
+			return orgs[i].Personal
+		}
+
+		return orgs[i].Name < orgs[j].Name
 	})
 }
 

--- a/internal/wireguard/wg.go
+++ b/internal/wireguard/wg.go
@@ -12,7 +12,6 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
-	fly "github.com/superfly/fly-go"
 	"github.com/superfly/flyctl/flyctl"
 	"github.com/superfly/flyctl/internal/config"
 	"github.com/superfly/flyctl/internal/flyutil"
@@ -46,8 +45,10 @@ func generatePeerName(ctx context.Context, apiClient flyutil.Client) (string, er
 	return name, nil
 }
 
-func StateForOrg(ctx context.Context, apiClient flyutil.Client, org *fly.Organization, regionCode string, name string, reestablish bool, network string) (*wg.WireGuardState, error) {
-	state, err := getWireGuardStateForOrg(org.Slug, network)
+// StateForOrg returns the WireGuard state for the org identified by its
+// GraphQL ID and slug, creating a peer when none is cached.
+func StateForOrg(ctx context.Context, apiClient flyutil.Client, orgID, orgSlug string, regionCode string, name string, reestablish bool, network string) (*wg.WireGuardState, error) {
+	state, err := getWireGuardStateForOrg(orgSlug, network)
 	if err != nil {
 		return nil, err
 	}
@@ -57,19 +58,19 @@ func StateForOrg(ctx context.Context, apiClient flyutil.Client, org *fly.Organiz
 
 	terminal.Debugf("Can't find matching WireGuard configuration; creating new one\n")
 
-	stateb, err := Create(apiClient, org, regionCode, name, network, "interactive")
+	stateb, err := Create(apiClient, orgID, orgSlug, regionCode, name, network, "interactive")
 	if err != nil {
 		return nil, err
 	}
 
-	if err := setWireGuardStateForOrg(ctx, org.Slug, network, stateb); err != nil {
+	if err := setWireGuardStateForOrg(ctx, orgSlug, network, stateb); err != nil {
 		return nil, err
 	}
 
 	return stateb, nil
 }
 
-func Create(apiClient flyutil.Client, org *fly.Organization, regionCode, name, network string, namePrefix string) (*wg.WireGuardState, error) {
+func Create(apiClient flyutil.Client, orgID, orgSlug, regionCode, name, network string, namePrefix string) (*wg.WireGuardState, error) {
 	ctx := context.TODO()
 	var (
 		err error
@@ -101,11 +102,11 @@ func Create(apiClient flyutil.Client, org *fly.Organization, regionCode, name, n
 		return nil, errors.New("name must consist solely of letters, numbers, and the dash character")
 	}
 
-	fmt.Printf("Creating WireGuard peer \"%s\" in region \"%s\" for organization %s\n", name, regionCode, org.Slug)
+	fmt.Printf("Creating WireGuard peer \"%s\" in region \"%s\" for organization %s\n", name, regionCode, orgSlug)
 
 	pubkey, privatekey := C25519pair()
 
-	data, err := apiClient.CreateWireGuardPeer(ctx, org.ID, regionCode, name, pubkey, network)
+	data, err := apiClient.CreateWireGuardPeer(ctx, orgID, regionCode, name, pubkey, network)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +114,7 @@ func Create(apiClient flyutil.Client, org *fly.Organization, regionCode, name, n
 	return &wg.WireGuardState{
 		Name:         name,
 		Region:       regionCode,
-		Org:          org.Slug,
+		Org:          orgSlug,
 		LocalPublic:  pubkey,
 		LocalPrivate: privatekey,
 		Peer:         *data,


### PR DESCRIPTION
prompt.Org, prompt.SelectOrg, and the orgs package helpers now list and fetch organizations through ui-ex and return a uiex.Organization. The admin-only filter maps to the list endpoint's admin parameter, and the personal flag replaces the GraphQL type for sorting, the prompt callout, and the orgs list Type column. The ui-ex org carries the same global ID GraphQL reports, so the mutations downstream are unchanged.

The flypg cluster input, extensions core params, statics package, Redis and Postgres cluster creation, and the launch state's cached org take the ui-ex org. The WireGuard library takes an org ID and slug so the commands and the agent server call it the same way. Launch's determineOrg lists through ui-ex, and apps list lists per org through Flaps with deploy times from the ui-ex timestamps endpoint, grouping by org and mapping raw slugs back to their aliases so its output is unchanged.

Still on GraphQL: the org-token refresher in config, which needs user-token-only auth, the agent server's org fetch, and the LiteFS Cloud command slated for removal.


Claude-Session: https://claude.ai/code/session_01DMttEkUAVhL7YZFRFjhHwB
