### PR TITLE
Write the config file atomically

### DIFF
--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -179,10 +179,44 @@ func marshal(path string, v any) (err error) {
 
 func marshalUnlocked(path string, v any) (err error) {
 	var b bytes.Buffer
-	if err = yaml.NewEncoder(&b).Encode(v); err == nil {
-		// TODO: os.WriteFile does not flush
-		err = os.WriteFile(path, b.Bytes(), 0o600)
+	if err = yaml.NewEncoder(&b).Encode(v); err != nil {
+		return err
 	}
 
-	return
+	return writeFileAtomically(path, b.Bytes(), 0o600)
+}
+
+// writeFileAtomically writes data to a temporary file beside path, flushes it
+// to disk, and renames it over path. A write that fails part way, for example
+// on a full disk, leaves whatever was at path untouched. os.WriteFile
+// truncates first and writes second, so the same failure would leave an empty
+// file behind, and an empty config reads back as a logged-out flyctl.
+func writeFileAtomically(path string, data []byte, perm os.FileMode) (err error) {
+	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+
+	defer func() {
+		if err != nil {
+			_ = f.Close()
+			_ = os.Remove(tmp)
+		}
+	}()
+
+	if _, err = f.Write(data); err != nil {
+		return err
+	}
+	if err = f.Sync(); err != nil {
+		return err
+	}
+	if err = f.Chmod(perm); err != nil {
+		return err
+	}
+	if err = f.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmp, path)
 }

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteFileAtomicallyReplacesContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+
+	require.NoError(t, os.WriteFile(path, []byte("access_token: old\n"), 0o600))
+	require.NoError(t, writeFileAtomically(path, []byte("access_token: new\n"), 0o600))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "access_token: new\n", string(got))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "no temporary file should be left behind")
+}
+
+func TestWriteFileAtomicallyKeepsOldContentOnFailure(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root ignores directory permissions")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yml")
+	require.NoError(t, os.WriteFile(path, []byte("access_token: old\n"), 0o600))
+
+	// A read-only directory makes the temporary file impossible to create,
+	// which is the closest portable stand-in for a write failing.
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	require.Error(t, writeFileAtomically(path, []byte("access_token: new\n"), 0o600))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "access_token: old\n", string(got), "a failed write must not touch the existing file")
+}
+
+func TestSetAccessTokenRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yml")
+
+	require.NoError(t, SetAccessToken(path, "fo1_token"))
+
+	token, err := ReadAccessToken(path)
+	require.NoError(t, err)
+	require.Equal(t, "fo1_token", token)
+}

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,9 +20,12 @@ func TestWriteFileAtomicallyReplacesContent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "access_token: new\n", string(got))
 
-	info, err := os.Stat(path)
-	require.NoError(t, err)
-	require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	if runtime.GOOS != "windows" {
+		// Windows has no Unix permission bits; Go reports 0666 for every file.
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
@@ -29,6 +33,9 @@ func TestWriteFileAtomicallyReplacesContent(t *testing.T) {
 }
 
 func TestWriteFileAtomicallyKeepsOldContentOnFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("a read-only directory does not block file creation on Windows")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("root ignores directory permissions")
 	}


### PR DESCRIPTION
The config file was written with os.WriteFile, which truncates before it writes. When the write then failed, for example on a full disk, the file was left empty, and an empty config reads back as a logged-out flyctl, so every token refresh on a full disk logged the user out.

Write to a temporary file beside the config, sync it, and rename it into place, so a failed write leaves the previous contents untouched.


Claude-Session: https://claude.ai/code/session_01DMttEkUAVhL7YZFRFjhHwB
