### PR TITLE
apps list: scope release timestamps to --org and make them non-fatal

### DIFF
--- a/internal/command/apps/list.go
+++ b/internal/command/apps/list.go
@@ -16,6 +16,7 @@ import (
 	"github.com/superfly/flyctl/internal/uiex"
 	"github.com/superfly/flyctl/internal/uiexutil"
 	"github.com/superfly/flyctl/iostreams"
+	"github.com/superfly/flyctl/terminal"
 
 	"github.com/superfly/flyctl/internal/command"
 	"github.com/superfly/flyctl/internal/config"
@@ -127,14 +128,19 @@ func runList(ctx context.Context) (err error) {
 
 // getApps lists the apps the user can see, or only those in orgSlug when it
 // is set, through Flaps. The latest deploy time comes from the ui-ex
-// current-release timestamps, which cover every app in one request.
+// current-release timestamps, one request for every app in the listed orgs.
 func getApps(ctx context.Context, orgSlug string) ([]fly.App, error) {
 	flapsClient := flapsutil.ClientFromContext(ctx)
 	uiexClient := uiexutil.ClientFromContext(ctx)
 
 	// Flaps reports raw org slugs; show the slug the user knows the org by,
 	// which is "personal" for their personal org, as the GraphQL listing did.
+	//
+	// releaseOrgSlug narrows the current-release timestamps request to one
+	// org. It stays empty when listing every org. It is the org's raw slug
+	// because "personal" is a flyctl alias, not a slug the API knows.
 	var orgs []uiex.Organization
+	var releaseOrgSlug string
 	if orgSlug == "" {
 		var err error
 		if orgs, err = uiexClient.ListOrganizations(ctx, false); err != nil {
@@ -146,6 +152,7 @@ func getApps(ctx context.Context, orgSlug string) ([]fly.App, error) {
 			return nil, err
 		}
 		orgs = []uiex.Organization{*org}
+		releaseOrgSlug = org.RawSlug
 	}
 	// The GraphQL listing grouped apps by org, personal org first, and
 	// sorted by name within each org; keep that order.
@@ -155,9 +162,15 @@ func getApps(ctx context.Context, orgSlug string) ([]fly.App, error) {
 		slugByRawSlug[org.RawSlug] = org.Slug
 	}
 
-	releaseTimes, err := uiexClient.GetAllAppsCurrentReleaseTimestamps(ctx)
+	// Without the org filter the server computes timestamps for every app on
+	// the token, which for a member of a very large org can take longer than
+	// the API's request timeout. The timestamps only fill the "Latest Deploy"
+	// column, so if the request fails anyway, warn and list the apps without
+	// it rather than fail.
+	releaseTimes, err := uiexClient.GetAllAppsCurrentReleaseTimestamps(ctx, releaseOrgSlug)
 	if err != nil {
-		return nil, err
+		terminal.Warnf("Could not fetch latest deploy times: %v\n", err)
+		releaseTimes = nil
 	}
 
 	apps := []fly.App{}

--- a/internal/command/apps/list_test.go
+++ b/internal/command/apps/list_test.go
@@ -2,6 +2,7 @@ package apps
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -53,7 +54,7 @@ func TestRunListEmptyApps(t *testing.T) {
 				ListOrganizationsFunc: func(ctx context.Context, admin bool) ([]uiex.Organization, error) {
 					return []uiex.Organization{{Slug: "personal", RawSlug: "raw-personal", Personal: true}}, nil
 				},
-				GetAllAppsCurrentReleaseTimestampsFunc: func(ctx context.Context) (*map[string]time.Time, error) {
+				GetAllAppsCurrentReleaseTimestampsFunc: func(ctx context.Context, orgSlug string) (*map[string]time.Time, error) {
 					return &map[string]time.Time{}, nil
 				},
 			})
@@ -66,6 +67,86 @@ func TestRunListEmptyApps(t *testing.T) {
 			})
 
 			require.NoError(t, runList(ctx))
+			require.Equal(t, tt.want, out.String())
+		})
+	}
+}
+
+// The current-release timestamps only fill the "Latest Deploy" column. When
+// --org is set the request is narrowed to that org's raw slug, and if it
+// fails the apps are still listed, without deploy times.
+func TestRunListReleaseTimestamps(t *testing.T) {
+	tests := []struct {
+		name         string
+		org          string
+		wantOrgSlug  string
+		timestampErr error
+		want         string
+	}{
+		{
+			name:        "org flag forwards the raw slug",
+			org:         "personal",
+			wantOrgSlug: "raw-personal",
+			want: " NAME │ OWNER    │ STATUS   │ LATEST DEPLOY     \n" +
+				" one  │ personal │ deployed │ Nov 14 2025 17:09 \n\n",
+		},
+		{
+			name:        "no org flag asks for every app",
+			wantOrgSlug: "",
+			want: " NAME │ OWNER    │ STATUS   │ LATEST DEPLOY     \n" +
+				" one  │ personal │ deployed │ Nov 14 2025 17:09 \n\n",
+		},
+		{
+			name:         "timestamp failure still lists apps",
+			org:          "personal",
+			wantOrgSlug:  "raw-personal",
+			timestampErr: errors.New("boom"),
+			want: " NAME │ OWNER    │ STATUS   │ LATEST DEPLOY \n" +
+				" one  │ personal │ deployed │               \n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			io, _, out, _ := iostreams.Test()
+			ctx := iostreams.NewContext(context.Background(), io)
+			ctx = config.NewContext(ctx, &config.Config{})
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			flags.Bool("quiet", false, "")
+			flags.String("org", tt.org, "")
+			ctx = flag.NewContext(ctx, flags)
+
+			org := uiex.Organization{Slug: "personal", RawSlug: "raw-personal", Personal: true}
+			var gotOrgSlug string
+			ctx = uiexutil.NewContextWithClient(ctx, &mock.UiexClient{
+				ListOrganizationsFunc: func(ctx context.Context, admin bool) ([]uiex.Organization, error) {
+					return []uiex.Organization{org}, nil
+				},
+				GetOrganizationFunc: func(ctx context.Context, orgSlug string) (*uiex.Organization, error) {
+					require.Equal(t, "personal", orgSlug)
+					return &org, nil
+				},
+				GetAllAppsCurrentReleaseTimestampsFunc: func(ctx context.Context, orgSlug string) (*map[string]time.Time, error) {
+					gotOrgSlug = orgSlug
+					if tt.timestampErr != nil {
+						return nil, tt.timestampErr
+					}
+					return &map[string]time.Time{"one": time.Date(2025, 11, 14, 17, 9, 53, 0, time.UTC)}, nil
+				},
+			})
+			ctx = flapsutil.NewContextWithClient(ctx, &mock.FlapsClient{
+				ListAppsFunc: func(ctx context.Context, req flaps.ListAppsRequest) ([]flaps.App, error) {
+					require.Equal(t, "personal", req.OrgSlug)
+					return []flaps.App{{
+						Name:         "one",
+						Status:       "deployed",
+						Organization: flaps.AppOrganizationInfo{Slug: "raw-personal", Name: "personal"},
+					}}, nil
+				},
+			})
+
+			require.NoError(t, runList(ctx))
+			require.Equal(t, tt.wantOrgSlug, gotOrgSlug)
 			require.Equal(t, tt.want, out.String())
 		})
 	}

--- a/internal/command/launch/plan/postgres_test.go
+++ b/internal/command/launch/plan/postgres_test.go
@@ -74,7 +74,7 @@ func (m *mockUIEXClient) CreateFlyManagedBuilder(ctx context.Context, orgSlug st
 	return uiex.CreateFlyManagedBuilderResponse{}, nil
 }
 
-func (m *mockUIEXClient) GetAllAppsCurrentReleaseTimestamps(ctx context.Context) (*map[string]time.Time, error) {
+func (m *mockUIEXClient) GetAllAppsCurrentReleaseTimestamps(ctx context.Context, orgSlug string) (*map[string]time.Time, error) {
 	return &map[string]time.Time{}, nil
 }
 

--- a/internal/mock/uiex_client.go
+++ b/internal/mock/uiex_client.go
@@ -22,7 +22,7 @@ type UiexClient struct {
 	FinishBuildFunc                        func(ctx context.Context, in uiex.FinishBuildRequest) (*uiex.BuildResponse, error)
 	EnsureDepotBuilderFunc                 func(ctx context.Context, in uiex.EnsureDepotBuilderRequest) (*uiex.EnsureDepotBuilderResponse, error)
 	CreateFlyManagedBuilderFunc            func(ctx context.Context, orgSlug string, region string) (uiex.CreateFlyManagedBuilderResponse, error)
-	GetAllAppsCurrentReleaseTimestampsFunc func(ctx context.Context) (*map[string]time.Time, error)
+	GetAllAppsCurrentReleaseTimestampsFunc func(ctx context.Context, orgSlug string) (*map[string]time.Time, error)
 	ListReleasesFunc                       func(ctx context.Context, appName string, count int) ([]uiex.Release, error)
 	GetCurrentReleaseFunc                  func(ctx context.Context, appName string) (*uiex.Release, error)
 	CreateReleaseFunc                      func(ctx context.Context, req uiex.CreateReleaseRequest) (*uiex.Release, error)
@@ -93,9 +93,9 @@ func (m *UiexClient) CreateFlyManagedBuilder(ctx context.Context, orgSlug string
 	return uiex.CreateFlyManagedBuilderResponse{}, nil
 }
 
-func (m *UiexClient) GetAllAppsCurrentReleaseTimestamps(ctx context.Context) (*map[string]time.Time, error) {
+func (m *UiexClient) GetAllAppsCurrentReleaseTimestamps(ctx context.Context, orgSlug string) (*map[string]time.Time, error) {
 	if m.GetAllAppsCurrentReleaseTimestampsFunc != nil {
-		return m.GetAllAppsCurrentReleaseTimestampsFunc(ctx)
+		return m.GetAllAppsCurrentReleaseTimestampsFunc(ctx, orgSlug)
 	}
 
 	return &map[string]time.Time{}, nil

--- a/internal/uiex/releases.go
+++ b/internal/uiex/releases.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"time"
 
 	"github.com/superfly/flyctl/internal/config"
@@ -75,9 +76,12 @@ type CreateReleaseRequest struct {
 	Strategy   DeploymentStrategy `json:"strategy"`
 }
 
-func (c *Client) GetAllAppsCurrentReleaseTimestamps(ctx context.Context) (out *map[string]time.Time, err error) {
+func (c *Client) GetAllAppsCurrentReleaseTimestamps(ctx context.Context, orgSlug string) (out *map[string]time.Time, err error) {
 	cfg := config.FromContext(ctx)
 	url := fmt.Sprintf("%s/api/v1/releases/all_current", c.baseUrl)
+	if orgSlug != "" {
+		url += "?org=" + neturl.QueryEscape(orgSlug)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/internal/uiexutil/client.go
+++ b/internal/uiexutil/client.go
@@ -28,7 +28,7 @@ type Client interface {
 	CreateFlyManagedBuilder(ctx context.Context, orgSlug string, region string) (uiex.CreateFlyManagedBuilderResponse, error)
 
 	// Releases
-	GetAllAppsCurrentReleaseTimestamps(ctx context.Context) (*map[string]time.Time, error)
+	GetAllAppsCurrentReleaseTimestamps(ctx context.Context, orgSlug string) (*map[string]time.Time, error)
 	ListReleases(ctx context.Context, appName string, count int) ([]uiex.Release, error)
 	GetCurrentRelease(ctx context.Context, appName string) (*uiex.Release, error)
 	CreateRelease(ctx context.Context, req uiex.CreateReleaseRequest) (*uiex.Release, error)


### PR DESCRIPTION
`fly apps list` fills the "Latest Deploy" column from GET /api/v1/releases/all_current, which returned the current release of every app on the token. The call ignored --org, so a member of an org with tens of thousands of apps waited on all of them to list a small org, and could hit the API's request timeout. A failure there also failed the whole command.

Pass the selected org's raw slug as `org=` so the server only computes that org's timestamps (superfly/web#all-current-releases-org-scope), and when the request fails warn and list the apps without deploy times instead of erroring out.


Claude-Session: https://claude.ai/code/session_01HbvEXCrYWj9tKfZeH7zxs8
